### PR TITLE
test: Wave 27 - fill coverage gaps in algorithm crates

### DIFF
--- a/crates/uselesskey-ecdsa/tests/coverage_gaps.rs
+++ b/crates/uselesskey-ecdsa/tests/coverage_gaps.rs
@@ -1,0 +1,209 @@
+//! Coverage-gap tests for uselesskey-ecdsa.
+//!
+//! Fills gaps not covered by existing prop/keypair/jwk tests:
+//! - P-384 tempfile round-trip
+//! - Random mode smoke for both specs
+//! - Different specs produce different keys for same label
+//! - Determinism across separate factories for P-384
+//! - Corrupt PEM variants beyond BadBase64
+//! - P-384 JWK private key d field length
+
+#[allow(dead_code)]
+mod testutil;
+
+use uselesskey_core::negative::CorruptPem;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+// =========================================================================
+// P-384 tempfile round-trip
+// =========================================================================
+
+#[test]
+fn p384_tempfiles_match_in_memory() {
+    let fx = Factory::random();
+    let key = fx.ecdsa("p384-tempfile", EcdsaSpec::es384());
+
+    let priv_tf = key.write_private_key_pkcs8_pem().expect("private tempfile");
+    let pub_tf = key.write_public_key_spki_pem().expect("public tempfile");
+
+    let priv_contents = std::fs::read_to_string(priv_tf.path()).expect("read private");
+    let pub_contents = std::fs::read_to_string(pub_tf.path()).expect("read public");
+
+    assert_eq!(priv_contents, key.private_key_pkcs8_pem());
+    assert_eq!(pub_contents, key.public_key_spki_pem());
+}
+
+// =========================================================================
+// Random mode smoke tests
+// =========================================================================
+
+#[test]
+fn random_mode_es256_produces_valid_keys() {
+    let fx = Factory::random();
+    let key = fx.ecdsa("random-es256", EcdsaSpec::es256());
+
+    assert!(key.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(key.public_key_spki_pem().contains("BEGIN PUBLIC KEY"));
+    assert!(!key.private_key_pkcs8_der().is_empty());
+    assert!(!key.public_key_spki_der().is_empty());
+}
+
+#[test]
+fn random_mode_es384_produces_valid_keys() {
+    let fx = Factory::random();
+    let key = fx.ecdsa("random-es384", EcdsaSpec::es384());
+
+    assert!(key.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(key.public_key_spki_pem().contains("BEGIN PUBLIC KEY"));
+
+    use p384::pkcs8::{DecodePrivateKey as _, DecodePublicKey as _};
+    assert!(p384::SecretKey::from_pkcs8_der(key.private_key_pkcs8_der()).is_ok());
+    assert!(p384::PublicKey::from_public_key_der(key.public_key_spki_der()).is_ok());
+}
+
+#[test]
+fn random_mode_caches_same_identity() {
+    let fx = Factory::random();
+    let k1 = fx.ecdsa("cache-test", EcdsaSpec::es256());
+    let k2 = fx.ecdsa("cache-test", EcdsaSpec::es256());
+
+    assert_eq!(k1.private_key_pkcs8_der(), k2.private_key_pkcs8_der());
+}
+
+// =========================================================================
+// Different specs produce different keys for same label
+// =========================================================================
+
+#[test]
+fn different_specs_produce_different_keys_for_same_label() {
+    let fx = Factory::deterministic(Seed::from_env_value("ecdsa-spec-iso").unwrap());
+    let es256 = fx.ecdsa("same-label", EcdsaSpec::es256());
+    let es384 = fx.ecdsa("same-label", EcdsaSpec::es384());
+
+    assert_ne!(es256.private_key_pkcs8_der(), es384.private_key_pkcs8_der());
+    assert_ne!(es256.public_key_spki_der(), es384.public_key_spki_der());
+}
+
+// =========================================================================
+// Determinism across separate factories for P-384
+// =========================================================================
+
+#[test]
+fn p384_determinism_across_factories() {
+    let seed1 = Seed::from_env_value("ecdsa-p384-cross").unwrap();
+    let seed2 = Seed::from_env_value("ecdsa-p384-cross").unwrap();
+    let fx1 = Factory::deterministic(seed1);
+    let fx2 = Factory::deterministic(seed2);
+
+    let k1 = fx1.ecdsa("cross-factory", EcdsaSpec::es384());
+    let k2 = fx2.ecdsa("cross-factory", EcdsaSpec::es384());
+
+    assert_eq!(k1.private_key_pkcs8_der(), k2.private_key_pkcs8_der());
+    assert_eq!(k1.public_key_spki_der(), k2.public_key_spki_der());
+}
+
+// =========================================================================
+// Corrupt PEM variants beyond BadBase64
+// =========================================================================
+
+#[test]
+fn corrupt_pem_bad_header_for_both_specs() {
+    let fx = Factory::random();
+
+    for spec in [EcdsaSpec::es256(), EcdsaSpec::es384()] {
+        let key = fx.ecdsa("corrupt-hdr", spec);
+        let bad = key.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+        assert!(bad.contains("CORRUPTED"));
+        assert_ne!(bad, key.private_key_pkcs8_pem());
+    }
+}
+
+#[test]
+fn corrupt_pem_bad_footer_for_both_specs() {
+    let fx = Factory::random();
+
+    for spec in [EcdsaSpec::es256(), EcdsaSpec::es384()] {
+        let key = fx.ecdsa("corrupt-ftr", spec);
+        let bad = key.private_key_pkcs8_pem_corrupt(CorruptPem::BadFooter);
+        assert_ne!(bad, key.private_key_pkcs8_pem());
+    }
+}
+
+#[test]
+fn corrupt_pem_extra_blank_line_for_both_specs() {
+    let fx = Factory::random();
+
+    for spec in [EcdsaSpec::es256(), EcdsaSpec::es384()] {
+        let key = fx.ecdsa("corrupt-blank", spec);
+        let bad = key.private_key_pkcs8_pem_corrupt(CorruptPem::ExtraBlankLine);
+        assert_ne!(bad, key.private_key_pkcs8_pem());
+    }
+}
+
+// =========================================================================
+// P-384 JWK coverage (feature-gated)
+// =========================================================================
+
+#[cfg(feature = "jwk")]
+mod jwk_coverage_gaps {
+    use super::*;
+
+    #[test]
+    fn p384_private_jwk_d_length_is_48() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = Factory::deterministic(Seed::from_env_value("ecdsa-p384-jwk-d").unwrap());
+        let key = fx.ecdsa("p384-d-len", EcdsaSpec::es384());
+        let jwk = key.private_key_jwk().to_value();
+
+        let d = jwk["d"].as_str().unwrap();
+        let decoded = URL_SAFE_NO_PAD.decode(d).expect("valid base64url");
+        assert_eq!(decoded.len(), 48, "P-384 private scalar should be 48 bytes");
+    }
+
+    #[test]
+    fn p256_private_jwk_d_length_is_32() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = Factory::deterministic(Seed::from_env_value("ecdsa-p256-jwk-d").unwrap());
+        let key = fx.ecdsa("p256-d-len", EcdsaSpec::es256());
+        let jwk = key.private_key_jwk().to_value();
+
+        let d = jwk["d"].as_str().unwrap();
+        let decoded = URL_SAFE_NO_PAD.decode(d).expect("valid base64url");
+        assert_eq!(decoded.len(), 32, "P-256 private scalar should be 32 bytes");
+    }
+
+    #[test]
+    fn p384_jwks_wraps_correctly() {
+        let fx = Factory::deterministic(Seed::from_env_value("ecdsa-p384-jwks").unwrap());
+        let key = fx.ecdsa("p384-jwks", EcdsaSpec::es384());
+        let jwks = key.public_jwks().to_value();
+        let keys = jwks["keys"].as_array().expect("keys array");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0]["crv"], "P-384");
+        assert_eq!(keys[0]["alg"], "ES384");
+    }
+
+    #[test]
+    fn p384_json_helpers_match_to_value() {
+        let fx = Factory::deterministic(Seed::from_env_value("ecdsa-p384-json").unwrap());
+        let key = fx.ecdsa("p384-json", EcdsaSpec::es384());
+
+        assert_eq!(key.public_jwk_json(), key.public_jwk().to_value());
+        assert_eq!(key.public_jwks_json(), key.public_jwks().to_value());
+        assert_eq!(key.private_key_jwk_json(), key.private_key_jwk().to_value());
+    }
+
+    #[test]
+    fn p384_kid_differs_from_p256_kid_for_same_label() {
+        let fx = Factory::deterministic(Seed::from_env_value("ecdsa-kid-diff").unwrap());
+        let k256 = fx.ecdsa("same-label", EcdsaSpec::es256());
+        let k384 = fx.ecdsa("same-label", EcdsaSpec::es384());
+
+        assert_ne!(k256.kid(), k384.kid());
+    }
+}

