### PR TITLE
test: Wave 30 - cross-adapter integration tests

### DIFF
--- a/crates/uselesskey-ring/tests/adapter_integration.rs
+++ b/crates/uselesskey-ring/tests/adapter_integration.rs
@@ -1,0 +1,398 @@
+//! Cross-adapter integration tests for uselesskey-ring.
+//!
+//! Tests cover:
+//! - All key types through ring sign/verify round-trip
+//! - ECDSA P-256 and P-384 ring compatibility
+//! - Ed25519 ring compatibility
+//! - Deterministic mode produces same ring keys
+//! - Cross-key verification failures
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-ring-adapter-integration-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+    .clone()
+}
+
+// =========================================================================
+// RSA through ring verification
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_ring {
+    use super::*;
+    use ring::{rand::SystemRandom, signature};
+    use uselesskey_ring::RingRsaKeyPairExt;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn rsa_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.rsa("ring-rsa-rt", RsaSpec::rs256());
+        let ring_kp = kp.rsa_key_pair_ring();
+
+        let msg = b"ring rsa roundtrip";
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; ring_kp.public().modulus_len()];
+        ring_kp
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            ring_kp.public().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify");
+    }
+
+    #[test]
+    fn rsa_modulus_len_matches_spec() {
+        let fx = fx();
+        for (bits, label) in [(2048, "rsa-2k"), (4096, "rsa-4k")] {
+            let kp = fx.rsa(label, RsaSpec::new(bits));
+            let ring_kp = kp.rsa_key_pair_ring();
+            assert_eq!(
+                ring_kp.public().modulus_len(),
+                bits / 8,
+                "modulus_len should match {bits}-bit spec"
+            );
+        }
+    }
+
+    #[test]
+    fn rsa_deterministic_same_ring_key() {
+        let seed = Seed::from_env_value("ring-rsa-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.rsa("det-rsa", RsaSpec::rs256());
+        let kp2 = fx2.rsa("det-rsa", RsaSpec::rs256());
+
+        assert_eq!(kp1.private_key_pkcs8_der(), kp2.private_key_pkcs8_der());
+
+        // Both sign/verify correctly
+        let ring1 = kp1.rsa_key_pair_ring();
+        let ring2 = kp2.rsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let msg = b"deterministic";
+        let mut sig1 = vec![0u8; ring1.public().modulus_len()];
+        let mut sig2 = vec![0u8; ring2.public().modulus_len()];
+        ring1
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig1)
+            .unwrap();
+        ring2
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig2)
+            .unwrap();
+
+        // Verify each signature with the other's public key (same key)
+        let pk1 = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            ring1.public().as_ref(),
+        );
+        pk1.verify(msg, &sig2).expect("cross-verify should succeed");
+    }
+
+    #[test]
+    fn rsa_wrong_key_rejects_signature() {
+        let fx = fx();
+        let kp_a = fx.rsa("ring-rsa-a", RsaSpec::rs256());
+        let kp_b = fx.rsa("ring-rsa-b", RsaSpec::rs256());
+
+        let ring_a = kp_a.rsa_key_pair_ring();
+        let ring_b = kp_b.rsa_key_pair_ring();
+
+        let msg = b"mismatch test";
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; ring_a.public().modulus_len()];
+        ring_a
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .unwrap();
+
+        let pk_b = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            ring_b.public().as_ref(),
+        );
+        assert!(pk_b.verify(msg, &sig).is_err());
+    }
+}
+
+// =========================================================================
+// ECDSA P-256 and P-384 ring compatibility
+// =========================================================================
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_ring {
+    use super::*;
+    use ring::{
+        rand::SystemRandom,
+        signature::{self, KeyPair},
+    };
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ring::RingEcdsaKeyPairExt;
+
+    #[test]
+    fn ecdsa_p256_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.ecdsa("ring-p256-rt", EcdsaSpec::es256());
+        let ring_kp = kp.ecdsa_key_pair_ring();
+
+        let msg = b"p256 roundtrip";
+        let rng = SystemRandom::new();
+        let sig = ring_kp.sign(&rng, msg).expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            ring_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, sig.as_ref()).expect("verify");
+    }
+
+    #[test]
+    fn ecdsa_p384_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.ecdsa("ring-p384-rt", EcdsaSpec::es384());
+        let ring_kp = kp.ecdsa_key_pair_ring();
+
+        let msg = b"p384 roundtrip";
+        let rng = SystemRandom::new();
+        let sig = ring_kp.sign(&rng, msg).expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P384_SHA384_ASN1,
+            ring_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, sig.as_ref()).expect("verify");
+    }
+
+    #[test]
+    fn ecdsa_deterministic_same_ring_key() {
+        let seed = Seed::from_env_value("ring-ecdsa-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ecdsa("det-ec", EcdsaSpec::es256());
+        let kp2 = fx2.ecdsa("det-ec", EcdsaSpec::es256());
+
+        assert_eq!(kp1.private_key_pkcs8_der(), kp2.private_key_pkcs8_der());
+
+        let ring1 = kp1.ecdsa_key_pair_ring();
+        let ring2 = kp2.ecdsa_key_pair_ring();
+        assert_eq!(ring1.public_key().as_ref(), ring2.public_key().as_ref());
+    }
+
+    #[test]
+    fn ecdsa_p256_wrong_key_rejects() {
+        let fx = fx();
+        let kp_a = fx.ecdsa("ring-ec-a", EcdsaSpec::es256());
+        let kp_b = fx.ecdsa("ring-ec-b", EcdsaSpec::es256());
+
+        let ring_a = kp_a.ecdsa_key_pair_ring();
+        let ring_b = kp_b.ecdsa_key_pair_ring();
+
+        let msg = b"cross-key test";
+        let rng = SystemRandom::new();
+        let sig = ring_a.sign(&rng, msg).unwrap();
+
+        let pk_b = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            ring_b.public_key().as_ref(),
+        );
+        assert!(pk_b.verify(msg, sig.as_ref()).is_err());
+    }
+
+    #[test]
+    fn ecdsa_p384_wrong_key_rejects() {
+        let fx = fx();
+        let kp_a = fx.ecdsa("ring-p384-a", EcdsaSpec::es384());
+        let kp_b = fx.ecdsa("ring-p384-b", EcdsaSpec::es384());
+
+        let ring_a = kp_a.ecdsa_key_pair_ring();
+        let ring_b = kp_b.ecdsa_key_pair_ring();
+
+        let msg = b"cross-key p384";
+        let rng = SystemRandom::new();
+        let sig = ring_a.sign(&rng, msg).unwrap();
+
+        let pk_b = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P384_SHA384_ASN1,
+            ring_b.public_key().as_ref(),
+        );
+        assert!(pk_b.verify(msg, sig.as_ref()).is_err());
+    }
+
+    #[test]
+    fn ecdsa_tampered_message_rejects() {
+        let fx = fx();
+        let kp = fx.ecdsa("ring-ec-tamper", EcdsaSpec::es256());
+        let ring_kp = kp.ecdsa_key_pair_ring();
+
+        let rng = SystemRandom::new();
+        let sig = ring_kp.sign(&rng, b"original").unwrap();
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            ring_kp.public_key().as_ref(),
+        );
+        assert!(pk.verify(b"tampered", sig.as_ref()).is_err());
+    }
+}
+
+// =========================================================================
+// Ed25519 ring compatibility
+// =========================================================================
+
+#[cfg(feature = "ed25519")]
+mod ed25519_ring {
+    use super::*;
+    use ring::signature::{self, KeyPair};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_ring::RingEd25519KeyPairExt;
+
+    #[test]
+    fn ed25519_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.ed25519("ring-ed-rt", Ed25519Spec::new());
+        let ring_kp = kp.ed25519_key_pair_ring();
+
+        let msg = b"ed25519 roundtrip";
+        let sig = ring_kp.sign(msg);
+
+        let pk =
+            signature::UnparsedPublicKey::new(&signature::ED25519, ring_kp.public_key().as_ref());
+        pk.verify(msg, sig.as_ref()).expect("verify");
+    }
+
+    #[test]
+    fn ed25519_deterministic_same_ring_key() {
+        let seed = Seed::from_env_value("ring-ed-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ed25519("det-ed", Ed25519Spec::new());
+        let kp2 = fx2.ed25519("det-ed", Ed25519Spec::new());
+
+        assert_eq!(kp1.private_key_pkcs8_der(), kp2.private_key_pkcs8_der());
+
+        let ring1 = kp1.ed25519_key_pair_ring();
+        let ring2 = kp2.ed25519_key_pair_ring();
+        assert_eq!(ring1.public_key().as_ref(), ring2.public_key().as_ref());
+    }
+
+    #[test]
+    fn ed25519_deterministic_signatures_identical() {
+        let seed = Seed::from_env_value("ring-ed-sig-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ed25519("ed-sig-det", Ed25519Spec::new());
+        let kp2 = fx2.ed25519("ed-sig-det", Ed25519Spec::new());
+
+        let ring1 = kp1.ed25519_key_pair_ring();
+        let ring2 = kp2.ed25519_key_pair_ring();
+
+        let msg = b"deterministic signature";
+        let sig1 = ring1.sign(msg);
+        let sig2 = ring2.sign(msg);
+        assert_eq!(
+            sig1.as_ref(),
+            sig2.as_ref(),
+            "Ed25519 signatures should be deterministic"
+        );
+    }
+
+    #[test]
+    fn ed25519_wrong_key_rejects() {
+        let fx = fx();
+        let kp_a = fx.ed25519("ring-ed-a", Ed25519Spec::new());
+        let kp_b = fx.ed25519("ring-ed-b", Ed25519Spec::new());
+
+        let ring_a = kp_a.ed25519_key_pair_ring();
+        let ring_b = kp_b.ed25519_key_pair_ring();
+
+        let msg = b"cross-key ed25519";
+        let sig = ring_a.sign(msg);
+
+        let pk_b =
+            signature::UnparsedPublicKey::new(&signature::ED25519, ring_b.public_key().as_ref());
+        assert!(pk_b.verify(msg, sig.as_ref()).is_err());
+    }
+
+    #[test]
+    fn ed25519_tampered_message_rejects() {
+        let fx = fx();
+        let kp = fx.ed25519("ring-ed-tamper", Ed25519Spec::new());
+        let ring_kp = kp.ed25519_key_pair_ring();
+
+        let sig = ring_kp.sign(b"original");
+
+        let pk =
+            signature::UnparsedPublicKey::new(&signature::ED25519, ring_kp.public_key().as_ref());
+        pk.verify(b"original", sig.as_ref()).expect("verify ok");
+        assert!(pk.verify(b"tampered", sig.as_ref()).is_err());
+    }
+}
+
+// =========================================================================
+// Cross-algorithm: signing with one type, verifying with another fails
+// =========================================================================
+
+#[cfg(all(feature = "rsa", feature = "ecdsa", feature = "ed25519"))]
+mod cross_algorithm {
+    use super::*;
+    use ring::{
+        rand::SystemRandom,
+        signature::{self, KeyPair},
+    };
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_ring::{RingEcdsaKeyPairExt, RingEd25519KeyPairExt, RingRsaKeyPairExt};
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn rsa_sig_fails_ecdsa_verify() {
+        let fx = fx();
+        let rsa_kp = fx.rsa("cross-rsa", RsaSpec::rs256()).rsa_key_pair_ring();
+        let ec_kp = fx
+            .ecdsa("cross-ecdsa", EcdsaSpec::es256())
+            .ecdsa_key_pair_ring();
+
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; rsa_kp.public().modulus_len()];
+        rsa_kp
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, b"msg", &mut sig)
+            .unwrap();
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            ec_kp.public_key().as_ref(),
+        );
+        assert!(pk.verify(b"msg", &sig).is_err());
+    }
+
+    #[test]
+    fn ed25519_sig_fails_ecdsa_verify() {
+        let fx = fx();
+        let ed_kp = fx
+            .ed25519("cross-ed", Ed25519Spec::new())
+            .ed25519_key_pair_ring();
+        let ec_kp = fx
+            .ecdsa("cross-ecdsa2", EcdsaSpec::es256())
+            .ecdsa_key_pair_ring();
+
+        let sig = ed_kp.sign(b"msg");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            ec_kp.public_key().as_ref(),
+        );
+        assert!(pk.verify(b"msg", sig.as_ref()).is_err());
+    }
+}

