### PR TITLE
test: property-based tests for core derivation and caching

### DIFF
--- a/crates/uselesskey-core-id/tests/id_tests.rs
+++ b/crates/uselesskey-core-id/tests/id_tests.rs
@@ -397,5 +397,52 @@ mod proptest_tests {
             let s_domain = derive_seed(&master, &alt_domain);
             prop_assert_ne!(base_seed.bytes(), s_domain.bytes());
         }
+
+        /// Different spec bytes produce different spec fingerprints in ArtifactId.
+        #[test]
+        fn prop_different_spec_fingerprints_produce_different_ids(
+            spec_a in proptest::collection::vec(any::<u8>(), 1..64),
+            spec_b in proptest::collection::vec(any::<u8>(), 1..64),
+        ) {
+            prop_assume!(spec_a != spec_b);
+            let a = ArtifactId::new("d", "l", &spec_a, "v", DerivationVersion::V1);
+            let b = ArtifactId::new("d", "l", &spec_b, "v", DerivationVersion::V1);
+            prop_assert_ne!(
+                a.spec_fingerprint, b.spec_fingerprint,
+                "different spec bytes should produce different fingerprints"
+            );
+        }
+
+        /// ArtifactId Debug output always contains the domain, label, and variant.
+        #[test]
+        fn prop_artifact_id_debug_format_is_consistent(
+            label in "[a-zA-Z0-9_]{1,20}",
+            variant in "[a-zA-Z0-9_]{1,20}",
+        ) {
+            let id = ArtifactId::new("domain:prop", &label, b"spec", &variant, DerivationVersion::V1);
+            let dbg = format!("{id:?}");
+
+            prop_assert!(dbg.contains("domain:prop"), "Debug missing domain: {dbg}");
+            prop_assert!(dbg.contains(&label), "Debug missing label: {dbg}");
+            prop_assert!(dbg.contains(&variant), "Debug missing variant: {dbg}");
+            prop_assert!(dbg.contains("DerivationVersion"), "Debug missing version wrapper: {dbg}");
+        }
+
+        /// derive_seed output is always 32 bytes and never all-zero.
+        #[test]
+        fn prop_derived_seed_is_32_bytes_nonzero(
+            master_bytes in any::<[u8; 32]>(),
+            label in "[a-zA-Z0-9]{1,16}",
+        ) {
+            let master = Seed::new(master_bytes);
+            let id = ArtifactId::new("d", &label, b"spec", "v", DerivationVersion::V1);
+            let derived = derive_seed(&master, &id);
+
+            prop_assert_eq!(derived.bytes().len(), 32);
+            prop_assert!(
+                derived.bytes().iter().any(|&b| b != 0),
+                "derived seed should not be all-zero"
+            );
+        }
     }
 }

--- a/crates/uselesskey-core/tests/core_prop.rs
+++ b/crates/uselesskey-core/tests/core_prop.rs
@@ -230,4 +230,105 @@ proptest! {
             );
         }
     }