--- a/crates/uselesskey-hmac/tests/coverage_gaps.rs
+++ b/crates/uselesskey-hmac/tests/coverage_gaps.rs
@@ -1,0 +1,233 @@
+//! Coverage-gap tests for uselesskey-hmac.
+//!
+//! Fills gaps not covered by existing prop/unit/inline tests:
+//! - Random mode for HS384 and HS512 (inline only tests HS256 in random)
+//! - Determinism across separate factories for all specs
+//! - Cache clear for HS384 and HS512
+//! - Debug safety for HS384 and HS512
+//! - Different specs produce different secrets for same label (already tested HS256 vs HS512)
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+
+// =========================================================================
+// Random mode for HS384 and HS512
+// =========================================================================
+
+#[test]
+fn random_mode_hs384_produces_correct_length() {
+    let fx = Factory::random();
+    let secret = fx.hmac("random-hs384", HmacSpec::hs384());
+    assert_eq!(secret.secret_bytes().len(), 48);
+}
+
+#[test]
+fn random_mode_hs512_produces_correct_length() {
+    let fx = Factory::random();
+    let secret = fx.hmac("random-hs512", HmacSpec::hs512());
+    assert_eq!(secret.secret_bytes().len(), 64);
+}
+
+#[test]
+fn random_mode_caches_same_identity() {
+    let fx = Factory::random();
+
+    for spec in [HmacSpec::hs256(), HmacSpec::hs384(), HmacSpec::hs512()] {
+        let s1 = fx.hmac("cache-test", spec);
+        let s2 = fx.hmac("cache-test", spec);
+        assert_eq!(
+            s1.secret_bytes(),
+            s2.secret_bytes(),
+            "Random mode should cache for {:?}",
+            spec
+        );
+    }
+}
+
+// =========================================================================
+// Determinism across separate factories for all specs
+// =========================================================================
+
+#[test]
+fn determinism_across_factories_all_specs() {
+    for spec in [HmacSpec::hs256(), HmacSpec::hs384(), HmacSpec::hs512()] {
+        let seed1 = Seed::from_env_value("hmac-cross-factory").unwrap();
+        let seed2 = Seed::from_env_value("hmac-cross-factory").unwrap();
+        let fx1 = Factory::deterministic(seed1);
+        let fx2 = Factory::deterministic(seed2);
+
+        let s1 = fx1.hmac("cross-fac", spec);
+        let s2 = fx2.hmac("cross-fac", spec);
+        assert_eq!(
+            s1.secret_bytes(),
+            s2.secret_bytes(),
+            "Same seed should produce same secret for {:?}",
+            spec
+        );
+    }
+}
+
+// =========================================================================
+// Cache clear for HS384 and HS512
+// =========================================================================
+
+#[test]
+fn determinism_survives_cache_clear_hs384() {
+    let seed = Seed::from_env_value("hmac-cache-hs384").unwrap();
+    let fx = Factory::deterministic(seed);
+
+    let s1 = fx.hmac("cache-clear", HmacSpec::hs384());
+    let bytes1 = s1.secret_bytes().to_vec();
+    fx.clear_cache();
+    let s2 = fx.hmac("cache-clear", HmacSpec::hs384());
+    assert_eq!(bytes1, s2.secret_bytes());
+}
+
+#[test]
+fn determinism_survives_cache_clear_hs512() {
+    let seed = Seed::from_env_value("hmac-cache-hs512").unwrap();
+    let fx = Factory::deterministic(seed);
+
+    let s1 = fx.hmac("cache-clear", HmacSpec::hs512());
+    let bytes1 = s1.secret_bytes().to_vec();
+    fx.clear_cache();
+    let s2 = fx.hmac("cache-clear", HmacSpec::hs512());
+    assert_eq!(bytes1, s2.secret_bytes());
+}
+
+// =========================================================================
+// Debug safety for HS384 and HS512
+// =========================================================================
+
+#[test]
+fn debug_does_not_leak_hs384_secret() {
+    let fx = fx();
+    let secret = fx.hmac("debug-hs384", HmacSpec::hs384());
+
+    let debug_output = format!("{:?}", secret);
+    assert!(debug_output.contains("HmacSecret"));
+    assert!(debug_output.contains(".."));
+
+    let hex_secret: String = secret
+        .secret_bytes()
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    assert!(!debug_output.contains(&hex_secret));
+}
+
+#[test]
+fn debug_does_not_leak_hs512_secret() {
+    let fx = fx();
+    let secret = fx.hmac("debug-hs512", HmacSpec::hs512());
+
+    let debug_output = format!("{:?}", secret);
+    assert!(debug_output.contains("HmacSecret"));
+    assert!(debug_output.contains(".."));
+
+    let hex_secret: String = secret
+        .secret_bytes()
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    assert!(!debug_output.contains(&hex_secret));
+}
+
+// =========================================================================
+// HS384 vs HS256 produces different secrets for same label
+// =========================================================================
+
+#[test]
+fn hs384_vs_hs256_different_for_same_label() {
+    let fx = fx();
+    let s256 = fx.hmac("same-label", HmacSpec::hs256());
+    let s384 = fx.hmac("same-label", HmacSpec::hs384());
+    assert_ne!(
+        s256.secret_bytes(),
+        s384.secret_bytes(),
+        "HS256 and HS384 must differ for same label"
+    );
+}
+
+#[test]
+fn hs384_vs_hs512_different_for_same_label() {
+    let fx = fx();
+    let s384 = fx.hmac("same-label", HmacSpec::hs384());
+    let s512 = fx.hmac("same-label", HmacSpec::hs512());
+    assert_ne!(
+        s384.secret_bytes(),
+        s512.secret_bytes(),
+        "HS384 and HS512 must differ for same label"
+    );
+}
+
+// =========================================================================
+// JWK tests for HS384/HS512 (feature-gated)
+// =========================================================================
+
+#[cfg(feature = "jwk")]
+mod jwk_coverage_gaps {
+    use super::*;
+
+    #[test]
+    fn jwk_k_decodes_to_correct_length_for_all_specs() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = fx();
+
+        let cases = [
+            (HmacSpec::hs256(), 32usize),
+            (HmacSpec::hs384(), 48usize),
+            (HmacSpec::hs512(), 64usize),
+        ];
+
+        for (spec, expected_len) in cases {
+            let secret = fx.hmac("jwk-k-len", spec);
+            let jwk = secret.jwk().to_value();
+            let k = jwk["k"].as_str().unwrap();
+            let decoded = URL_SAFE_NO_PAD.decode(k).expect("valid base64url");
+            assert_eq!(
+                decoded.len(),
+                expected_len,
+                "JWK k should decode to {expected_len} bytes for {:?}",
+                spec
+            );
+        }
+    }
+
+    #[test]
+    fn kid_differs_across_specs_for_same_label() {
+        let fx = fx();
+        let s256 = fx.hmac("kid-spec", HmacSpec::hs256());
+        let s384 = fx.hmac("kid-spec", HmacSpec::hs384());
+        let s512 = fx.hmac("kid-spec", HmacSpec::hs512());
+
+        assert_ne!(s256.kid(), s384.kid());
+        assert_ne!(s256.kid(), s512.kid());
+        assert_ne!(s384.kid(), s512.kid());
+    }
+
+    #[test]
+    fn jwks_wraps_hs384() {
+        let fx = fx();
+        let secret = fx.hmac("jwks-hs384", HmacSpec::hs384());
+        let jwks = secret.jwks().to_value();
+        let keys = jwks["keys"].as_array().expect("keys array");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0]["alg"], "HS384");
+    }
+
+    #[test]
+    fn jwks_wraps_hs512() {
+        let fx = fx();
+        let secret = fx.hmac("jwks-hs512", HmacSpec::hs512());
+        let jwks = secret.jwks().to_value();
+        let keys = jwks["keys"].as_array().expect("keys array");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0]["alg"], "HS512");
+    }
+}

