### PR TITLE
test: Wave 36 - cross-adapter interop test expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,16 +3659,25 @@ dependencies = [
 name = "uselesskey-interop-tests"
 version = "0.0.0"
 dependencies = [
+ "aws-lc-rs",
  "ed25519-dalek",
+ "hmac",
  "p256",
  "ring",
  "rsa",
+ "rustls",
  "sha2",
  "signature",
+ "uselesskey-aws-lc-rs",
  "uselesskey-core",
  "uselesskey-ecdsa",
  "uselesskey-ed25519",
+ "uselesskey-hmac",
+ "uselesskey-ring",
  "uselesskey-rsa",
+ "uselesskey-rustcrypto",
+ "uselesskey-rustls",
+ "uselesskey-x509",
 ]
 
 [[package]]

--- a/crates/uselesskey-interop-tests/Cargo.toml
+++ b/crates/uselesskey-interop-tests/Cargo.toml
@@ -6,6 +6,16 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[dependencies]
+# Adapter crates — optional, gated behind features
+uselesskey-ring = { path = "../uselesskey-ring", features = ["all"], optional = true }
+uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", features = ["all"], optional = true }
+uselesskey-aws-lc-rs = { path = "../uselesskey-aws-lc-rs", features = ["all"], optional = true }
+uselesskey-rustls = { path = "../uselesskey-rustls", features = ["tls-config", "all", "rustls-ring"], optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", optional = true }
+aws-lc-rs = { workspace = true, optional = true }
+
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core" }
 uselesskey-rsa = { path = "../uselesskey-rsa" }
@@ -19,3 +29,12 @@ ed25519-dalek = { workspace = true }
 rsa = { workspace = true }
 sha2 = { version = "0.10", features = ["oid"] }
 signature = "2"
+hmac = "0.12"
+rustls = { workspace = true }
+
+[features]
+default = []
+cross-signing = ["dep:uselesskey-ring", "dep:uselesskey-rustcrypto", "dep:uselesskey-hmac"]
+cross-tls = ["dep:uselesskey-x509", "dep:uselesskey-rustls"]
+aws-lc-rs-interop = ["dep:uselesskey-aws-lc-rs", "dep:aws-lc-rs", "uselesskey-rustls?/rustls-aws-lc-rs"]
+all = ["cross-signing", "cross-tls", "aws-lc-rs-interop"]

--- a/crates/uselesskey-interop-tests/build.rs
+++ b/crates/uselesskey-interop-tests/build.rs
@@ -1,0 +1,22 @@
+//! Build script for uselesskey-interop-tests.
+//!
+//! Checks for NASM availability so aws-lc-rs interop tests can be gated
+//! gracefully on Windows.
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(has_nasm)");
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-env-changed=PATH");
+
+    let nasm_available = Command::new("nasm")
+        .arg("-v")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+
+    if nasm_available {
+        println!("cargo::rustc-cfg=has_nasm");
+    }
+}

--- a/crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs
+++ b/crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs
@@ -1,0 +1,395 @@
+//! Cross-adapter signing interoperability tests.
+//!
+//! These tests sign with one crypto backend adapter and verify with another,
+//! confirming that uselesskey-generated keys produce compatible results across
+//! different libraries.
+
+#![cfg(feature = "cross-signing")]
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> &'static Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-cross-signing-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+}
+
+// =========================================================================
+// ASN.1 helpers
+// =========================================================================
+
+fn extract_public_key_from_spki(spki_der: &[u8]) -> &[u8] {
+    let (_, rest) = skip_tag_and_length(spki_der);
+    let (inner_len, rest) = skip_tag_and_length(rest);
+    let rest = &rest[inner_len..];
+    assert_eq!(rest[0], 0x03, "expected BIT STRING tag");
+    let (bit_string_len, rest) = skip_tag_and_length(rest);
+    assert_eq!(rest[0], 0x00, "expected 0 unused bits");
+    &rest[1..bit_string_len]
+}
+
+fn skip_tag_and_length(data: &[u8]) -> (usize, &[u8]) {
+    let data = &data[1..];
+    if data[0] & 0x80 == 0 {
+        let len = data[0] as usize;
+        (len, &data[1..])
+    } else {
+        let num_bytes = (data[0] & 0x7f) as usize;
+        let mut len: usize = 0;
+        for i in 0..num_bytes {
+            len = (len << 8) | (data[1 + i] as usize);
+        }
+        (len, &data[1 + num_bytes..])
+    }
+}
+
+// =========================================================================
+// RSA: ring ↔ RustCrypto
+// =========================================================================
+
+mod rsa_cross {
+    use super::*;
+    use ring::signature as ring_sig;
+    use rsa::pkcs1v15;
+    use rsa::signature::{SignatureEncoding, Signer, Verifier};
+    use sha2::Sha256;
+    use uselesskey_ring::RingRsaKeyPairExt;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    use uselesskey_rustcrypto::RustCryptoRsaExt;
+
+    #[test]
+    fn ring_sign_rustcrypto_verify() {
+        let fx = fx();
+        let keypair = fx.rsa("cross-rsa-r2rc", RsaSpec::rs256());
+
+        // Sign with ring
+        let ring_kp = keypair.rsa_key_pair_ring();
+        let rng = ring::rand::SystemRandom::new();
+        let msg = b"ring-to-rustcrypto RSA test";
+        let mut sig = vec![0u8; ring_kp.public().modulus_len()];
+        ring_kp
+            .sign(&ring_sig::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("ring sign");
+
+        // Verify with RustCrypto
+        let public_key = keypair.rsa_public_key();
+        let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(public_key);
+        let signature =
+            pkcs1v15::Signature::try_from(sig.as_slice()).expect("valid signature bytes");
+        verifying_key
+            .verify(msg, &signature)
+            .expect("rustcrypto should verify ring-signed RSA signature");
+    }
+
+    #[test]
+    fn rustcrypto_sign_ring_verify() {
+        let fx = fx();
+        let keypair = fx.rsa("cross-rsa-rc2r", RsaSpec::rs256());
+
+        // Sign with RustCrypto
+        let private_key = keypair.rsa_private_key();
+        let signing_key = pkcs1v15::SigningKey::<Sha256>::new(private_key);
+        let msg = b"rustcrypto-to-ring RSA test";
+        let sig = signing_key.sign(msg);
+
+        // Verify with ring
+        let raw_pubkey = extract_public_key_from_spki(keypair.public_key_spki_der());
+        let public_key =
+            ring_sig::UnparsedPublicKey::new(&ring_sig::RSA_PKCS1_2048_8192_SHA256, raw_pubkey);
+        public_key
+            .verify(msg, &sig.to_bytes())
+            .expect("ring should verify rustcrypto-signed RSA signature");
+    }
+}
+
+// =========================================================================
+// ECDSA P-256: ring ↔ RustCrypto
+// =========================================================================
+
+mod ecdsa_p256_cross {
+    use super::*;
+    use p256::ecdsa::signature::Verifier;
+    use ring::signature as ring_sig;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ring::RingEcdsaKeyPairExt;
+    use uselesskey_rustcrypto::RustCryptoEcdsaExt;
+
+    #[test]
+    fn ring_sign_rustcrypto_verify() {
+        let fx = fx();
+        let keypair = fx.ecdsa("cross-p256-r2rc", EcdsaSpec::es256());
+
+        // Sign with ring
+        let ring_kp = keypair.ecdsa_key_pair_ring();
+        let rng = ring::rand::SystemRandom::new();
+        let msg = b"ring-to-rustcrypto ECDSA P-256 test";
+        let sig = ring_kp.sign(&rng, msg).expect("ring sign");
+
+        // Verify with RustCrypto (p256)
+        let verifying_key = keypair.p256_verifying_key();
+        let der_sig =
+            p256::ecdsa::DerSignature::try_from(sig.as_ref()).expect("valid ASN.1 signature");
+        verifying_key
+            .verify(msg, &der_sig)
+            .expect("rustcrypto should verify ring-signed ECDSA P-256 signature");
+    }
+
+    #[test]
+    fn rustcrypto_sign_ring_verify() {
+        let fx = fx();
+        let keypair = fx.ecdsa("cross-p256-rc2r", EcdsaSpec::es256());
+
+        // Sign with RustCrypto (p256)
+        use p256::ecdsa::signature::Signer;
+        let signing_key = keypair.p256_signing_key();
+        let msg = b"rustcrypto-to-ring ECDSA P-256 test";
+        let sig: p256::ecdsa::DerSignature = signing_key.sign(msg);
+
+        // Verify with ring
+        let raw_pubkey = extract_public_key_from_spki(keypair.public_key_spki_der());
+        let public_key =
+            ring_sig::UnparsedPublicKey::new(&ring_sig::ECDSA_P256_SHA256_ASN1, raw_pubkey);
+        public_key
+            .verify(msg, sig.as_bytes())
+            .expect("ring should verify rustcrypto-signed ECDSA P-256 signature");
+    }
+}
+
+// =========================================================================
+// Ed25519: ring ↔ RustCrypto
+// =========================================================================
+
+mod ed25519_cross {
+    use super::*;
+    use ed25519_dalek::Verifier;
+    use ring::signature as ring_sig;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_ring::RingEd25519KeyPairExt;
+    use uselesskey_rustcrypto::RustCryptoEd25519Ext;
+
+    #[test]
+    fn ring_sign_rustcrypto_verify() {
+        let fx = fx();
+        let keypair = fx.ed25519("cross-ed25519-r2rc", Ed25519Spec::new());
+
+        // Sign with ring
+        let ring_kp = keypair.ed25519_key_pair_ring();
+        let msg = b"ring-to-rustcrypto Ed25519 test";
+        let sig = ring_kp.sign(msg);
+
+        // Verify with RustCrypto (ed25519-dalek)
+        let verifying_key = keypair.ed25519_verifying_key();
+        let dalek_sig =
+            ed25519_dalek::Signature::from_slice(sig.as_ref()).expect("valid 64-byte signature");
+        verifying_key
+            .verify(msg, &dalek_sig)
+            .expect("rustcrypto should verify ring-signed Ed25519 signature");
+    }
+
+    #[test]
+    fn rustcrypto_sign_ring_verify() {
+        let fx = fx();
+        let keypair = fx.ed25519("cross-ed25519-rc2r", Ed25519Spec::new());
+
+        // Sign with RustCrypto (ed25519-dalek)
+        use ed25519_dalek::Signer;
+        let signing_key = keypair.ed25519_signing_key();
+        let msg = b"rustcrypto-to-ring Ed25519 test";
+        let sig = signing_key.sign(msg);
+
+        // Verify with ring
+        let raw_pubkey = extract_public_key_from_spki(keypair.public_key_spki_der());
+        let public_key = ring_sig::UnparsedPublicKey::new(&ring_sig::ED25519, raw_pubkey);
+        public_key
+            .verify(msg, sig.to_bytes().as_ref())
+            .expect("ring should verify rustcrypto-signed Ed25519 signature");
+    }
+}
+
+// =========================================================================
+// aws-lc-rs → ring
+// =========================================================================
+
+#[cfg(all(feature = "aws-lc-rs-interop", any(not(windows), has_nasm)))]
+mod aws_lc_rs_to_ring {
+    use super::*;
+    use ring::signature as ring_sig;
+    use uselesskey_aws_lc_rs::{
+        AwsLcRsEcdsaKeyPairExt, AwsLcRsEd25519KeyPairExt, AwsLcRsRsaKeyPairExt,
+    };
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn rsa_aws_sign_ring_verify() {
+        let fx = fx();
+        let keypair = fx.rsa("cross-rsa-aws2r", RsaSpec::rs256());
+
+        // Sign with aws-lc-rs
+        let aws_kp = keypair.rsa_key_pair_aws_lc_rs();
+        let rng = aws_lc_rs::rand::SystemRandom::new();
+        let msg = b"aws-lc-rs-to-ring RSA test";
+        let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+        aws_kp
+            .sign(&aws_lc_rs::signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("aws sign");
+
+        // Verify with ring
+        let raw_pubkey = extract_public_key_from_spki(keypair.public_key_spki_der());
+        let public_key =
+            ring_sig::UnparsedPublicKey::new(&ring_sig::RSA_PKCS1_2048_8192_SHA256, raw_pubkey);
+        public_key
+            .verify(msg, &sig)
+            .expect("ring should verify aws-lc-rs-signed RSA signature");
+    }
+
+    #[test]
+    fn ecdsa_p256_aws_sign_ring_verify() {
+        let fx = fx();
+        let keypair = fx.ecdsa("cross-p256-aws2r", EcdsaSpec::es256());
+
+        // Sign with aws-lc-rs
+        let aws_kp = keypair.ecdsa_key_pair_aws_lc_rs();
+        let rng = aws_lc_rs::rand::SystemRandom::new();
+        let msg = b"aws-lc-rs-to-ring ECDSA P-256 test";
+        let sig = aws_kp.sign(&rng, msg).expect("aws sign");
+
+        // Verify with ring
+        let raw_pubkey = extract_public_key_from_spki(keypair.public_key_spki_der());
+        let public_key =
+            ring_sig::UnparsedPublicKey::new(&ring_sig::ECDSA_P256_SHA256_ASN1, raw_pubkey);
+        public_key
+            .verify(msg, sig.as_ref())
+            .expect("ring should verify aws-lc-rs-signed ECDSA P-256 signature");
+    }
+
+    #[test]
+    fn ed25519_aws_sign_ring_verify() {
+        let fx = fx();
+        let keypair = fx.ed25519("cross-ed25519-aws2r", Ed25519Spec::new());
+
+        // Sign with aws-lc-rs
+        let aws_kp = keypair.ed25519_key_pair_aws_lc_rs();
+        let msg = b"aws-lc-rs-to-ring Ed25519 test";
+        let sig = aws_kp.sign(msg);
+
+        // Verify with ring
+        let raw_pubkey = extract_public_key_from_spki(keypair.public_key_spki_der());
+        let public_key = ring_sig::UnparsedPublicKey::new(&ring_sig::ED25519, raw_pubkey);
+        public_key
+            .verify(msg, sig.as_ref())
+            .expect("ring should verify aws-lc-rs-signed Ed25519 signature");
+    }
+}
+
+// =========================================================================
+// HMAC: ring ↔ RustCrypto
+// =========================================================================
+
+mod hmac_cross {
+    use super::*;
+    use hmac::Mac;
+    use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    use uselesskey_rustcrypto::RustCryptoHmacExt;
+
+    #[test]
+    fn ring_tag_rustcrypto_verify_sha256() {
+        let fx = fx();
+        let secret = fx.hmac("cross-hmac-256-r2rc", HmacSpec::hs256());
+
+        // Tag with ring
+        let ring_key = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, secret.secret_bytes());
+        let msg = b"ring-to-rustcrypto HMAC-SHA256 test";
+        let ring_tag = ring::hmac::sign(&ring_key, msg);
+
+        // Verify with RustCrypto
+        let mut mac = secret.hmac_sha256();
+        mac.update(msg);
+        mac.verify_slice(ring_tag.as_ref())
+            .expect("rustcrypto should verify ring HMAC-SHA256 tag");
+    }
+
+    #[test]
+    fn rustcrypto_tag_ring_verify_sha256() {
+        let fx = fx();
+        let secret = fx.hmac("cross-hmac-256-rc2r", HmacSpec::hs256());
+
+        // Tag with RustCrypto
+        let mut mac = secret.hmac_sha256();
+        let msg = b"rustcrypto-to-ring HMAC-SHA256 test";
+        mac.update(msg);
+        let tag = mac.finalize().into_bytes();
+
+        // Verify with ring
+        let ring_key = ring::hmac::Key::new(ring::hmac::HMAC_SHA256, secret.secret_bytes());
+        ring::hmac::verify(&ring_key, msg, &tag)
+            .expect("ring should verify rustcrypto HMAC-SHA256 tag");
+    }
+
+    #[test]
+    fn ring_tag_rustcrypto_verify_sha384() {
+        let fx = fx();
+        let secret = fx.hmac("cross-hmac-384-r2rc", HmacSpec::hs384());
+
+        let ring_key = ring::hmac::Key::new(ring::hmac::HMAC_SHA384, secret.secret_bytes());
+        let msg = b"ring-to-rustcrypto HMAC-SHA384 test";
+        let ring_tag = ring::hmac::sign(&ring_key, msg);
+
+        let mut mac = secret.hmac_sha384();
+        mac.update(msg);
+        mac.verify_slice(ring_tag.as_ref())
+            .expect("rustcrypto should verify ring HMAC-SHA384 tag");
+    }
+
+    #[test]
+    fn rustcrypto_tag_ring_verify_sha384() {
+        let fx = fx();
+        let secret = fx.hmac("cross-hmac-384-rc2r", HmacSpec::hs384());
+
+        let mut mac = secret.hmac_sha384();
+        let msg = b"rustcrypto-to-ring HMAC-SHA384 test";
+        mac.update(msg);
+        let tag = mac.finalize().into_bytes();
+
+        let ring_key = ring::hmac::Key::new(ring::hmac::HMAC_SHA384, secret.secret_bytes());
+        ring::hmac::verify(&ring_key, msg, &tag)
+            .expect("ring should verify rustcrypto HMAC-SHA384 tag");
+    }
+
+    #[test]
+    fn ring_tag_rustcrypto_verify_sha512() {
+        let fx = fx();
+        let secret = fx.hmac("cross-hmac-512-r2rc", HmacSpec::hs512());
+
+        let ring_key = ring::hmac::Key::new(ring::hmac::HMAC_SHA512, secret.secret_bytes());
+        let msg = b"ring-to-rustcrypto HMAC-SHA512 test";
+        let ring_tag = ring::hmac::sign(&ring_key, msg);
+
+        let mut mac = secret.hmac_sha512();
+        mac.update(msg);
+        mac.verify_slice(ring_tag.as_ref())
+            .expect("rustcrypto should verify ring HMAC-SHA512 tag");
+    }
+
+    #[test]
+    fn rustcrypto_tag_ring_verify_sha512() {
+        let fx = fx();
+        let secret = fx.hmac("cross-hmac-512-rc2r", HmacSpec::hs512());
+
+        let mut mac = secret.hmac_sha512();
+        let msg = b"rustcrypto-to-ring HMAC-SHA512 test";
+        mac.update(msg);
+        let tag = mac.finalize().into_bytes();
+
+        let ring_key = ring::hmac::Key::new(ring::hmac::HMAC_SHA512, secret.secret_bytes());
+        ring::hmac::verify(&ring_key, msg, &tag)
+            .expect("ring should verify rustcrypto HMAC-SHA512 tag");
+    }
+}

--- a/crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs
+++ b/crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs
@@ -1,0 +1,189 @@
+//! Cross-adapter TLS interoperability tests.
+//!
+//! These tests create X.509 certificates with uselesskey-x509 and verify they
+//! work for TLS handshakes with different crypto providers.
+
+#![cfg(feature = "cross-tls")]
+
+use std::sync::{Arc, OnceLock};
+
+use uselesskey_core::{Factory, Seed};
+use uselesskey_rustls::{RustlsClientConfigExt, RustlsServerConfigExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> &'static Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-cross-tls-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+}
+
+const MAX_HANDSHAKE_ITERATIONS: usize = 10;
+
+/// Drive a TLS handshake to completion by exchanging bytes between client and
+/// server until neither side needs to write.
+fn complete_handshake(
+    client: &mut rustls::ClientConnection,
+    server: &mut rustls::ServerConnection,
+) {
+    let mut buf = Vec::new();
+    for iteration in 0..MAX_HANDSHAKE_ITERATIONS {
+        let mut progress = false;
+
+        buf.clear();
+        if client.wants_write() {
+            client.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                server.read_tls(&mut &buf[..]).unwrap();
+                server.process_new_packets().unwrap();
+                progress = true;
+            }
+        }
+
+        buf.clear();
+        if server.wants_write() {
+            server.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                client.read_tls(&mut &buf[..]).unwrap();
+                client.process_new_packets().unwrap();
+                progress = true;
+            }
+        }
+
+        if !progress {
+            break;
+        }
+
+        assert!(
+            iteration < MAX_HANDSHAKE_ITERATIONS - 1,
+            "TLS handshake did not complete within {MAX_HANDSHAKE_ITERATIONS} iterations",
+        );
+    }
+
+    assert!(!client.is_handshaking());
+    assert!(!server.is_handshaking());
+}
+
+// =========================================================================
+// TLS with the ring crypto provider
+// =========================================================================
+
+mod ring_provider {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    fn ring_provider() -> Arc<rustls::crypto::CryptoProvider> {
+        Arc::new(rustls::crypto::ring::default_provider())
+    }
+
+    #[test]
+    fn tls_handshake_chain() {
+        let fx = fx();
+        let chain = fx.x509_chain("tls-ring-chain", ChainSpec::new("ring.example.com"));
+
+        let provider = ring_provider();
+        let server_config = Arc::new(chain.server_config_rustls_with_provider(provider.clone()));
+        let client_config = Arc::new(chain.client_config_rustls_with_provider(provider));
+
+        let server_name = "ring.example.com".try_into().unwrap();
+        let mut server = rustls::ServerConnection::new(server_config).unwrap();
+        let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();
+
+        complete_handshake(&mut client, &mut server);
+    }
+
+    #[test]
+    fn ring_accepts_uselesskey_rsa_key() {
+        let fx = fx();
+        let keypair = fx.rsa("tls-ring-rsa", RsaSpec::rs256());
+        let _ring_kp = ring::rsa::KeyPair::from_pkcs8(keypair.private_key_pkcs8_der())
+            .expect("ring should accept uselesskey RSA key");
+    }
+
+    #[test]
+    fn ring_accepts_uselesskey_ecdsa_key() {
+        let fx = fx();
+        let keypair = fx.ecdsa("tls-ring-ecdsa", EcdsaSpec::es256());
+        let _ring_kp = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
+            keypair.private_key_pkcs8_der(),
+            &ring::rand::SystemRandom::new(),
+        )
+        .expect("ring should accept uselesskey ECDSA key");
+    }
+
+    #[test]
+    fn ring_accepts_uselesskey_ed25519_key() {
+        let fx = fx();
+        let keypair = fx.ed25519("tls-ring-ed25519", Ed25519Spec::new());
+        let _ring_kp = ring::signature::Ed25519KeyPair::from_pkcs8_maybe_unchecked(
+            keypair.private_key_pkcs8_der(),
+        )
+        .expect("ring should accept uselesskey Ed25519 key");
+    }
+}
+
+// =========================================================================
+// TLS with the aws-lc-rs crypto provider
+// =========================================================================
+
+#[cfg(all(feature = "aws-lc-rs-interop", any(not(windows), has_nasm)))]
+mod aws_lc_rs_provider {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    fn aws_provider() -> Arc<rustls::crypto::CryptoProvider> {
+        Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+    }
+
+    #[test]
+    fn tls_handshake_chain() {
+        let fx = fx();
+        let chain = fx.x509_chain("tls-aws-chain", ChainSpec::new("aws.example.com"));
+
+        let provider = aws_provider();
+        let server_config = Arc::new(chain.server_config_rustls_with_provider(provider.clone()));
+        let client_config = Arc::new(chain.client_config_rustls_with_provider(provider));
+
+        let server_name = "aws.example.com".try_into().unwrap();
+        let mut server = rustls::ServerConnection::new(server_config).unwrap();
+        let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();
+
+        complete_handshake(&mut client, &mut server);
+    }
+
+    #[test]
+    fn aws_lc_rs_accepts_uselesskey_rsa_key() {
+        let fx = fx();
+        let keypair = fx.rsa("tls-aws-rsa", RsaSpec::rs256());
+        let _aws_kp = aws_lc_rs::rsa::KeyPair::from_pkcs8(keypair.private_key_pkcs8_der())
+            .expect("aws-lc-rs should accept uselesskey RSA key");
+    }
+
+    #[test]
+    fn aws_lc_rs_accepts_uselesskey_ecdsa_key() {
+        let fx = fx();
+        let keypair = fx.ecdsa("tls-aws-ecdsa", EcdsaSpec::es256());
+        let _aws_kp = aws_lc_rs::signature::EcdsaKeyPair::from_pkcs8(
+            &aws_lc_rs::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
+            keypair.private_key_pkcs8_der(),
+        )
+        .expect("aws-lc-rs should accept uselesskey ECDSA key");
+    }
+
+    #[test]
+    fn aws_lc_rs_accepts_uselesskey_ed25519_key() {
+        let fx = fx();
+        let keypair = fx.ed25519("tls-aws-ed25519", Ed25519Spec::new());
+        let _aws_kp =
+            aws_lc_rs::signature::Ed25519KeyPair::from_pkcs8(keypair.private_key_pkcs8_der())
+                .expect("aws-lc-rs should accept uselesskey Ed25519 key");
+    }
+}


### PR DESCRIPTION
Adds cross-adapter interop tests for sign/verify and TLS.