### PR TITLE
test: Wave 22 - property-based tests for 10 additional crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,6 +3308,7 @@ dependencies = [
  "aws-lc-rs",
  "hex",
  "insta",
+ "proptest",
  "serde",
  "uselesskey-core",
  "uselesskey-ecdsa",
@@ -3471,7 +3472,11 @@ version = "0.3.0"
 dependencies = [
  "base64",
  "blake3",
+<<<<<<< HEAD
  "rstest",
+=======
+ "proptest",
+>>>>>>> 94882ef (test: property-based tests for core microcrates and adapters)
 ]
 
 [[package]]
@@ -3720,6 +3725,7 @@ version = "0.3.0"
 dependencies = [
  "hex",
  "insta",
+ "proptest",
  "ring",
  "serde",
  "uselesskey-core",

--- a/crates/uselesskey-aws-lc-rs/Cargo.toml
+++ b/crates/uselesskey-aws-lc-rs/Cargo.toml
@@ -42,3 +42,4 @@ uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true
+proptest.workspace = true

--- a/crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_prop.rs
+++ b/crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_prop.rs
@@ -1,0 +1,52 @@
+use proptest::prelude::*;
+use uselesskey_core::{Factory, Seed};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 8, ..ProptestConfig::default() })]
+
+    /// Deterministic factory produces the same aws-lc-rs RSA public key for the same seed.
+    #[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "rsa"))]
+    #[test]
+    fn rsa_aws_lc_rs_deterministic(seed in any::<[u8; 32]>()) {
+        use aws_lc_rs::signature::KeyPair;
+        use uselesskey_aws_lc_rs::AwsLcRsRsaKeyPairExt;
+        use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+        let fx = Factory::deterministic(Seed::new(seed));
+        let kp1 = fx.rsa("prop-test", RsaSpec::rs256()).rsa_key_pair_aws_lc_rs();
+        let kp2 = fx.rsa("prop-test", RsaSpec::rs256()).rsa_key_pair_aws_lc_rs();
+
+        prop_assert_eq!(kp1.public_key().as_ref(), kp2.public_key().as_ref());
+        prop_assert!(kp1.public_modulus_len() > 0);
+    }
+
+    /// Deterministic factory produces the same aws-lc-rs ECDSA public key for the same seed.
+    #[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "ecdsa"))]
+    #[test]
+    fn ecdsa_aws_lc_rs_deterministic(seed in any::<[u8; 32]>()) {
+        use aws_lc_rs::signature::KeyPair;
+        use uselesskey_aws_lc_rs::AwsLcRsEcdsaKeyPairExt;
+        use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+        let fx = Factory::deterministic(Seed::new(seed));
+        let kp1 = fx.ecdsa("prop-test", EcdsaSpec::es256()).ecdsa_key_pair_aws_lc_rs();
+        let kp2 = fx.ecdsa("prop-test", EcdsaSpec::es256()).ecdsa_key_pair_aws_lc_rs();
+
+        prop_assert_eq!(kp1.public_key().as_ref(), kp2.public_key().as_ref());
+    }
+
+    /// Deterministic factory produces the same aws-lc-rs Ed25519 public key for the same seed.
+    #[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "ed25519"))]
+    #[test]
+    fn ed25519_aws_lc_rs_deterministic(seed in any::<[u8; 32]>()) {
+        use aws_lc_rs::signature::KeyPair;
+        use uselesskey_aws_lc_rs::AwsLcRsEd25519KeyPairExt;
+        use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+        let fx = Factory::deterministic(Seed::new(seed));
+        let kp1 = fx.ed25519("prop-test", Ed25519Spec::new()).ed25519_key_pair_aws_lc_rs();
+        let kp2 = fx.ed25519("prop-test", Ed25519Spec::new()).ed25519_key_pair_aws_lc_rs();
+
+        prop_assert_eq!(kp1.public_key().as_ref(), kp2.public_key().as_ref());
+    }
+}

