### PR TITLE
test: add insta snapshot tests for uselesskey-rustls adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,8 +3773,11 @@ dependencies = [
 name = "uselesskey-rustls"
 version = "0.3.0"
 dependencies = [
+ "hex",
+ "insta",
  "rustls",
  "rustls-pki-types",
+ "serde",
  "uselesskey-core",
  "uselesskey-ecdsa",
  "uselesskey-ed25519",

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -47,3 +47,6 @@ uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
 uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
 uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
 rustls = { version = "0.23", features = ["ring"] }
+hex = "0.4"
+serde.workspace = true
+insta.workspace = true

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__ecdsa_snapshots__rustls_ecdsa_p256_private_key.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__ecdsa_snapshots__rustls_ecdsa_p256_private_key.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+key_type: ECDSA-P256
+der_variant: Pkcs8
+der_len: 138
+der_hex: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__ecdsa_snapshots__rustls_ecdsa_p384_private_key.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__ecdsa_snapshots__rustls_ecdsa_p384_private_key.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+key_type: ECDSA-P384
+der_variant: Pkcs8
+der_len: 185
+der_hex: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__ed25519_snapshots__rustls_ed25519_private_key.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__ed25519_snapshots__rustls_ed25519_private_key.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+key_type: Ed25519
+der_variant: Pkcs8
+der_len: 83
+der_hex: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rsa_snapshots__rustls_rsa_2048_private_key.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rsa_snapshots__rustls_rsa_2048_private_key.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+key_type: RSA-2048
+der_variant: Pkcs8
+der_len: 1218
+der_hex: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rsa_snapshots__rustls_rsa_key_sizes.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rsa_snapshots__rustls_rsa_key_sizes.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: cases
+---
+- label: rsa-2048
+  bits: 2048
+  der_len: 1218
+- label: rsa-4096
+  bits: 4096
+  der_len: 2376

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_chain_metadata.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_chain_metadata.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+chain_len: 2
+leaf_cert_der_len: 803
+leaf_cert_der_hex: "[REDACTED]"
+intermediate_cert_der_len: 802
+intermediate_cert_der_hex: "[REDACTED]"
+root_cert_der_len: 794
+root_cert_der_hex: "[REDACTED]"
+private_key_der_len: 1217
+private_key_der_hex: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_self_signed_cert.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_self_signed_cert.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+cert_der_len: 758
+cert_der_hex: "[REDACTED]"
+private_key_der_len: 1220
+private_key_der_hex: "[REDACTED]"
+der_variant: Pkcs8

--- a/crates/uselesskey-rustls/tests/snapshots_rustls.rs
+++ b/crates/uselesskey-rustls/tests/snapshots_rustls.rs
@@ -1,0 +1,234 @@
+//! Insta snapshot tests for uselesskey-rustls adapter.
+//!
+//! These tests snapshot key and certificate metadata produced by deterministic
+//! fixtures to detect unintended changes in adapter output.
+//! CRITICAL: No actual key bytes appear in snapshots — all crypto material is redacted.
+
+mod testutil;
+
+use serde::Serialize;
+use testutil::fx;
+
+#[derive(Serialize)]
+struct RustlsKeySnapshot {
+    key_type: &'static str,
+    der_variant: &'static str,
+    der_len: usize,
+    der_hex: String,
+}
+
+// =========================================================================
+// RSA snapshots
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_snapshots {
+    use super::*;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    use uselesskey_rustls::RustlsPrivateKeyExt;
+
+    #[test]
+    fn snapshot_rustls_rsa_2048_private_key() {
+        let fx = fx();
+        let keypair = fx.rsa("snapshot-rsa-2048", RsaSpec::rs256());
+        let key = keypair.private_key_der_rustls();
+
+        let result = RustlsKeySnapshot {
+            key_type: "RSA-2048",
+            der_variant: "Pkcs8",
+            der_len: key.secret_der().len(),
+            der_hex: hex::encode(key.secret_der()),
+        };
+
+        insta::assert_yaml_snapshot!("rustls_rsa_2048_private_key", result, {
+            ".der_hex" => "[REDACTED]",
+        });
+    }
+
+    #[test]
+    fn snapshot_rustls_rsa_key_sizes() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct RsaSizeInfo {
+            label: &'static str,
+            bits: usize,
+            der_len: usize,
+        }
+
+        let cases: Vec<RsaSizeInfo> = [(2048, "rsa-2048"), (4096, "rsa-4096")]
+            .into_iter()
+            .map(|(bits, label)| {
+                let kp = fx.rsa(label, RsaSpec::new(bits));
+                let key = kp.private_key_der_rustls();
+                RsaSizeInfo {
+                    label,
+                    bits,
+                    der_len: key.secret_der().len(),
+                }
+            })
+            .collect();
+
+        insta::assert_yaml_snapshot!("rustls_rsa_key_sizes", cases);
+    }
+}
+
+// =========================================================================
+// ECDSA snapshots
+// =========================================================================
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_snapshots {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_rustls::RustlsPrivateKeyExt;
+
+    #[test]
+    fn snapshot_rustls_ecdsa_p256_private_key() {
+        let fx = fx();
+        let keypair = fx.ecdsa("snapshot-ecdsa-p256", EcdsaSpec::es256());
+        let key = keypair.private_key_der_rustls();
+
+        let result = RustlsKeySnapshot {
+            key_type: "ECDSA-P256",
+            der_variant: "Pkcs8",
+            der_len: key.secret_der().len(),
+            der_hex: hex::encode(key.secret_der()),
+        };
+
+        insta::assert_yaml_snapshot!("rustls_ecdsa_p256_private_key", result, {
+            ".der_hex" => "[REDACTED]",
+        });
+    }
+
+    #[test]
+    fn snapshot_rustls_ecdsa_p384_private_key() {
+        let fx = fx();
+        let keypair = fx.ecdsa("snapshot-ecdsa-p384", EcdsaSpec::es384());
+        let key = keypair.private_key_der_rustls();
+
+        let result = RustlsKeySnapshot {
+            key_type: "ECDSA-P384",
+            der_variant: "Pkcs8",
+            der_len: key.secret_der().len(),
+            der_hex: hex::encode(key.secret_der()),
+        };
+
+        insta::assert_yaml_snapshot!("rustls_ecdsa_p384_private_key", result, {
+            ".der_hex" => "[REDACTED]",
+        });
+    }
+}
+
+// =========================================================================
+// Ed25519 snapshots
+// =========================================================================
+
+#[cfg(feature = "ed25519")]
+mod ed25519_snapshots {
+    use super::*;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rustls::RustlsPrivateKeyExt;
+
+    #[test]
+    fn snapshot_rustls_ed25519_private_key() {
+        let fx = fx();
+        let keypair = fx.ed25519("snapshot-ed25519", Ed25519Spec::new());
+        let key = keypair.private_key_der_rustls();
+
+        let result = RustlsKeySnapshot {
+            key_type: "Ed25519",
+            der_variant: "Pkcs8",
+            der_len: key.secret_der().len(),
+            der_hex: hex::encode(key.secret_der()),
+        };
+
+        insta::assert_yaml_snapshot!("rustls_ed25519_private_key", result, {
+            ".der_hex" => "[REDACTED]",
+        });
+    }
+}
+
+// =========================================================================
+// X.509 certificate snapshots
+// =========================================================================
+
+#[cfg(feature = "x509")]
+mod x509_snapshots {
+    use super::*;
+    use uselesskey_rustls::{RustlsCertExt, RustlsChainExt, RustlsPrivateKeyExt};
+    use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+    #[test]
+    fn snapshot_rustls_self_signed_cert() {
+        let fx = fx();
+        let cert = fx.x509_self_signed("snapshot-ss", X509Spec::self_signed("test.example.com"));
+
+        #[derive(Serialize)]
+        struct SelfSignedInfo {
+            cert_der_len: usize,
+            cert_der_hex: String,
+            private_key_der_len: usize,
+            private_key_der_hex: String,
+            der_variant: &'static str,
+        }
+
+        let cert_der = cert.certificate_der_rustls();
+        let key = cert.private_key_der_rustls();
+
+        let result = SelfSignedInfo {
+            cert_der_len: cert_der.as_ref().len(),
+            cert_der_hex: hex::encode(cert_der.as_ref()),
+            private_key_der_len: key.secret_der().len(),
+            private_key_der_hex: hex::encode(key.secret_der()),
+            der_variant: "Pkcs8",
+        };
+
+        insta::assert_yaml_snapshot!("rustls_self_signed_cert", result, {
+            ".cert_der_hex" => "[REDACTED]",
+            ".private_key_der_hex" => "[REDACTED]",
+        });
+    }
+
+    #[test]
+    fn snapshot_rustls_chain_metadata() {
+        let fx = fx();
+        let chain = fx.x509_chain("snapshot-chain", ChainSpec::new("test.example.com"));
+
+        #[derive(Serialize)]
+        struct ChainInfo {
+            chain_len: usize,
+            leaf_cert_der_len: usize,
+            leaf_cert_der_hex: String,
+            intermediate_cert_der_len: usize,
+            intermediate_cert_der_hex: String,
+            root_cert_der_len: usize,
+            root_cert_der_hex: String,
+            private_key_der_len: usize,
+            private_key_der_hex: String,
+        }
+
+        let chain_certs = chain.chain_der_rustls();
+        let root = chain.root_certificate_der_rustls();
+        let key = chain.private_key_der_rustls();
+
+        let result = ChainInfo {
+            chain_len: chain_certs.len(),
+            leaf_cert_der_len: chain_certs[0].as_ref().len(),
+            leaf_cert_der_hex: hex::encode(chain_certs[0].as_ref()),
+            intermediate_cert_der_len: chain_certs[1].as_ref().len(),
+            intermediate_cert_der_hex: hex::encode(chain_certs[1].as_ref()),
+            root_cert_der_len: root.as_ref().len(),
+            root_cert_der_hex: hex::encode(root.as_ref()),
+            private_key_der_len: key.secret_der().len(),
+            private_key_der_hex: hex::encode(key.secret_der()),
+        };
+
+        insta::assert_yaml_snapshot!("rustls_chain_metadata", result, {
+            ".leaf_cert_der_hex" => "[REDACTED]",
+            ".intermediate_cert_der_hex" => "[REDACTED]",
+            ".root_cert_der_hex" => "[REDACTED]",
+            ".private_key_der_hex" => "[REDACTED]",
+        });
+    }
+}

--- a/crates/uselesskey-rustls/tests/testutil.rs
+++ b/crates/uselesskey-rustls/tests/testutil.rs
@@ -1,0 +1,16 @@
+#![allow(unused)]
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+pub(crate) fn fx() -> Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-rustls-test-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+    .clone()
+}


