### PR TITLE
test: Wave 26 - trait implementation tests for core type crates

### DIFF
--- a/crates/uselesskey-core-hash/tests/trait_impls.rs
+++ b/crates/uselesskey-core-hash/tests/trait_impls.rs
@@ -1,0 +1,107 @@
+//! Tests for trait implementations on the re-exported `blake3::Hash` type.
+//!
+//! The `uselesskey-core-hash` crate re-exports `blake3::Hash` as its primary
+//! output type. These tests verify the expected trait impls are available
+//! through the re-export.
+
+use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hasher as StdHasher;
+
+use uselesskey_core_hash::{Hash as Blake3Hash, hash32};
+
+fn std_hash_of(val: &Blake3Hash) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    // blake3::Hash implements std::hash::Hash
+    std::hash::Hash::hash(val, &mut hasher);
+    hasher.finish()
+}
+
+// --- Clone (via Copy) ---
+
+#[test]
+fn hash_clone_is_available() {
+    let h = hash32(b"test");
+    let cloned: Blake3Hash = Clone::clone(&h);
+    assert_eq!(h, cloned);
+}
+
+#[test]
+fn hash_copy_produces_equal_value() {
+    let h = hash32(b"test");
+    let copied = h;
+    // Original still usable because blake3::Hash is Copy.
+    assert_eq!(h, copied);
+}
+
+// --- PartialEq / Eq ---
+
+#[test]
+fn hash_eq_same_input() {
+    let a = hash32(b"test");
+    let b = hash32(b"test");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn hash_ne_different_input() {
+    let a = hash32(b"test-a");
+    let b = hash32(b"test-b");
+    assert_ne!(a, b);
+}
+
+// --- std::hash::Hash ---
+
+#[test]
+fn hash_std_hash_consistent() {
+    let a = hash32(b"test");
+    let b = hash32(b"test");
+    assert_eq!(std_hash_of(&a), std_hash_of(&b));
+}
+
+#[test]
+fn hash_std_hash_differs_for_different_values() {
+    let a = hash32(b"test-a");
+    let b = hash32(b"test-b");
+    assert_ne!(std_hash_of(&a), std_hash_of(&b));
+}
+
+#[test]
+fn hash_usable_in_hash_set() {
+    let mut set = HashSet::new();
+    set.insert(hash32(b"a"));
+    set.insert(hash32(b"a")); // duplicate
+    set.insert(hash32(b"b"));
+    assert_eq!(set.len(), 2);
+}
+
+// --- Debug / Display ---
+
+#[test]
+fn hash_debug_is_nonempty() {
+    let h = hash32(b"test");
+    let debug = format!("{h:?}");
+    assert!(!debug.is_empty());
+}
+
+#[test]
+fn hash_display_is_hex() {
+    let h = hash32(b"test");
+    let display = format!("{h}");
+    // blake3::Hash Display outputs 64 lowercase hex characters.
+    assert_eq!(display.len(), 64);
+    assert!(
+        display.chars().all(|c| c.is_ascii_hexdigit()),
+        "Display should be hex: {display}"
+    );
+}
+
+#[test]
+fn hash_as_bytes_roundtrip() {
+    let h = hash32(b"test");
+    let bytes = h.as_bytes();
+    assert_eq!(bytes.len(), 32);
+    // Reconstruct and verify equality
+    let reconstructed = Blake3Hash::from_bytes(*bytes);
+    assert_eq!(h, reconstructed);
+}

--- a/crates/uselesskey-core-id/tests/trait_impls.rs
+++ b/crates/uselesskey-core-id/tests/trait_impls.rs
@@ -1,0 +1,231 @@
+//! Tests for derived traits on `ArtifactId` and `DerivationVersion`.
+
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{BTreeSet, HashSet};
+use std::hash::{Hash, Hasher};
+
+use uselesskey_core_id::{ArtifactId, DerivationVersion};
+
+fn hash_of<T: Hash>(val: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    val.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn make_id(label: &str, variant: &str) -> ArtifactId {
+    ArtifactId::new(
+        "domain:test",
+        label,
+        b"spec",
+        variant,
+        DerivationVersion::V1,
+    )
+}
+
+// ==================== DerivationVersion ====================
+
+// --- Clone (via Copy) ---
+
+#[test]
+fn derivation_version_clone_is_available() {
+    let v = DerivationVersion::V1;
+    let cloned: DerivationVersion = Clone::clone(&v);
+    assert_eq!(v, cloned);
+}
+
+#[test]
+fn derivation_version_copy() {
+    let v = DerivationVersion::V1;
+    let copied = v;
+    // Original still usable because DerivationVersion is Copy.
+    assert_eq!(v, copied);
+}
+
+// --- PartialEq / Eq ---
+
+#[test]
+fn derivation_version_eq_same() {
+    assert_eq!(DerivationVersion(1), DerivationVersion(1));
+}
+
+#[test]
+fn derivation_version_ne_different() {
+    assert_ne!(DerivationVersion(1), DerivationVersion(2));
+}
+
+// --- PartialOrd / Ord ---
+
+#[test]
+fn derivation_version_ord() {
+    assert!(DerivationVersion(1) < DerivationVersion(2));
+    assert!(DerivationVersion(3) > DerivationVersion(2));
+}
+
+#[test]
+fn derivation_version_sort() {
+    let mut versions = vec![
+        DerivationVersion(3),
+        DerivationVersion(1),
+        DerivationVersion(2),
+    ];
+    versions.sort();
+    assert_eq!(
+        versions,
+        vec![
+            DerivationVersion(1),
+            DerivationVersion(2),
+            DerivationVersion(3),
+        ]
+    );
+}
+
+// --- Hash ---
+
+#[test]
+fn derivation_version_hash_consistent() {
+    let a = DerivationVersion(1);
+    let b = DerivationVersion(1);
+    assert_eq!(hash_of(&a), hash_of(&b));
+}
+
+#[test]
+fn derivation_version_hash_differs() {
+    let a = DerivationVersion(1);
+    let b = DerivationVersion(2);
+    assert_ne!(hash_of(&a), hash_of(&b));
+}
+
+// --- Debug ---
+
+#[test]
+fn derivation_version_debug_contains_type_name() {
+    let debug = format!("{:?}", DerivationVersion::V1);
+    assert!(debug.contains("DerivationVersion"));
+}
+
+#[test]
+fn derivation_version_debug_contains_value() {
+    let debug = format!("{:?}", DerivationVersion(42));
+    assert!(debug.contains("42"));
+}
+
+// ==================== ArtifactId ====================
+
+// --- Clone ---
+
+#[test]
+fn artifact_id_clone_equals_original() {
+    let id = make_id("label", "variant");
+    let cloned = id.clone();
+    assert_eq!(id, cloned);
+}
+
+// --- PartialEq / Eq ---
+
+#[test]
+fn artifact_id_eq_same_fields() {
+    let a = make_id("label", "variant");
+    let b = make_id("label", "variant");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn artifact_id_ne_different_label() {
+    let a = make_id("label-a", "variant");
+    let b = make_id("label-b", "variant");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn artifact_id_ne_different_variant() {
+    let a = make_id("label", "variant-a");
+    let b = make_id("label", "variant-b");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn artifact_id_ne_different_domain() {
+    let a = ArtifactId::new("domain:a", "l", b"s", "v", DerivationVersion::V1);
+    let b = ArtifactId::new("domain:b", "l", b"s", "v", DerivationVersion::V1);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn artifact_id_ne_different_spec() {
+    let a = ArtifactId::new("d", "l", b"spec-a", "v", DerivationVersion::V1);
+    let b = ArtifactId::new("d", "l", b"spec-b", "v", DerivationVersion::V1);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn artifact_id_ne_different_version() {
+    let a = ArtifactId::new("d", "l", b"s", "v", DerivationVersion(1));
+    let b = ArtifactId::new("d", "l", b"s", "v", DerivationVersion(2));
+    assert_ne!(a, b);
+}
+
+// --- Hash ---
+
+#[test]
+fn artifact_id_hash_consistent() {
+    let a = make_id("label", "variant");
+    let b = make_id("label", "variant");
+    assert_eq!(hash_of(&a), hash_of(&b));
+}
+
+#[test]
+fn artifact_id_hash_differs_for_different_ids() {
+    let a = make_id("label-a", "variant");
+    let b = make_id("label-b", "variant");
+    assert_ne!(hash_of(&a), hash_of(&b));
+}
+
+#[test]
+fn artifact_id_usable_in_hash_set() {
+    let mut set = HashSet::new();
+    set.insert(make_id("a", "v"));
+    set.insert(make_id("a", "v")); // duplicate
+    set.insert(make_id("b", "v"));
+    assert_eq!(set.len(), 2);
+}
+
+// --- PartialOrd / Ord ---
+
+#[test]
+fn artifact_id_ord_by_label() {
+    let a = make_id("aaa", "v");
+    let b = make_id("bbb", "v");
+    assert!(a < b);
+}
+
+#[test]
+fn artifact_id_usable_in_btree_set() {
+    let mut set = BTreeSet::new();
+    set.insert(make_id("c", "v"));
+    set.insert(make_id("a", "v"));
+    set.insert(make_id("b", "v"));
+    set.insert(make_id("a", "v")); // duplicate
+    assert_eq!(set.len(), 3);
+
+    let labels: Vec<_> = set.iter().map(|id| id.label.as_str()).collect();
+    assert_eq!(labels, vec!["a", "b", "c"]);
+}
+
+// --- Debug ---
+
+#[test]
+fn artifact_id_debug_contains_fields() {
+    let id = make_id("test-label", "test-variant");
+    let debug = format!("{id:?}");
+    assert!(debug.contains("ArtifactId"));
+    assert!(debug.contains("test-label"));
+    assert!(debug.contains("test-variant"));
+    assert!(debug.contains("domain:test"));
+}
+
+#[test]
+fn artifact_id_debug_contains_derivation_version() {
+    let id = ArtifactId::new("d", "l", b"s", "v", DerivationVersion(7));
+    let debug = format!("{id:?}");
+    assert!(debug.contains("7"));
+}

--- a/crates/uselesskey-core-seed/tests/trait_impls.rs
+++ b/crates/uselesskey-core-seed/tests/trait_impls.rs
@@ -1,0 +1,129 @@
+//! Tests for derived and manually-implemented traits on the `Seed` type.
+
+use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use uselesskey_core_seed::Seed;
+
+fn hash_of<T: Hash>(val: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    val.hash(&mut hasher);
+    hasher.finish()
+}
+
+// --- Clone (via Copy — Seed is Copy, so clone is implicit) ---
+
+#[test]
+fn seed_clone_is_available() {
+    let seed = Seed::new([1u8; 32]);
+    // Seed is Copy, so clone is redundant but the trait is still derived.
+    let cloned: Seed = Clone::clone(&seed);
+    assert_eq!(seed, cloned);
+}
+
+#[test]
+fn seed_copy_produces_equal_value() {
+    let seed = Seed::new([2u8; 32]);
+    let copied = seed;
+    // Original is still usable because Seed is Copy.
+    assert_eq!(seed, copied);
+}
+
+// --- PartialEq / Eq ---
+
+#[test]
+fn seed_eq_reflexive() {
+    let seed = Seed::new([3u8; 32]);
+    assert_eq!(seed, seed);
+}
+
+#[test]
+fn seed_eq_same_bytes() {
+    let a = Seed::new([3u8; 32]);
+    let b = Seed::new([3u8; 32]);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn seed_ne_different_bytes() {
+    let a = Seed::new([3u8; 32]);
+    let b = Seed::new([4u8; 32]);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn seed_eq_symmetric() {
+    let a = Seed::new([5u8; 32]);
+    let b = Seed::new([5u8; 32]);
+    assert_eq!(a, b);
+    assert_eq!(b, a);
+}
+
+// --- Hash ---
+
+#[test]
+fn seed_hash_consistent_for_equal_values() {
+    let a = Seed::new([5u8; 32]);
+    let b = Seed::new([5u8; 32]);
+    assert_eq!(hash_of(&a), hash_of(&b));
+}
+
+#[test]
+fn seed_hash_differs_for_different_values() {
+    let a = Seed::new([5u8; 32]);
+    let b = Seed::new([6u8; 32]);
+    assert_ne!(hash_of(&a), hash_of(&b));
+}
+
+#[test]
+fn seed_usable_in_hash_set() {
+    let mut set = HashSet::new();
+    set.insert(Seed::new([7u8; 32]));
+    set.insert(Seed::new([7u8; 32])); // duplicate
+    set.insert(Seed::new([8u8; 32]));
+    assert_eq!(set.len(), 2);
+}
+
+// --- Debug (redaction) ---
+
+#[test]
+fn seed_debug_does_not_leak_raw_bytes() {
+    let seed = Seed::new([0xAB; 32]);
+    let debug = format!("{seed:?}");
+    // Must not contain hex representation of the byte 0xAB
+    assert!(!debug.contains("ab"), "Debug must not leak hex bytes");
+    assert!(!debug.contains("AB"), "Debug must not leak hex bytes");
+    assert!(
+        !debug.contains("171"),
+        "Debug must not leak decimal byte values"
+    );
+}
+
+#[test]
+fn seed_debug_mentions_redaction() {
+    let seed = Seed::new([0u8; 32]);
+    let debug = format!("{seed:?}");
+    assert!(
+        debug.contains("redacted"),
+        "Debug output should mention redaction"
+    );
+}
+
+#[test]
+fn seed_debug_stable_across_different_values() {
+    let a = format!("{:?}", Seed::new([0u8; 32]));
+    let b = format!("{:?}", Seed::new([0xFF; 32]));
+    assert_eq!(a, b, "Debug output must not vary with seed contents");
+}
+
+// --- Display not implemented (compile-time guarantee via negative reasoning) ---
+// Seed intentionally does not implement Display to prevent accidental leakage.
+// We verify Debug is the only formatting trait by checking the redacted output.
+
+#[test]
+fn seed_from_env_value_preserves_traits() {
+    let seed = Seed::from_env_value("test-passphrase").unwrap();
+    let cloned = seed;
+    assert_eq!(hash_of(&seed), hash_of(&cloned));
+}

--- a/crates/uselesskey-core-x509-derive/tests/trait_impls.rs
+++ b/crates/uselesskey-core-x509-derive/tests/trait_impls.rs
@@ -1,0 +1,128 @@
+//! Tests for type properties of values returned by X.509 derivation helpers.
+//!
+//! The `uselesskey-core-x509-derive` crate returns `time::OffsetDateTime` and
+//! `rcgen::SerialNumber` from its public API. These tests verify the returned
+//! values satisfy expected trait-level contracts (Eq, Ord, Clone, Debug).
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use uselesskey_core_x509_derive::{
+    BASE_TIME_EPOCH_UNIX, BASE_TIME_WINDOW_DAYS, SERIAL_NUMBER_BYTES, deterministic_base_time,
+    deterministic_base_time_from_parts, deterministic_serial_number,
+};
+
+// ==================== OffsetDateTime trait tests ====================
+
+#[test]
+fn base_time_copy_equals_original() {
+    let t = deterministic_base_time_from_parts(&[b"label"]);
+    let copied = t;
+    assert_eq!(t, copied);
+}
+
+#[test]
+fn base_time_eq_for_same_parts() {
+    let a = deterministic_base_time_from_parts(&[b"label", b"leaf"]);
+    let b = deterministic_base_time_from_parts(&[b"label", b"leaf"]);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn base_time_ne_for_different_parts() {
+    let a = deterministic_base_time_from_parts(&[b"label-a"]);
+    let b = deterministic_base_time_from_parts(&[b"label-b"]);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn base_time_ord_is_consistent() {
+    let a = deterministic_base_time_from_parts(&[b"alpha"]);
+    let b = deterministic_base_time_from_parts(&[b"beta"]);
+    let cmp1 = a.cmp(&b);
+    let cmp2 = a.cmp(&b);
+    assert_eq!(cmp1, cmp2);
+}
+
+#[test]
+fn base_time_debug_is_nonempty() {
+    let t = deterministic_base_time_from_parts(&[b"label"]);
+    let debug = format!("{t:?}");
+    assert!(!debug.is_empty());
+}
+
+#[test]
+fn base_time_partial_ord_matches_ord() {
+    let a = deterministic_base_time_from_parts(&[b"x"]);
+    let b = deterministic_base_time_from_parts(&[b"y"]);
+    assert_eq!(a.partial_cmp(&b), Some(a.cmp(&b)));
+}
+
+// ==================== SerialNumber trait tests ====================
+
+#[test]
+fn serial_number_clone_equals_original() {
+    let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+    let serial = deterministic_serial_number(&mut rng);
+    let cloned = serial.clone();
+    assert_eq!(serial.to_bytes(), cloned.to_bytes());
+}
+
+#[test]
+fn serial_number_debug_is_nonempty() {
+    let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+    let serial = deterministic_serial_number(&mut rng);
+    let debug = format!("{serial:?}");
+    assert!(!debug.is_empty());
+}
+
+#[test]
+fn serial_number_deterministic_from_same_seed() {
+    let mut rng_a = ChaCha20Rng::from_seed([99u8; 32]);
+    let mut rng_b = ChaCha20Rng::from_seed([99u8; 32]);
+    let a = deterministic_serial_number(&mut rng_a);
+    let b = deterministic_serial_number(&mut rng_b);
+    assert_eq!(a.to_bytes(), b.to_bytes());
+}
+
+#[test]
+fn serial_number_differs_across_seeds() {
+    let mut rng_a = ChaCha20Rng::from_seed([1u8; 32]);
+    let mut rng_b = ChaCha20Rng::from_seed([2u8; 32]);
+    let a = deterministic_serial_number(&mut rng_a);
+    let b = deterministic_serial_number(&mut rng_b);
+    assert_ne!(a.to_bytes(), b.to_bytes());
+}
+
+// ==================== Constants ====================
+
+#[test]
+fn epoch_constant_is_2025_01_01() {
+    let epoch =
+        time::OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).expect("valid epoch");
+    assert_eq!(epoch.year(), 2025);
+    assert_eq!(epoch.month(), time::Month::January);
+    assert_eq!(epoch.day(), 1);
+}
+
+#[test]
+fn window_days_is_one_year() {
+    assert_eq!(BASE_TIME_WINDOW_DAYS, 365);
+}
+
+#[test]
+fn serial_number_bytes_is_sixteen() {
+    assert_eq!(SERIAL_NUMBER_BYTES, 16);
+}
+
+// ==================== Hasher (used internally) ====================
+
+#[test]
+fn deterministic_base_time_from_hasher_is_stable() {
+    let hasher = uselesskey_core_hash::Hasher::new();
+    let a = deterministic_base_time(hasher);
+
+    let hasher = uselesskey_core_hash::Hasher::new();
+    let b = deterministic_base_time(hasher);
+
+    assert_eq!(a, b);
+}


### PR DESCRIPTION
Adds 61 trait implementation tests across 4 core crates:
- uselesskey-core-seed: 13 tests for Clone/Copy/Eq/Hash/Debug redaction
- uselesskey-core-id: 24 tests for ArtifactId and DerivationVersion traits
- uselesskey-core-hash: 10 tests for blake3::Hash trait impls
- uselesskey-core-x509-derive: 14 tests for OffsetDateTime/SerialNumber types

Determinism impact: none
Policy impact: none