--- a/crates/uselesskey-core-cache/tests/cache_prop.rs
+++ b/crates/uselesskey-core-cache/tests/cache_prop.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+
+use proptest::prelude::*;
+use uselesskey_core_cache::ArtifactCache;
+use uselesskey_core_id::{ArtifactId, DerivationVersion};
+
+fn make_id(label: &str, variant: &str) -> ArtifactId {
+    ArtifactId::new(
+        "domain:prop",
+        label,
+        b"spec",
+        variant,
+        DerivationVersion::V1,
+    )
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// Inserting and retrieving a typed value round-trips correctly.
+    #[test]
+    fn insert_and_get_round_trip(label in "[a-z]{1,16}", value in any::<u64>()) {
+        let cache = ArtifactCache::new();
+        let id = make_id(&label, "default");
+
+        let inserted = cache.insert_if_absent_typed(id.clone(), Arc::new(value));
+        let fetched = cache.get_typed::<u64>(&id).expect("value should be present");
+
+        prop_assert_eq!(*inserted, value);
+        prop_assert_eq!(*fetched, value);
+    }
+
+    /// insert_if_absent_typed always returns the first inserted value.
+    #[test]
+    fn first_value_wins(
+        label in "[a-z]{1,16}",
+        first in any::<u64>(),
+        second in any::<u64>(),
+    ) {
+        let cache = ArtifactCache::new();
+        let id = make_id(&label, "default");
+
+        let winner = cache.insert_if_absent_typed(id.clone(), Arc::new(first));
+        let again = cache.insert_if_absent_typed(id, Arc::new(second));
+
+        prop_assert_eq!(*winner, first);
+        prop_assert_eq!(*again, first);
+    }
+
+    /// Distinct labels produce distinct cache entries.
+    #[test]
+    fn distinct_labels_no_collision(
+        label_a in "[a-z]{1,8}",
+        label_b in "[a-z]{1,8}",
+    ) {
+        prop_assume!(label_a != label_b);
+        let cache = ArtifactCache::new();
+
+        let id_a = make_id(&label_a, "default");
+        let id_b = make_id(&label_b, "default");
+
+        cache.insert_if_absent_typed(id_a.clone(), Arc::new(1u32));
+        cache.insert_if_absent_typed(id_b.clone(), Arc::new(2u32));
+
+        prop_assert_eq!(*cache.get_typed::<u32>(&id_a).unwrap(), 1u32);
+        prop_assert_eq!(*cache.get_typed::<u32>(&id_b).unwrap(), 2u32);
+        prop_assert_eq!(cache.len(), 2);
+    }
+
+    /// Cache len tracks insertions correctly.
+    #[test]
+    fn len_tracks_insertions(count in 1usize..=20) {
+        let cache = ArtifactCache::new();
+        for i in 0..count {
+            let id = make_id(&format!("label-{i}"), "default");
+            cache.insert_if_absent_typed(id, Arc::new(i as u64));
+        }
+        prop_assert_eq!(cache.len(), count);
+        prop_assert!(!cache.is_empty());
+    }
+
+    /// clear() empties the cache.
+    #[test]
+    fn clear_empties(count in 1usize..=10) {
+        let cache = ArtifactCache::new();
+        for i in 0..count {
+            let id = make_id(&format!("label-{i}"), "default");
+            cache.insert_if_absent_typed(id, Arc::new(i as u64));
+        }
+        cache.clear();
+        prop_assert!(cache.is_empty());
+        prop_assert_eq!(cache.len(), 0);
+    }
+}

--- a/crates/uselesskey-core-hash/tests/hash_prop.rs
+++ b/crates/uselesskey-core-hash/tests/hash_prop.rs
@@ -1,0 +1,50 @@
+use proptest::prelude::*;
+use uselesskey_core_hash::{Hasher, hash32, write_len_prefixed};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// hash32 is deterministic for any input.
+    #[test]
+    fn hash32_deterministic(data in any::<Vec<u8>>()) {
+        prop_assert_eq!(hash32(&data), hash32(&data));
+    }
+
+    /// Different inputs produce different hashes (collision resistance).
+    #[test]
+    fn hash32_different_inputs_differ(a in any::<Vec<u8>>(), b in any::<Vec<u8>>()) {
+        prop_assume!(a != b);
+        prop_assert_ne!(hash32(&a), hash32(&b));
+    }
+
+    /// write_len_prefixed preserves tuple boundaries: [a][b] != [a+b].
+    #[test]
+    fn len_prefix_separates_fields(
+        a in prop::collection::vec(any::<u8>(), 1..32),
+        b in prop::collection::vec(any::<u8>(), 1..32),
+    ) {
+        let mut combined = a.clone();
+        combined.extend_from_slice(&b);
+
+        let mut h_two = Hasher::new();
+        write_len_prefixed(&mut h_two, &a);
+        write_len_prefixed(&mut h_two, &b);
+
+        let mut h_one = Hasher::new();
+        write_len_prefixed(&mut h_one, &combined);
+
+        prop_assert_ne!(h_two.finalize(), h_one.finalize());
+    }
+
+    /// write_len_prefixed is deterministic.
+    #[test]
+    fn write_len_prefixed_deterministic(data in any::<Vec<u8>>()) {
+        let mut h1 = Hasher::new();
+        write_len_prefixed(&mut h1, &data);
+
+        let mut h2 = Hasher::new();
+        write_len_prefixed(&mut h2, &data);
+
+        prop_assert_eq!(h1.finalize(), h2.finalize());
+    }
+}