### PR DESCRIPTION
## Wave 50: Adapter Snapshot Tests

Adds insta snapshot tests for the **uselesskey-rustls** adapter crate — the only adapter crate that was missing snapshot coverage.

### Snapshots Added (7 total)

| Snapshot | What it captures |
|----------|-----------------|
| `rustls_rsa_2048_private_key` | RSA-2048 key type, PKCS#8 variant, DER length (key bytes redacted) |
| `rustls_rsa_key_sizes` | RSA-2048 and RSA-4096 DER lengths side by side |
| `rustls_ecdsa_p256_private_key` | ECDSA P-256 key metadata (key bytes redacted) |
| `rustls_ecdsa_p384_private_key` | ECDSA P-384 key metadata (key bytes redacted) |
| `rustls_ed25519_private_key` | Ed25519 key metadata (key bytes redacted) |
| `rustls_self_signed_cert` | Self-signed X.509 cert + key DER lengths (all bytes redacted) |
| `rustls_chain_metadata` | Full chain: leaf, intermediate, root cert + key DER lengths (all bytes redacted) |

### Pre-existing adapter snapshot coverage

The other 4 adapter crates already had snapshot tests:
- uselesskey-jsonwebtoken — snapshots_jwt.rs (4 snapshots)
- uselesskey-ring — snapshots_ring.rs (5 snapshots)
- uselesskey-rustcrypto — snapshots_rustcrypto.rs (6 snapshots)
- uselesskey-aws-lc-rs — snapshots_aws_lc_rs.rs (5 snapshots)

### Changes

- `crates/uselesskey-rustls/tests/snapshots_rustls.rs` — new snapshot test file
- `crates/uselesskey-rustls/tests/testutil.rs` — shared deterministic factory helper
- `crates/uselesskey-rustls/tests/snapshots/` — 7 accepted snapshot files
- `crates/uselesskey-rustls/Cargo.toml` — added insta, serde, hex to dev-dependencies
- `Cargo.lock` — updated lockfile

### Verification

- All 7 snapshot tests pass
- All existing rustls tests pass (20 unit + 7 snapshot + 1 doctest)
- cargo clippy passes clean
- cargo fmt applied
- All crypto material properly redacted with [REDACTED] in snapshot files