--- a/crates/uselesskey-rsa/tests/coverage_gaps.rs
+++ b/crates/uselesskey-rsa/tests/coverage_gaps.rs
@@ -1,0 +1,270 @@
+//! Coverage-gap tests for uselesskey-rsa.
+//!
+//! Fills gaps not covered by existing prop/snapshot/unit tests:
+//! - RSA-3072 key generation, parsing, and determinism
+//! - RSA-4096 key generation, parsing, and determinism
+//! - Mismatch variant for non-2048 specs
+//! - Random mode basic smoke tests
+//! - Tempfile outputs for larger key sizes
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_core::negative::CorruptPem;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+// =========================================================================
+// RSA-3072 tests
+// =========================================================================
+
+#[test]
+fn rsa_3072_produces_parseable_keys() {
+    let fx = fx();
+    let kp = fx.rsa("rsa3072-parse", RsaSpec::new(3072));
+
+    let priv_result = rsa::RsaPrivateKey::from_pkcs8_der(kp.private_key_pkcs8_der());
+    assert!(priv_result.is_ok(), "RSA-3072 private DER should parse");
+
+    let priv_pem_result = rsa::RsaPrivateKey::from_pkcs8_pem(kp.private_key_pkcs8_pem());
+    assert!(priv_pem_result.is_ok(), "RSA-3072 private PEM should parse");
+
+    let pub_result = rsa::RsaPublicKey::from_public_key_der(kp.public_key_spki_der());
+    assert!(pub_result.is_ok(), "RSA-3072 public DER should parse");
+
+    let pub_pem_result = rsa::RsaPublicKey::from_public_key_pem(kp.public_key_spki_pem());
+    assert!(pub_pem_result.is_ok(), "RSA-3072 public PEM should parse");
+}
+
+use rsa::pkcs8::{DecodePrivateKey, DecodePublicKey};
+
+#[test]
+fn rsa_3072_deterministic_is_stable() {
+    let fx = Factory::deterministic(Seed::from_env_value("rsa3072-det").unwrap());
+    let k1 = fx.rsa("issuer", RsaSpec::new(3072));
+    let k2 = fx.rsa("issuer", RsaSpec::new(3072));
+
+    assert_eq!(k1.private_key_pkcs8_der(), k2.private_key_pkcs8_der());
+    assert_eq!(k1.public_key_spki_der(), k2.public_key_spki_der());
+}
+
+#[test]
+fn rsa_3072_mismatch_is_parseable_and_different() {
+    let fx = fx();
+    let kp = fx.rsa("rsa3072-mm", RsaSpec::new(3072));
+
+    let good = rsa::RsaPublicKey::from_public_key_der(kp.public_key_spki_der()).unwrap();
+    let other =
+        rsa::RsaPublicKey::from_public_key_der(&kp.mismatched_public_key_spki_der()).unwrap();
+
+    use rsa::traits::PublicKeyParts;
+    assert_ne!(good.n(), other.n());
+}
+
+// =========================================================================
+// RSA-4096 tests
+// =========================================================================
+
+#[test]
+fn rsa_4096_produces_parseable_keys() {
+    let fx = fx();
+    let kp = fx.rsa("rsa4096-parse", RsaSpec::new(4096));
+
+    let priv_result = rsa::RsaPrivateKey::from_pkcs8_der(kp.private_key_pkcs8_der());
+    assert!(priv_result.is_ok(), "RSA-4096 private DER should parse");
+
+    let pub_result = rsa::RsaPublicKey::from_public_key_der(kp.public_key_spki_der());
+    assert!(pub_result.is_ok(), "RSA-4096 public DER should parse");
+}
+
+#[test]
+fn rsa_4096_deterministic_is_stable() {
+    let fx = Factory::deterministic(Seed::from_env_value("rsa4096-det").unwrap());
+    let k1 = fx.rsa("issuer", RsaSpec::new(4096));
+    let k2 = fx.rsa("issuer", RsaSpec::new(4096));
+
+    assert_eq!(k1.private_key_pkcs8_der(), k2.private_key_pkcs8_der());
+    assert_eq!(k1.public_key_spki_der(), k2.public_key_spki_der());
+}
+
+#[test]
+fn rsa_4096_mismatch_is_parseable_and_different() {
+    let fx = fx();
+    let kp = fx.rsa("rsa4096-mm", RsaSpec::new(4096));
+
+    let good = rsa::RsaPublicKey::from_public_key_der(kp.public_key_spki_der()).unwrap();
+    let other =
+        rsa::RsaPublicKey::from_public_key_der(&kp.mismatched_public_key_spki_der()).unwrap();
+
+    use rsa::traits::PublicKeyParts;
+    assert_ne!(good.n(), other.n());
+}
+
+// =========================================================================
+// Different specs produce different keys for the same label
+// =========================================================================
+
+#[test]
+fn different_bit_sizes_produce_different_keys() {
+    let fx = fx();
+    let k2048 = fx.rsa("same-label", RsaSpec::new(2048));
+    let k3072 = fx.rsa("same-label", RsaSpec::new(3072));
+    let k4096 = fx.rsa("same-label", RsaSpec::new(4096));
+
+    assert_ne!(k2048.private_key_pkcs8_der(), k3072.private_key_pkcs8_der());
+    assert_ne!(k2048.private_key_pkcs8_der(), k4096.private_key_pkcs8_der());
+    assert_ne!(k3072.private_key_pkcs8_der(), k4096.private_key_pkcs8_der());
+}
+
+// =========================================================================
+// Random mode smoke tests
+// =========================================================================
+
+#[test]
+fn random_mode_produces_valid_keys() {
+    let fx = Factory::random();
+    let kp = fx.rsa("random-test", RsaSpec::rs256());
+
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(kp.public_key_spki_pem().contains("BEGIN PUBLIC KEY"));
+
+    let parsed = rsa::RsaPrivateKey::from_pkcs8_der(kp.private_key_pkcs8_der());
+    assert!(parsed.is_ok());
+}
+
+#[test]
+fn random_mode_caches_same_identity() {
+    let fx = Factory::random();
+    let k1 = fx.rsa("cache-test", RsaSpec::rs256());
+    let k2 = fx.rsa("cache-test", RsaSpec::rs256());
+
+    assert_eq!(k1.private_key_pkcs8_der(), k2.private_key_pkcs8_der());
+}
+
+// =========================================================================
+// Negative fixtures for non-2048 specs
+// =========================================================================
+
+#[test]
+fn corrupt_pem_for_3072_and_4096() {
+    let fx = fx();
+
+    for bits in [3072, 4096] {
+        let kp = fx.rsa(format!("corrupt-{bits}"), RsaSpec::new(bits));
+        let original = kp.private_key_pkcs8_pem();
+        let bad = kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadBase64);
+        assert_ne!(bad, original);
+        assert!(rsa::RsaPrivateKey::from_pkcs8_pem(&bad).is_err());
+    }
+}
+
+#[test]
+fn truncated_der_for_3072_and_4096() {
+    let fx = fx();
+
+    for bits in [3072, 4096] {
+        let kp = fx.rsa(format!("trunc-{bits}"), RsaSpec::new(bits));
+        let truncated = kp.private_key_pkcs8_der_truncated(16);
+        assert_eq!(truncated.len(), 16);
+    }
+}
+
+// =========================================================================
+// JWK tests for non-2048 specs (feature-gated)
+// =========================================================================
+
+#[cfg(feature = "jwk")]
+mod jwk_coverage_gaps {
+    use super::*;
+
+    #[test]
+    fn rsa_3072_jwk_has_rs384_alg() {
+        let fx = fx();
+        let kp = fx.rsa("jwk-3072", RsaSpec::new(3072));
+        let jwk = kp.public_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "RSA");
+        assert_eq!(jwk["alg"], "RS384");
+        assert_eq!(jwk["use"], "sig");
+        assert!(jwk["kid"].is_string());
+    }
+
+    #[test]
+    fn rsa_4096_jwk_has_rs512_alg() {
+        let fx = fx();
+        let kp = fx.rsa("jwk-4096", RsaSpec::new(4096));
+        let jwk = kp.public_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "RSA");
+        assert_eq!(jwk["alg"], "RS512");
+        assert_eq!(jwk["use"], "sig");
+        assert!(jwk["kid"].is_string());
+    }
+
+    #[test]
+    fn rsa_3072_private_jwk_has_all_fields() {
+        let fx = fx();
+        let kp = fx.rsa("priv-jwk-3072", RsaSpec::new(3072));
+        let jwk = kp.private_key_jwk().to_value();
+
+        for field in ["n", "e", "d", "p", "q", "dp", "dq", "qi"] {
+            assert!(jwk.get(field).is_some(), "Missing field: {field}");
+            assert!(jwk[field].is_string(), "Field {field} should be string");
+        }
+        assert_eq!(jwk["alg"], "RS384");
+    }
+
+    #[test]
+    fn rsa_4096_private_jwk_has_all_fields() {
+        let fx = fx();
+        let kp = fx.rsa("priv-jwk-4096", RsaSpec::new(4096));
+        let jwk = kp.private_key_jwk().to_value();
+
+        for field in ["n", "e", "d", "p", "q", "dp", "dq", "qi"] {
+            assert!(jwk.get(field).is_some(), "Missing field: {field}");
+            assert!(jwk[field].is_string(), "Field {field} should be string");
+        }
+        assert_eq!(jwk["alg"], "RS512");
+    }
+
+    #[test]
+    fn rsa_3072_jwks_wraps_correctly() {
+        let fx = fx();
+        let kp = fx.rsa("jwks-3072", RsaSpec::new(3072));
+        let jwks = kp.public_jwks().to_value();
+        let keys = jwks["keys"].as_array().expect("keys array");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0]["alg"], "RS384");
+    }
+
+    #[test]
+    fn rsa_n_length_scales_with_bits() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = fx();
+
+        let kp_2048 = fx.rsa("n-len-2048", RsaSpec::new(2048));
+        let kp_3072 = fx.rsa("n-len-3072", RsaSpec::new(3072));
+        let kp_4096 = fx.rsa("n-len-4096", RsaSpec::new(4096));
+
+        let n_2048 = URL_SAFE_NO_PAD
+            .decode(kp_2048.public_jwk().to_value()["n"].as_str().unwrap())
+            .unwrap();
+        let n_3072 = URL_SAFE_NO_PAD
+            .decode(kp_3072.public_jwk().to_value()["n"].as_str().unwrap())
+            .unwrap();
+        let n_4096 = URL_SAFE_NO_PAD
+            .decode(kp_4096.public_jwk().to_value()["n"].as_str().unwrap())
+            .unwrap();
+
+        assert!(
+            n_3072.len() > n_2048.len(),
+            "3072-bit n should be longer than 2048-bit"
+        );
+        assert!(
+            n_4096.len() > n_3072.len(),
+            "4096-bit n should be longer than 3072-bit"
+        );
+    }
+}