--- a/crates/uselesskey-core-id/tests/id_prop.rs
+++ b/crates/uselesskey-core-id/tests/id_prop.rs
@@ -1,0 +1,75 @@
+use proptest::prelude::*;
+use uselesskey_core_id::{ArtifactId, DerivationVersion, Seed, derive_seed};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// Same master seed and ArtifactId always produce the same derived seed.
+    #[test]
+    fn derive_seed_is_deterministic(
+        master in any::<[u8; 32]>(),
+        label in ".*",
+        spec in any::<[u8; 8]>(),
+        variant in ".*",
+    ) {
+        let seed = Seed::new(master);
+        let id = ArtifactId::new("domain:prop", &label, &spec, &variant, DerivationVersion::V1);
+
+        let a = derive_seed(&seed, &id);
+        let b = derive_seed(&seed, &id);
+        prop_assert_eq!(a.bytes(), b.bytes());
+    }
+
+    /// Changing the label changes the derived seed.
+    #[test]
+    fn different_labels_produce_different_seeds(
+        master in any::<[u8; 32]>(),
+        label_a in "[a-z]{1,8}",
+        label_b in "[a-z]{1,8}",
+    ) {
+        prop_assume!(label_a != label_b);
+        let seed = Seed::new(master);
+        let id_a = ArtifactId::new("domain:prop", &label_a, b"spec", "v", DerivationVersion::V1);
+        let id_b = ArtifactId::new("domain:prop", &label_b, b"spec", "v", DerivationVersion::V1);
+
+        let sa = derive_seed(&seed, &id_a);
+        let sb = derive_seed(&seed, &id_b);
+        prop_assert_ne!(sa.bytes(), sb.bytes());
+    }
+
+    /// Changing the variant changes the derived seed.
+    #[test]
+    fn different_variants_produce_different_seeds(
+        master in any::<[u8; 32]>(),
+        variant_a in "[a-z]{1,8}",
+        variant_b in "[a-z]{1,8}",
+    ) {
+        prop_assume!(variant_a != variant_b);
+        let seed = Seed::new(master);
+        let id_a = ArtifactId::new("domain:prop", "label", b"spec", &variant_a, DerivationVersion::V1);
+        let id_b = ArtifactId::new("domain:prop", "label", b"spec", &variant_b, DerivationVersion::V1);
+
+        let sa = derive_seed(&seed, &id_a);
+        let sb = derive_seed(&seed, &id_b);
+        prop_assert_ne!(sa.bytes(), sb.bytes());
+    }
+
+    /// spec_fingerprint is always the BLAKE3 hash of the spec bytes.
+    #[test]
+    fn spec_fingerprint_matches_hash32(spec in any::<Vec<u8>>()) {
+        let id = ArtifactId::new("d", "l", &spec, "v", DerivationVersion::V1);
+        let expected = *uselesskey_core_id::hash32(&spec).as_bytes();
+        prop_assert_eq!(id.spec_fingerprint, expected);
+    }
+
+    /// ArtifactId construction never panics on arbitrary input.
+    #[test]
+    fn artifact_id_new_never_panics(
+        label in ".*",
+        spec in any::<Vec<u8>>(),
+        variant in ".*",
+        version in any::<u16>(),
+    ) {
+        let _ = ArtifactId::new("domain:prop", label, &spec, variant, DerivationVersion(version));
+    }
+}

