### PR TITLE
test: Wave 29 - integration tests for untested core crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3471,6 +3471,7 @@ version = "0.3.0"
 dependencies = [
  "base64",
  "blake3",
+ "rstest",
 ]
 
 [[package]]

--- a/crates/uselesskey-core-cache/tests/integration.rs
+++ b/crates/uselesskey-core-cache/tests/integration.rs
@@ -1,0 +1,199 @@
+use std::sync::Arc;
+use std::thread;
+
+use rstest::rstest;
+use uselesskey_core_cache::ArtifactCache;
+use uselesskey_core_id::{ArtifactId, DerivationVersion};
+
+fn make_id(domain: &'static str, label: &str, variant: &str) -> ArtifactId {
+    ArtifactId::new(domain, label, b"spec", variant, DerivationVersion::V1)
+}
+
+// ── insert and retrieve ──────────────────────────────────────────────
+
+#[test]
+fn insert_and_retrieve_u32() {
+    let cache = ArtifactCache::new();
+    let id = make_id("domain:test", "key", "good");
+
+    cache.insert_if_absent_typed(id.clone(), Arc::new(42u32));
+    let got = cache.get_typed::<u32>(&id).expect("should exist");
+    assert_eq!(*got, 42u32);
+}
+
+#[test]
+fn insert_and_retrieve_string() {
+    let cache = ArtifactCache::new();
+    let id = make_id("domain:test", "key", "good");
+
+    cache.insert_if_absent_typed(id.clone(), Arc::new(String::from("hello")));
+    let got = cache.get_typed::<String>(&id).expect("should exist");
+    assert_eq!(*got, "hello");
+}
+
+#[test]
+fn get_typed_returns_none_for_absent_key() {
+    let cache = ArtifactCache::new();
+    let id = make_id("domain:test", "missing", "good");
+    assert!(cache.get_typed::<u32>(&id).is_none());
+}
+
+// ── cache hits return same Arc ───────────────────────────────────────
+
+#[test]
+fn cache_hit_returns_same_arc() {
+    let cache = ArtifactCache::new();
+    let id = make_id("domain:test", "key", "good");
+
+    let first = cache.insert_if_absent_typed(id.clone(), Arc::new(99u64));
+    let second = cache.insert_if_absent_typed(id.clone(), Arc::new(100u64));
+    let fetched = cache.get_typed::<u64>(&id).unwrap();
+
+    assert!(Arc::ptr_eq(&first, &second));
+    assert!(Arc::ptr_eq(&first, &fetched));
+    assert_eq!(*fetched, 99u64);
+}
+
+// ── different keys produce different entries ──────────────────────────
+
+#[rstest]
+#[case("label-a", "label-b")]
+#[case("x", "y")]
+fn different_labels_produce_different_entries(#[case] label_a: &str, #[case] label_b: &str) {
+    let cache = ArtifactCache::new();
+    let id_a = make_id("domain:test", label_a, "good");
+    let id_b = make_id("domain:test", label_b, "good");
+
+    cache.insert_if_absent_typed(id_a.clone(), Arc::new(1u32));
+    cache.insert_if_absent_typed(id_b.clone(), Arc::new(2u32));
+
+    assert_eq!(*cache.get_typed::<u32>(&id_a).unwrap(), 1);
+    assert_eq!(*cache.get_typed::<u32>(&id_b).unwrap(), 2);
+    assert_eq!(cache.len(), 2);
+}
+
+#[test]
+fn different_variants_produce_different_entries() {
+    let cache = ArtifactCache::new();
+    let id_good = make_id("domain:test", "key", "good");
+    let id_bad = make_id("domain:test", "key", "corrupt:v1");
+
+    cache.insert_if_absent_typed(id_good.clone(), Arc::new(10u32));
+    cache.insert_if_absent_typed(id_bad.clone(), Arc::new(20u32));
+
+    assert_eq!(*cache.get_typed::<u32>(&id_good).unwrap(), 10);
+    assert_eq!(*cache.get_typed::<u32>(&id_bad).unwrap(), 20);
+}
+
+#[test]
+fn different_domains_produce_different_entries() {
+    let cache = ArtifactCache::new();
+    let id_rsa = make_id("domain:rsa", "key", "good");
+    let id_ec = make_id("domain:ecdsa", "key", "good");
+
+    cache.insert_if_absent_typed(id_rsa.clone(), Arc::new(100u32));
+    cache.insert_if_absent_typed(id_ec.clone(), Arc::new(200u32));
+
+    assert_eq!(*cache.get_typed::<u32>(&id_rsa).unwrap(), 100);
+    assert_eq!(*cache.get_typed::<u32>(&id_ec).unwrap(), 200);
+}
+
+// ── type safety (correct downcasting) ────────────────────────────────
+
+#[test]
+#[should_panic(expected = "artifact type mismatch")]
+fn get_typed_wrong_type_panics() {
+    let cache = ArtifactCache::new();
+    let id = make_id("domain:test", "key", "good");
+
+    cache.insert_if_absent_typed(id.clone(), Arc::new(42u32));
+    let _ = cache.get_typed::<String>(&id);
+}
+
+// ── concurrent access (basic thread safety) ──────────────────────────
+
+#[test]
+fn concurrent_inserts_are_safe() {
+    let cache = Arc::new(ArtifactCache::new());
+    let mut handles = Vec::new();
+
+    for i in 0..8 {
+        let cache = Arc::clone(&cache);
+        handles.push(thread::spawn(move || {
+            let id = make_id("domain:test", &format!("thread-{i}"), "good");
+            cache.insert_if_absent_typed(id.clone(), Arc::new(i as u32));
+            let got = cache.get_typed::<u32>(&id).unwrap();
+            assert_eq!(*got, i as u32);
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+
+    assert_eq!(cache.len(), 8);
+}
+
+#[test]
+fn concurrent_reads_on_same_key() {
+    let cache = Arc::new(ArtifactCache::new());
+    let id = make_id("domain:test", "shared", "good");
+    cache.insert_if_absent_typed(id.clone(), Arc::new(777u64));
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let cache = Arc::clone(&cache);
+        let id = id.clone();
+        handles.push(thread::spawn(move || {
+            let val = cache.get_typed::<u64>(&id).unwrap();
+            assert_eq!(*val, 777u64);
+        }));
+    }
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+}
+
+// ── len / is_empty / clear ───────────────────────────────────────────
+
+#[test]
+fn new_cache_is_empty() {
+    let cache = ArtifactCache::new();
+    assert!(cache.is_empty());
+    assert_eq!(cache.len(), 0);
+}
+
+#[test]
+fn clear_removes_all_entries() {
+    let cache = ArtifactCache::new();
+    for i in 0..5 {
+        let id = make_id("domain:test", &format!("k{i}"), "good");
+        cache.insert_if_absent_typed(id, Arc::new(i));
+    }
+    assert_eq!(cache.len(), 5);
+
+    cache.clear();
+    assert!(cache.is_empty());
+}
+
+// ── Debug impl ───────────────────────────────────────────────────────
+
+#[test]
+fn debug_does_not_leak_values() {
+    let cache = ArtifactCache::new();
+    let id = make_id("domain:test", "secret-key", "good");
+    cache.insert_if_absent_typed(id, Arc::new(String::from("SUPER_SECRET")));
+
+    let dbg = format!("{cache:?}");
+    assert!(dbg.contains("ArtifactCache"));
+    assert!(!dbg.contains("SUPER_SECRET"));
+}
+
+// ── Default impl ─────────────────────────────────────────────────────
+
+#[test]
+fn default_creates_empty_cache() {
+    let cache = ArtifactCache::default();
+    assert!(cache.is_empty());
+}

--- a/crates/uselesskey-core-kid/Cargo.toml
+++ b/crates/uselesskey-core-kid/Cargo.toml
@@ -17,5 +17,8 @@ authors.workspace = true
 blake3.workspace = true
 base64.workspace = true
 
+[dev-dependencies]
+rstest.workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-kid/tests/integration.rs
+++ b/crates/uselesskey-core-kid/tests/integration.rs
@@ -1,0 +1,121 @@
+use rstest::rstest;
+use uselesskey_core_kid::{DEFAULT_KID_PREFIX_BYTES, kid_from_bytes, kid_from_bytes_with_prefix};
+
+// ── determinism ──────────────────────────────────────────────────────
+
+#[test]
+fn kid_is_deterministic_from_same_spki_bytes() {
+    let spki = b"mock-spki-public-key-bytes";
+    assert_eq!(kid_from_bytes(spki), kid_from_bytes(spki));
+}
+
+#[rstest]
+#[case(b"key-a" as &[u8])]
+#[case(b"key-b")]
+#[case(b"")]
+#[case(&[0u8; 256])]
+fn kid_is_stable_across_calls(#[case] input: &[u8]) {
+    let first = kid_from_bytes(input);
+    let second = kid_from_bytes(input);
+    assert_eq!(first, second);
+}
+
+// ── different inputs produce different KIDs ──────────────────────────
+
+#[test]
+fn different_spki_bytes_produce_different_kids() {
+    let kid_a = kid_from_bytes(b"public-key-a");
+    let kid_b = kid_from_bytes(b"public-key-b");
+    assert_ne!(kid_a, kid_b);
+}
+
+#[test]
+fn single_bit_difference_produces_different_kid() {
+    let a = [0u8; 32];
+    let mut b = [0u8; 32];
+    b[0] = 1;
+    assert_ne!(kid_from_bytes(&a), kid_from_bytes(&b));
+
+    let mut c = [0u8; 32];
+    c[31] = 0xFF;
+    let mut d = [0u8; 32];
+    d[31] = 0xFE;
+    assert_ne!(kid_from_bytes(&c), kid_from_bytes(&d));
+}
+
+// ── KID format (base64url, correct length) ───────────────────────────
+
+#[test]
+fn kid_is_valid_base64url_no_padding() {
+    let kid = kid_from_bytes(b"test-key-material");
+
+    // base64url charset: A-Z, a-z, 0-9, -, _
+    for ch in kid.chars() {
+        assert!(
+            ch.is_ascii_alphanumeric() || ch == '-' || ch == '_',
+            "unexpected character '{ch}' in KID"
+        );
+    }
+
+    // No padding characters
+    assert!(!kid.contains('='));
+}
+
+#[test]
+fn default_kid_decodes_to_expected_byte_count() {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let kid = kid_from_bytes(b"test-key");
+    let decoded = URL_SAFE_NO_PAD.decode(kid.as_bytes()).unwrap();
+    assert_eq!(decoded.len(), DEFAULT_KID_PREFIX_BYTES);
+}
+
+#[test]
+fn default_kid_has_expected_string_length() {
+    let kid = kid_from_bytes(b"test-key");
+    // 12 bytes → ceil(12 * 4/3) = 16 base64 characters (no padding needed since 12 is divisible by 3)
+    assert_eq!(kid.len(), 16);
+}
+
+// ── custom prefix lengths ────────────────────────────────────────────
+
+#[rstest]
+#[case(1)]
+#[case(4)]
+#[case(12)]
+#[case(16)]
+#[case(32)]
+fn custom_prefix_produces_correct_decoded_length(#[case] prefix_bytes: usize) {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let kid = kid_from_bytes_with_prefix(b"test-key", prefix_bytes);
+    let decoded = URL_SAFE_NO_PAD.decode(kid.as_bytes()).unwrap();
+    assert_eq!(decoded.len(), prefix_bytes);
+}
+
+#[test]
+#[should_panic(expected = "prefix_bytes must be in 1..=32")]
+fn prefix_zero_panics() {
+    let _ = kid_from_bytes_with_prefix(b"test", 0);
+}
+
+#[test]
+#[should_panic(expected = "prefix_bytes must be in 1..=32")]
+fn prefix_too_large_panics() {
+    let _ = kid_from_bytes_with_prefix(b"test", 33);
+}
+
+// ── no key material leakage ──────────────────────────────────────────
+
+#[test]
+fn kid_does_not_contain_raw_input() {
+    let input = b"my-secret-public-key-bytes-1234567890";
+    let kid = kid_from_bytes(input);
+
+    // KID should be a short hash, not contain the raw input
+    let input_str = String::from_utf8_lossy(input);
+    assert!(!kid.contains(&*input_str));
+    assert!(kid.len() < input.len());
+}

--- a/crates/uselesskey-core-negative/tests/integration.rs
+++ b/crates/uselesskey-core-negative/tests/integration.rs
@@ -1,0 +1,157 @@
+use rstest::rstest;
+use uselesskey_core_negative::{
+    CorruptPem, corrupt_der_deterministic, corrupt_pem, corrupt_pem_deterministic, flip_byte,
+    truncate_der,
+};
+
+// ── truncate_der ─────────────────────────────────────────────────────
+
+#[test]
+fn truncate_der_shortens_to_requested_length() {
+    let der = vec![0x30, 0x82, 0x01, 0x22, 0x10];
+    let truncated = truncate_der(&der, 3);
+    assert_eq!(truncated, &[0x30, 0x82, 0x01]);
+}
+
+#[test]
+fn truncate_der_returns_full_when_len_exceeds() {
+    let der = vec![0x30, 0x82];
+    let result = truncate_der(&der, 100);
+    assert_eq!(result, der);
+}
+
+#[test]
+fn truncate_der_to_zero() {
+    let der = vec![0x30, 0x82, 0x01];
+    let truncated = truncate_der(&der, 0);
+    assert!(truncated.is_empty());
+}
+
+// ── flip_byte ────────────────────────────────────────────────────────
+
+#[test]
+fn flip_byte_xors_target_only() {
+    let der = vec![0x00, 0xFF, 0x80];
+    let flipped = flip_byte(&der, 1);
+    assert_eq!(flipped, &[0x00, 0xFE, 0x80]);
+}
+
+#[test]
+fn flip_byte_out_of_bounds_returns_copy() {
+    let der = vec![0x30, 0x82];
+    let result = flip_byte(&der, 100);
+    assert_eq!(result, der);
+}
+
+#[rstest]
+#[case(0, 0x01)]
+#[case(1, 0x03)]
+fn flip_byte_at_various_offsets(#[case] offset: usize, #[case] expected: u8) {
+    let der = vec![0x00, 0x02, 0xFF];
+    let flipped = flip_byte(&der, offset);
+    assert_eq!(flipped[offset], expected);
+}
+
+// ── corrupt_der_deterministic ────────────────────────────────────────
+
+#[test]
+fn corrupt_der_deterministic_is_stable() {
+    let der = vec![0x30, 0x82, 0x01, 0x22, 0x10, 0x20, 0x30, 0x40];
+    let a = corrupt_der_deterministic(&der, "corrupt:test-v1");
+    let b = corrupt_der_deterministic(&der, "corrupt:test-v1");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn corrupt_der_deterministic_differs_from_original() {
+    let der = vec![0x30, 0x82, 0x01, 0x22, 0x10, 0x20, 0x30, 0x40];
+    let corrupted = corrupt_der_deterministic(&der, "corrupt:test");
+    assert_ne!(corrupted, der);
+}
+
+#[test]
+fn corrupt_der_deterministic_different_variants_differ() {
+    let der = vec![0x30, 0x82, 0x01, 0x22, 0x10, 0x20, 0x30, 0x40];
+    let a = corrupt_der_deterministic(&der, "corrupt:variant-a");
+    let b = corrupt_der_deterministic(&der, "corrupt:variant-b");
+    // Not guaranteed to differ but overwhelmingly likely for different variant strings
+    // We test determinism by checking they're individually stable
+    let a2 = corrupt_der_deterministic(&der, "corrupt:variant-a");
+    assert_eq!(a, a2);
+    let b2 = corrupt_der_deterministic(&der, "corrupt:variant-b");
+    assert_eq!(b, b2);
+}
+
+// ── corrupt_pem re-exports ───────────────────────────────────────────
+
+const SAMPLE_PEM: &str = "-----BEGIN RSA PRIVATE KEY-----\nABC=\n-----END RSA PRIVATE KEY-----\n";
+
+#[test]
+fn corrupt_pem_bad_header() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::BadHeader);
+    assert!(out.starts_with("-----BEGIN CORRUPTED KEY-----"));
+    assert!(!out.starts_with("-----BEGIN RSA PRIVATE KEY-----"));
+}
+
+#[test]
+fn corrupt_pem_bad_footer() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::BadFooter);
+    assert!(out.contains("-----END CORRUPTED KEY-----"));
+    assert!(!out.contains("-----END RSA PRIVATE KEY-----"));
+}
+
+#[test]
+fn corrupt_pem_bad_base64() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::BadBase64);
+    assert!(out.contains("THIS_IS_NOT_BASE64!!!"));
+}
+
+#[test]
+fn corrupt_pem_truncate() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::Truncate { bytes: 10 });
+    assert_eq!(out.len(), 10);
+    assert!(out.len() < SAMPLE_PEM.len());
+}
+
+#[test]
+fn corrupt_pem_extra_blank_line() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::ExtraBlankLine);
+    assert!(out.contains("\n\n"));
+}
+
+#[rstest]
+#[case(CorruptPem::BadHeader)]
+#[case(CorruptPem::BadFooter)]
+#[case(CorruptPem::BadBase64)]
+#[case(CorruptPem::ExtraBlankLine)]
+#[case(CorruptPem::Truncate { bytes: 15 })]
+fn all_variants_produce_non_empty_output(#[case] variant: CorruptPem) {
+    let out = corrupt_pem(SAMPLE_PEM, variant);
+    assert!(!out.is_empty());
+}
+
+#[rstest]
+#[case(CorruptPem::BadHeader)]
+#[case(CorruptPem::BadFooter)]
+#[case(CorruptPem::BadBase64)]
+#[case(CorruptPem::ExtraBlankLine)]
+#[case(CorruptPem::Truncate { bytes: 15 })]
+fn all_variants_differ_from_original(#[case] variant: CorruptPem) {
+    let out = corrupt_pem(SAMPLE_PEM, variant);
+    assert_ne!(out, SAMPLE_PEM);
+}
+
+// ── corrupt_pem_deterministic re-export ──────────────────────────────
+
+#[test]
+fn corrupt_pem_deterministic_is_stable() {
+    let a = corrupt_pem_deterministic(SAMPLE_PEM, "corrupt:det-v1");
+    let b = corrupt_pem_deterministic(SAMPLE_PEM, "corrupt:det-v1");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn corrupt_pem_deterministic_differs_from_original() {
+    let out = corrupt_pem_deterministic(SAMPLE_PEM, "corrupt:det-test");
+    assert_ne!(out, SAMPLE_PEM);
+}

--- a/crates/uselesskey-core-sink/tests/integration.rs
+++ b/crates/uselesskey-core-sink/tests/integration.rs
@@ -1,0 +1,118 @@
+use uselesskey_core_sink::TempArtifact;
+
+// ── tempfile creation and read-back ──────────────────────────────────
+
+#[test]
+fn new_bytes_round_trip() {
+    let data = vec![0x30, 0x82, 0x01, 0x22, 0xFF];
+    let temp = TempArtifact::new_bytes("uk-test-", ".der", &data).unwrap();
+
+    let read_back = temp.read_to_bytes().unwrap();
+    assert_eq!(read_back, data);
+}
+
+#[test]
+fn new_string_round_trip() {
+    let pem = "-----BEGIN PRIVATE KEY-----\nMIIBVQ==\n-----END PRIVATE KEY-----\n";
+    let temp = TempArtifact::new_string("uk-test-", ".pem", pem).unwrap();
+
+    let read_back = temp.read_to_string().unwrap();
+    assert_eq!(read_back, pem);
+}
+
+#[test]
+fn empty_content_round_trip() {
+    let temp = TempArtifact::new_bytes("uk-test-", ".bin", &[]).unwrap();
+    let read_back = temp.read_to_bytes().unwrap();
+    assert!(read_back.is_empty());
+}
+
+// ── PEM content written correctly ────────────────────────────────────
+
+#[test]
+fn pem_content_preserves_structure() {
+    let pem = "-----BEGIN PUBLIC KEY-----\nABCDEF==\n-----END PUBLIC KEY-----\n";
+    let temp = TempArtifact::new_string("uk-pem-", ".pem", pem).unwrap();
+
+    let content = temp.read_to_string().unwrap();
+    assert!(content.starts_with("-----BEGIN PUBLIC KEY-----"));
+    assert!(content.contains("ABCDEF=="));
+    assert!(content.ends_with("-----END PUBLIC KEY-----\n"));
+}
+
+#[test]
+fn pem_file_has_correct_extension() {
+    let temp = TempArtifact::new_string(
+        "uk-test-",
+        ".pem",
+        "-----BEGIN KEY-----\n-----END KEY-----\n",
+    )
+    .unwrap();
+    assert_eq!(temp.path().extension().unwrap(), "pem");
+}
+
+#[test]
+fn der_file_has_correct_extension() {
+    let temp = TempArtifact::new_bytes("uk-test-", ".der", &[0x30]).unwrap();
+    assert_eq!(temp.path().extension().unwrap(), "der");
+}
+
+// ── path is valid while alive ────────────────────────────────────────
+
+#[test]
+fn path_exists_while_artifact_alive() {
+    let temp = TempArtifact::new_string("uk-test-", ".txt", "alive").unwrap();
+    assert!(temp.path().exists());
+    assert!(temp.path().is_file());
+}
+
+// ── file cleanup on drop ─────────────────────────────────────────────
+
+#[test]
+fn file_deleted_on_drop() {
+    let path = {
+        let temp = TempArtifact::new_string("uk-test-", ".txt", "drop-me").unwrap();
+        let p = temp.path().to_path_buf();
+        assert!(p.exists());
+        p
+    };
+    // After drop, file should be removed
+    // Small retry for filesystem latency on Windows
+    for _ in 0..10 {
+        if !path.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(!path.exists(), "tempfile should be deleted on drop");
+}
+
+// ── Debug does not leak content ──────────────────────────────────────
+
+#[test]
+fn debug_contains_type_name_but_not_content() {
+    let temp = TempArtifact::new_string("uk-test-", ".pem", "SECRET_MATERIAL").unwrap();
+    let dbg = format!("{temp:?}");
+    assert!(dbg.contains("TempArtifact"));
+    assert!(!dbg.contains("SECRET_MATERIAL"));
+}
+
+// ── read_to_string handles non-utf8 ─────────────────────────────────
+
+#[test]
+fn read_to_string_replaces_invalid_utf8() {
+    let bytes = [0xFF, 0xFE, 0xFD];
+    let temp = TempArtifact::new_bytes("uk-test-", ".bin", &bytes).unwrap();
+    let s = temp.read_to_string().unwrap();
+    assert!(s.contains('\u{FFFD}'));
+}
+
+// ── large content round trip ─────────────────────────────────────────
+
+#[test]
+fn large_content_round_trip() {
+    let data: Vec<u8> = (0..10_000).map(|i| (i % 256) as u8).collect();
+    let temp = TempArtifact::new_bytes("uk-large-", ".bin", &data).unwrap();
+    let read_back = temp.read_to_bytes().unwrap();
+    assert_eq!(read_back, data);
+}


### PR DESCRIPTION
Adds 71 integration tests for 4 previously untested core microcrates: core-cache (15), core-kid (18), core-negative (27), core-sink (11). All pass, clippy clean, formatted. No determinism/policy impact.