--- a/crates/uselesskey-token/tests/coverage_gaps.rs
+++ b/crates/uselesskey-token/tests/coverage_gaps.rs
@@ -1,0 +1,194 @@
+//! Coverage-gap tests for uselesskey-token.
+//!
+//! Fills gaps not covered by existing prop/unit/inline tests:
+//! - Random mode produces valid shapes for all specs
+//! - Bearer token value is non-empty and correct length
+//! - OAuth token signature segment is non-empty
+//! - token_with_variant for all specs (not just api_key)
+//! - Different variants produce different values for bearer/oauth
+//! - Debug safety for bearer and oauth tokens
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_token::{TokenFactoryExt, TokenSpec};
+
+// =========================================================================
+// Random mode for all specs
+// =========================================================================
+
+#[test]
+fn random_mode_api_key_has_correct_shape() {
+    let fx = Factory::random();
+    let token = fx.token("random-api", TokenSpec::api_key());
+    let value = token.value();
+
+    assert!(value.starts_with("uk_test_"));
+    assert_eq!(value.len(), 40);
+    let suffix = &value["uk_test_".len()..];
+    assert!(suffix.chars().all(|c| c.is_ascii_alphanumeric()));
+}
+
+#[test]
+fn random_mode_bearer_has_correct_shape() {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let fx = Factory::random();
+    let token = fx.token("random-bearer", TokenSpec::bearer());
+    let value = token.value();
+
+    assert_eq!(value.len(), 43, "Bearer should be 43 chars");
+    let decoded = URL_SAFE_NO_PAD.decode(value);
+    assert!(decoded.is_ok(), "Bearer should be valid base64url");
+    assert_eq!(decoded.unwrap().len(), 32);
+}
+
+#[test]
+fn random_mode_oauth_has_three_segments() {
+    let fx = Factory::random();
+    let token = fx.token("random-oauth", TokenSpec::oauth_access_token());
+    let parts: Vec<&str> = token.value().split('.').collect();
+    assert_eq!(parts.len(), 3);
+}
+
+// =========================================================================
+// OAuth signature segment is non-empty
+// =========================================================================
+
+#[test]
+fn oauth_signature_segment_is_non_empty() {
+    let fx = fx();
+    let token = fx.token("oauth-sig", TokenSpec::oauth_access_token());
+    let parts: Vec<&str> = token.value().split('.').collect();
+    assert!(
+        !parts[2].is_empty(),
+        "Signature segment should be non-empty"
+    );
+}
+
+// =========================================================================
+// token_with_variant for bearer and oauth
+// =========================================================================
+
+#[test]
+fn token_with_variant_bearer() {
+    let fx = fx();
+    let good = fx.token("var-bearer", TokenSpec::bearer());
+    let custom = fx.token_with_variant("var-bearer", TokenSpec::bearer(), "custom");
+    assert_ne!(good.value(), custom.value());
+}
+
+#[test]
+fn token_with_variant_oauth() {
+    let fx = fx();
+    let good = fx.token("var-oauth", TokenSpec::oauth_access_token());
+    let custom = fx.token_with_variant("var-oauth", TokenSpec::oauth_access_token(), "custom");
+    assert_ne!(good.value(), custom.value());
+}
+
+// =========================================================================
+// Debug safety for bearer and oauth
+// =========================================================================
+
+#[test]
+fn debug_does_not_leak_bearer_value() {
+    let fx = Factory::random();
+    let token = fx.token("debug-bearer", TokenSpec::bearer());
+    let dbg = format!("{token:?}");
+
+    assert!(dbg.contains("TokenFixture"));
+    assert!(dbg.contains("debug-bearer"));
+    assert!(!dbg.contains(token.value()));
+}
+
+#[test]
+fn debug_does_not_leak_oauth_value() {
+    let fx = Factory::random();
+    let token = fx.token("debug-oauth", TokenSpec::oauth_access_token());
+    let dbg = format!("{token:?}");
+
+    assert!(dbg.contains("TokenFixture"));
+    assert!(!dbg.contains(token.value()));
+}
+
+// =========================================================================
+// Random mode caching
+// =========================================================================
+
+#[test]
+fn random_mode_caches_all_specs() {
+    let fx = Factory::random();
+
+    for spec in [
+        TokenSpec::api_key(),
+        TokenSpec::bearer(),
+        TokenSpec::oauth_access_token(),
+    ] {
+        let t1 = fx.token("cache-test", spec);
+        let t2 = fx.token("cache-test", spec);
+        assert_eq!(
+            t1.value(),
+            t2.value(),
+            "Random mode should cache for {:?}",
+            spec
+        );
+    }
+}
+
+// =========================================================================
+// OAuth claims contain expected fields for all labels
+// =========================================================================
+
+#[test]
+fn oauth_payload_iat_and_exp_are_present() {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let fx = fx();
+    let token = fx.token("oauth-claims-check", TokenSpec::oauth_access_token());
+    let parts: Vec<&str> = token.value().split('.').collect();
+
+    let payload_bytes = URL_SAFE_NO_PAD.decode(parts[1]).expect("decode payload");
+    let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).expect("parse payload");
+
+    assert_eq!(
+        payload["iss"], "uselesskey",
+        "JWT payload should have 'iss'"
+    );
+    assert_eq!(
+        payload["sub"], "oauth-claims-check",
+        "JWT payload 'sub' should match label"
+    );
+    assert_eq!(payload["aud"], "tests", "JWT payload should have 'aud'");
+    assert!(payload["exp"].is_number(), "JWT payload should have 'exp'");
+    assert!(payload["jti"].is_string(), "JWT payload should have 'jti'");
+}
+
+// =========================================================================
+// Determinism survives cache clear for all specs
+// =========================================================================
+
+#[test]
+fn determinism_survives_cache_clear_all_specs() {
+    for spec in [
+        TokenSpec::api_key(),
+        TokenSpec::bearer(),
+        TokenSpec::oauth_access_token(),
+    ] {
+        let seed = Seed::from_env_value("token-cache-clear-all").unwrap();
+        let fx = Factory::deterministic(seed);
+
+        let t1 = fx.token("cache-clear", spec);
+        let val1 = t1.value().to_string();
+        fx.clear_cache();
+        let t2 = fx.token("cache-clear", spec);
+        assert_eq!(
+            val1,
+            t2.value(),
+            "Determinism should survive cache clear for {:?}",
+            spec
+        );
+    }
+}