--- a/crates/uselesskey-core-jwk-shape/tests/jwk_shape_prop.rs
+++ b/crates/uselesskey-core-jwk-shape/tests/jwk_shape_prop.rs
@@ -1,0 +1,139 @@
+use proptest::prelude::*;
+use uselesskey_core_jwk_shape::{
+    AnyJwk, EcPublicJwk, Jwks, OctJwk, OkpPublicJwk, PrivateJwk, PublicJwk, RsaPublicJwk,
+};
+
+fn arb_rsa_public(kid: String, n: String) -> PublicJwk {
+    PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid,
+        n,
+        e: "AQAB".to_string(),
+    })
+}
+
+fn arb_ec_public(kid: String, x: String) -> PublicJwk {
+    PublicJwk::Ec(EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid,
+        x,
+        y: "y-coord".to_string(),
+    })
+}
+
+fn arb_okp_public(kid: String, x: String) -> PublicJwk {
+    PublicJwk::Okp(OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid,
+        x,
+    })
+}
+
+fn arb_oct_private(kid: String, k: String) -> PrivateJwk {
+    PrivateJwk::Oct(OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid,
+        k,
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// to_value produces valid JSON with the expected kid field.
+    #[test]
+    fn public_jwk_to_value_contains_kid(
+        kid in "[a-zA-Z0-9._-]{1,24}",
+        n in "[A-Za-z0-9]{1,32}",
+    ) {
+        let jwk = arb_rsa_public(kid.clone(), n);
+        let val = jwk.to_value();
+        prop_assert_eq!(val["kid"].as_str().unwrap(), kid.as_str());
+        prop_assert_eq!(val["kty"].as_str().unwrap(), "RSA");
+    }
+
+    /// Display and to_value produce equivalent JSON.
+    #[test]
+    fn display_equals_to_value(
+        kid in "[a-zA-Z0-9._-]{1,24}",
+        n in "[A-Za-z0-9]{1,32}",
+    ) {
+        let jwk = arb_rsa_public(kid, n);
+        let from_display: serde_json::Value = serde_json::from_str(&jwk.to_string())
+            .expect("Display should produce valid JSON");
+        let from_value = jwk.to_value();
+        prop_assert_eq!(from_display, from_value);
+    }
+
+    /// kid() accessor returns the correct value for all PublicJwk variants.
+    #[test]
+    fn public_jwk_kid_accessor(
+        kid in "[a-zA-Z0-9._-]{1,24}",
+        variant in 0u8..3,
+    ) {
+        let jwk = match variant {
+            0 => arb_rsa_public(kid.clone(), "n".into()),
+            1 => arb_ec_public(kid.clone(), "x".into()),
+            _ => arb_okp_public(kid.clone(), "x".into()),
+        };
+        prop_assert_eq!(jwk.kid(), kid.as_str());
+    }
+
+    /// kid() accessor returns the correct value for PrivateJwk::Oct.
+    #[test]
+    fn private_oct_kid_accessor(
+        kid in "[a-zA-Z0-9._-]{1,24}",
+        k in "[A-Za-z0-9]{1,32}",
+    ) {
+        let jwk = arb_oct_private(kid.clone(), k);
+        prop_assert_eq!(jwk.kid(), kid.as_str());
+    }
+
+    /// AnyJwk::from conversions preserve kid.
+    #[test]
+    fn any_jwk_from_preserves_kid(
+        kid in "[a-zA-Z0-9._-]{1,24}",
+    ) {
+        let pub_jwk = arb_rsa_public(kid.clone(), "n".into());
+        let any = AnyJwk::from(pub_jwk);
+        prop_assert_eq!(any.kid(), kid.as_str());
+    }
+
+    /// Jwks serialization always produces a JSON object with "keys" array.
+    #[test]
+    fn jwks_has_keys_array(
+        kid_a in "[a-zA-Z0-9._-]{1,16}",
+        kid_b in "[a-zA-Z0-9._-]{1,16}",
+    ) {
+        let jwks = Jwks {
+            keys: vec![
+                AnyJwk::from(arb_rsa_public(kid_a, "n1".into())),
+                AnyJwk::from(arb_okp_public(kid_b, "x1".into())),
+            ],
+        };
+        let val = jwks.to_value();
+        let keys = val["keys"].as_array().expect("keys should be an array");
+        prop_assert_eq!(keys.len(), 2);
+    }
+
+    /// Debug output for private JWK types never contains the secret material.
+    #[test]
+    fn debug_omits_secret(
+        kid in "[a-zA-Z0-9._-]{1,24}",
+        secret in "[A-Za-z0-9]{8,32}",
+    ) {
+        let jwk = arb_oct_private(kid, secret.clone());
+        let dbg = format!("{:?}", jwk);
+        prop_assert!(!dbg.contains(&secret));
+    }
+}

--- a/crates/uselesskey-core-keypair-material/tests/material_prop.rs
+++ b/crates/uselesskey-core-keypair-material/tests/material_prop.rs
@@ -1,0 +1,105 @@
+use proptest::prelude::*;
+use uselesskey_core::negative::CorruptPem;
+use uselesskey_core_keypair_material::Pkcs8SpkiKeyMaterial;
+
+fn sample_material() -> Pkcs8SpkiKeyMaterial {
+    Pkcs8SpkiKeyMaterial::new(
+        vec![0x30, 0x82, 0x01, 0x22],
+        "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n",
+        vec![0x30, 0x59, 0x30, 0x13],
+        "-----BEGIN PUBLIC KEY-----\nBBBB\n-----END PUBLIC KEY-----\n",
+    )
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// kid is deterministic for fixed SPKI bytes.
+    #[test]
+    fn kid_is_deterministic(spki in any::<[u8; 4]>()) {
+        let m = Pkcs8SpkiKeyMaterial::new(
+            vec![0x30],
+            "-----BEGIN PRIVATE KEY-----\nX\n-----END PRIVATE KEY-----\n",
+            spki.to_vec(),
+            "-----BEGIN PUBLIC KEY-----\nY\n-----END PUBLIC KEY-----\n",
+        );
+        prop_assert_eq!(m.kid(), m.kid());
+        prop_assert!(!m.kid().is_empty());
+    }
+
+    /// Different SPKI bytes produce different kids.
+    #[test]
+    fn different_spki_different_kid(
+        spki_a in any::<[u8; 4]>(),
+        spki_b in any::<[u8; 4]>(),
+    ) {
+        prop_assume!(spki_a != spki_b);
+        let m_a = Pkcs8SpkiKeyMaterial::new(vec![0x30], "pem", spki_a.to_vec(), "pub");
+        let m_b = Pkcs8SpkiKeyMaterial::new(vec![0x30], "pem", spki_b.to_vec(), "pub");
+        prop_assert_ne!(m_a.kid(), m_b.kid());
+    }
+
+    /// Deterministic PEM corruption is stable for the same variant.
+    #[test]
+    fn deterministic_pem_corruption_stable(variant in "[a-zA-Z0-9]{1,24}") {
+        let m = sample_material();
+        let a = m.private_key_pkcs8_pem_corrupt_deterministic(&variant);
+        let b = m.private_key_pkcs8_pem_corrupt_deterministic(&variant);
+        prop_assert_eq!(a, b);
+    }
+
+    /// Deterministic DER corruption is stable for the same variant.
+    #[test]
+    fn deterministic_der_corruption_stable(variant in "[a-zA-Z0-9]{1,24}") {
+        let m = sample_material();
+        let a = m.private_key_pkcs8_der_corrupt_deterministic(&variant);
+        let b = m.private_key_pkcs8_der_corrupt_deterministic(&variant);
+        prop_assert_eq!(a, b);
+    }
+
+    /// Truncation length is capped at the DER length.
+    #[test]
+    fn truncation_capped(
+        der in prop::collection::vec(any::<u8>(), 0..64),
+        request in 0usize..128,
+    ) {
+        let m = Pkcs8SpkiKeyMaterial::new(
+            der.clone(),
+            "pem",
+            vec![0x30],
+            "pub",
+        );
+        let truncated = m.private_key_pkcs8_der_truncated(request);
+        prop_assert_eq!(truncated.len(), request.min(der.len()));
+    }
+
+    /// BadHeader corruption always produces output containing "CORRUPTED KEY".
+    #[test]
+    fn bad_header_produces_corrupted_key(
+        body in "[A-Za-z0-9+/=]{4,32}",
+    ) {
+        let m = Pkcs8SpkiKeyMaterial::new(
+            vec![0x30],
+            format!("-----BEGIN PRIVATE KEY-----\n{body}\n-----END PRIVATE KEY-----\n"),
+            vec![0x30],
+            "pub",
+        );
+        let corrupted = m.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+        prop_assert!(corrupted.contains("CORRUPTED KEY"));
+    }
+
+    /// Debug output never leaks PEM material.
+    #[test]
+    fn debug_no_pem_leak(
+        body in "[A-Za-z0-9+/=]{8,32}",
+    ) {
+        let m = Pkcs8SpkiKeyMaterial::new(
+            vec![0x30],
+            format!("-----BEGIN PRIVATE KEY-----\n{body}\n-----END PRIVATE KEY-----\n"),
+            vec![0x30],
+            "pub",
+        );
+        let dbg = format!("{m:?}");
+        prop_assert!(!dbg.contains(&body));
+    }
+}

--- a/crates/uselesskey-core-kid/Cargo.toml
+++ b/crates/uselesskey-core-kid/Cargo.toml
@@ -19,6 +19,7 @@ blake3.workspace = true
 base64.workspace = true
 
 [dev-dependencies]
+proptest.workspace = true
 rstest.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-core-kid/tests/kid_prop.rs
+++ b/crates/uselesskey-core-kid/tests/kid_prop.rs
@@ -1,0 +1,54 @@
+use proptest::prelude::*;
+use uselesskey_core_kid::{DEFAULT_KID_PREFIX_BYTES, kid_from_bytes, kid_from_bytes_with_prefix};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// kid_from_bytes is deterministic for any input.
+    #[test]
+    fn kid_deterministic(data in any::<Vec<u8>>()) {
+        prop_assert_eq!(kid_from_bytes(&data), kid_from_bytes(&data));
+    }
+
+    /// kid_from_bytes always produces valid base64url (no padding).
+    #[test]
+    fn kid_is_valid_base64url(data in any::<Vec<u8>>()) {
+        let kid = kid_from_bytes(&data);
+        prop_assert!(
+            kid.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "kid contains invalid base64url characters: {kid}"
+        );
+    }
+
+    /// kid_from_bytes output decodes to DEFAULT_KID_PREFIX_BYTES bytes.
+    #[test]
+    fn kid_default_length(data in any::<Vec<u8>>()) {
+        let kid = kid_from_bytes(&data);
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(kid.as_bytes())
+            .expect("kid should be valid base64url");
+        prop_assert_eq!(decoded.len(), DEFAULT_KID_PREFIX_BYTES);
+    }
+
+    /// Different inputs produce different kids (collision resistance).
+    #[test]
+    fn kid_different_inputs_differ(a in any::<Vec<u8>>(), b in any::<Vec<u8>>()) {
+        prop_assume!(a != b);
+        prop_assert_ne!(kid_from_bytes(&a), kid_from_bytes(&b));
+    }
+
+    /// kid_from_bytes_with_prefix respects the prefix_bytes parameter.
+    #[test]
+    fn kid_with_prefix_respects_length(
+        data in any::<Vec<u8>>(),
+        prefix in 1u8..=32u8,
+    ) {
+        let kid = kid_from_bytes_with_prefix(&data, prefix as usize);
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(kid.as_bytes())
+            .expect("kid should be valid base64url");
+        prop_assert_eq!(decoded.len(), prefix as usize);
+    }
+}
+
+use base64::Engine as _;

