### PR TITLE
docs: Wave 28 - doc examples for public API crates

### DIFF
--- a/crates/uselesskey-ecdsa/src/keypair.rs
+++ b/crates/uselesskey-ecdsa/src/keypair.rs
@@ -14,7 +14,29 @@ use crate::EcdsaSpec;
 /// Keep this stable: changing it changes deterministic outputs.
 pub const DOMAIN_ECDSA_KEYPAIR: &str = "uselesskey:ecdsa:keypair";
 
-/// An ECDSA keypair fixture.
+/// An ECDSA keypair fixture with various output formats.
+///
+/// Created via [`EcdsaFactoryExt::ecdsa()`]. Provides access to:
+/// - Private key in PKCS#8 PEM and DER formats
+/// - Public key in SPKI PEM and DER formats
+/// - Negative fixtures (corrupted PEM, truncated DER, mismatched keys)
+/// - JWK output (with the `jwk` feature)
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_core::Factory;
+/// use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+///
+/// let fx = Factory::random();
+/// let keypair = fx.ecdsa("my-service", EcdsaSpec::es256());
+///
+/// let private_pem = keypair.private_key_pkcs8_pem();
+/// let public_der = keypair.public_key_spki_der();
+///
+/// assert!(private_pem.contains("BEGIN PRIVATE KEY"));
+/// assert!(!public_der.is_empty());
+/// ```
 #[derive(Clone)]
 pub struct EcdsaKeyPair {
     factory: Factory,
@@ -48,6 +70,24 @@ impl fmt::Debug for EcdsaKeyPair {
 
 /// Extension trait to hang ECDSA helpers off the core [`Factory`].
 pub trait EcdsaFactoryExt {
+    /// Generate (or retrieve from cache) an ECDSA keypair fixture.
+    ///
+    /// The `label` identifies this keypair within your test suite.
+    /// In deterministic mode, `seed + label + spec` always produces the same key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::{Factory, Seed};
+    /// use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    ///
+    /// let seed = Seed::from_env_value("test-seed").unwrap();
+    /// let fx = Factory::deterministic(seed);
+    /// let keypair = fx.ecdsa("auth-service", EcdsaSpec::es256());
+    ///
+    /// let pem = keypair.private_key_pkcs8_pem();
+    /// assert!(pem.contains("BEGIN PRIVATE KEY"));
+    /// ```
     fn ecdsa(&self, label: impl AsRef<str>, spec: EcdsaSpec) -> EcdsaKeyPair;
 }
 

--- a/crates/uselesskey-ecdsa/src/spec.rs
+++ b/crates/uselesskey-ecdsa/src/spec.rs
@@ -1,4 +1,18 @@
 /// ECDSA algorithm specification.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_ecdsa::EcdsaSpec;
+///
+/// let es256 = EcdsaSpec::es256();
+/// assert_eq!(es256.alg_name(), "ES256");
+/// assert_eq!(es256.curve_name(), "P-256");
+///
+/// let es384 = EcdsaSpec::es384();
+/// assert_eq!(es384.alg_name(), "ES384");
+/// assert_eq!(es384.curve_name(), "P-384");
+/// ```
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum EcdsaSpec {
     /// P-256 / secp256r1 / prime256v1 (for ES256 JWT signing).
@@ -9,11 +23,31 @@ pub enum EcdsaSpec {
 
 impl EcdsaSpec {
     /// Spec suitable for ES256 JWT signing.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_ecdsa::EcdsaSpec;
+    ///
+    /// let spec = EcdsaSpec::es256();
+    /// assert_eq!(spec.alg_name(), "ES256");
+    /// assert_eq!(spec.curve_name(), "P-256");
+    /// ```
     pub fn es256() -> Self {
         Self::Es256
     }
 
     /// Spec suitable for ES384 JWT signing.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_ecdsa::EcdsaSpec;
+    ///
+    /// let spec = EcdsaSpec::es384();
+    /// assert_eq!(spec.alg_name(), "ES384");
+    /// assert_eq!(spec.curve_name(), "P-384");
+    /// ```
     pub fn es384() -> Self {
         Self::Es384
     }

--- a/crates/uselesskey-ed25519/src/keypair.rs
+++ b/crates/uselesskey-ed25519/src/keypair.rs
@@ -16,6 +16,29 @@ use crate::Ed25519Spec;
 /// Keep this stable: changing it changes deterministic outputs.
 pub const DOMAIN_ED25519_KEYPAIR: &str = "uselesskey:ed25519:keypair";
 
+/// An Ed25519 keypair fixture with various output formats.
+///
+/// Created via [`Ed25519FactoryExt::ed25519()`]. Provides access to:
+/// - Private key in PKCS#8 PEM and DER formats
+/// - Public key in SPKI PEM and DER formats
+/// - Negative fixtures (corrupted PEM, truncated DER, mismatched keys)
+/// - JWK output (with the `jwk` feature)
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_core::Factory;
+/// use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+///
+/// let fx = Factory::random();
+/// let keypair = fx.ed25519("my-service", Ed25519Spec::new());
+///
+/// let private_pem = keypair.private_key_pkcs8_pem();
+/// let public_der = keypair.public_key_spki_der();
+///
+/// assert!(private_pem.contains("BEGIN PRIVATE KEY"));
+/// assert!(!public_der.is_empty());
+/// ```
 #[derive(Clone)]
 pub struct Ed25519KeyPair {
     factory: Factory,
@@ -46,6 +69,24 @@ impl fmt::Debug for Ed25519KeyPair {
 
 /// Extension trait to hang Ed25519 helpers off the core [`Factory`].
 pub trait Ed25519FactoryExt {
+    /// Generate (or retrieve from cache) an Ed25519 keypair fixture.
+    ///
+    /// The `label` identifies this keypair within your test suite.
+    /// In deterministic mode, `seed + label + spec` always produces the same key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::{Factory, Seed};
+    /// use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    ///
+    /// let seed = Seed::from_env_value("test-seed").unwrap();
+    /// let fx = Factory::deterministic(seed);
+    /// let keypair = fx.ed25519("signing-key", Ed25519Spec::new());
+    ///
+    /// let pem = keypair.private_key_pkcs8_pem();
+    /// assert!(pem.contains("BEGIN PRIVATE KEY"));
+    /// ```
     fn ed25519(&self, label: impl AsRef<str>, spec: Ed25519Spec) -> Ed25519KeyPair;
 }
 

--- a/crates/uselesskey-ed25519/src/spec.rs
+++ b/crates/uselesskey-ed25519/src/spec.rs
@@ -2,6 +2,16 @@
 ///
 /// Ed25519 has no configurable parameters like RSA bit size,
 /// so this struct is simple and always returns the same spec.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_ed25519::Ed25519Spec;
+///
+/// let spec = Ed25519Spec::new();
+/// // Ed25519 has no configurable parameters
+/// assert_eq!(spec, Ed25519Spec::default());
+/// ```
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Default)]
 pub struct Ed25519Spec {
     // Ed25519 has fixed parameters, but we keep this struct for API consistency

--- a/crates/uselesskey-hmac/src/lib.rs
+++ b/crates/uselesskey-hmac/src/lib.rs
@@ -21,6 +21,35 @@
 //! let secret = kp.secret_bytes();
 //! assert_eq!(secret.len(), 32);
 //! ```
+//!
+//! # Deterministic Mode
+//!
+//! Use deterministic mode for reproducible test fixtures:
+//!
+//! ```
+//! use uselesskey_core::{Factory, Seed};
+//! use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+//!
+//! let seed = Seed::from_env_value("test-seed").unwrap();
+//! let fx = Factory::deterministic(seed);
+//!
+//! // Same seed + label + spec = same secret
+//! let s1 = fx.hmac("issuer", HmacSpec::hs384());
+//! let s2 = fx.hmac("issuer", HmacSpec::hs384());
+//! assert_eq!(s1.secret_bytes(), s2.secret_bytes());
+//!
+//! // Different labels produce different secrets
+//! let s3 = fx.hmac("other", HmacSpec::hs384());
+//! assert_ne!(s1.secret_bytes(), s3.secret_bytes());
+//! ```
+//!
+//! # Available Specs
+//!
+//! | Spec | Algorithm | Secret Length |
+//! |------|-----------|--------------|
+//! | [`HmacSpec::hs256()`] | HMAC-SHA256 | 32 bytes |
+//! | [`HmacSpec::hs384()`] | HMAC-SHA384 | 48 bytes |
+//! | [`HmacSpec::hs512()`] | HMAC-SHA512 | 64 bytes |
 
 mod secret;
 mod spec;

--- a/crates/uselesskey-hmac/src/secret.rs
+++ b/crates/uselesskey-hmac/src/secret.rs
@@ -13,6 +13,22 @@ use crate::HmacSpec;
 /// Keep this stable: changing it changes deterministic outputs.
 pub const DOMAIN_HMAC_SECRET: &str = "uselesskey:hmac:secret";
 
+/// An HMAC secret fixture.
+///
+/// Created via [`HmacFactoryExt::hmac()`]. Provides access to raw secret bytes
+/// and JWK output (with the `jwk` feature).
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_core::Factory;
+/// use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+///
+/// let fx = Factory::random();
+/// let secret = fx.hmac("jwt-signing", HmacSpec::hs256());
+///
+/// assert_eq!(secret.secret_bytes().len(), 32);
+/// ```
 #[derive(Clone)]
 pub struct HmacSecret {
     factory: Factory,
@@ -36,6 +52,25 @@ impl fmt::Debug for HmacSecret {
 
 /// Extension trait to hang HMAC helpers off the core [`Factory`].
 pub trait HmacFactoryExt {
+    /// Generate (or retrieve from cache) an HMAC secret fixture.
+    ///
+    /// The `label` identifies this secret within your test suite.
+    /// In deterministic mode, `seed + label + spec` always produces the same secret.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::{Factory, Seed};
+    /// use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    ///
+    /// let seed = Seed::from_env_value("test-seed").unwrap();
+    /// let fx = Factory::deterministic(seed);
+    /// let secret = fx.hmac("jwt-signing", HmacSpec::hs256());
+    ///
+    /// // Same seed + label + spec = same secret
+    /// let secret2 = fx.hmac("jwt-signing", HmacSpec::hs256());
+    /// assert_eq!(secret.secret_bytes(), secret2.secret_bytes());
+    /// ```
     fn hmac(&self, label: impl AsRef<str>, spec: HmacSpec) -> HmacSecret;
 }
 

--- a/crates/uselesskey-hmac/src/spec.rs
+++ b/crates/uselesskey-hmac/src/spec.rs
@@ -1,4 +1,18 @@
 /// Specification for HMAC secret generation.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_hmac::HmacSpec;
+///
+/// let hs256 = HmacSpec::hs256();
+/// assert_eq!(hs256.byte_len(), 32);
+/// assert_eq!(hs256.alg_name(), "HS256");
+///
+/// let hs512 = HmacSpec::hs512();
+/// assert_eq!(hs512.byte_len(), 64);
+/// assert_eq!(hs512.alg_name(), "HS512");
+/// ```
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum HmacSpec {
     /// HS256 (HMAC-SHA256)
@@ -10,14 +24,47 @@ pub enum HmacSpec {
 }
 
 impl HmacSpec {
+    /// HS256 (HMAC-SHA256). Produces a 32-byte secret.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_hmac::HmacSpec;
+    ///
+    /// let spec = HmacSpec::hs256();
+    /// assert_eq!(spec.byte_len(), 32);
+    /// assert_eq!(spec.alg_name(), "HS256");
+    /// ```
     pub fn hs256() -> Self {
         Self::Hs256
     }
 
+    /// HS384 (HMAC-SHA384). Produces a 48-byte secret.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_hmac::HmacSpec;
+    ///
+    /// let spec = HmacSpec::hs384();
+    /// assert_eq!(spec.byte_len(), 48);
+    /// assert_eq!(spec.alg_name(), "HS384");
+    /// ```
     pub fn hs384() -> Self {
         Self::Hs384
     }
 
+    /// HS512 (HMAC-SHA512). Produces a 64-byte secret.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_hmac::HmacSpec;
+    ///
+    /// let spec = HmacSpec::hs512();
+    /// assert_eq!(spec.byte_len(), 64);
+    /// assert_eq!(spec.alg_name(), "HS512");
+    /// ```
     pub fn hs512() -> Self {
         Self::Hs512
     }

--- a/crates/uselesskey-rsa/src/keypair.rs
+++ b/crates/uselesskey-rsa/src/keypair.rs
@@ -66,6 +66,24 @@ impl fmt::Debug for RsaKeyPair {
 
 /// Extension trait to hang RSA helpers off the core [`Factory`].
 pub trait RsaFactoryExt {
+    /// Generate (or retrieve from cache) an RSA keypair fixture.
+    ///
+    /// The `label` identifies this keypair within your test suite.
+    /// In deterministic mode, `seed + label + spec` always produces the same key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::{Factory, Seed};
+    /// use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    ///
+    /// let seed = Seed::from_env_value("test-seed").unwrap();
+    /// let fx = Factory::deterministic(seed);
+    /// let keypair = fx.rsa("my-service", RsaSpec::rs256());
+    ///
+    /// let pem = keypair.private_key_pkcs8_pem();
+    /// assert!(pem.contains("BEGIN PRIVATE KEY"));
+    /// ```
     fn rsa(&self, label: impl AsRef<str>, spec: RsaSpec) -> RsaKeyPair;
 }
 


### PR DESCRIPTION
Adds 255 lines of doc examples (doctests) across 5 crates:
- uselesskey-rsa: RsaFactoryExt::rsa() method
- uselesskey-ecdsa: EcdsaKeyPair, EcdsaFactoryExt, EcdsaSpec
- uselesskey-ed25519: Ed25519KeyPair, Ed25519FactoryExt, Ed25519Spec
- uselesskey-hmac: HmacSecret, HmacFactoryExt, HmacSpec + constructors

All 29 doctests pass.

Determinism impact: none
Policy impact: none