### PR TITLE
fuzz: expand fuzz targets for under-fuzzed code paths

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ rand_chacha = "0.3.1"
 blake3 = "1.8.3"
 
 # fuzz targets
-uselesskey = { path = "../crates/uselesskey", features = ["ecdsa", "token"] }
+uselesskey = { path = "../crates/uselesskey", features = ["ecdsa", "ed25519", "hmac", "token", "x509"] }
 uselesskey-jwk = { path = "../crates/uselesskey-jwk" }
 uselesskey-core-jwks-order = { path = "../crates/uselesskey-core-jwks-order" }
 uselesskey-core-keypair-material = { path = "../crates/uselesskey-core-keypair-material" }
@@ -27,8 +27,13 @@ uselesskey-core-x509-negative = { path = "../crates/uselesskey-core-x509-negativ
 uselesskey-core-x509-spec = { path = "../crates/uselesskey-core-x509-spec" }
 uselesskey-core-token-shape = { path = "../crates/uselesskey-core-token-shape" }
 uselesskey-core-jwk-shape = { path = "../crates/uselesskey-core-jwk-shape" }
+uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa" }
+uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519" }
+uselesskey-hmac = { path = "../crates/uselesskey-hmac" }
+uselesskey-x509 = { path = "../crates/uselesskey-x509" }
 rsa = { version = "0.9", features = ["pem"] }
 p256 = { version = "0.13", features = ["ecdsa", "pkcs8", "pem"] }
+ed25519-dalek = { version = "2", features = ["pkcs8"] }
 serde_json = "1"
 
 [[bin]]
@@ -160,5 +165,47 @@ doc = false
 [[bin]]
 name = "jwks_builder"
 path = "fuzz_targets/jwks_builder.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_ecdsa_keygen"
+path = "fuzz_targets/fuzz_ecdsa_keygen.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_ed25519_keygen"
+path = "fuzz_targets/fuzz_ed25519_keygen.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_hmac_keygen"
+path = "fuzz_targets/fuzz_hmac_keygen.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_x509_cert"
+path = "fuzz_targets/fuzz_x509_cert.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_negative_fixtures"
+path = "fuzz_targets/fuzz_negative_fixtures.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_derivation_stability"
+path = "fuzz_targets/fuzz_derivation_stability.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_token_generation"
+path = "fuzz_targets/fuzz_token_generation.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/fuzz_derivation_stability.rs
+++ b/fuzz/fuzz_targets/fuzz_derivation_stability.rs
@@ -1,0 +1,90 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{
+    EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, HmacFactoryExt,
+    HmacSpec, Seed, TokenFactoryExt, TokenSpec,
+};
+
+/// Verify that generating multiple key types on the same Factory
+/// does not perturb each other's outputs regardless of call order.
+#[derive(Arbitrary, Debug)]
+struct StabilityInput {
+    seed: [u8; 32],
+    label_a: String,
+    label_b: String,
+    /// Controls call order: each bit selects which key type to generate first.
+    order_bits: u8,
+}
+
+fuzz_target!(|input: StabilityInput| {
+    // Limit label lengths to keep execution bounded.
+    if input.label_a.len() > 128 || input.label_b.len() > 128 {
+        return;
+    }
+
+    let seed = Seed::new(input.seed);
+
+    // --- Pass 1: generate in one order ---
+    let fx1 = Factory::deterministic(seed.clone());
+    let results_1 = if input.order_bits & 1 == 0 {
+        generate_forward(&fx1, &input.label_a, &input.label_b)
+    } else {
+        generate_reverse(&fx1, &input.label_a, &input.label_b)
+    };
+
+    // --- Pass 2: generate in the opposite order ---
+    let fx2 = Factory::deterministic(seed);
+    let results_2 = if input.order_bits & 1 == 0 {
+        generate_reverse(&fx2, &input.label_a, &input.label_b)
+    } else {
+        generate_forward(&fx2, &input.label_a, &input.label_b)
+    };
+
+    // All artifacts must be identical regardless of generation order.
+    assert_eq!(results_1.ecdsa_pem, results_2.ecdsa_pem, "ECDSA mismatch");
+    assert_eq!(
+        results_1.ed25519_pem, results_2.ed25519_pem,
+        "Ed25519 mismatch"
+    );
+    assert_eq!(results_1.hmac_bytes, results_2.hmac_bytes, "HMAC mismatch");
+    assert_eq!(
+        results_1.token_value, results_2.token_value,
+        "Token mismatch"
+    );
+});
+
+struct Results {
+    ecdsa_pem: String,
+    ed25519_pem: String,
+    hmac_bytes: Vec<u8>,
+    token_value: String,
+}
+
+fn generate_forward(fx: &Factory, label_a: &str, label_b: &str) -> Results {
+    let ec = fx.ecdsa(label_a, EcdsaSpec::es256());
+    let ed = fx.ed25519(label_b, Ed25519Spec::new());
+    let hm = fx.hmac(label_a, HmacSpec::hs256());
+    let tok = fx.token(label_b, TokenSpec::bearer());
+    Results {
+        ecdsa_pem: ec.private_key_pkcs8_pem().to_string(),
+        ed25519_pem: ed.private_key_pkcs8_pem().to_string(),
+        hmac_bytes: hm.secret_bytes().to_vec(),
+        token_value: tok.value().to_string(),
+    }
+}
+
+fn generate_reverse(fx: &Factory, label_a: &str, label_b: &str) -> Results {
+    let tok = fx.token(label_b, TokenSpec::bearer());
+    let hm = fx.hmac(label_a, HmacSpec::hs256());
+    let ed = fx.ed25519(label_b, Ed25519Spec::new());
+    let ec = fx.ecdsa(label_a, EcdsaSpec::es256());
+    Results {
+        ecdsa_pem: ec.private_key_pkcs8_pem().to_string(),
+        ed25519_pem: ed.private_key_pkcs8_pem().to_string(),
+        hmac_bytes: hm.secret_bytes().to_vec(),
+        token_value: tok.value().to_string(),
+    }
+}

--- a/fuzz/fuzz_targets/fuzz_ecdsa_keygen.rs
+++ b/fuzz/fuzz_targets/fuzz_ecdsa_keygen.rs
@@ -1,0 +1,60 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{EcdsaFactoryExt, EcdsaSpec, Factory, Seed};
+
+#[derive(Arbitrary, Debug)]
+struct EcdsaInput {
+    seed: [u8; 32],
+    label: String,
+    use_es384: bool,
+}
+
+fuzz_target!(|input: EcdsaInput| {
+    let fx = Factory::deterministic(Seed::new(input.seed));
+    let spec = if input.use_es384 {
+        EcdsaSpec::es384()
+    } else {
+        EcdsaSpec::es256()
+    };
+
+    let kp = fx.ecdsa(&input.label, spec);
+
+    // Private key PEM must have correct envelope
+    let priv_pem = kp.private_key_pkcs8_pem();
+    assert!(
+        priv_pem.starts_with("-----BEGIN PRIVATE KEY-----"),
+        "bad private PEM header"
+    );
+    assert!(
+        priv_pem.contains("-----END PRIVATE KEY-----"),
+        "bad private PEM footer"
+    );
+
+    // Public key PEM must have correct envelope
+    let pub_pem = kp.public_key_spki_pem();
+    assert!(
+        pub_pem.starts_with("-----BEGIN PUBLIC KEY-----"),
+        "bad public PEM header"
+    );
+    assert!(
+        pub_pem.contains("-----END PUBLIC KEY-----"),
+        "bad public PEM footer"
+    );
+
+    // DER bytes must be non-empty
+    assert!(!kp.private_key_pkcs8_der().is_empty());
+    assert!(!kp.public_key_spki_der().is_empty());
+
+    // Determinism: same factory + label + spec = same output
+    let kp2 = fx.ecdsa(&input.label, spec);
+    assert_eq!(kp.private_key_pkcs8_pem(), kp2.private_key_pkcs8_pem());
+    assert_eq!(kp.public_key_spki_der(), kp2.public_key_spki_der());
+
+    // Mismatched key must differ from the real public key
+    let mismatch = kp.mismatched_public_key_spki_der();
+    assert!(!mismatch.is_empty());
+    assert_ne!(mismatch, kp.public_key_spki_der());
+});

--- a/fuzz/fuzz_targets/fuzz_ed25519_keygen.rs
+++ b/fuzz/fuzz_targets/fuzz_ed25519_keygen.rs
@@ -1,0 +1,58 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{Ed25519FactoryExt, Ed25519Spec, Factory, Seed};
+
+#[derive(Arbitrary, Debug)]
+struct Ed25519Input {
+    seed: [u8; 32],
+    label: String,
+}
+
+fuzz_target!(|input: Ed25519Input| {
+    let fx = Factory::deterministic(Seed::new(input.seed));
+    let kp = fx.ed25519(&input.label, Ed25519Spec::new());
+
+    // Private key PEM envelope
+    let priv_pem = kp.private_key_pkcs8_pem();
+    assert!(
+        priv_pem.starts_with("-----BEGIN PRIVATE KEY-----"),
+        "bad private PEM header"
+    );
+    assert!(
+        priv_pem.contains("-----END PRIVATE KEY-----"),
+        "bad private PEM footer"
+    );
+
+    // Public key PEM envelope
+    let pub_pem = kp.public_key_spki_pem();
+    assert!(
+        pub_pem.starts_with("-----BEGIN PUBLIC KEY-----"),
+        "bad public PEM header"
+    );
+    assert!(
+        pub_pem.contains("-----END PUBLIC KEY-----"),
+        "bad public PEM footer"
+    );
+
+    // DER bytes must be non-empty
+    assert!(!kp.private_key_pkcs8_der().is_empty());
+    assert!(!kp.public_key_spki_der().is_empty());
+
+    // Determinism: same factory + label = same output
+    let kp2 = fx.ed25519(&input.label, Ed25519Spec::new());
+    assert_eq!(kp.private_key_pkcs8_pem(), kp2.private_key_pkcs8_pem());
+    assert_eq!(kp.public_key_spki_der(), kp2.public_key_spki_der());
+
+    // Mismatched key must differ
+    let mismatch = kp.mismatched_public_key_spki_der();
+    assert!(!mismatch.is_empty());
+    assert_ne!(mismatch, kp.public_key_spki_der());
+
+    // Ed25519 PEM should be parseable by ed25519-dalek
+    use ed25519_dalek::pkcs8::DecodePrivateKey;
+    let parsed = ed25519_dalek::SigningKey::from_pkcs8_pem(priv_pem);
+    assert!(parsed.is_ok(), "generated Ed25519 PEM must be valid");
+});

--- a/fuzz/fuzz_targets/fuzz_hmac_keygen.rs
+++ b/fuzz/fuzz_targets/fuzz_hmac_keygen.rs
@@ -1,0 +1,49 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{Factory, HmacFactoryExt, HmacSpec, Seed};
+
+#[derive(Arbitrary, Debug)]
+struct HmacInput {
+    seed: [u8; 32],
+    label: String,
+    /// 0 = HS256, 1 = HS384, 2 = HS512
+    spec_idx: u8,
+}
+
+fuzz_target!(|input: HmacInput| {
+    let fx = Factory::deterministic(Seed::new(input.seed));
+    let spec = match input.spec_idx % 3 {
+        0 => HmacSpec::hs256(),
+        1 => HmacSpec::hs384(),
+        _ => HmacSpec::hs512(),
+    };
+
+    let secret = fx.hmac(&input.label, spec);
+    let bytes = secret.secret_bytes();
+
+    // Length must match spec
+    let expected_len = spec.byte_len();
+    assert_eq!(
+        bytes.len(),
+        expected_len,
+        "HMAC secret length mismatch for {}",
+        spec.alg_name()
+    );
+
+    // Must be non-zero (probabilistically impossible for random, but check shape)
+    // Note: we don't assert non-zero — a zero seed could deterministically produce
+    // all-zero bytes, which is valid for test fixtures.
+
+    // Determinism: same factory + label + spec = same output
+    let secret2 = fx.hmac(&input.label, spec);
+    assert_eq!(bytes, secret2.secret_bytes());
+
+    // Different labels should (in general) produce different secrets
+    let other_label = format!("{}-other", input.label);
+    let other = fx.hmac(&other_label, spec);
+    // We only check it doesn't panic; collisions are theoretically possible.
+    let _ = other.secret_bytes();
+});

--- a/fuzz/fuzz_targets/fuzz_negative_fixtures.rs
+++ b/fuzz/fuzz_targets/fuzz_negative_fixtures.rs
@@ -1,0 +1,85 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::negative::CorruptPem;
+use uselesskey::{EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, Seed};
+
+#[derive(Arbitrary, Debug)]
+struct NegativeInput {
+    seed: [u8; 32],
+    label: String,
+    /// 0 = BadHeader, 1 = BadFooter, 2 = BadBase64, 3 = ExtraBlankLine, 4+ = Truncate
+    corruption_idx: u8,
+    truncate_len: usize,
+    /// 0 = ECDSA ES256, 1 = ECDSA ES384, 2 = Ed25519
+    key_type: u8,
+    /// Variant string for deterministic corruption
+    variant: String,
+}
+
+fuzz_target!(|input: NegativeInput| {
+    let fx = Factory::deterministic(Seed::new(input.seed));
+
+    let corruption = match input.corruption_idx % 5 {
+        0 => CorruptPem::BadHeader,
+        1 => CorruptPem::BadFooter,
+        2 => CorruptPem::BadBase64,
+        3 => CorruptPem::ExtraBlankLine,
+        _ => CorruptPem::Truncate {
+            bytes: input.truncate_len % 128,
+        },
+    };
+
+    match input.key_type % 3 {
+        0 => {
+            let kp = fx.ecdsa(&input.label, EcdsaSpec::es256());
+
+            // Corrupt PEM must not panic
+            let bad = kp.private_key_pkcs8_pem_corrupt(corruption);
+            assert!(!bad.is_empty());
+
+            // Deterministic corruption must not panic
+            if !input.variant.is_empty() && input.variant.len() <= 64 {
+                let det = kp.private_key_pkcs8_pem_corrupt_deterministic(&input.variant);
+                assert!(!det.is_empty());
+                // Same variant = same output
+                let det2 = kp.private_key_pkcs8_pem_corrupt_deterministic(&input.variant);
+                assert_eq!(det, det2);
+            }
+
+            // Truncated DER must not panic and must respect bounds
+            let trunc = kp.private_key_pkcs8_der_truncated(input.truncate_len % 256);
+            assert!(trunc.len() <= kp.private_key_pkcs8_der().len());
+
+            // DER deterministic corruption must not panic
+            if !input.variant.is_empty() && input.variant.len() <= 64 {
+                let _ = kp.private_key_pkcs8_der_corrupt_deterministic(&input.variant);
+            }
+        }
+        1 => {
+            let kp = fx.ecdsa(&input.label, EcdsaSpec::es384());
+            let bad = kp.private_key_pkcs8_pem_corrupt(corruption);
+            assert!(!bad.is_empty());
+            let trunc = kp.private_key_pkcs8_der_truncated(input.truncate_len % 256);
+            assert!(trunc.len() <= kp.private_key_pkcs8_der().len());
+        }
+        _ => {
+            let kp = fx.ed25519(&input.label, Ed25519Spec::new());
+
+            let bad = kp.private_key_pkcs8_pem_corrupt(corruption);
+            assert!(!bad.is_empty());
+
+            if !input.variant.is_empty() && input.variant.len() <= 64 {
+                let det = kp.private_key_pkcs8_pem_corrupt_deterministic(&input.variant);
+                assert!(!det.is_empty());
+                let det2 = kp.private_key_pkcs8_pem_corrupt_deterministic(&input.variant);
+                assert_eq!(det, det2);
+            }
+
+            let trunc = kp.private_key_pkcs8_der_truncated(input.truncate_len % 256);
+            assert!(trunc.len() <= kp.private_key_pkcs8_der().len());
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_token_generation.rs
+++ b/fuzz/fuzz_targets/fuzz_token_generation.rs
@@ -1,0 +1,62 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{Factory, Seed, TokenFactoryExt, TokenSpec};
+
+#[derive(Arbitrary, Debug)]
+struct TokenInput {
+    seed: [u8; 32],
+    label: String,
+    /// 0 = ApiKey, 1 = Bearer, 2 = OAuthAccessToken
+    spec_idx: u8,
+}
+
+fuzz_target!(|input: TokenInput| {
+    // Limit label length.
+    if input.label.len() > 256 {
+        return;
+    }
+
+    let fx = Factory::deterministic(Seed::new(input.seed));
+    let spec = match input.spec_idx % 3 {
+        0 => TokenSpec::api_key(),
+        1 => TokenSpec::bearer(),
+        _ => TokenSpec::oauth_access_token(),
+    };
+
+    let tok = fx.token(&input.label, spec);
+    let value = tok.value();
+
+    // Token must be non-empty
+    assert!(!value.is_empty(), "token value must not be empty");
+
+    // Format-specific invariants
+    match input.spec_idx % 3 {
+        0 => {
+            // API key must start with prefix
+            assert!(
+                value.starts_with("uk_test_"),
+                "API key must start with uk_test_, got: {}",
+                &value[..value.len().min(20)]
+            );
+        }
+        1 => {
+            // Bearer token: base64url of 32 bytes = 43 chars
+            assert_eq!(value.len(), 43, "Bearer token must be 43 characters");
+        }
+        _ => {
+            // OAuth JWT shape: exactly 2 dots (3 segments)
+            assert_eq!(
+                value.matches('.').count(),
+                2,
+                "OAuth token must have exactly 2 dots"
+            );
+        }
+    }
+
+    // Determinism: same inputs = same output
+    let tok2 = fx.token(&input.label, spec);
+    assert_eq!(value, tok2.value());
+});

--- a/fuzz/fuzz_targets/fuzz_x509_cert.rs
+++ b/fuzz/fuzz_targets/fuzz_x509_cert.rs
@@ -1,0 +1,64 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{Factory, Seed, X509FactoryExt, X509Spec};
+
+#[derive(Arbitrary, Debug)]
+struct X509Input {
+    seed: [u8; 32],
+    label: String,
+    subject_cn: String,
+}
+
+fuzz_target!(|input: X509Input| {
+    // Skip empty subject CN — X509Spec requires a non-empty CN.
+    if input.subject_cn.is_empty() {
+        return;
+    }
+
+    // Limit subject CN length to avoid excessive allocation in cert generation.
+    if input.subject_cn.len() > 256 {
+        return;
+    }
+
+    // Limit label length similarly.
+    if input.label.len() > 256 {
+        return;
+    }
+
+    let fx = Factory::deterministic(Seed::new(input.seed));
+    let spec = X509Spec::self_signed(&input.subject_cn);
+    let cert = fx.x509_self_signed(&input.label, spec);
+
+    // Certificate PEM must have correct envelope
+    let cert_pem = cert.cert_pem();
+    assert!(
+        cert_pem.starts_with("-----BEGIN CERTIFICATE-----"),
+        "bad cert PEM header"
+    );
+    assert!(
+        cert_pem.contains("-----END CERTIFICATE-----"),
+        "bad cert PEM footer"
+    );
+
+    // Private key PEM must have correct envelope
+    let key_pem = cert.private_key_pkcs8_pem();
+    assert!(
+        key_pem.starts_with("-----BEGIN PRIVATE KEY-----"),
+        "bad key PEM header"
+    );
+    assert!(
+        key_pem.contains("-----END PRIVATE KEY-----"),
+        "bad key PEM footer"
+    );
+
+    // DER bytes must be non-empty
+    assert!(!cert.cert_der().is_empty());
+    assert!(!cert.private_key_pkcs8_der().is_empty());
+
+    // Determinism: same inputs = same output
+    let cert2 = fx.x509_self_signed(&input.label, X509Spec::self_signed(&input.subject_cn));
+    assert_eq!(cert.cert_pem(), cert2.cert_pem());
+});


### PR DESCRIPTION
Adds 7 new fuzz targets covering ECDSA keygen, Ed25519 keygen, HMAC secret generation, X.509 cert generation, negative fixtures (corrupt PEM/DER), cross-type derivation stability, and structured token generation. Updated fuzz/Cargo.toml with new features and dependencies.