--- a/crates/uselesskey-core-negative-pem/tests/pem_prop.rs
+++ b/crates/uselesskey-core-negative-pem/tests/pem_prop.rs
@@ -1,0 +1,81 @@
+use proptest::prelude::*;
+use uselesskey_core_negative_pem::{CorruptPem, corrupt_pem, corrupt_pem_deterministic};
+
+fn valid_pem() -> &'static str {
+    "-----BEGIN TEST KEY-----\nABCDEFGH\n-----END TEST KEY-----\n"
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// corrupt_pem_deterministic is stable for the same variant.
+    #[test]
+    fn deterministic_corruption_is_stable(variant in ".*") {
+        let a = corrupt_pem_deterministic(valid_pem(), &variant);
+        let b = corrupt_pem_deterministic(valid_pem(), &variant);
+        prop_assert_eq!(a, b);
+    }
+
+    /// corrupt_pem_deterministic always produces output different from input.
+    #[test]
+    fn deterministic_corruption_changes_output(variant in "[a-z]{1,16}") {
+        let result = corrupt_pem_deterministic(valid_pem(), &variant);
+        prop_assert_ne!(result, valid_pem());
+    }
+
+    /// BadHeader corruption always replaces the first line.
+    #[test]
+    fn bad_header_replaces_first_line(
+        body in "[A-Za-z0-9+/=]{4,32}",
+    ) {
+        let pem = format!("-----BEGIN TEST-----\n{body}\n-----END TEST-----\n");
+        let corrupted = corrupt_pem(&pem, CorruptPem::BadHeader);
+        prop_assert!(corrupted.starts_with("-----BEGIN CORRUPTED KEY-----\n"));
+        prop_assert!(corrupted.contains(&body));
+    }
+
+    /// BadFooter corruption always replaces the last line.
+    #[test]
+    fn bad_footer_replaces_last_line(
+        body in "[A-Za-z0-9+/=]{4,32}",
+    ) {
+        let pem = format!("-----BEGIN TEST-----\n{body}\n-----END TEST-----\n");
+        let corrupted = corrupt_pem(&pem, CorruptPem::BadFooter);
+        prop_assert!(corrupted.contains("-----END CORRUPTED KEY-----\n"));
+        prop_assert!(corrupted.contains(&body));
+    }
+
+    /// BadBase64 corruption injects invalid base64 into the PEM.
+    #[test]
+    fn bad_base64_injects_invalid_data(
+        body in "[A-Za-z0-9+/=]{4,32}",
+    ) {
+        let pem = format!("-----BEGIN TEST-----\n{body}\n-----END TEST-----\n");
+        let corrupted = corrupt_pem(&pem, CorruptPem::BadBase64);
+        prop_assert!(corrupted.contains("THIS_IS_NOT_BASE64!!!"));
+    }
+
+    /// Truncate corruption produces output no longer than the requested byte count.
+    #[test]
+    fn truncate_respects_limit(bytes in 0usize..=128) {
+        let corrupted = corrupt_pem(valid_pem(), CorruptPem::Truncate { bytes });
+        prop_assert!(corrupted.len() <= bytes);
+    }
+
+    /// corrupt_pem never panics on any CorruptPem variant and valid PEM input.
+    #[test]
+    fn corrupt_pem_never_panics_on_valid_pem(
+        body in "[A-Za-z0-9+/=]{4,32}",
+        strategy in 0u8..5,
+    ) {
+        let pem = format!("-----BEGIN TEST-----\n{body}\n-----END TEST-----\n");
+        let how = match strategy {
+            0 => CorruptPem::BadHeader,
+            1 => CorruptPem::BadFooter,
+            2 => CorruptPem::BadBase64,
+            3 => CorruptPem::ExtraBlankLine,
+            _ => CorruptPem::Truncate { bytes: 10 },
+        };
+        let _ = corrupt_pem(&pem, how);
+    }
+}

