### PR TITLE
docs: Wave 19 - module-level documentation for crates.io readiness

### DIFF
--- a/crates/uselesskey-core-cache/src/lib.rs
+++ b/crates/uselesskey-core-cache/src/lib.rs
@@ -1,3 +1,11 @@
+//! Per-process artifact cache keyed by [`ArtifactId`].
+//!
+//! Stores generated fixtures behind `Arc<dyn Any>` so expensive key generation
+//! (especially RSA) only happens once per unique identity tuple. Thread-safe:
+//! uses `DashMap` with `std`, `spin::Mutex` without.
+//!
+//! The primary type is [`ArtifactCache`].
+
 #![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 //! Identity-keyed typed cache primitives for uselesskey fixture factories.

--- a/crates/uselesskey-core-kid/src/lib.rs
+++ b/crates/uselesskey-core-kid/src/lib.rs
@@ -1,3 +1,9 @@
+//! Deterministic key-ID generation from raw key bytes.
+//!
+//! Produces URL-safe, base64url-encoded BLAKE3 hashes truncated to 96 bits
+//! by default. Use [`kid_from_bytes`] for the standard length or
+//! [`kid_from_bytes_with_prefix`] for a custom hash prefix.
+
 #![forbid(unsafe_code)]
 //! Deterministic key-id (kid) helpers for uselesskey fixture crates.
 //!

--- a/crates/uselesskey-core-negative/src/lib.rs
+++ b/crates/uselesskey-core-negative/src/lib.rs
@@ -1,3 +1,10 @@
+//! Negative-fixture helpers for corrupting DER and PEM encodings.
+//!
+//! Provides [`truncate_der`], [`flip_byte`], and [`corrupt_der_deterministic`]
+//! for generating intentionally broken key material. PEM corruption is
+//! re-exported from `uselesskey-core-negative-pem` ([`CorruptPem`],
+//! [`corrupt_pem`], [`corrupt_pem_deterministic`]).
+
 #![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 //! Negative fixture builders for PEM/DER corruption.

--- a/crates/uselesskey-feature-grid/src/lib.rs
+++ b/crates/uselesskey-feature-grid/src/lib.rs
@@ -1,3 +1,8 @@
+//! Canonical feature-matrix definitions for workspace CI and BDD automation.
+//!
+//! Exports [`FeatureSet`] entries and the [`CORE_FEATURE_MATRIX`] /
+//! [`BDD_FEATURE_MATRIX`] slices consumed by `xtask` and CI receipts.
+
 #![forbid(unsafe_code)]
 //! Canonical feature and matrix definitions for uselesskey automation.
 //!


### PR DESCRIPTION
Adds //! module-level docs to 4 core microcrates missing them: core-cache, core-kid, core-negative, feature-grid. All other crates already had module docs.

**Determinism impact:** None
**Policy impact:** None