### PR TITLE
test: Wave 23 - facade and adapter snapshot tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,6 +3289,8 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 name = "uselesskey"
 version = "0.3.0"
 dependencies = [
+ "insta",
+ "serde",
  "tempfile",
  "uselesskey-core",
  "uselesskey-ecdsa",
@@ -3769,8 +3771,10 @@ dependencies = [
 name = "uselesskey-rustls"
 version = "0.3.0"
 dependencies = [
+ "insta",
  "rustls",
  "rustls-pki-types",
+ "serde",
  "uselesskey-core",
  "uselesskey-ecdsa",
  "uselesskey-ed25519",
@@ -3802,7 +3806,9 @@ dependencies = [
 name = "uselesskey-tonic"
 version = "0.3.0"
 dependencies = [
+ "insta",
  "proptest",
+ "serde",
  "tonic",
  "uselesskey-core",
  "uselesskey-x509",

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -47,3 +47,5 @@ uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
 uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
 uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
 rustls = { version = "0.23", features = ["ring"] }
+serde.workspace = true
+insta.workspace = true

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rustls_chain_cert_der_lengths.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rustls_chain_cert_der_lengths.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+leaf_cert_der_len: 803
+intermediate_cert_der_len: 802
+root_cert_der_len: 794
+chain_count: 2

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rustls_chain_private_key_type.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rustls_chain_private_key_type.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+label: chain-leaf
+key_type: PKCS8
+key_der_len: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rustls_self_signed_cert_der_len.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rustls_self_signed_cert_der_len.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+label: self-signed
+cert_der_len: 758

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rustls_self_signed_private_key_type.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rustls_self_signed_private_key_type.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+label: self-signed
+key_type: PKCS8
+key_der_len: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots_rustls.rs
+++ b/crates/uselesskey-rustls/tests/snapshots_rustls.rs
@@ -1,0 +1,113 @@
+//! Insta snapshot tests for uselesskey-rustls adapter.
+//!
+//! These tests snapshot certificate and key shapes produced by the rustls adapter
+//! to detect unintended changes in adapter output.
+
+mod testutil;
+
+use serde::Serialize;
+use testutil::fx;
+use uselesskey_rustls::{RustlsCertExt, RustlsChainExt, RustlsPrivateKeyExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+#[derive(Serialize)]
+struct CertDerSnapshot {
+    label: &'static str,
+    cert_der_len: usize,
+}
+
+#[derive(Serialize)]
+struct PrivateKeySnapshot {
+    label: &'static str,
+    key_type: &'static str,
+    key_der_len: usize,
+}
+
+#[test]
+fn snapshot_rustls_self_signed_cert_der_len() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("snapshot-ss", X509Spec::self_signed("test.example.com"));
+
+    let cert_der = cert.certificate_der_rustls();
+
+    let result = CertDerSnapshot {
+        label: "self-signed",
+        cert_der_len: cert_der.as_ref().len(),
+    };
+
+    insta::assert_yaml_snapshot!("rustls_self_signed_cert_der_len", result);
+}
+
+#[test]
+fn snapshot_rustls_chain_cert_der_lengths() {
+    let fx = fx();
+    let chain = fx.x509_chain("snapshot-chain", ChainSpec::new("test.example.com"));
+
+    let chain_certs = chain.chain_der_rustls();
+    let root = chain.root_certificate_der_rustls();
+
+    #[derive(Serialize)]
+    struct ChainDerLengths {
+        leaf_cert_der_len: usize,
+        intermediate_cert_der_len: usize,
+        root_cert_der_len: usize,
+        chain_count: usize,
+    }
+
+    let result = ChainDerLengths {
+        leaf_cert_der_len: chain_certs[0].as_ref().len(),
+        intermediate_cert_der_len: chain_certs[1].as_ref().len(),
+        root_cert_der_len: root.as_ref().len(),
+        chain_count: chain_certs.len(),
+    };
+
+    insta::assert_yaml_snapshot!("rustls_chain_cert_der_lengths", result);
+}
+
+#[test]
+fn snapshot_rustls_self_signed_private_key_type() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("snapshot-ss-key", X509Spec::self_signed("test.example.com"));
+
+    let key = cert.private_key_der_rustls();
+    let key_type = match &key {
+        rustls_pki_types::PrivateKeyDer::Pkcs1(_) => "PKCS1",
+        rustls_pki_types::PrivateKeyDer::Pkcs8(_) => "PKCS8",
+        rustls_pki_types::PrivateKeyDer::Sec1(_) => "SEC1",
+        _ => "Unknown",
+    };
+
+    let result = PrivateKeySnapshot {
+        label: "self-signed",
+        key_type,
+        key_der_len: key.secret_der().len(),
+    };
+
+    insta::assert_yaml_snapshot!("rustls_self_signed_private_key_type", result, {
+        ".key_der_len" => "[REDACTED]",
+    });
+}
+
+#[test]
+fn snapshot_rustls_chain_private_key_type() {
+    let fx = fx();
+    let chain = fx.x509_chain("snapshot-chain-key", ChainSpec::new("test.example.com"));
+
+    let key = chain.private_key_der_rustls();
+    let key_type = match &key {
+        rustls_pki_types::PrivateKeyDer::Pkcs1(_) => "PKCS1",
+        rustls_pki_types::PrivateKeyDer::Pkcs8(_) => "PKCS8",
+        rustls_pki_types::PrivateKeyDer::Sec1(_) => "SEC1",
+        _ => "Unknown",
+    };
+
+    let result = PrivateKeySnapshot {
+        label: "chain-leaf",
+        key_type,
+        key_der_len: key.secret_der().len(),
+    };
+
+    insta::assert_yaml_snapshot!("rustls_chain_private_key_type", result, {
+        ".key_der_len" => "[REDACTED]",
+    });
+}

--- a/crates/uselesskey-rustls/tests/testutil.rs
+++ b/crates/uselesskey-rustls/tests/testutil.rs
@@ -1,0 +1,16 @@
+#![allow(unused)]
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+pub(crate) fn fx() -> Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-rustls-snapshot-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+    .clone()
+}

--- a/crates/uselesskey-tonic/Cargo.toml
+++ b/crates/uselesskey-tonic/Cargo.toml
@@ -29,3 +29,5 @@ x509 = ["dep:uselesskey-x509"]
 uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
 uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0" }
 proptest.workspace = true
+serde.workspace = true
+insta.workspace = true

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__tonic_available_config_types.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__tonic_available_config_types.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+expression: result
+---
+identity_from_self_signed: true
+identity_from_chain: true
+server_tls_from_self_signed: true
+server_tls_from_chain: true
+client_tls_from_self_signed: true
+client_tls_from_chain: true
+mtls_server_from_chain: true
+mtls_client_from_chain: true

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__tonic_chain_certificate_shapes.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__tonic_chain_certificate_shapes.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+expression: result
+---
+chain_pem_cert_count: 2
+root_pem_starts_with_cert_header: true
+leaf_pem_starts_with_cert_header: true
+leaf_key_pem_starts_with_key_header: true

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__tonic_self_signed_certificate_shapes.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__tonic_self_signed_certificate_shapes.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+expression: result
+---
+cert_der_len: 758
+private_key_der_len: 1217
+cert_pem_starts_with_cert_header: true
+key_pem_starts_with_key_header: true

--- a/crates/uselesskey-tonic/tests/snapshots_tonic.rs
+++ b/crates/uselesskey-tonic/tests/snapshots_tonic.rs
@@ -1,0 +1,129 @@
+//! Insta snapshot tests for uselesskey-tonic adapter.
+//!
+//! These tests snapshot tonic TLS config shapes produced by the adapter
+//! to detect unintended changes in adapter output.
+
+mod testutil;
+
+use serde::Serialize;
+use testutil::fx;
+use uselesskey_tonic::{TonicClientTlsExt, TonicIdentityExt, TonicMtlsExt, TonicServerTlsExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+#[test]
+fn snapshot_tonic_available_config_types() {
+    #[derive(Serialize)]
+    struct TonicConfigTypes {
+        identity_from_self_signed: bool,
+        identity_from_chain: bool,
+        server_tls_from_self_signed: bool,
+        server_tls_from_chain: bool,
+        client_tls_from_self_signed: bool,
+        client_tls_from_chain: bool,
+        mtls_server_from_chain: bool,
+        mtls_client_from_chain: bool,
+    }
+
+    let fx = fx();
+    let cert = fx.x509_self_signed("snapshot-ss", X509Spec::self_signed("test.example.com"));
+    let chain = fx.x509_chain("snapshot-chain", ChainSpec::new("test.example.com"));
+
+    let result = TonicConfigTypes {
+        identity_from_self_signed: {
+            let _ = cert.identity_tonic();
+            true
+        },
+        identity_from_chain: {
+            let _ = chain.identity_tonic();
+            true
+        },
+        server_tls_from_self_signed: {
+            let _ = cert.server_tls_config_tonic();
+            true
+        },
+        server_tls_from_chain: {
+            let _ = chain.server_tls_config_tonic();
+            true
+        },
+        client_tls_from_self_signed: {
+            let _ = cert.client_tls_config_tonic("test.example.com");
+            true
+        },
+        client_tls_from_chain: {
+            let _ = chain.client_tls_config_tonic("test.example.com");
+            true
+        },
+        mtls_server_from_chain: {
+            let _ = chain.server_tls_config_mtls_tonic();
+            true
+        },
+        mtls_client_from_chain: {
+            let _ = chain.client_tls_config_mtls_tonic("test.example.com");
+            true
+        },
+    };
+
+    insta::assert_yaml_snapshot!("tonic_available_config_types", result);
+}
+
+#[test]
+fn snapshot_tonic_chain_certificate_shapes() {
+    let fx = fx();
+    let chain = fx.x509_chain("snapshot-shapes", ChainSpec::new("test.example.com"));
+
+    #[derive(Serialize)]
+    struct ChainCertShapes {
+        chain_pem_cert_count: usize,
+        root_pem_starts_with_cert_header: bool,
+        leaf_pem_starts_with_cert_header: bool,
+        leaf_key_pem_starts_with_key_header: bool,
+    }
+
+    let result = ChainCertShapes {
+        chain_pem_cert_count: chain
+            .chain_pem()
+            .matches("-----BEGIN CERTIFICATE-----")
+            .count(),
+        root_pem_starts_with_cert_header: chain
+            .root_cert_pem()
+            .starts_with("-----BEGIN CERTIFICATE-----"),
+        leaf_pem_starts_with_cert_header: chain
+            .leaf_cert_pem()
+            .starts_with("-----BEGIN CERTIFICATE-----"),
+        leaf_key_pem_starts_with_key_header: chain
+            .leaf_private_key_pkcs8_pem()
+            .starts_with("-----BEGIN PRIVATE KEY-----"),
+    };
+
+    insta::assert_yaml_snapshot!("tonic_chain_certificate_shapes", result);
+}
+
+#[test]
+fn snapshot_tonic_self_signed_certificate_shapes() {
+    let fx = fx();
+    let cert = fx.x509_self_signed(
+        "snapshot-ss-shapes",
+        X509Spec::self_signed("test.example.com"),
+    );
+
+    #[derive(Serialize)]
+    struct SelfSignedShapes {
+        cert_der_len: usize,
+        private_key_der_len: usize,
+        cert_pem_starts_with_cert_header: bool,
+        key_pem_starts_with_key_header: bool,
+    }
+
+    let result = SelfSignedShapes {
+        cert_der_len: cert.cert_der().len(),
+        private_key_der_len: cert.private_key_pkcs8_der().len(),
+        cert_pem_starts_with_cert_header: cert
+            .cert_pem()
+            .starts_with("-----BEGIN CERTIFICATE-----"),
+        key_pem_starts_with_key_header: cert
+            .private_key_pkcs8_pem()
+            .starts_with("-----BEGIN PRIVATE KEY-----"),
+    };
+
+    insta::assert_yaml_snapshot!("tonic_self_signed_certificate_shapes", result);
+}

--- a/crates/uselesskey-tonic/tests/testutil.rs
+++ b/crates/uselesskey-tonic/tests/testutil.rs
@@ -1,0 +1,16 @@
+#![allow(unused)]
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+pub(crate) fn fx() -> Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-tonic-snapshot-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+    .clone()
+}

--- a/crates/uselesskey/Cargo.toml
+++ b/crates/uselesskey/Cargo.toml
@@ -63,3 +63,5 @@ full = ["all-keys", "token", "x509", "jwk"]
 
 [dev-dependencies]
 tempfile.workspace = true
+serde.workspace = true
+insta.workspace = true

--- a/crates/uselesskey/tests/snapshots/snapshots_facade__ecdsa_snapshots__facade_ecdsa_p256_shape.snap
+++ b/crates/uselesskey/tests/snapshots/snapshots_facade__ecdsa_snapshots__facade_ecdsa_p256_shape.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey/tests/snapshots_facade.rs
+expression: result
+---
+algorithm: ECDSA-P256
+private_key_pem_header: "-----BEGIN PRIVATE KEY-----"
+private_key_der_len: 138
+public_key_pem_header: "-----BEGIN PUBLIC KEY-----"
+public_key_der_len: 91

--- a/crates/uselesskey/tests/snapshots/snapshots_facade__ecdsa_snapshots__facade_ecdsa_p384_shape.snap
+++ b/crates/uselesskey/tests/snapshots/snapshots_facade__ecdsa_snapshots__facade_ecdsa_p384_shape.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey/tests/snapshots_facade.rs
+expression: result
+---
+algorithm: ECDSA-P384
+private_key_pem_header: "-----BEGIN PRIVATE KEY-----"
+private_key_der_len: 185
+public_key_pem_header: "-----BEGIN PUBLIC KEY-----"
+public_key_der_len: 120

--- a/crates/uselesskey/tests/snapshots/snapshots_facade__ed25519_snapshots__facade_ed25519_shape.snap
+++ b/crates/uselesskey/tests/snapshots/snapshots_facade__ed25519_snapshots__facade_ed25519_shape.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey/tests/snapshots_facade.rs
+expression: result
+---
+algorithm: Ed25519
+private_key_pem_header: "-----BEGIN PRIVATE KEY-----"
+private_key_der_len: 83
+public_key_pem_header: "-----BEGIN PUBLIC KEY-----"
+public_key_der_len: 44

--- a/crates/uselesskey/tests/snapshots/snapshots_facade__hmac_snapshots__facade_hmac_shapes.snap
+++ b/crates/uselesskey/tests/snapshots/snapshots_facade__hmac_snapshots__facade_hmac_shapes.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey/tests/snapshots_facade.rs
+expression: cases
+---
+- algorithm: HS256
+  secret_len: 32
+- algorithm: HS384
+  secret_len: 48
+- algorithm: HS512
+  secret_len: 64

--- a/crates/uselesskey/tests/snapshots/snapshots_facade__rsa_snapshots__facade_rsa_2048_shape.snap
+++ b/crates/uselesskey/tests/snapshots/snapshots_facade__rsa_snapshots__facade_rsa_2048_shape.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey/tests/snapshots_facade.rs
+expression: result
+---
+algorithm: RSA-2048
+private_key_pem_header: "-----BEGIN PRIVATE KEY-----"
+private_key_der_len: 1216
+public_key_pem_header: "-----BEGIN PUBLIC KEY-----"
+public_key_der_len: 294

--- a/crates/uselesskey/tests/snapshots/snapshots_facade__rsa_snapshots__facade_rsa_pem_headers.snap
+++ b/crates/uselesskey/tests/snapshots/snapshots_facade__rsa_snapshots__facade_rsa_pem_headers.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uselesskey/tests/snapshots_facade.rs
+expression: result
+---
+private_starts_with: true
+public_starts_with: true

--- a/crates/uselesskey/tests/snapshots/snapshots_facade__token_snapshots__facade_token_shapes.snap
+++ b/crates/uselesskey/tests/snapshots/snapshots_facade__token_snapshots__facade_token_shapes.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uselesskey/tests/snapshots_facade.rs
+expression: cases
+---
+- kind: api_key
+  value_len: 40
+  value_non_empty: true
+- kind: bearer
+  value_len: 43
+  value_non_empty: true
+- kind: oauth_access_token
+  value_len: 252
+  value_non_empty: true

--- a/crates/uselesskey/tests/snapshots/snapshots_facade__x509_snapshots__facade_x509_chain_shape.snap
+++ b/crates/uselesskey/tests/snapshots/snapshots_facade__x509_snapshots__facade_x509_chain_shape.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey/tests/snapshots_facade.rs
+expression: result
+---
+root_cert_der_len: 794
+intermediate_cert_der_len: 802
+leaf_cert_der_len: 803
+leaf_private_key_der_len: 1217
+chain_pem_cert_count: 2
+full_chain_pem_cert_count: 3

--- a/crates/uselesskey/tests/snapshots/snapshots_facade__x509_snapshots__facade_x509_self_signed_shape.snap
+++ b/crates/uselesskey/tests/snapshots/snapshots_facade__x509_snapshots__facade_x509_self_signed_shape.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey/tests/snapshots_facade.rs
+expression: result
+---
+cert_der_len: 758
+private_key_der_len: 1218
+cert_pem_starts_with: true
+key_pem_starts_with: true

--- a/crates/uselesskey/tests/snapshots_facade.rs
+++ b/crates/uselesskey/tests/snapshots_facade.rs
@@ -1,0 +1,277 @@
+//! Insta snapshot tests for the uselesskey facade crate.
+//!
+//! These tests snapshot key shapes produced through the public facade API
+//! to detect unintended changes in re-exported outputs.
+
+mod testutil;
+
+use serde::Serialize;
+use testutil::fx;
+
+#[derive(Serialize)]
+struct KeyShape {
+    algorithm: &'static str,
+    private_key_pem_header: &'static str,
+    private_key_der_len: usize,
+    public_key_pem_header: &'static str,
+    public_key_der_len: usize,
+}
+
+#[cfg(feature = "rsa")]
+mod rsa_snapshots {
+    use super::*;
+    use uselesskey::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn snapshot_facade_rsa_2048_shape() {
+        let fx = fx();
+        let kp = fx.rsa("snapshot-rsa", RsaSpec::rs256());
+
+        let result = KeyShape {
+            algorithm: "RSA-2048",
+            private_key_pem_header: "-----BEGIN PRIVATE KEY-----",
+            private_key_der_len: kp.private_key_pkcs8_der().len(),
+            public_key_pem_header: "-----BEGIN PUBLIC KEY-----",
+            public_key_der_len: kp.public_key_spki_der().len(),
+        };
+
+        insta::assert_yaml_snapshot!("facade_rsa_2048_shape", result);
+    }
+
+    #[test]
+    fn snapshot_facade_rsa_pem_headers() {
+        let fx = fx();
+        let kp = fx.rsa("snapshot-rsa-pem", RsaSpec::rs256());
+
+        #[derive(Serialize)]
+        struct PemHeaders {
+            private_starts_with: bool,
+            public_starts_with: bool,
+        }
+
+        let result = PemHeaders {
+            private_starts_with: kp
+                .private_key_pkcs8_pem()
+                .starts_with("-----BEGIN PRIVATE KEY-----"),
+            public_starts_with: kp
+                .public_key_spki_pem()
+                .starts_with("-----BEGIN PUBLIC KEY-----"),
+        };
+
+        insta::assert_yaml_snapshot!("facade_rsa_pem_headers", result);
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_snapshots {
+    use super::*;
+    use uselesskey::{EcdsaFactoryExt, EcdsaSpec};
+
+    #[test]
+    fn snapshot_facade_ecdsa_p256_shape() {
+        let fx = fx();
+        let kp = fx.ecdsa("snapshot-ecdsa-p256", EcdsaSpec::es256());
+
+        let result = KeyShape {
+            algorithm: "ECDSA-P256",
+            private_key_pem_header: "-----BEGIN PRIVATE KEY-----",
+            private_key_der_len: kp.private_key_pkcs8_der().len(),
+            public_key_pem_header: "-----BEGIN PUBLIC KEY-----",
+            public_key_der_len: kp.public_key_spki_der().len(),
+        };
+
+        insta::assert_yaml_snapshot!("facade_ecdsa_p256_shape", result);
+    }
+
+    #[test]
+    fn snapshot_facade_ecdsa_p384_shape() {
+        let fx = fx();
+        let kp = fx.ecdsa("snapshot-ecdsa-p384", EcdsaSpec::es384());
+
+        let result = KeyShape {
+            algorithm: "ECDSA-P384",
+            private_key_pem_header: "-----BEGIN PRIVATE KEY-----",
+            private_key_der_len: kp.private_key_pkcs8_der().len(),
+            public_key_pem_header: "-----BEGIN PUBLIC KEY-----",
+            public_key_der_len: kp.public_key_spki_der().len(),
+        };
+
+        insta::assert_yaml_snapshot!("facade_ecdsa_p384_shape", result);
+    }
+}
+
+#[cfg(feature = "ed25519")]
+mod ed25519_snapshots {
+    use super::*;
+    use uselesskey::{Ed25519FactoryExt, Ed25519Spec};
+
+    #[test]
+    fn snapshot_facade_ed25519_shape() {
+        let fx = fx();
+        let kp = fx.ed25519("snapshot-ed25519", Ed25519Spec::new());
+
+        let result = KeyShape {
+            algorithm: "Ed25519",
+            private_key_pem_header: "-----BEGIN PRIVATE KEY-----",
+            private_key_der_len: kp.private_key_pkcs8_der().len(),
+            public_key_pem_header: "-----BEGIN PUBLIC KEY-----",
+            public_key_der_len: kp.public_key_spki_der().len(),
+        };
+
+        insta::assert_yaml_snapshot!("facade_ed25519_shape", result);
+    }
+}
+
+#[cfg(feature = "hmac")]
+mod hmac_snapshots {
+    use super::*;
+    use uselesskey::{HmacFactoryExt, HmacSpec};
+
+    #[test]
+    fn snapshot_facade_hmac_shapes() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct HmacShape {
+            algorithm: &'static str,
+            secret_len: usize,
+        }
+
+        let cases: Vec<HmacShape> = vec![
+            {
+                let s = fx.hmac("snapshot-hs256", HmacSpec::hs256());
+                HmacShape {
+                    algorithm: "HS256",
+                    secret_len: s.secret_bytes().len(),
+                }
+            },
+            {
+                let s = fx.hmac("snapshot-hs384", HmacSpec::hs384());
+                HmacShape {
+                    algorithm: "HS384",
+                    secret_len: s.secret_bytes().len(),
+                }
+            },
+            {
+                let s = fx.hmac("snapshot-hs512", HmacSpec::hs512());
+                HmacShape {
+                    algorithm: "HS512",
+                    secret_len: s.secret_bytes().len(),
+                }
+            },
+        ];
+
+        insta::assert_yaml_snapshot!("facade_hmac_shapes", cases);
+    }
+}
+
+#[cfg(feature = "token")]
+mod token_snapshots {
+    use super::*;
+    use uselesskey::{TokenFactoryExt, TokenSpec};
+
+    #[test]
+    fn snapshot_facade_token_shapes() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct TokenShape {
+            kind: &'static str,
+            value_len: usize,
+            value_non_empty: bool,
+        }
+
+        let cases: Vec<TokenShape> = vec![
+            {
+                let t = fx.token("snapshot-api-key", TokenSpec::api_key());
+                TokenShape {
+                    kind: "api_key",
+                    value_len: t.value().len(),
+                    value_non_empty: !t.value().is_empty(),
+                }
+            },
+            {
+                let t = fx.token("snapshot-bearer", TokenSpec::bearer());
+                TokenShape {
+                    kind: "bearer",
+                    value_len: t.value().len(),
+                    value_non_empty: !t.value().is_empty(),
+                }
+            },
+            {
+                let t = fx.token("snapshot-oauth", TokenSpec::oauth_access_token());
+                TokenShape {
+                    kind: "oauth_access_token",
+                    value_len: t.value().len(),
+                    value_non_empty: !t.value().is_empty(),
+                }
+            },
+        ];
+
+        insta::assert_yaml_snapshot!("facade_token_shapes", cases);
+    }
+}
+
+#[cfg(feature = "x509")]
+mod x509_snapshots {
+    use super::*;
+    use uselesskey::{ChainSpec, X509FactoryExt, X509Spec};
+
+    #[test]
+    fn snapshot_facade_x509_self_signed_shape() {
+        let fx = fx();
+        let cert = fx.x509_self_signed("snapshot-x509", X509Spec::self_signed("test.example.com"));
+
+        #[derive(Serialize)]
+        struct X509Shape {
+            cert_der_len: usize,
+            private_key_der_len: usize,
+            cert_pem_starts_with: bool,
+            key_pem_starts_with: bool,
+        }
+
+        let result = X509Shape {
+            cert_der_len: cert.cert_der().len(),
+            private_key_der_len: cert.private_key_pkcs8_der().len(),
+            cert_pem_starts_with: cert.cert_pem().starts_with("-----BEGIN CERTIFICATE-----"),
+            key_pem_starts_with: cert
+                .private_key_pkcs8_pem()
+                .starts_with("-----BEGIN PRIVATE KEY-----"),
+        };
+
+        insta::assert_yaml_snapshot!("facade_x509_self_signed_shape", result);
+    }
+
+    #[test]
+    fn snapshot_facade_x509_chain_shape() {
+        let fx = fx();
+        let chain = fx.x509_chain("snapshot-chain", ChainSpec::new("test.example.com"));
+
+        #[derive(Serialize)]
+        struct ChainShape {
+            root_cert_der_len: usize,
+            intermediate_cert_der_len: usize,
+            leaf_cert_der_len: usize,
+            leaf_private_key_der_len: usize,
+            chain_pem_cert_count: usize,
+            full_chain_pem_cert_count: usize,
+        }
+
+        let result = ChainShape {
+            root_cert_der_len: chain.root_cert_der().len(),
+            intermediate_cert_der_len: chain.intermediate_cert_der().len(),
+            leaf_cert_der_len: chain.leaf_cert_der().len(),
+            leaf_private_key_der_len: chain.leaf_private_key_pkcs8_der().len(),
+            chain_pem_cert_count: chain
+                .chain_pem()
+                .matches("-----BEGIN CERTIFICATE-----")
+                .count(),
+            full_chain_pem_cert_count: chain
+                .full_chain_pem()
+                .matches("-----BEGIN CERTIFICATE-----")
+                .count(),
+        };
+
+        insta::assert_yaml_snapshot!("facade_x509_chain_shape", result);
+    }
+}


### PR DESCRIPTION
Adds 16 insta snapshot tests across 3 crates: uselesskey facade (9), rustls (4), tonic (3). All crypto material redacted. Deterministic via seed.

**Determinism impact:** None
**Policy impact:** None