--- a/crates/uselesskey-core-token-shape/tests/token_shape_prop.rs
+++ b/crates/uselesskey-core-token-shape/tests/token_shape_prop.rs
@@ -1,0 +1,89 @@
+use proptest::prelude::*;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use uselesskey_core_token_shape::{
+    API_KEY_PREFIX, API_KEY_RANDOM_LEN, TokenKind, authorization_scheme, generate_api_key,
+    generate_bearer_token, generate_oauth_access_token, generate_token, random_base62,
+};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// generate_token is deterministic for the same seed and kind.
+    #[test]
+    fn generate_token_deterministic(
+        seed in any::<[u8; 32]>(),
+        kind_idx in 0u8..3,
+    ) {
+        let kind = match kind_idx {
+            0 => TokenKind::ApiKey,
+            1 => TokenKind::Bearer,
+            _ => TokenKind::OAuthAccessToken,
+        };
+        let mut rng_a = ChaCha20Rng::from_seed(seed);
+        let mut rng_b = ChaCha20Rng::from_seed(seed);
+        prop_assert_eq!(
+            generate_token("label", kind, &mut rng_a),
+            generate_token("label", kind, &mut rng_b)
+        );
+    }
+
+    /// API keys always start with the expected prefix and have the right suffix length.
+    #[test]
+    fn api_key_format(seed in any::<[u8; 32]>()) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let key = generate_api_key(&mut rng);
+        prop_assert!(key.starts_with(API_KEY_PREFIX));
+        let suffix = &key[API_KEY_PREFIX.len()..];
+        prop_assert_eq!(suffix.len(), API_KEY_RANDOM_LEN);
+        prop_assert!(suffix.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    /// Bearer tokens always decode to 32 bytes.
+    #[test]
+    fn bearer_decodes_to_32_bytes(seed in any::<[u8; 32]>()) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let token = generate_bearer_token(&mut rng);
+        let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(&token)
+            .expect("bearer should be valid base64url");
+        prop_assert_eq!(decoded.len(), 32);
+    }
+
+    /// OAuth access tokens always have exactly 3 dot-separated segments.
+    #[test]
+    fn oauth_has_three_segments(
+        seed in any::<[u8; 32]>(),
+        label in "[a-z0-9_-]{1,16}",
+    ) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let token = generate_oauth_access_token(&label, &mut rng);
+        prop_assert_eq!(token.matches('.').count(), 2);
+    }
+
+    /// random_base62 always produces the requested length of alphanumeric chars.
+    #[test]
+    fn random_base62_length_and_charset(
+        seed in any::<[u8; 32]>(),
+        len in 0usize..=128,
+    ) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let result = random_base62(&mut rng, len);
+        prop_assert_eq!(result.len(), len);
+        prop_assert!(result.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    /// authorization_scheme never panics.
+    #[test]
+    fn authorization_scheme_never_panics(kind_idx in 0u8..3) {
+        let kind = match kind_idx {
+            0 => TokenKind::ApiKey,
+            1 => TokenKind::Bearer,
+            _ => TokenKind::OAuthAccessToken,
+        };
+        let scheme = authorization_scheme(kind);
+        prop_assert!(!scheme.is_empty());
+    }
+}
+
+use base64::Engine as _;