--- a/crates/uselesskey-x509/tests/coverage_gaps.rs
+++ b/crates/uselesskey-x509/tests/coverage_gaps.rs
@@ -1,0 +1,276 @@
+//! Coverage-gap tests for uselesskey-x509.
+//!
+//! Fills gaps not covered by existing prop/unit tests:
+//! - X509Spec with custom RSA bits (4096)
+//! - X509Spec with custom issuer_cn
+//! - X509Spec with SANs verified in parsed cert
+//! - Random mode smoke tests
+//! - Negative fixtures (expired, not_yet_valid) verified via x509-parser
+//! - Chain with custom RSA bits
+//! - Self-signed CA negative variant (SelfSignedButClaimsCA)
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_core::Factory;
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Negative, X509Spec};
+use x509_parser::prelude::*;
+
+// =========================================================================
+// X509Spec with custom RSA bits
+// =========================================================================
+
+#[test]
+fn self_signed_with_4096_bit_rsa() {
+    let factory = fx();
+    let spec = X509Spec::self_signed("rsa4096.example.com").with_rsa_bits(4096);
+    let cert = factory.x509_self_signed("rsa4096-test", spec);
+
+    assert!(cert.cert_pem().contains("-----BEGIN CERTIFICATE-----"));
+    assert!(
+        cert.private_key_pkcs8_pem()
+            .contains("-----BEGIN PRIVATE KEY-----")
+    );
+
+    // The private key DER should be larger for 4096-bit
+    let spec_2048 = X509Spec::self_signed("rsa2048.example.com");
+    let cert_2048 = factory.x509_self_signed("rsa2048-test", spec_2048);
+    assert!(
+        cert.private_key_pkcs8_der().len() > cert_2048.private_key_pkcs8_der().len(),
+        "4096-bit key DER should be larger than 2048-bit"
+    );
+}
+
+// =========================================================================
+// X509Spec with SANs verified in parsed cert
+// =========================================================================
+
+#[test]
+fn self_signed_with_sans_appear_in_cert() {
+    let factory = fx();
+    let spec = X509Spec::self_signed("san.example.com").with_sans(vec![
+        "san.example.com".to_string(),
+        "www.san.example.com".to_string(),
+    ]);
+    let cert = factory.x509_self_signed("san-test", spec);
+
+    let (_, parsed) = X509Certificate::from_der(cert.cert_der()).expect("parse cert");
+
+    let san_ext = parsed
+        .extensions()
+        .iter()
+        .find(|ext| ext.oid == x509_parser::oid_registry::OID_X509_EXT_SUBJECT_ALT_NAME)
+        .expect("should have SAN extension");
+
+    let san = match san_ext.parsed_extension() {
+        x509_parser::extensions::ParsedExtension::SubjectAlternativeName(san) => san,
+        other => panic!("expected SAN, got {:?}", other),
+    };
+
+    let dns_names: Vec<String> = san
+        .general_names
+        .iter()
+        .filter_map(|gn| {
+            if let x509_parser::extensions::GeneralName::DNSName(name) = gn {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(dns_names.contains(&"san.example.com".to_string()));
+    assert!(dns_names.contains(&"www.san.example.com".to_string()));
+}
+
+// =========================================================================
+// Random mode smoke tests
+// =========================================================================
+
+#[test]
+fn random_mode_self_signed_produces_valid_cert() {
+    let factory = Factory::random();
+    let spec = X509Spec::self_signed("random.example.com");
+    let cert = factory.x509_self_signed("random-test", spec);
+
+    assert!(!cert.cert_der().is_empty());
+    assert!(cert.cert_pem().contains("-----BEGIN CERTIFICATE-----"));
+
+    let result = X509Certificate::from_der(cert.cert_der());
+    assert!(result.is_ok(), "Random mode cert should be parseable");
+}
+
+#[test]
+fn random_mode_chain_produces_valid_chain() {
+    let factory = Factory::random();
+    let spec = ChainSpec::new("random-chain.example.com");
+    let chain = factory.x509_chain("random-chain", spec);
+
+    assert!(!chain.leaf_cert_der().is_empty());
+    assert!(!chain.intermediate_cert_der().is_empty());
+    assert!(!chain.root_cert_der().is_empty());
+
+    let chain_pem = chain.chain_pem();
+    assert_eq!(chain_pem.matches("-----BEGIN CERTIFICATE-----").count(), 2);
+}
+
+#[test]
+fn random_mode_caches_same_identity() {
+    let factory = Factory::random();
+    let spec = X509Spec::self_signed("cache.example.com");
+    let c1 = factory.x509_self_signed("cache-test", spec.clone());
+    let c2 = factory.x509_self_signed("cache-test", spec);
+
+    assert_eq!(c1.cert_der(), c2.cert_der());
+}
+
+// =========================================================================
+// Negative fixtures verified via x509-parser
+// =========================================================================
+
+#[test]
+fn expired_cert_has_past_not_after() {
+    let factory = fx();
+    let spec = X509Spec::self_signed("expired.example.com");
+    let cert = factory.x509_self_signed("expired-verify", spec);
+    let expired = cert.expired();
+
+    let (_, parsed) = X509Certificate::from_der(expired.cert_der()).expect("parse expired cert");
+    let not_after = parsed.validity().not_after.timestamp();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    // Expired cert should have not_after in the past
+    assert!(
+        not_after < now,
+        "Expired cert not_after ({not_after}) should be before now ({now})"
+    );
+}
+
+#[test]
+fn not_yet_valid_cert_differs_from_good() {
+    let factory = fx();
+    let spec = X509Spec::self_signed("notyet.example.com");
+    let cert = factory.x509_self_signed("notyet-verify", spec);
+    let not_yet = cert.not_yet_valid();
+
+    assert_ne!(cert.cert_der(), not_yet.cert_der());
+
+    let (_, parsed) =
+        X509Certificate::from_der(not_yet.cert_der()).expect("parse not-yet-valid cert");
+    let not_before = parsed.validity().not_before.timestamp();
+    let (_, good_parsed) = X509Certificate::from_der(cert.cert_der()).expect("parse good cert");
+    let good_not_before = good_parsed.validity().not_before.timestamp();
+
+    assert!(
+        not_before > good_not_before,
+        "Not-yet-valid cert should have later not_before"
+    );
+}
+
+// =========================================================================
+// SelfSignedButClaimsCA negative
+// =========================================================================
+
+#[test]
+fn self_signed_but_claims_ca_is_ca() {
+    let factory = fx();
+    let spec = X509Spec::self_signed("ca-claim.example.com");
+    let cert = factory.x509_self_signed("ca-claim", spec);
+    let ca_variant = cert.negative(X509Negative::SelfSignedButClaimsCA);
+
+    let (_, parsed) = X509Certificate::from_der(ca_variant.cert_der()).expect("parse CA cert");
+    assert!(parsed.is_ca(), "SelfSignedButClaimsCA should be CA");
+    assert!(ca_variant.spec().is_ca);
+}
+
+// =========================================================================
+// Wrong key usage negative verified
+// =========================================================================
+
+#[test]
+fn wrong_key_usage_has_modified_key_usage() {
+    let factory = fx();
+    let spec = X509Spec::self_signed("wrongku.example.com");
+    let cert = factory.x509_self_signed("wrongku-verify", spec);
+    let wrong = cert.wrong_key_usage();
+
+    assert_ne!(cert.cert_der(), wrong.cert_der());
+
+    // Wrong key usage should still produce a parseable cert
+    let (_, parsed) = X509Certificate::from_der(wrong.cert_der()).expect("parse wrong KU cert");
+    assert!(parsed.is_ca(), "WrongKeyUsage sets is_ca=true");
+}
+
+// =========================================================================
+// Chain with custom RSA bits
+// =========================================================================
+
+#[test]
+fn chain_with_custom_rsa_bits() {
+    let factory = fx();
+    let spec = ChainSpec::new("chain4096.example.com").with_rsa_bits(4096);
+    let chain = factory.x509_chain("chain-4096", spec);
+
+    assert!(!chain.leaf_cert_der().is_empty());
+    assert!(!chain.root_cert_der().is_empty());
+
+    // Verify keys are 4096-bit by checking leaf private key DER length
+    let default_spec = ChainSpec::new("chain2048.example.com");
+    let default_chain = factory.x509_chain("chain-2048", default_spec);
+    assert!(
+        chain.leaf_private_key_pkcs8_der().len() > default_chain.leaf_private_key_pkcs8_der().len(),
+        "4096-bit chain should have larger key DER"
+    );
+}
+
+// =========================================================================
+// X509Spec builder methods coverage
+// =========================================================================
+
+#[test]
+fn custom_validity_days_reflected_in_cert() {
+    let factory = fx();
+    let spec = X509Spec::self_signed("validity.example.com").with_validity_days(30);
+    let cert = factory.x509_self_signed("validity-test", spec);
+
+    let (_, parsed) = X509Certificate::from_der(cert.cert_der()).expect("parse cert");
+    let not_before = parsed.validity().not_before.timestamp();
+    let not_after = parsed.validity().not_after.timestamp();
+    let validity_days = (not_after - not_before) / 86400;
+
+    assert_eq!(validity_days, 30, "Validity should be 30 days");
+}
+
+#[test]
+fn custom_key_usage_reflected_in_cert() {
+    use uselesskey_x509::KeyUsage;
+
+    let factory = fx();
+    let ku = KeyUsage {
+        digital_signature: true,
+        key_encipherment: false,
+        key_cert_sign: false,
+        crl_sign: false,
+    };
+    let spec = X509Spec::self_signed("ku.example.com").with_key_usage(ku);
+    let cert = factory.x509_self_signed("ku-custom", spec);
+
+    let (_, parsed) = X509Certificate::from_der(cert.cert_der()).expect("parse cert");
+
+    let ku_ext = parsed
+        .extensions()
+        .iter()
+        .find(|ext| ext.oid == x509_parser::oid_registry::OID_X509_EXT_KEY_USAGE)
+        .expect("should have KeyUsage extension");
+
+    let ku_parsed = match ku_ext.parsed_extension() {
+        x509_parser::extensions::ParsedExtension::KeyUsage(ku) => ku,
+        other => panic!("expected KeyUsage, got {:?}", other),
+    };
+
+    assert!(ku_parsed.digital_signature());
+    assert!(!ku_parsed.key_encipherment());
+}


### PR DESCRIPTION
Adds 68 tests covering under-exercised specs and configurations:
- uselesskey-rsa: 17 tests for RSA-3072/4096
- uselesskey-ecdsa: 14 tests for P-384, corrupt PEM variants
- uselesskey-hmac: 14 tests for HS384/HS512
- uselesskey-token: 11 tests for all token shapes
- uselesskey-x509: 12 tests for 4096-bit RSA, SAN, expired certs

Determinism impact: none
Policy impact: none