+
+    // =========================================================================
+    // Order-independence (proptest)
+    // =========================================================================
+
+    /// Derivation order does not affect results: requesting artifacts in any
+    /// order produces the same values.
+    #[test]
+    fn prop_order_independence(
+        seed_bytes in any::<[u8; 32]>(),
+        label_a in "[a-zA-Z]{1,8}",
+        label_b in "[a-zA-Z]{1,8}",
+    ) {
+        prop_assume!(label_a != label_b);
+        let spec = spec_bytes(2048, 65537);
+
+        // Order 1: a then b.
+        let fx1 = Factory::deterministic(Seed::new(seed_bytes));
+        let a1 = fx1.get_or_init("domain:ord", &label_a, &spec, "good", |rng| {
+            use rand_core::RngCore;
+            let mut out = [0u8; 32];
+            rng.fill_bytes(&mut out);
+            out
+        });
+        let b1 = fx1.get_or_init("domain:ord", &label_b, &spec, "good", |rng| {
+            use rand_core::RngCore;
+            let mut out = [0u8; 32];
+            rng.fill_bytes(&mut out);
+            out
+        });
+
+        // Order 2: b then a (fresh factory, same seed).
+        let fx2 = Factory::deterministic(Seed::new(seed_bytes));
+        let b2 = fx2.get_or_init("domain:ord", &label_b, &spec, "good", |rng| {
+            use rand_core::RngCore;
+            let mut out = [0u8; 32];
+            rng.fill_bytes(&mut out);
+            out
+        });
+        let a2 = fx2.get_or_init("domain:ord", &label_a, &spec, "good", |rng| {
+            use rand_core::RngCore;
+            let mut out = [0u8; 32];
+            rng.fill_bytes(&mut out);
+            out
+        });
+
+        prop_assert_eq!(*a1, *a2, "label_a value should be identical regardless of order");
+        prop_assert_eq!(*b1, *b2, "label_b value should be identical regardless of order");
+    }
+
+    // =========================================================================
+    // Cache Arc pointer identity
+    // =========================================================================
+
+    /// Cache hits return the exact same Arc pointer, not just equal values.
+    #[test]
+    fn prop_cache_hit_returns_same_arc(
+        seed_bytes in any::<[u8; 32]>(),
+        label in "[a-zA-Z0-9]{1,16}",
+    ) {
+        let fx = Factory::deterministic(Seed::new(seed_bytes));
+        let spec = spec_bytes(2048, 65537);
+
+        let first = fx.get_or_init("domain:arc", &label, &spec, "good", |rng| {
+            use rand_core::RngCore;
+            let mut out = [0u8; 32];
+            rng.fill_bytes(&mut out);
+            out
+        });
+        let second = fx.get_or_init("domain:arc", &label, &spec, "good", |rng| {
+            use rand_core::RngCore;
+            let mut out = [0u8; 32];
+            rng.fill_bytes(&mut out);
+            out
+        });
+
+        prop_assert!(
+            std::sync::Arc::ptr_eq(&first, &second),
+            "cache hit should return the same Arc pointer"
+        );
+    }
+
+    // =========================================================================
+    // Derived seeds are 32 bytes and non-zero
+    // =========================================================================
+
+    /// Derived seeds are always 32 bytes and never all-zero.
+    #[test]
+    fn prop_derived_seed_is_32_bytes_nonzero(
+        seed_bytes in any::<[u8; 32]>(),
+        label in "[a-zA-Z0-9]{1,16}",
+    ) {
+        let master = Seed::new(seed_bytes);
+        let derived = derive_seed_for_test(&master, "domain:sz", &label, "good");
+
+        prop_assert_eq!(derived.bytes().len(), 32);
+        prop_assert!(
+            derived.bytes().iter().any(|&b| b != 0),
+            "derived seed should not be all-zero"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Adds **6 proptest-based property tests** covering the core derivation and caching layer invariants across two crates.

### uselesskey-core (3 tests in \core_prop.rs\)

| Test | Property |
|------|----------|
| \prop_order_independence\ | For any seed, requesting artifacts in different orders produces identical values |
| \prop_cache_hit_returns_same_arc\ | Cache hits return the exact same \Arc\ pointer (not just equal values) |
| \prop_derived_seed_is_32_bytes_nonzero\ | Derived seeds are always 32 bytes and never all-zero |

### uselesskey-core-id (3 tests in \id_tests.rs\)

| Test | Property |
|------|----------|
| \prop_different_spec_fingerprints_produce_different_ids\ | Different spec bytes produce different fingerprints |
| \prop_artifact_id_debug_format_is_consistent\ | Debug output always contains domain, label, variant, and version |
| \prop_derived_seed_is_32_bytes_nonzero\ | \derive_seed()\ output is 32 bytes and non-zero |

### Verification

- \cargo test -p uselesskey-core --all-features -- prop_\ — 3/3 pass
- \cargo test -p uselesskey-core-id --all-features -- prop_\ — 3/3 pass
- \cargo fmt -- --check\ — clean
- \cargo clippy -p uselesskey-core -p uselesskey-core-id --all-features --tests -- -D warnings\ — clean