--- a/crates/uselesskey-ring/Cargo.toml
+++ b/crates/uselesskey-ring/Cargo.toml
@@ -37,3 +37,4 @@ uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true
+proptest.workspace = true

--- a/crates/uselesskey-ring/tests/ring_prop.rs
+++ b/crates/uselesskey-ring/tests/ring_prop.rs
@@ -1,0 +1,51 @@
+use proptest::prelude::*;
+use uselesskey_core::{Factory, Seed};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 8, ..ProptestConfig::default() })]
+
+    /// Deterministic factory produces the same ring RSA KeyPair modulus for the same seed.
+    #[cfg(feature = "rsa")]
+    #[test]
+    fn rsa_ring_deterministic(seed in any::<[u8; 32]>()) {
+        use uselesskey_ring::RingRsaKeyPairExt;
+        use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+        let fx = Factory::deterministic(Seed::new(seed));
+        let kp1 = fx.rsa("prop-test", RsaSpec::rs256()).rsa_key_pair_ring();
+        let kp2 = fx.rsa("prop-test", RsaSpec::rs256()).rsa_key_pair_ring();
+
+        prop_assert_eq!(kp1.public().as_ref(), kp2.public().as_ref());
+        prop_assert!(kp1.public().modulus_len() > 0);
+    }
+
+    /// Deterministic factory produces the same ring ECDSA public key for the same seed.
+    #[cfg(feature = "ecdsa")]
+    #[test]
+    fn ecdsa_ring_deterministic(seed in any::<[u8; 32]>()) {
+        use ring::signature::KeyPair;
+        use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+        use uselesskey_ring::RingEcdsaKeyPairExt;
+
+        let fx = Factory::deterministic(Seed::new(seed));
+        let kp1 = fx.ecdsa("prop-test", EcdsaSpec::es256()).ecdsa_key_pair_ring();
+        let kp2 = fx.ecdsa("prop-test", EcdsaSpec::es256()).ecdsa_key_pair_ring();
+
+        prop_assert_eq!(kp1.public_key().as_ref(), kp2.public_key().as_ref());
+    }
+
+    /// Deterministic factory produces the same ring Ed25519 public key for the same seed.
+    #[cfg(feature = "ed25519")]
+    #[test]
+    fn ed25519_ring_deterministic(seed in any::<[u8; 32]>()) {
+        use ring::signature::KeyPair;
+        use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+        use uselesskey_ring::RingEd25519KeyPairExt;
+
+        let fx = Factory::deterministic(Seed::new(seed));
+        let kp1 = fx.ed25519("prop-test", Ed25519Spec::new()).ed25519_key_pair_ring();
+        let kp2 = fx.ed25519("prop-test", Ed25519Spec::new()).ed25519_key_pair_ring();
+
+        prop_assert_eq!(kp1.public_key().as_ref(), kp2.public_key().as_ref());
+    }
+}


### PR DESCRIPTION
Adds proptest suites for: core-id, core-hash, core-kid, core-cache, core-negative-pem, core-token-shape, core-jwk-shape, core-keypair-material, ring, aws-lc-rs. Total: 52 new property-based tests covering determinism, format validity, and panic safety.

**Determinism impact:** None
**Policy impact:** None