### PR TITLE
docs: improve sub-crate READMEs and lib.rs docs for crates.io readiness

### DIFF
--- a/crates/uselesskey-aws-lc-rs/README.md
+++ b/crates/uselesskey-aws-lc-rs/README.md
@@ -37,6 +37,8 @@ assert!(keypair.public_modulus_len() > 0);
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-core-cache/README.md
+++ b/crates/uselesskey-core-cache/README.md
@@ -20,4 +20,8 @@ This microcrate is intentionally focused on cache mechanics, not derivation or k
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-core/README.md
+++ b/crates/uselesskey-core/README.md
@@ -1,8 +1,16 @@
 # uselesskey-core
 
-Core factory, deterministic derivation, and cache primitives for `uselesskey` test fixtures.
+[![Crates.io](https://img.shields.io/crates/v/uselesskey-core.svg)](https://crates.io/crates/uselesskey-core)
+[![docs.rs](https://docs.rs/uselesskey-core/badge.svg)](https://docs.rs/uselesskey-core)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
-Most test suites should depend on the facade crate (`uselesskey`). Use `uselesskey-core` directly when building extension crates.
+Core factory, deterministic derivation, and cache primitives for
+[`uselesskey`](https://crates.io/crates/uselesskey) test fixtures.
+
+Most test suites should depend on the **facade crate**
+([`uselesskey`](https://crates.io/crates/uselesskey)). Use `uselesskey-core`
+directly when building extension crates or when you need only the core
+primitives.
 
 ## What It Provides
 
@@ -24,12 +32,20 @@ Most test suites should depend on the facade crate (`uselesskey`). Use `uselessk
 ```rust
 use uselesskey_core::{Factory, Mode, Seed};
 
+// Deterministic mode: same seed always produces the same artifacts
 let seed = Seed::from_env_value("ci-seed").unwrap();
 let fx = Factory::deterministic(seed);
 
 assert!(matches!(fx.mode(), Mode::Deterministic { .. }));
+
+// Random mode: different keys each run (still cached per-process)
+let fx = Factory::random();
 ```
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
+
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-ecdsa/README.md
+++ b/crates/uselesskey-ecdsa/README.md
@@ -61,8 +61,8 @@ let mismatch  = keypair.mismatched_public_key_spki_der();
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or
-[MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
 See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
 documentation.

--- a/crates/uselesskey-ed25519/README.md
+++ b/crates/uselesskey-ed25519/README.md
@@ -54,8 +54,8 @@ let mismatch  = keypair.mismatched_public_key_spki_der();
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or
-[MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
 See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
 documentation.

--- a/crates/uselesskey-hmac/README.md
+++ b/crates/uselesskey-hmac/README.md
@@ -1,16 +1,17 @@
 # uselesskey-hmac
 
-HMAC secret fixtures for `uselesskey` test suites.
+[![Crates.io](https://img.shields.io/crates/v/uselesskey-hmac.svg)](https://crates.io/crates/uselesskey-hmac)
+[![docs.rs](https://docs.rs/uselesskey-hmac/badge.svg)](https://docs.rs/uselesskey-hmac)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
-Generates deterministic or random symmetric secrets for HS256, HS384, and HS512 tests.
+HMAC secret fixtures for testing — generates deterministic or random symmetric
+secrets for HS256, HS384, and HS512 workflows.
 
-## Features
+Part of the [`uselesskey`](https://crates.io/crates/uselesskey) workspace. Use
+the facade crate for the simplest experience, or depend on this crate directly
+for minimal compile time.
 
-| Feature | Description |
-|---------|-------------|
-| `jwk` | Octet JWK/JWKS output via `uselesskey-jwk` |
-
-## Example
+## Usage
 
 ```rust
 use uselesskey_core::Factory;
@@ -22,8 +23,39 @@ let secret = fx.hmac("issuer", HmacSpec::hs256());
 assert_eq!(secret.secret_bytes().len(), 32);
 ```
 
+### Specs
+
+| Constructor | Algorithm | Secret Length |
+|-------------|-----------|--------------|
+| `HmacSpec::hs256()` | HMAC-SHA256 | 32 bytes |
+| `HmacSpec::hs384()` | HMAC-SHA384 | 48 bytes |
+| `HmacSpec::hs512()` | HMAC-SHA512 | 64 bytes |
+
+### Deterministic Mode
+
+```rust
+use uselesskey_core::{Factory, Seed};
+use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+
+let seed = Seed::from_env_value("test-seed").unwrap();
+let fx = Factory::deterministic(seed);
+
+// Same seed + label + spec = same secret
+let s1 = fx.hmac("issuer", HmacSpec::hs384());
+let s2 = fx.hmac("issuer", HmacSpec::hs384());
+assert_eq!(s1.secret_bytes(), s2.secret_bytes());
+```
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| `jwk` | Octet JWK/JWKS output via `uselesskey-jwk` |
+
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-jsonwebtoken/README.md
+++ b/crates/uselesskey-jsonwebtoken/README.md
@@ -1,8 +1,14 @@
 # uselesskey-jsonwebtoken
 
-`jsonwebtoken` adapter traits for `uselesskey` fixtures.
+[![Crates.io](https://img.shields.io/crates/v/uselesskey-jsonwebtoken.svg)](https://crates.io/crates/uselesskey-jsonwebtoken)
+[![docs.rs](https://docs.rs/uselesskey-jsonwebtoken/badge.svg)](https://docs.rs/uselesskey-jsonwebtoken)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
-Implements `JwtKeyExt` so fixture types return `jsonwebtoken::EncodingKey` and `jsonwebtoken::DecodingKey` directly.
+[`jsonwebtoken`](https://crates.io/crates/jsonwebtoken) adapter for
+[`uselesskey`](https://crates.io/crates/uselesskey) test fixtures.
+
+Implements `JwtKeyExt` so fixture types return `jsonwebtoken::EncodingKey` and
+`jsonwebtoken::DecodingKey` directly — no manual PEM parsing needed in tests.
 
 ## Features
 
@@ -14,7 +20,7 @@ Implements `JwtKeyExt` so fixture types return `jsonwebtoken::EncodingKey` and `
 | `hmac` | HMAC secrets (HS256/HS384/HS512) |
 | `all` | All key types |
 
-## Example
+## Usage
 
 ```toml
 [dev-dependencies]
@@ -47,6 +53,8 @@ assert_eq!(decoded.claims, claims);
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-jwk/README.md
+++ b/crates/uselesskey-jwk/README.md
@@ -25,6 +25,8 @@ assert_eq!(jwks.keys.len(), 1);
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-pgp/README.md
+++ b/crates/uselesskey-pgp/README.md
@@ -24,6 +24,8 @@ Use this crate for test fixtures only, not production key management.
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-ring/README.md
+++ b/crates/uselesskey-ring/README.md
@@ -34,6 +34,8 @@ assert!(keypair.public().modulus_len() > 0);
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-rsa/README.md
+++ b/crates/uselesskey-rsa/README.md
@@ -61,8 +61,8 @@ let mismatch  = rsa.mismatched_public_key_spki_der();
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or
-[MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
 See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
 documentation.

--- a/crates/uselesskey-rustcrypto/README.md
+++ b/crates/uselesskey-rustcrypto/README.md
@@ -41,6 +41,8 @@ verifying_key.verify(b"hello", &signature).unwrap();
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-rustls/README.md
+++ b/crates/uselesskey-rustls/README.md
@@ -1,17 +1,24 @@
 # uselesskey-rustls
 
-`rustls-pki-types` and `rustls` config adapters for `uselesskey` fixtures.
+[![Crates.io](https://img.shields.io/crates/v/uselesskey-rustls.svg)](https://crates.io/crates/uselesskey-rustls)
+[![docs.rs](https://docs.rs/uselesskey-rustls/badge.svg)](https://docs.rs/uselesskey-rustls)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 
-Converts fixture certs and keys into `CertificateDer` / `PrivateKeyDer`, with optional server/client/mTLS config builders.
+[`rustls`](https://crates.io/crates/rustls) /
+[`rustls-pki-types`](https://crates.io/crates/rustls-pki-types) adapter for
+[`uselesskey`](https://crates.io/crates/uselesskey) test fixtures.
+
+Converts fixture certs and keys into `CertificateDer` / `PrivateKeyDer`, with
+optional `ServerConfig` / `ClientConfig` builders (including mTLS support).
 
 ## Features
 
 | Feature | Description |
 |---------|-------------|
 | `x509` (default) | X.509 cert and chain conversions |
-| `rsa` | RSA keypairs -> `PrivateKeyDer` |
-| `ecdsa` | ECDSA keypairs -> `PrivateKeyDer` |
-| `ed25519` | Ed25519 keypairs -> `PrivateKeyDer` |
+| `rsa` | RSA keypairs → `PrivateKeyDer` |
+| `ecdsa` | ECDSA keypairs → `PrivateKeyDer` |
+| `ed25519` | Ed25519 keypairs → `PrivateKeyDer` |
 | `all` | All key conversion traits |
 | `server-config` | `rustls::ServerConfig` builders |
 | `client-config` | `rustls::ClientConfig` builders |
@@ -19,7 +26,7 @@ Converts fixture certs and keys into `CertificateDer` / `PrivateKeyDer`, with op
 | `rustls-ring` | ring crypto provider integration |
 | `rustls-aws-lc-rs` | aws-lc-rs crypto provider integration |
 
-## Example
+## Usage
 
 ```toml
 [dev-dependencies]
@@ -42,6 +49,8 @@ let _ = (server, client);
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-token/README.md
+++ b/crates/uselesskey-token/README.md
@@ -1,8 +1,17 @@
 # uselesskey-token
 
+[![Crates.io](https://img.shields.io/crates/v/uselesskey-token.svg)](https://crates.io/crates/uselesskey-token)
+[![docs.rs](https://docs.rs/uselesskey-token/badge.svg)](https://docs.rs/uselesskey-token)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+
 Token-shaped fixtures for tests, built on `uselesskey-core`.
 
-Generates deterministic or random token strings so authorization code paths can be tested without committing secret-looking blobs.
+Generates deterministic or random token strings so authorization code paths can
+be tested without committing secret-looking blobs.
+
+Part of the [`uselesskey`](https://crates.io/crates/uselesskey) workspace. Use
+the facade crate for the simplest experience, or depend on this crate directly
+for minimal compile time.
 
 ## What It Provides
 
@@ -10,7 +19,7 @@ Generates deterministic or random token strings so authorization code paths can 
 - Opaque bearer tokens: base64url data
 - OAuth access tokens in JWT shape: `header.payload.signature`
 
-## Example
+## Usage
 
 ```rust
 use uselesskey_core::Factory;
@@ -27,8 +36,25 @@ assert!(bearer.authorization_header().starts_with("Bearer "));
 assert_eq!(oauth.value().split('.').count(), 3);
 ```
 
+### Deterministic Mode
+
+```rust
+use uselesskey_core::{Factory, Seed};
+use uselesskey_token::{TokenFactoryExt, TokenSpec};
+
+let seed = Seed::from_env_value("test-seed").unwrap();
+let fx = Factory::deterministic(seed);
+
+// Same seed + label + spec = same token
+let t1 = fx.token("billing", TokenSpec::api_key());
+let t2 = fx.token("billing", TokenSpec::api_key());
+assert_eq!(t1.value(), t2.value());
+```
+
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-token/src/lib.rs
+++ b/crates/uselesskey-token/src/lib.rs
@@ -5,10 +5,13 @@
 //! This crate generates realistic test-token shapes without committing
 //! secret-looking blobs to version control.
 //!
+//! Most users should depend on the [`uselesskey`](https://crates.io/crates/uselesskey)
+//! facade crate, which re-exports this crate's types behind the `token` feature flag.
+//!
 //! Supported token kinds:
-//! - API key style tokens
-//! - Opaque bearer tokens
-//! - OAuth-style JWT access tokens
+//! - API key style tokens (`uk_test_<base62>`)
+//! - Opaque bearer tokens (base64url)
+//! - OAuth-style JWT access tokens (`header.payload.signature`)
 //!
 //! # Examples
 //!
@@ -20,6 +23,27 @@
 //! let tok = fx.token("api-key", TokenSpec::api_key());
 //! let value = tok.value();
 //! assert!(!value.is_empty());
+//! ```
+//!
+//! # Deterministic Mode
+//!
+//! Use deterministic mode for reproducible test fixtures:
+//!
+//! ```
+//! use uselesskey_core::{Factory, Seed};
+//! use uselesskey_token::{TokenFactoryExt, TokenSpec};
+//!
+//! let seed = Seed::from_env_value("test-seed").unwrap();
+//! let fx = Factory::deterministic(seed);
+//!
+//! // Same seed + label + spec = same token
+//! let t1 = fx.token("billing", TokenSpec::api_key());
+//! let t2 = fx.token("billing", TokenSpec::api_key());
+//! assert_eq!(t1.value(), t2.value());
+//!
+//! // Different labels produce different tokens
+//! let t3 = fx.token("other", TokenSpec::api_key());
+//! assert_ne!(t1.value(), t3.value());
 //! ```
 
 mod spec;

--- a/crates/uselesskey-tonic/README.md
+++ b/crates/uselesskey-tonic/README.md
@@ -40,6 +40,8 @@ let _ = (server_tls, client_tls);
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or [MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
-See the [main uselesskey README](../../README.md) for full documentation.
+See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
+documentation.

--- a/crates/uselesskey-x509/README.md
+++ b/crates/uselesskey-x509/README.md
@@ -79,8 +79,8 @@ let crl_pem = revoked.crl_pem().expect("CRL present for revoked variant");
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or
-[MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.
 
 See the [`uselesskey` crate](https://crates.io/crates/uselesskey) for full
 documentation.

--- a/crates/uselesskey/README.md
+++ b/crates/uselesskey/README.md
@@ -167,5 +167,5 @@ on the implementation crate directly:
 
 ## License
 
-Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or
-[MIT license](../../LICENSE-MIT) at your option.
+Licensed under either of [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT license](https://opensource.org/licenses/MIT) at your option.


### PR DESCRIPTION
## Summary

Improve README and crate-level documentation across 18 sub-crates for crates.io readiness.

### Changes

**Badge additions** (5 priority crates):
- Added crates.io/docs.rs/license badges to: `uselesskey-core`, `uselesskey-hmac`, `uselesskey-token`, `uselesskey-jsonwebtoken`, `uselesskey-rustls`

**Broken link fixes** (18 crates):
- Replaced all `../../LICENSE-APACHE` and `../../LICENSE-MIT` relative links with absolute URLs — relative links don't resolve on crates.io
- Replaced `../../README.md` references with links to the `uselesskey` crate on crates.io

**Content improvements**:
- `uselesskey-core` README: Added badges, expanded example with random mode, added workspace link
- `uselesskey-hmac` README: Added badges, specs table, deterministic mode example, workspace context
- `uselesskey-token` README: Added badges, deterministic mode example, workspace context
- `uselesskey-token` lib.rs: Added deterministic mode doc example, facade crate link, token format details
- `uselesskey-jsonwebtoken` README: Added badges, expanded description, workspace link
- `uselesskey-rustls` README: Added badges, improved feature table with arrows, workspace link

### Verification

- `cargo doc --workspace --all-features --no-deps` builds cleanly (no warnings)
- `cargo fmt` applied
- No code changes — documentation only