--- a/crates/uselesskey-rustcrypto/tests/adapter_integration.rs
+++ b/crates/uselesskey-rustcrypto/tests/adapter_integration.rs
@@ -1,0 +1,410 @@
+//! Cross-adapter integration tests for uselesskey-rustcrypto.
+//!
+//! Tests cover:
+//! - RSA signature verification through RustCrypto
+//! - ECDSA verification through RustCrypto (P-256 and P-384)
+//! - Ed25519 sign/verify through ed25519-dalek
+//! - Key serialization round-trips (DER -> RustCrypto -> DER)
+//! - Deterministic mode consistency
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-rustcrypto-adapter-integration-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+    .clone()
+}
+
+// =========================================================================
+// RSA signature verification through RustCrypto
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_rustcrypto {
+    use super::*;
+    use rsa::pkcs1v15::{SigningKey, VerifyingKey};
+    use rsa::signature::{Signer, Verifier};
+    use sha2::Sha256;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    use uselesskey_rustcrypto::RustCryptoRsaExt;
+
+    #[test]
+    fn rsa_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.rsa("rc-rsa-rt", RsaSpec::rs256());
+
+        let signing_key = SigningKey::<Sha256>::new_unprefixed(kp.rsa_private_key());
+        let signature = signing_key.sign(b"hello rustcrypto");
+
+        let verifying_key = VerifyingKey::<Sha256>::new_unprefixed(kp.rsa_public_key());
+        verifying_key
+            .verify(b"hello rustcrypto", &signature)
+            .expect("verify");
+    }
+
+    #[test]
+    fn rsa_wrong_message_rejects() {
+        let fx = fx();
+        let kp = fx.rsa("rc-rsa-reject", RsaSpec::rs256());
+
+        let signing_key = SigningKey::<Sha256>::new_unprefixed(kp.rsa_private_key());
+        let signature = signing_key.sign(b"correct");
+
+        let verifying_key = VerifyingKey::<Sha256>::new_unprefixed(kp.rsa_public_key());
+        assert!(verifying_key.verify(b"wrong", &signature).is_err());
+    }
+
+    #[test]
+    fn rsa_wrong_key_rejects() {
+        let fx = fx();
+        let kp_a = fx.rsa("rc-rsa-a", RsaSpec::rs256());
+        let kp_b = fx.rsa("rc-rsa-b", RsaSpec::rs256());
+
+        let signing_key = SigningKey::<Sha256>::new_unprefixed(kp_a.rsa_private_key());
+        let signature = signing_key.sign(b"cross-key");
+
+        let verifying_key = VerifyingKey::<Sha256>::new_unprefixed(kp_b.rsa_public_key());
+        assert!(verifying_key.verify(b"cross-key", &signature).is_err());
+    }
+
+    #[test]
+    fn rsa_deterministic_same_keys() {
+        let seed = Seed::from_env_value("rc-rsa-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.rsa("det-rsa", RsaSpec::rs256());
+        let kp2 = fx2.rsa("det-rsa", RsaSpec::rs256());
+
+        assert_eq!(kp1.private_key_pkcs8_der(), kp2.private_key_pkcs8_der());
+
+        // Sign with one, verify with the other (same key)
+        let signing_key = SigningKey::<Sha256>::new_unprefixed(kp1.rsa_private_key());
+        let signature = signing_key.sign(b"deterministic");
+
+        let verifying_key = VerifyingKey::<Sha256>::new_unprefixed(kp2.rsa_public_key());
+        verifying_key
+            .verify(b"deterministic", &signature)
+            .expect("cross-instance verify");
+    }
+
+    #[test]
+    fn rsa_key_serialization_roundtrip() {
+        use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+
+        let fx = fx();
+        let kp = fx.rsa("rc-rsa-serde", RsaSpec::rs256());
+
+        let private_key = kp.rsa_private_key();
+        let re_encoded = private_key.to_pkcs8_der().expect("encode");
+        let decoded = rsa::RsaPrivateKey::from_pkcs8_der(re_encoded.as_bytes()).expect("re-decode");
+
+        // Verify the round-tripped key still works
+        let signing_key = SigningKey::<Sha256>::new_unprefixed(decoded);
+        let signature = signing_key.sign(b"round-trip");
+
+        let verifying_key = VerifyingKey::<Sha256>::new_unprefixed(kp.rsa_public_key());
+        verifying_key
+            .verify(b"round-trip", &signature)
+            .expect("verify after round-trip");
+    }
+}
+
+// =========================================================================
+// ECDSA verification through RustCrypto
+// =========================================================================
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_rustcrypto {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_rustcrypto::RustCryptoEcdsaExt;
+
+    #[test]
+    fn p256_sign_verify_roundtrip() {
+        use p256::ecdsa::signature::{Signer, Verifier};
+
+        let fx = fx();
+        let kp = fx.ecdsa("rc-p256-rt", EcdsaSpec::es256());
+
+        let signing_key = kp.p256_signing_key();
+        let sig: p256::ecdsa::Signature = signing_key.sign(b"p256 hello");
+
+        let verifying_key = kp.p256_verifying_key();
+        verifying_key.verify(b"p256 hello", &sig).expect("verify");
+    }
+
+    #[test]
+    fn p384_sign_verify_roundtrip() {
+        use p384::ecdsa::signature::{Signer, Verifier};
+
+        let fx = fx();
+        let kp = fx.ecdsa("rc-p384-rt", EcdsaSpec::es384());
+
+        let signing_key = kp.p384_signing_key();
+        let sig: p384::ecdsa::Signature = signing_key.sign(b"p384 hello");
+
+        let verifying_key = kp.p384_verifying_key();
+        verifying_key.verify(b"p384 hello", &sig).expect("verify");
+    }
+
+    #[test]
+    fn p256_wrong_message_rejects() {
+        use p256::ecdsa::signature::{Signer, Verifier};
+
+        let fx = fx();
+        let kp = fx.ecdsa("rc-p256-reject", EcdsaSpec::es256());
+
+        let sig: p256::ecdsa::Signature = kp.p256_signing_key().sign(b"correct");
+        assert!(kp.p256_verifying_key().verify(b"wrong", &sig).is_err());
+    }
+
+    #[test]
+    fn p384_wrong_key_rejects() {
+        use p384::ecdsa::signature::{Signer, Verifier};
+
+        let fx = fx();
+        let kp_a = fx.ecdsa("rc-p384-a", EcdsaSpec::es384());
+        let kp_b = fx.ecdsa("rc-p384-b", EcdsaSpec::es384());
+
+        let sig: p384::ecdsa::Signature = kp_a.p384_signing_key().sign(b"cross-key");
+        assert!(
+            kp_b.p384_verifying_key()
+                .verify(b"cross-key", &sig)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ecdsa_deterministic_same_keys() {
+        let seed = Seed::from_env_value("rc-ecdsa-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ecdsa("det-ec", EcdsaSpec::es256());
+        let kp2 = fx2.ecdsa("det-ec", EcdsaSpec::es256());
+
+        assert_eq!(kp1.private_key_pkcs8_der(), kp2.private_key_pkcs8_der());
+    }
+
+    #[test]
+    fn p256_key_serialization_roundtrip() {
+        use p256::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+
+        let fx = fx();
+        let kp = fx.ecdsa("rc-p256-serde", EcdsaSpec::es256());
+
+        let signing_key = kp.p256_signing_key();
+        let encoded = signing_key.to_pkcs8_der().expect("encode");
+        let decoded = p256::ecdsa::SigningKey::from_pkcs8_der(encoded.as_bytes()).expect("decode");
+
+        // Verify round-tripped key produces valid signatures
+        use p256::ecdsa::signature::{Signer, Verifier};
+        let sig: p256::ecdsa::Signature = decoded.sign(b"round-trip");
+        kp.p256_verifying_key()
+            .verify(b"round-trip", &sig)
+            .expect("verify after round-trip");
+    }
+
+    #[test]
+    fn p384_key_serialization_roundtrip() {
+        use p384::pkcs8::{DecodePrivateKey, EncodePrivateKey};
+
+        let fx = fx();
+        let kp = fx.ecdsa("rc-p384-serde", EcdsaSpec::es384());
+
+        let signing_key = kp.p384_signing_key();
+        let encoded = signing_key.to_pkcs8_der().expect("encode");
+        let decoded = p384::ecdsa::SigningKey::from_pkcs8_der(encoded.as_bytes()).expect("decode");
+
+        use p384::ecdsa::signature::{Signer, Verifier};
+        let sig: p384::ecdsa::Signature = decoded.sign(b"round-trip");
+        kp.p384_verifying_key()
+            .verify(b"round-trip", &sig)
+            .expect("verify after round-trip");
+    }
+
+    #[test]
+    #[should_panic(expected = "expected P-384")]
+    fn p384_on_p256_key_panics() {
+        let fx = fx();
+        let kp = fx.ecdsa("rc-wrong-curve", EcdsaSpec::es256());
+        let _ = kp.p384_signing_key();
+    }
+}
+
+// =========================================================================
+// Ed25519 through ed25519-dalek
+// =========================================================================
+
+#[cfg(feature = "ed25519")]
+mod ed25519_rustcrypto {
+    use super::*;
+    use ed25519_dalek::{Signer, Verifier};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rustcrypto::RustCryptoEd25519Ext;
+
+    #[test]
+    fn ed25519_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.ed25519("rc-ed-rt", Ed25519Spec::new());
+
+        let signing_key = kp.ed25519_signing_key();
+        let sig = signing_key.sign(b"ed25519 hello");
+
+        let verifying_key = kp.ed25519_verifying_key();
+        verifying_key
+            .verify(b"ed25519 hello", &sig)
+            .expect("verify");
+    }
+
+    #[test]
+    fn ed25519_wrong_message_rejects() {
+        let fx = fx();
+        let kp = fx.ed25519("rc-ed-reject", Ed25519Spec::new());
+
+        let sig = kp.ed25519_signing_key().sign(b"correct");
+        assert!(kp.ed25519_verifying_key().verify(b"wrong", &sig).is_err());
+    }
+
+    #[test]
+    fn ed25519_wrong_key_rejects() {
+        let fx = fx();
+        let kp_a = fx.ed25519("rc-ed-a", Ed25519Spec::new());
+        let kp_b = fx.ed25519("rc-ed-b", Ed25519Spec::new());
+
+        let sig = kp_a.ed25519_signing_key().sign(b"cross-key");
+        assert!(
+            kp_b.ed25519_verifying_key()
+                .verify(b"cross-key", &sig)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn ed25519_deterministic_same_keys() {
+        let seed = Seed::from_env_value("rc-ed-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ed25519("det-ed", Ed25519Spec::new());
+        let kp2 = fx2.ed25519("det-ed", Ed25519Spec::new());
+
+        assert_eq!(kp1.private_key_pkcs8_der(), kp2.private_key_pkcs8_der());
+
+        // Deterministic signatures
+        let sig1 = kp1.ed25519_signing_key().sign(b"det msg");
+        let sig2 = kp2.ed25519_signing_key().sign(b"det msg");
+        assert_eq!(sig1.to_bytes(), sig2.to_bytes());
+    }
+
+    #[test]
+    fn ed25519_key_serialization_roundtrip() {
+        use ed25519_dalek::pkcs8::DecodePrivateKey;
+
+        let fx = fx();
+        let kp = fx.ed25519("rc-ed-serde", Ed25519Spec::new());
+
+        let signing_key = kp.ed25519_signing_key();
+        let der_bytes = kp.private_key_pkcs8_der();
+        let decoded = ed25519_dalek::SigningKey::from_pkcs8_der(der_bytes).expect("decode");
+
+        assert_eq!(
+            signing_key.verifying_key(),
+            decoded.verifying_key(),
+            "round-tripped key should have same verifying key"
+        );
+    }
+}
+
+// =========================================================================
+// HMAC through RustCrypto
+// =========================================================================
+
+#[cfg(feature = "hmac")]
+mod hmac_rustcrypto {
+    use super::*;
+    use hmac::Mac;
+    use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    use uselesskey_rustcrypto::RustCryptoHmacExt;
+
+    #[test]
+    fn hmac_sha256_create_and_verify() {
+        let fx = fx();
+        let secret = fx.hmac("rc-hmac-256", HmacSpec::hs256());
+
+        let mut mac = secret.hmac_sha256();
+        mac.update(b"hmac message");
+        let result = mac.finalize();
+
+        let mut mac2 = secret.hmac_sha256();
+        mac2.update(b"hmac message");
+        mac2.verify(&result.into_bytes()).expect("verify");
+    }
+
+    #[test]
+    fn hmac_sha384_create_and_verify() {
+        let fx = fx();
+        let secret = fx.hmac("rc-hmac-384", HmacSpec::hs384());
+
+        let mut mac = secret.hmac_sha384();
+        mac.update(b"hmac384 message");
+        let result = mac.finalize();
+
+        let mut mac2 = secret.hmac_sha384();
+        mac2.update(b"hmac384 message");
+        mac2.verify(&result.into_bytes()).expect("verify");
+    }
+
+    #[test]
+    fn hmac_sha512_create_and_verify() {
+        let fx = fx();
+        let secret = fx.hmac("rc-hmac-512", HmacSpec::hs512());
+
+        let mut mac = secret.hmac_sha512();
+        mac.update(b"hmac512 message");
+        let result = mac.finalize();
+
+        let mut mac2 = secret.hmac_sha512();
+        mac2.update(b"hmac512 message");
+        mac2.verify(&result.into_bytes()).expect("verify");
+    }
+
+    #[test]
+    fn hmac_different_secrets_produce_different_tags() {
+        let fx = fx();
+        let s_a = fx.hmac("rc-hmac-a", HmacSpec::hs256());
+        let s_b = fx.hmac("rc-hmac-b", HmacSpec::hs256());
+
+        let mut mac_a = s_a.hmac_sha256();
+        mac_a.update(b"same message");
+        let tag_a = mac_a.finalize().into_bytes();
+
+        let mut mac_b = s_b.hmac_sha256();
+        mac_b.update(b"same message");
+        let tag_b = mac_b.finalize().into_bytes();
+
+        assert_ne!(tag_a, tag_b);
+    }
+
+    #[test]
+    fn hmac_wrong_message_rejects() {
+        let fx = fx();
+        let secret = fx.hmac("rc-hmac-reject", HmacSpec::hs256());
+
+        let mut mac = secret.hmac_sha256();
+        mac.update(b"correct");
+        let tag = mac.finalize().into_bytes();
+
+        let mut mac2 = secret.hmac_sha256();
+        mac2.update(b"wrong");
+        assert!(mac2.verify(&tag).is_err());
+    }
+}

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -42,4 +42,7 @@ rustls-aws-lc-rs = ["rustls?/aws_lc_rs"]
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
 uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
 rustls = { version = "0.23", features = ["ring"] }

--- a/crates/uselesskey-rustls/tests/adapter_integration.rs
+++ b/crates/uselesskey-rustls/tests/adapter_integration.rs
@@ -1,0 +1,338 @@
+//! Cross-adapter integration tests for uselesskey-rustls.
+//!
+//! Tests cover:
+//! - RSA, ECDSA, and Ed25519 key conversion to rustls types
+//! - Private key PEM/DER parsing via rustls-pki-types
+//! - X.509 certificate chain building for TLS handshakes
+//! - Deterministic mode produces consistent rustls keys
+
+use std::sync::{Arc, Once, OnceLock};
+
+use rustls::crypto::CryptoProvider;
+use rustls_pki_types::PrivateKeyDer;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_rustls::RustlsPrivateKeyExt;
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-rustls-adapter-integration-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+    .clone()
+}
+
+static INIT: Once = Once::new();
+
+fn install_provider() {
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+fn ring_provider() -> Arc<CryptoProvider> {
+    Arc::new(rustls::crypto::ring::default_provider())
+}
+
+const MAX_HANDSHAKE_ITERATIONS: usize = 10;
+
+fn try_handshake(
+    server: &mut rustls::ServerConnection,
+    client: &mut rustls::ClientConnection,
+) -> Result<(), rustls::Error> {
+    let mut buf = Vec::new();
+    for _iteration in 0..MAX_HANDSHAKE_ITERATIONS {
+        let mut progress = false;
+
+        buf.clear();
+        if client.wants_write() {
+            client.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                server.read_tls(&mut &buf[..]).unwrap();
+                server.process_new_packets()?;
+                progress = true;
+            }
+        }
+
+        buf.clear();
+        if server.wants_write() {
+            server.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                client.read_tls(&mut &buf[..]).unwrap();
+                client.process_new_packets()?;
+                progress = true;
+            }
+        }
+
+        if !progress {
+            break;
+        }
+    }
+    Ok(())
+}
+
+// =========================================================================
+// RSA key conversion
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_rustls {
+    use super::*;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn rsa_private_key_converts_to_pkcs8() {
+        let fx = fx();
+        let kp = fx.rsa("rustls-rsa", RsaSpec::rs256());
+        let key = kp.private_key_der_rustls();
+
+        match &key {
+            PrivateKeyDer::Pkcs8(_) => {}
+            _ => panic!("expected PKCS#8 variant"),
+        }
+        assert_eq!(key.secret_der(), kp.private_key_pkcs8_der());
+    }
+
+    #[test]
+    fn rsa_private_key_der_is_nonempty() {
+        let fx = fx();
+        let kp = fx.rsa("rustls-rsa-nonempty", RsaSpec::rs256());
+        let key = kp.private_key_der_rustls();
+        assert!(!key.secret_der().is_empty());
+    }
+
+    #[test]
+    fn rsa_deterministic_produces_same_rustls_key() {
+        let seed = Seed::from_env_value("rustls-rsa-det-test").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.rsa("det-rsa", RsaSpec::rs256());
+        let kp2 = fx2.rsa("det-rsa", RsaSpec::rs256());
+
+        let key1 = kp1.private_key_der_rustls();
+        let key2 = kp2.private_key_der_rustls();
+        assert_eq!(key1.secret_der(), key2.secret_der());
+    }
+
+    #[test]
+    fn rsa_different_labels_produce_different_keys() {
+        let fx = fx();
+        let kp_a = fx.rsa("rsa-label-a", RsaSpec::rs256());
+        let kp_b = fx.rsa("rsa-label-b", RsaSpec::rs256());
+
+        let key_a = kp_a.private_key_der_rustls();
+        let key_b = kp_b.private_key_der_rustls();
+        assert_ne!(key_a.secret_der(), key_b.secret_der());
+    }
+}
+
+// =========================================================================
+// ECDSA key conversion
+// =========================================================================
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_rustls {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    #[test]
+    fn ecdsa_p256_converts_to_pkcs8() {
+        let fx = fx();
+        let kp = fx.ecdsa("rustls-ec256", EcdsaSpec::es256());
+        let key = kp.private_key_der_rustls();
+
+        match &key {
+            PrivateKeyDer::Pkcs8(_) => {}
+            _ => panic!("expected PKCS#8 variant"),
+        }
+        assert_eq!(key.secret_der(), kp.private_key_pkcs8_der());
+    }
+
+    #[test]
+    fn ecdsa_p384_converts_to_pkcs8() {
+        let fx = fx();
+        let kp = fx.ecdsa("rustls-ec384", EcdsaSpec::es384());
+        let key = kp.private_key_der_rustls();
+
+        match &key {
+            PrivateKeyDer::Pkcs8(_) => {}
+            _ => panic!("expected PKCS#8 variant"),
+        }
+        assert_eq!(key.secret_der(), kp.private_key_pkcs8_der());
+    }
+
+    #[test]
+    fn ecdsa_deterministic_produces_same_rustls_key() {
+        let seed = Seed::from_env_value("rustls-ecdsa-det-test").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ecdsa("det-ec", EcdsaSpec::es256());
+        let kp2 = fx2.ecdsa("det-ec", EcdsaSpec::es256());
+
+        let key1 = kp1.private_key_der_rustls();
+        let key2 = kp2.private_key_der_rustls();
+        assert_eq!(key1.secret_der(), key2.secret_der());
+    }
+
+    #[test]
+    fn ecdsa_p256_and_p384_produce_different_keys() {
+        let fx = fx();
+        let kp_256 = fx.ecdsa("ec-curve-test", EcdsaSpec::es256());
+        let kp_384 = fx.ecdsa("ec-curve-test", EcdsaSpec::es384());
+
+        let key_256 = kp_256.private_key_der_rustls();
+        let key_384 = kp_384.private_key_der_rustls();
+        assert_ne!(key_256.secret_der(), key_384.secret_der());
+    }
+}
+
+// =========================================================================
+// Ed25519 key conversion
+// =========================================================================
+
+#[cfg(feature = "ed25519")]
+mod ed25519_rustls {
+    use super::*;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    #[test]
+    fn ed25519_converts_to_pkcs8() {
+        let fx = fx();
+        let kp = fx.ed25519("rustls-ed", Ed25519Spec::new());
+        let key = kp.private_key_der_rustls();
+
+        match &key {
+            PrivateKeyDer::Pkcs8(_) => {}
+            _ => panic!("expected PKCS#8 variant"),
+        }
+        assert_eq!(key.secret_der(), kp.private_key_pkcs8_der());
+    }
+
+    #[test]
+    fn ed25519_der_is_nonempty() {
+        let fx = fx();
+        let kp = fx.ed25519("rustls-ed-nonempty", Ed25519Spec::new());
+        let key = kp.private_key_der_rustls();
+        assert!(!key.secret_der().is_empty());
+    }
+
+    #[test]
+    fn ed25519_deterministic_produces_same_rustls_key() {
+        let seed = Seed::from_env_value("rustls-ed-det-test").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ed25519("det-ed", Ed25519Spec::new());
+        let kp2 = fx2.ed25519("det-ed", Ed25519Spec::new());
+
+        let key1 = kp1.private_key_der_rustls();
+        let key2 = kp2.private_key_der_rustls();
+        assert_eq!(key1.secret_der(), key2.secret_der());
+    }
+}
+
+// =========================================================================
+// X.509 chain TLS handshake integration
+// =========================================================================
+
+#[cfg(feature = "x509")]
+mod x509_tls_chain {
+    use super::*;
+    use uselesskey_rustls::{RustlsChainExt, RustlsClientConfigExt, RustlsServerConfigExt};
+    use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+    #[test]
+    fn chain_produces_leaf_plus_intermediate() {
+        let fx = fx();
+        let chain = fx.x509_chain("chain-len", ChainSpec::new("test.example.com"));
+        let certs = chain.chain_der_rustls();
+        assert_eq!(certs.len(), 2, "chain should have leaf + intermediate");
+    }
+
+    #[test]
+    fn chain_root_differs_from_leaf() {
+        let fx = fx();
+        let chain = fx.x509_chain("chain-diff", ChainSpec::new("test.example.com"));
+        let certs = chain.chain_der_rustls();
+        let root = chain.root_certificate_der_rustls();
+        assert_ne!(certs[0].as_ref(), root.as_ref());
+        assert_ne!(certs[1].as_ref(), root.as_ref());
+    }
+
+    #[test]
+    fn tls_handshake_succeeds_with_chain() {
+        install_provider();
+        let fx = fx();
+        let chain = fx.x509_chain("tls-ok", ChainSpec::new("test.example.com"));
+
+        let provider = ring_provider();
+        let server_config = Arc::new(chain.server_config_rustls_with_provider(provider.clone()));
+        let client_config = Arc::new(chain.client_config_rustls_with_provider(provider));
+
+        let server_name: rustls::pki_types::ServerName<'_> = "test.example.com".try_into().unwrap();
+        let mut server = rustls::ServerConnection::new(server_config).unwrap();
+        let mut client =
+            rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();
+
+        try_handshake(&mut server, &mut client).expect("handshake should succeed");
+        assert!(!client.is_handshaking());
+        assert!(!server.is_handshaking());
+    }
+
+    #[test]
+    fn self_signed_server_config_builds() {
+        install_provider();
+        let fx = fx();
+        let cert = fx.x509_self_signed("ss-build", X509Spec::self_signed("test.example.com"));
+        let _cfg = cert.server_config_rustls_with_provider(ring_provider());
+    }
+
+    #[test]
+    fn deterministic_chains_produce_same_handshake() {
+        install_provider();
+        let seed = Seed::from_env_value("rustls-chain-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let chain1 = fx1.x509_chain("det-chain", ChainSpec::new("test.example.com"));
+        let chain2 = fx2.x509_chain("det-chain", ChainSpec::new("test.example.com"));
+
+        assert_eq!(
+            chain1.leaf_cert_der(),
+            chain2.leaf_cert_der(),
+            "deterministic chains should produce identical leaf certs"
+        );
+        assert_eq!(
+            chain1.root_cert_der(),
+            chain2.root_cert_der(),
+            "deterministic chains should produce identical root certs"
+        );
+    }
+
+    #[test]
+    fn different_chains_fail_cross_verification() {
+        install_provider();
+        let fx = fx();
+        let chain_a = fx.x509_chain("cross-a", ChainSpec::new("test.example.com"));
+        let chain_b = fx.x509_chain("cross-b", ChainSpec::new("test.example.com"));
+
+        let provider = ring_provider();
+        let server_config = Arc::new(chain_a.server_config_rustls_with_provider(provider.clone()));
+        let client_config = Arc::new(chain_b.client_config_rustls_with_provider(provider));
+
+        let server_name: rustls::pki_types::ServerName<'_> = "test.example.com".try_into().unwrap();
+        let mut server = rustls::ServerConnection::new(server_config).unwrap();
+        let mut client =
+            rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();
+
+        let result = try_handshake(&mut server, &mut client);
+        assert!(
+            result.is_err(),
+            "cross-chain TLS handshake should fail (unknown CA)"
+        );
+    }
+}


### PR DESCRIPTION
Adds 51 integration tests across 3 adapter crates: rustls (17), ring (15), rustcrypto (19). Tests cover sign/verify round-trips, key conversion, TLS handshakes, determinism checks. All pass, clippy clean. No determinism/policy impact.