### PR TITLE
test: expand integration tests for core microcrates

### DIFF
--- a/crates/uselesskey-core-factory/tests/factory_concurrency.rs
+++ b/crates/uselesskey-core-factory/tests/factory_concurrency.rs
@@ -1,0 +1,155 @@
+//! Integration tests for Factory concurrency and cloning behavior.
+
+#![cfg(feature = "std")]
+
+use std::sync::Arc;
+use std::thread;
+
+use uselesskey_core_factory::Factory;
+use uselesskey_core_id::Seed;
+
+// ── concurrent get_or_init from multiple threads ─────────────────────
+
+#[test]
+fn concurrent_get_or_init_returns_same_arc() {
+    let fx = Arc::new(Factory::deterministic(Seed::new([42u8; 32])));
+    let mut handles = Vec::new();
+
+    for _ in 0..8 {
+        let fx = Arc::clone(&fx);
+        handles.push(thread::spawn(move || {
+            fx.get_or_init("domain:conc", "shared", b"spec", "good", |_rng| 123u64)
+        }));
+    }
+
+    let results: Vec<Arc<u64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // All threads should get the same Arc (same pointer)
+    for r in &results {
+        assert_eq!(**r, 123u64);
+        assert!(Arc::ptr_eq(r, &results[0]));
+    }
+}
+
+#[test]
+fn concurrent_different_keys_are_independent() {
+    let fx = Arc::new(Factory::deterministic(Seed::new([7u8; 32])));
+    let mut handles = Vec::new();
+
+    for i in 0u32..8 {
+        let fx = Arc::clone(&fx);
+        handles.push(thread::spawn(move || {
+            let label = format!("key-{i}");
+            let val = fx.get_or_init("domain:conc", &label, b"spec", "good", |_rng| i);
+            (label, *val)
+        }));
+    }
+
+    for h in handles {
+        let (label, val) = h.join().unwrap();
+        let expected: u32 = label.strip_prefix("key-").unwrap().parse().unwrap();
+        assert_eq!(val, expected);
+    }
+}
+
+// ── clone shares cache ───────────────────────────────────────────────
+
+#[test]
+fn cloned_factory_shares_cache() {
+    let fx = Factory::deterministic(Seed::new([5u8; 32]));
+    let fx2 = fx.clone();
+
+    let a = fx.get_or_init("domain:clone", "shared", b"spec", "good", |_rng| 999u32);
+    let b = fx2.get_or_init("domain:clone", "shared", b"spec", "good", |_rng| 0u32);
+
+    assert!(Arc::ptr_eq(&a, &b));
+    assert_eq!(*b, 999u32);
+}
+
+#[test]
+fn clear_cache_on_clone_affects_original() {
+    let fx = Factory::deterministic(Seed::new([8u8; 32]));
+    let fx2 = fx.clone();
+
+    let _ = fx.get_or_init("domain:clone", "key", b"spec", "good", |_rng| 10u8);
+    fx2.clear_cache();
+
+    // After clearing through clone, original should reinitialize
+    let reinit = fx.get_or_init("domain:clone", "key", b"spec", "good", |_rng| 20u8);
+    // Value comes from re-init so may differ from first init
+    // The key test: init was called again (not returning the old 10u8)
+    assert_eq!(*reinit, 20u8);
+}
+
+// ── deterministic reproducibility ────────────────────────────────────
+
+#[test]
+fn same_seed_same_label_same_value() {
+    let seed = Seed::new([99u8; 32]);
+    let fx1 = Factory::deterministic(seed);
+    let fx2 = Factory::deterministic(seed);
+
+    let a = fx1.get_or_init("domain:det", "label", b"spec", "good", |rng| {
+        use rand_chacha::rand_core::RngCore;
+        rng.next_u64()
+    });
+    let b = fx2.get_or_init("domain:det", "label", b"spec", "good", |rng| {
+        use rand_chacha::rand_core::RngCore;
+        rng.next_u64()
+    });
+
+    assert_eq!(*a, *b);
+}
+
+#[test]
+fn different_seeds_different_values() {
+    let fx1 = Factory::deterministic(Seed::new([1u8; 32]));
+    let fx2 = Factory::deterministic(Seed::new([2u8; 32]));
+
+    let a = fx1.get_or_init("domain:det", "label", b"spec", "good", |rng| {
+        use rand_chacha::rand_core::RngCore;
+        rng.next_u64()
+    });
+    let b = fx2.get_or_init("domain:det", "label", b"spec", "good", |rng| {
+        use rand_chacha::rand_core::RngCore;
+        rng.next_u64()
+    });
+
+    assert_ne!(*a, *b);
+}
+
+// ── random mode ──────────────────────────────────────────────────────
+
+#[test]
+fn random_mode_caches_after_first_init() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let fx = Factory::random();
+    let counter = AtomicUsize::new(0);
+
+    let a = fx.get_or_init("domain:rand", "once", b"spec", "good", |_rng| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        42u64
+    });
+    let b = fx.get_or_init("domain:rand", "once", b"spec", "good", |_rng| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        99u64
+    });
+
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+    assert!(Arc::ptr_eq(&a, &b));
+}
+
+// ── Debug format ─────────────────────────────────────────────────────
+
+#[test]
+fn debug_format_includes_mode_and_cache_size() {
+    let fx = Factory::deterministic(Seed::new([0u8; 32]));
+    let dbg = format!("{fx:?}");
+    assert!(dbg.contains("Factory"));
+    assert!(dbg.contains("Deterministic"));
+    assert!(dbg.contains("cache_size: 0"));
+
+    let _ = fx.get_or_init("domain:dbg", "k", b"s", "v", |_rng| 1u8);
+    let dbg = format!("{fx:?}");
+    assert!(dbg.contains("cache_size: 1"));
+}

--- a/crates/uselesskey-core-hash/tests/edge_cases.rs
+++ b/crates/uselesskey-core-hash/tests/edge_cases.rs
@@ -1,0 +1,113 @@
+//! Integration tests for core hash helpers — edge cases and boundary conditions.
+
+use uselesskey_core_hash::{Hash, Hasher, hash32, write_len_prefixed};
+
+// ── hash32 edge cases ────────────────────────────────────────────────
+
+#[test]
+fn hash32_empty_input_is_deterministic() {
+    let a = hash32(b"");
+    let b = hash32(b"");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn hash32_single_byte_differs_from_empty() {
+    assert_ne!(hash32(b""), hash32(b"\0"));
+}
+
+#[test]
+fn hash32_returns_32_byte_digest() {
+    let h = hash32(b"test");
+    assert_eq!(h.as_bytes().len(), 32);
+}
+
+// ── write_len_prefixed boundary hashing ──────────────────────────────
+
+#[test]
+fn different_tuple_boundaries_produce_different_hashes() {
+    // ("ab", "c") != ("a", "bc") due to length prefixes
+    let mut h1 = Hasher::new();
+    write_len_prefixed(&mut h1, b"ab");
+    write_len_prefixed(&mut h1, b"c");
+
+    let mut h2 = Hasher::new();
+    write_len_prefixed(&mut h2, b"a");
+    write_len_prefixed(&mut h2, b"bc");
+
+    assert_ne!(h1.finalize(), h2.finalize());
+}
+
+#[test]
+fn empty_field_is_distinguishable() {
+    // ("", "abc") != ("abc",) != ("abc", "")
+    let mut h1 = Hasher::new();
+    write_len_prefixed(&mut h1, b"");
+    write_len_prefixed(&mut h1, b"abc");
+
+    let mut h2 = Hasher::new();
+    write_len_prefixed(&mut h2, b"abc");
+
+    let mut h3 = Hasher::new();
+    write_len_prefixed(&mut h3, b"abc");
+    write_len_prefixed(&mut h3, b"");
+
+    assert_ne!(h1.finalize(), h2.finalize());
+    assert_ne!(h2.finalize(), h3.finalize());
+    assert_ne!(h1.finalize(), h3.finalize());
+}
+
+#[test]
+fn single_bit_difference_propagates() {
+    let a = [0u8; 64];
+    let mut b = [0u8; 64];
+    b[63] = 1;
+
+    assert_ne!(hash32(&a), hash32(&b));
+}
+
+// ── re-exported types are usable ─────────────────────────────────────
+
+#[test]
+fn hasher_reexport_can_finalize() {
+    let mut h = Hasher::new();
+    h.update(b"test");
+    let result: Hash = h.finalize();
+    assert_eq!(result, hash32(b"test"));
+}
+
+#[test]
+fn hash_display_is_hex() {
+    let h = hash32(b"test");
+    let s = format!("{h}");
+    assert!(s.chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(s.len(), 64); // 32 bytes = 64 hex chars
+}
+
+// ── multi-field determinism ──────────────────────────────────────────
+
+#[test]
+fn multi_field_hash_is_deterministic() {
+    let compute = || {
+        let mut h = Hasher::new();
+        write_len_prefixed(&mut h, b"domain");
+        write_len_prefixed(&mut h, b"label");
+        write_len_prefixed(&mut h, b"spec-bytes");
+        h.finalize()
+    };
+
+    assert_eq!(compute(), compute());
+}
+
+#[test]
+fn field_order_matters() {
+    let mut h1 = Hasher::new();
+    write_len_prefixed(&mut h1, b"alpha");
+    write_len_prefixed(&mut h1, b"beta");
+
+    let mut h2 = Hasher::new();
+    write_len_prefixed(&mut h2, b"beta");
+    write_len_prefixed(&mut h2, b"alpha");
+
+    assert_ne!(h1.finalize(), h2.finalize());
+}

--- a/crates/uselesskey-core-jwk-shape/tests/jwk_shape_integration.rs
+++ b/crates/uselesskey-core-jwk-shape/tests/jwk_shape_integration.rs
@@ -1,0 +1,379 @@
+//! Integration tests for JWK shape types — covers all key type variants,
+//! serialization, Debug safety, and Display/From conversions.
+
+use serde_json::Value;
+use uselesskey_core_jwk_shape::{
+    AnyJwk, EcPrivateJwk, EcPublicJwk, Jwks, OctJwk, OkpPrivateJwk, OkpPublicJwk, PrivateJwk,
+    PublicJwk, RsaPrivateJwk, RsaPublicJwk,
+};
+
+// ── EC public JWK serialization ──────────────────────────────────────
+
+#[test]
+fn ec_public_jwk_serializes_all_fields() {
+    let jwk = PublicJwk::Ec(EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: "ec-kid-1".to_string(),
+        x: "x-coord".to_string(),
+        y: "y-coord".to_string(),
+    });
+
+    let v = jwk.to_value();
+    assert_eq!(v["kty"], "EC");
+    assert_eq!(v["crv"], "P-256");
+    assert_eq!(v["kid"], "ec-kid-1");
+    assert_eq!(v["x"], "x-coord");
+    assert_eq!(v["y"], "y-coord");
+}
+
+// ── OKP public JWK serialization ─────────────────────────────────────
+
+#[test]
+fn okp_public_jwk_serializes_all_fields() {
+    let jwk = PublicJwk::Okp(OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: "okp-kid-1".to_string(),
+        x: "public-x".to_string(),
+    });
+
+    let v = jwk.to_value();
+    assert_eq!(v["kty"], "OKP");
+    assert_eq!(v["crv"], "Ed25519");
+    assert_eq!(v["kid"], "okp-kid-1");
+    assert_eq!(v["x"], "public-x");
+    assert!(v.get("y").is_none());
+}
+
+// ── RSA private JWK serialization ────────────────────────────────────
+
+#[test]
+fn rsa_private_jwk_serializes_all_crt_fields() {
+    let jwk = RsaPrivateJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: "rsa-priv-1".to_string(),
+        n: "n-val".to_string(),
+        e: "AQAB".to_string(),
+        d: "d-val".to_string(),
+        p: "p-val".to_string(),
+        q: "q-val".to_string(),
+        dp: "dp-val".to_string(),
+        dq: "dq-val".to_string(),
+        qi: "qi-val".to_string(),
+    };
+
+    let v = serde_json::to_value(&jwk).unwrap();
+    assert_eq!(v["kty"], "RSA");
+    assert_eq!(v["d"], "d-val");
+    assert_eq!(v["p"], "p-val");
+    assert_eq!(v["qi"], "qi-val");
+}
+
+// ── EC private JWK serialization ─────────────────────────────────────
+
+#[test]
+fn ec_private_jwk_serializes_d_field() {
+    let jwk = PrivateJwk::Ec(EcPrivateJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES384",
+        crv: "P-384",
+        kid: "ec-priv-1".to_string(),
+        x: "x".to_string(),
+        y: "y".to_string(),
+        d: "private-d".to_string(),
+    });
+
+    let v = jwk.to_value();
+    assert_eq!(v["crv"], "P-384");
+    assert_eq!(v["d"], "private-d");
+}
+
+// ── OKP private JWK serialization ────────────────────────────────────
+
+#[test]
+fn okp_private_jwk_serializes_d_field() {
+    let jwk = PrivateJwk::Okp(OkpPrivateJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: "okp-priv-1".to_string(),
+        x: "pub-x".to_string(),
+        d: "priv-d".to_string(),
+    });
+
+    let v = jwk.to_value();
+    assert_eq!(v["kty"], "OKP");
+    assert_eq!(v["d"], "priv-d");
+}
+
+// ── Debug never leaks private material ───────────────────────────────
+
+#[test]
+fn rsa_private_debug_omits_d_p_q() {
+    let jwk = RsaPrivateJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: "rsa-dbg".to_string(),
+        n: "n-secret".to_string(),
+        e: "AQAB".to_string(),
+        d: "SECRET-D".to_string(),
+        p: "SECRET-P".to_string(),
+        q: "SECRET-Q".to_string(),
+        dp: "SECRET-DP".to_string(),
+        dq: "SECRET-DQ".to_string(),
+        qi: "SECRET-QI".to_string(),
+    };
+
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("RsaPrivateJwk"));
+    assert!(!dbg.contains("SECRET-D"));
+    assert!(!dbg.contains("SECRET-P"));
+    assert!(!dbg.contains("SECRET-Q"));
+}
+
+#[test]
+fn ec_private_debug_omits_d() {
+    let jwk = EcPrivateJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: "ec-dbg".to_string(),
+        x: "x".to_string(),
+        y: "y".to_string(),
+        d: "SUPER-SECRET".to_string(),
+    };
+
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("EcPrivateJwk"));
+    assert!(!dbg.contains("SUPER-SECRET"));
+}
+
+#[test]
+fn okp_private_debug_omits_d() {
+    let jwk = OkpPrivateJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: "okp-dbg".to_string(),
+        x: "x".to_string(),
+        d: "HIDDEN-KEY".to_string(),
+    };
+
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("OkpPrivateJwk"));
+    assert!(!dbg.contains("HIDDEN-KEY"));
+}
+
+#[test]
+fn oct_debug_omits_k() {
+    let jwk = OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: "oct-dbg".to_string(),
+        k: "SECRET-HMAC-KEY".to_string(),
+    };
+
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("OctJwk"));
+    assert!(!dbg.contains("SECRET-HMAC-KEY"));
+}
+
+// ── JWKS with mixed key types ────────────────────────────────────────
+
+#[test]
+fn jwks_with_all_public_key_types() {
+    let jwks = Jwks {
+        keys: vec![
+            AnyJwk::Public(PublicJwk::Rsa(RsaPublicJwk {
+                kty: "RSA",
+                use_: "sig",
+                alg: "RS256",
+                kid: "rsa-1".to_string(),
+                n: "n".to_string(),
+                e: "AQAB".to_string(),
+            })),
+            AnyJwk::Public(PublicJwk::Ec(EcPublicJwk {
+                kty: "EC",
+                use_: "sig",
+                alg: "ES256",
+                crv: "P-256",
+                kid: "ec-1".to_string(),
+                x: "x".to_string(),
+                y: "y".to_string(),
+            })),
+            AnyJwk::Public(PublicJwk::Okp(OkpPublicJwk {
+                kty: "OKP",
+                use_: "sig",
+                alg: "EdDSA",
+                crv: "Ed25519",
+                kid: "okp-1".to_string(),
+                x: "x".to_string(),
+            })),
+        ],
+    };
+
+    let v = jwks.to_value();
+    let keys = v["keys"].as_array().unwrap();
+    assert_eq!(keys.len(), 3);
+    assert_eq!(keys[0]["kty"], "RSA");
+    assert_eq!(keys[1]["kty"], "EC");
+    assert_eq!(keys[2]["kty"], "OKP");
+}
+
+#[test]
+fn jwks_display_produces_valid_json() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::Public(PublicJwk::Rsa(RsaPublicJwk {
+            kty: "RSA",
+            use_: "sig",
+            alg: "RS256",
+            kid: "display-1".to_string(),
+            n: "n".to_string(),
+            e: "AQAB".to_string(),
+        }))],
+    };
+
+    let json_str = jwks.to_string();
+    let parsed: Value = serde_json::from_str(&json_str).expect("should be valid JSON");
+    assert!(parsed["keys"].is_array());
+}
+
+// ── From conversions ─────────────────────────────────────────────────
+
+#[test]
+fn any_jwk_from_public_preserves_kid() {
+    let public = PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: "from-pub".to_string(),
+        n: "n".to_string(),
+        e: "e".to_string(),
+    });
+    let any: AnyJwk = public.into();
+    assert_eq!(any.kid(), "from-pub");
+}
+
+#[test]
+fn any_jwk_from_private_preserves_kid() {
+    let private = PrivateJwk::Oct(OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: "from-priv".to_string(),
+        k: "secret".to_string(),
+    });
+    let any: AnyJwk = private.into();
+    assert_eq!(any.kid(), "from-priv");
+}
+
+// ── Empty JWKS ───────────────────────────────────────────────────────
+
+#[test]
+fn empty_jwks_serializes_to_empty_keys_array() {
+    let jwks = Jwks { keys: vec![] };
+    let v = jwks.to_value();
+    assert_eq!(v["keys"].as_array().unwrap().len(), 0);
+}
+
+// ── kid accessors on all public variants ─────────────────────────────
+
+#[test]
+fn public_jwk_kid_accessor_all_variants() {
+    let rsa = PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: "rsa-kid".to_string(),
+        n: "n".to_string(),
+        e: "e".to_string(),
+    });
+    assert_eq!(rsa.kid(), "rsa-kid");
+
+    let ec = PublicJwk::Ec(EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: "ec-kid".to_string(),
+        x: "x".to_string(),
+        y: "y".to_string(),
+    });
+    assert_eq!(ec.kid(), "ec-kid");
+
+    let okp = PublicJwk::Okp(OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: "okp-kid".to_string(),
+        x: "x".to_string(),
+    });
+    assert_eq!(okp.kid(), "okp-kid");
+}
+
+// ── kid accessors on all private variants ────────────────────────────
+
+#[test]
+fn private_jwk_kid_accessor_all_variants() {
+    let rsa = PrivateJwk::Rsa(RsaPrivateJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: "rsa-priv".to_string(),
+        n: "n".to_string(),
+        e: "e".to_string(),
+        d: "d".to_string(),
+        p: "p".to_string(),
+        q: "q".to_string(),
+        dp: "dp".to_string(),
+        dq: "dq".to_string(),
+        qi: "qi".to_string(),
+    });
+    assert_eq!(rsa.kid(), "rsa-priv");
+
+    let ec = PrivateJwk::Ec(EcPrivateJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: "ec-priv".to_string(),
+        x: "x".to_string(),
+        y: "y".to_string(),
+        d: "d".to_string(),
+    });
+    assert_eq!(ec.kid(), "ec-priv");
+
+    let okp = PrivateJwk::Okp(OkpPrivateJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: "okp-priv".to_string(),
+        x: "x".to_string(),
+        d: "d".to_string(),
+    });
+    assert_eq!(okp.kid(), "okp-priv");
+
+    let oct = PrivateJwk::Oct(OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: "oct-priv".to_string(),
+        k: "k".to_string(),
+    });
+    assert_eq!(oct.kid(), "oct-priv");
+}

--- a/crates/uselesskey-core-jwks-order/tests/edge_cases.rs
+++ b/crates/uselesskey-core-jwks-order/tests/edge_cases.rs
@@ -1,0 +1,163 @@
+//! Integration tests for KidSorted — edge cases, Debug format, and
+//! Default trait behavior.
+
+use uselesskey_core_jwks_order::{HasKid, KidSorted};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct Item {
+    kid: String,
+    seq: usize,
+}
+
+impl HasKid for Item {
+    fn kid(&self) -> &str {
+        &self.kid
+    }
+}
+
+fn item(kid: &str, seq: usize) -> Item {
+    Item {
+        kid: kid.to_string(),
+        seq,
+    }
+}
+
+// ── empty collection ─────────────────────────────────────────────────
+
+#[test]
+fn empty_build_returns_empty_vec() {
+    let sorter = KidSorted::<Item>::new();
+    let result = sorter.build();
+    assert!(result.is_empty());
+}
+
+// ── single item ──────────────────────────────────────────────────────
+
+#[test]
+fn single_item_build_returns_that_item() {
+    let mut sorter = KidSorted::new();
+    sorter.push(item("only", 1));
+    let result = sorter.build();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].kid, "only");
+}
+
+// ── lexicographic ordering ───────────────────────────────────────────
+
+#[test]
+fn sorts_lexicographically_by_kid() {
+    let mut sorter = KidSorted::new();
+    sorter.push(item("charlie", 0));
+    sorter.push(item("alpha", 1));
+    sorter.push(item("bravo", 2));
+
+    let result = sorter.build();
+    let kids: Vec<&str> = result.iter().map(|i| i.kid.as_str()).collect();
+    assert_eq!(kids, vec!["alpha", "bravo", "charlie"]);
+}
+
+#[test]
+fn numeric_kids_sort_lexicographically_not_numerically() {
+    let mut sorter = KidSorted::new();
+    sorter.push(item("9", 0));
+    sorter.push(item("10", 1));
+    sorter.push(item("2", 2));
+
+    let result = sorter.build();
+    let kids: Vec<&str> = result.iter().map(|i| i.kid.as_str()).collect();
+    // Lexicographic: "10" < "2" < "9"
+    assert_eq!(kids, vec!["10", "2", "9"]);
+}
+
+// ── stable tie-breaking ──────────────────────────────────────────────
+
+#[test]
+fn duplicate_kids_preserve_insertion_order() {
+    let mut sorter = KidSorted::new();
+    sorter.push(item("dup", 1));
+    sorter.push(item("dup", 2));
+    sorter.push(item("dup", 3));
+
+    let result = sorter.build();
+    let seqs: Vec<usize> = result.iter().map(|i| i.seq).collect();
+    assert_eq!(seqs, vec![1, 2, 3]);
+}
+
+#[test]
+fn mixed_unique_and_duplicate_kids() {
+    let mut sorter = KidSorted::new();
+    sorter.push(item("b", 1));
+    sorter.push(item("a", 2));
+    sorter.push(item("b", 3));
+    sorter.push(item("a", 4));
+
+    let result = sorter.build();
+    let kids: Vec<(&str, usize)> = result.iter().map(|i| (i.kid.as_str(), i.seq)).collect();
+    assert_eq!(kids, vec![("a", 2), ("a", 4), ("b", 1), ("b", 3)]);
+}
+
+// ── unicode kids ─────────────────────────────────────────────────────
+
+#[test]
+fn unicode_kids_sort_by_byte_order() {
+    let mut sorter = KidSorted::new();
+    sorter.push(item("ñ", 0));
+    sorter.push(item("a", 1));
+    sorter.push(item("z", 2));
+
+    let result = sorter.build();
+    // 'a' < 'z' < 'ñ' (ñ is multi-byte UTF-8: 0xC3 0xB1)
+    let kids: Vec<&str> = result.iter().map(|i| i.kid.as_str()).collect();
+    assert_eq!(kids, vec!["a", "z", "ñ"]);
+}
+
+// ── empty string kid ─────────────────────────────────────────────────
+
+#[test]
+fn empty_kid_sorts_first() {
+    let mut sorter = KidSorted::new();
+    sorter.push(item("z", 0));
+    sorter.push(item("", 1));
+    sorter.push(item("a", 2));
+
+    let result = sorter.build();
+    let kids: Vec<&str> = result.iter().map(|i| i.kid.as_str()).collect();
+    assert_eq!(kids, vec!["", "a", "z"]);
+}
+
+// ── Debug format ─────────────────────────────────────────────────────
+
+#[test]
+fn debug_shows_entry_count() {
+    let mut sorter = KidSorted::new();
+    sorter.push(item("a", 1));
+    sorter.push(item("b", 2));
+
+    let dbg = format!("{sorter:?}");
+    assert!(dbg.contains("KidSorted"));
+    assert!(dbg.contains("2"));
+}
+
+// ── Default trait ────────────────────────────────────────────────────
+
+#[test]
+fn default_creates_empty_sorter() {
+    let sorter = KidSorted::<Item>::default();
+    let result = sorter.build();
+    assert!(result.is_empty());
+}
+
+// ── large collection ─────────────────────────────────────────────────
+
+#[test]
+fn large_collection_sorts_correctly() {
+    let mut sorter = KidSorted::new();
+    for i in (0..100).rev() {
+        sorter.push(item(&format!("{i:03}"), i));
+    }
+
+    let result = sorter.build();
+    for (i, item) in result.iter().enumerate() {
+        assert_eq!(item.kid, format!("{i:03}"));
+    }
+}

--- a/crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs
+++ b/crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs
@@ -1,0 +1,155 @@
+//! Integration tests for negative fixture support in Pkcs8SpkiKeyMaterial.
+
+use uselesskey_core_keypair_material::Pkcs8SpkiKeyMaterial;
+
+fn sample() -> Pkcs8SpkiKeyMaterial {
+    Pkcs8SpkiKeyMaterial::new(
+        vec![0x30, 0x82, 0x01, 0x22, 0x10, 0x20, 0x30, 0x40],
+        "-----BEGIN PRIVATE KEY-----\nMIIBVQ==\n-----END PRIVATE KEY-----\n",
+        vec![0x30, 0x59, 0x30, 0x13, 0xAA, 0xBB, 0xCC, 0xDD],
+        "-----BEGIN PUBLIC KEY-----\nMFkwEw==\n-----END PUBLIC KEY-----\n",
+    )
+}
+
+// ── corrupt PEM ──────────────────────────────────────────────────────
+
+#[test]
+fn corrupt_pem_bad_header_replaces_header() {
+    use uselesskey_core::negative::CorruptPem;
+
+    let m = sample();
+    let corrupted = m.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+    assert!(corrupted.contains("CORRUPTED KEY"));
+    assert!(!corrupted.contains("BEGIN PRIVATE KEY"));
+}
+
+#[test]
+fn corrupt_pem_bad_base64_is_not_valid_base64() {
+    use uselesskey_core::negative::CorruptPem;
+
+    let m = sample();
+    let corrupted = m.private_key_pkcs8_pem_corrupt(CorruptPem::BadBase64);
+    assert!(corrupted.contains("THIS_IS_NOT_BASE64!!!"));
+}
+
+#[test]
+fn corrupt_pem_truncate_shortens_output() {
+    use uselesskey_core::negative::CorruptPem;
+
+    let m = sample();
+    let corrupted = m.private_key_pkcs8_pem_corrupt(CorruptPem::Truncate { bytes: 10 });
+    assert_eq!(corrupted.len(), 10);
+}
+
+// ── deterministic PEM corruption ─────────────────────────────────────
+
+#[test]
+fn deterministic_pem_corruption_is_reproducible() {
+    let m = sample();
+    let a = m.private_key_pkcs8_pem_corrupt_deterministic("corrupt:v1");
+    let b = m.private_key_pkcs8_pem_corrupt_deterministic("corrupt:v1");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn deterministic_pem_corruption_differs_across_variants() {
+    let m = sample();
+    let a = m.private_key_pkcs8_pem_corrupt_deterministic("corrupt:alpha");
+    let b = m.private_key_pkcs8_pem_corrupt_deterministic("corrupt:beta");
+    assert_ne!(a, b);
+}
+
+// ── truncated DER ────────────────────────────────────────────────────
+
+#[test]
+fn truncated_der_respects_length() {
+    let m = sample();
+    let truncated = m.private_key_pkcs8_der_truncated(3);
+    assert_eq!(truncated.len(), 3);
+    assert_eq!(truncated, &m.private_key_pkcs8_der()[..3]);
+}
+
+#[test]
+fn truncated_der_beyond_len_returns_full() {
+    let m = sample();
+    let truncated = m.private_key_pkcs8_der_truncated(1000);
+    assert_eq!(truncated, m.private_key_pkcs8_der());
+}
+
+#[test]
+fn truncated_der_to_zero_returns_empty() {
+    let m = sample();
+    let truncated = m.private_key_pkcs8_der_truncated(0);
+    assert!(truncated.is_empty());
+}
+
+// ── deterministic DER corruption ─────────────────────────────────────
+
+#[test]
+fn deterministic_der_corruption_is_reproducible() {
+    let m = sample();
+    let a = m.private_key_pkcs8_der_corrupt_deterministic("corrupt:d1");
+    let b = m.private_key_pkcs8_der_corrupt_deterministic("corrupt:d1");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn deterministic_der_corruption_differs_from_original() {
+    let m = sample();
+    let corrupted = m.private_key_pkcs8_der_corrupt_deterministic("corrupt:d1");
+    assert_ne!(corrupted, m.private_key_pkcs8_der());
+}
+
+#[test]
+fn deterministic_der_corruption_differs_across_variants() {
+    let m = sample();
+    let a = m.private_key_pkcs8_der_corrupt_deterministic("corrupt:x");
+    let b = m.private_key_pkcs8_der_corrupt_deterministic("corrupt:y");
+    assert_ne!(a, b);
+}
+
+// ── clone preserves data ─────────────────────────────────────────────
+
+#[test]
+fn clone_preserves_all_accessors() {
+    let m = sample();
+    let c = m.clone();
+    assert_eq!(c.private_key_pkcs8_der(), m.private_key_pkcs8_der());
+    assert_eq!(c.private_key_pkcs8_pem(), m.private_key_pkcs8_pem());
+    assert_eq!(c.public_key_spki_der(), m.public_key_spki_der());
+    assert_eq!(c.public_key_spki_pem(), m.public_key_spki_pem());
+    assert_eq!(c.kid(), m.kid());
+}
+
+// ── tempfile round trips ─────────────────────────────────────────────
+
+#[test]
+fn write_private_key_tempfile_has_pem_extension() {
+    let m = sample();
+    let temp = m.write_private_key_pkcs8_pem().unwrap();
+    let ext = temp.path().extension().unwrap().to_str().unwrap();
+    assert_eq!(ext, "pem");
+}
+
+#[test]
+fn write_public_key_tempfile_has_pem_extension() {
+    let m = sample();
+    let temp = m.write_public_key_spki_pem().unwrap();
+    let ext = temp.path().extension().unwrap().to_str().unwrap();
+    assert_eq!(ext, "pem");
+}
+
+#[test]
+fn tempfile_round_trip_preserves_content() {
+    let m = sample();
+    let private_temp = m.write_private_key_pkcs8_pem().unwrap();
+    let public_temp = m.write_public_key_spki_pem().unwrap();
+    assert_eq!(
+        private_temp.read_to_string().unwrap(),
+        m.private_key_pkcs8_pem()
+    );
+    assert_eq!(
+        public_temp.read_to_string().unwrap(),
+        m.public_key_spki_pem()
+    );
+}

--- a/crates/uselesskey-core-token-shape/tests/edge_cases.rs
+++ b/crates/uselesskey-core-token-shape/tests/edge_cases.rs
@@ -1,0 +1,137 @@
+//! Integration tests for token shape generation primitives — edge cases,
+//! constants, and cross-kind behavior.
+
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::SeedableRng;
+
+use uselesskey_core_token_shape::{
+    API_KEY_PREFIX, API_KEY_RANDOM_LEN, BEARER_RANDOM_BYTES, OAUTH_JTI_BYTES,
+    OAUTH_SIGNATURE_BYTES, TokenKind, authorization_scheme, generate_token, random_base62,
+};
+
+fn rng(seed: u8) -> ChaCha20Rng {
+    ChaCha20Rng::from_seed([seed; 32])
+}
+
+// ── constant values ──────────────────────────────────────────────────
+
+#[test]
+fn api_key_prefix_is_uk_test() {
+    assert_eq!(API_KEY_PREFIX, "uk_test_");
+}
+
+#[test]
+fn api_key_random_len_is_32() {
+    assert_eq!(API_KEY_RANDOM_LEN, 32);
+}
+
+#[test]
+fn bearer_random_bytes_is_32() {
+    assert_eq!(BEARER_RANDOM_BYTES, 32);
+}
+
+#[test]
+fn oauth_jti_bytes_is_16() {
+    assert_eq!(OAUTH_JTI_BYTES, 16);
+}
+
+#[test]
+fn oauth_signature_bytes_is_32() {
+    assert_eq!(OAUTH_SIGNATURE_BYTES, 32);
+}
+
+// ── TokenKind derives ────────────────────────────────────────────────
+
+#[test]
+fn token_kind_debug_format() {
+    assert_eq!(format!("{:?}", TokenKind::ApiKey), "ApiKey");
+    assert_eq!(format!("{:?}", TokenKind::Bearer), "Bearer");
+    assert_eq!(
+        format!("{:?}", TokenKind::OAuthAccessToken),
+        "OAuthAccessToken"
+    );
+}
+
+#[test]
+fn token_kind_clone_eq() {
+    let a = TokenKind::Bearer;
+    let b = a;
+    assert_eq!(a, b);
+}
+
+#[test]
+fn token_kind_hash_is_usable() {
+    use std::collections::HashSet;
+    let mut set = HashSet::new();
+    set.insert(TokenKind::ApiKey);
+    set.insert(TokenKind::Bearer);
+    set.insert(TokenKind::OAuthAccessToken);
+    assert_eq!(set.len(), 3);
+}
+
+// ── random_base62 edge cases ─────────────────────────────────────────
+
+#[test]
+fn random_base62_zero_length() {
+    let s = random_base62(&mut rng(1), 0);
+    assert!(s.is_empty());
+}
+
+#[test]
+fn random_base62_one_char() {
+    let s = random_base62(&mut rng(2), 1);
+    assert_eq!(s.len(), 1);
+    assert!(s.chars().next().unwrap().is_ascii_alphanumeric());
+}
+
+#[test]
+fn random_base62_large_length() {
+    let s = random_base62(&mut rng(3), 1000);
+    assert_eq!(s.len(), 1000);
+    assert!(s.chars().all(|c| c.is_ascii_alphanumeric()));
+}
+
+#[test]
+fn random_base62_deterministic() {
+    let a = random_base62(&mut rng(4), 50);
+    let b = random_base62(&mut rng(4), 50);
+    assert_eq!(a, b);
+}
+
+// ── cross-kind uniqueness ────────────────────────────────────────────
+
+#[test]
+fn same_seed_different_kinds_produce_different_tokens() {
+    let api = generate_token("label", TokenKind::ApiKey, &mut rng(20));
+    let bearer = generate_token("label", TokenKind::Bearer, &mut rng(20));
+    let oauth = generate_token("label", TokenKind::OAuthAccessToken, &mut rng(20));
+
+    assert_ne!(api, bearer);
+    assert_ne!(api, oauth);
+    assert_ne!(bearer, oauth);
+}
+
+// ── authorization_scheme exhaustive ──────────────────────────────────
+
+#[test]
+fn authorization_scheme_covers_all_kinds() {
+    assert_eq!(authorization_scheme(TokenKind::ApiKey), "ApiKey");
+    assert_eq!(authorization_scheme(TokenKind::Bearer), "Bearer");
+    assert_eq!(authorization_scheme(TokenKind::OAuthAccessToken), "Bearer");
+}
+
+// ── different seeds produce different output ─────────────────────────
+
+#[test]
+fn different_seeds_produce_different_api_keys() {
+    let a = generate_token("lbl", TokenKind::ApiKey, &mut rng(30));
+    let b = generate_token("lbl", TokenKind::ApiKey, &mut rng(31));
+    assert_ne!(a, b);
+}
+
+#[test]
+fn different_seeds_produce_different_bearer_tokens() {
+    let a = generate_token("lbl", TokenKind::Bearer, &mut rng(32));
+    let b = generate_token("lbl", TokenKind::Bearer, &mut rng(33));
+    assert_ne!(a, b);
+}

--- a/crates/uselesskey-core-token/tests/token_integration.rs
+++ b/crates/uselesskey-core-token/tests/token_integration.rs
@@ -1,0 +1,162 @@
+//! Integration tests for token generation facade — covers all token kinds,
+//! determinism, and structural invariants.
+
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::SeedableRng;
+
+use uselesskey_core_token::{
+    TokenKind, authorization_scheme, generate_api_key, generate_bearer_token,
+    generate_oauth_access_token, generate_token,
+};
+
+fn rng(seed: u8) -> ChaCha20Rng {
+    ChaCha20Rng::from_seed([seed; 32])
+}
+
+// ── API key structural invariants ────────────────────────────────────
+
+#[test]
+fn api_key_starts_with_prefix() {
+    let key = generate_api_key(&mut rng(1));
+    assert!(key.starts_with("uk_test_"));
+}
+
+#[test]
+fn api_key_is_exactly_40_chars() {
+    let key = generate_api_key(&mut rng(2));
+    assert_eq!(key.len(), 40); // 8 prefix + 32 random base62
+}
+
+#[test]
+fn api_key_suffix_is_alphanumeric() {
+    let key = generate_api_key(&mut rng(3));
+    let suffix = key.strip_prefix("uk_test_").unwrap();
+    assert!(suffix.chars().all(|c| c.is_ascii_alphanumeric()));
+}
+
+// ── bearer token structural invariants ───────────────────────────────
+
+#[test]
+fn bearer_token_is_base64url() {
+    let token = generate_bearer_token(&mut rng(4));
+    for ch in token.chars() {
+        assert!(
+            ch.is_ascii_alphanumeric() || ch == '-' || ch == '_',
+            "unexpected char: {ch}"
+        );
+    }
+}
+
+#[test]
+fn bearer_token_is_43_chars() {
+    let token = generate_bearer_token(&mut rng(5));
+    assert_eq!(token.len(), 43); // ceil(32 * 4/3) = 43 with no padding
+}
+
+#[test]
+fn bearer_token_decodes_to_32_bytes() {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let token = generate_bearer_token(&mut rng(6));
+    let decoded = URL_SAFE_NO_PAD.decode(token).unwrap();
+    assert_eq!(decoded.len(), 32);
+}
+
+// ── OAuth access token structural invariants ─────────────────────────
+
+#[test]
+fn oauth_token_has_three_dot_separated_segments() {
+    let token = generate_oauth_access_token("svc", &mut rng(7));
+    assert_eq!(token.matches('.').count(), 2);
+}
+
+#[test]
+fn oauth_token_payload_contains_label_as_sub() {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let token = generate_oauth_access_token("my-service", &mut rng(8));
+    let parts: Vec<&str> = token.split('.').collect();
+    let payload = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+    assert_eq!(json["sub"], "my-service");
+    assert_eq!(json["iss"], "uselesskey");
+    assert_eq!(json["aud"], "tests");
+}
+
+#[test]
+fn oauth_token_header_is_rs256_jwt() {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+    let token = generate_oauth_access_token("svc", &mut rng(9));
+    let parts: Vec<&str> = token.split('.').collect();
+    let header = URL_SAFE_NO_PAD.decode(parts[0]).unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&header).unwrap();
+    assert_eq!(json["alg"], "RS256");
+    assert_eq!(json["typ"], "JWT");
+}
+
+// ── generate_token dispatches correctly ──────────────────────────────
+
+#[test]
+fn generate_token_api_key_matches_direct() {
+    let a = generate_token("label", TokenKind::ApiKey, &mut rng(10));
+    let b = generate_api_key(&mut rng(10));
+    assert_eq!(a, b);
+}
+
+#[test]
+fn generate_token_bearer_matches_direct() {
+    let a = generate_token("label", TokenKind::Bearer, &mut rng(11));
+    let b = generate_bearer_token(&mut rng(11));
+    assert_eq!(a, b);
+}
+
+#[test]
+fn generate_token_oauth_matches_direct() {
+    let a = generate_token("label", TokenKind::OAuthAccessToken, &mut rng(12));
+    let b = generate_oauth_access_token("label", &mut rng(12));
+    assert_eq!(a, b);
+}
+
+// ── authorization_scheme ─────────────────────────────────────────────
+
+#[test]
+fn authorization_scheme_api_key() {
+    assert_eq!(authorization_scheme(TokenKind::ApiKey), "ApiKey");
+}
+
+#[test]
+fn authorization_scheme_bearer() {
+    assert_eq!(authorization_scheme(TokenKind::Bearer), "Bearer");
+}
+
+#[test]
+fn authorization_scheme_oauth() {
+    assert_eq!(authorization_scheme(TokenKind::OAuthAccessToken), "Bearer");
+}
+
+// ── determinism ──────────────────────────────────────────────────────
+
+#[test]
+fn all_token_kinds_are_deterministic() {
+    for kind in [
+        TokenKind::ApiKey,
+        TokenKind::Bearer,
+        TokenKind::OAuthAccessToken,
+    ] {
+        let a = generate_token("lbl", kind, &mut rng(50));
+        let b = generate_token("lbl", kind, &mut rng(50));
+        assert_eq!(a, b, "kind {kind:?} not deterministic");
+    }
+}
+
+#[test]
+fn different_labels_produce_different_oauth_tokens() {
+    let a = generate_oauth_access_token("service-a", &mut rng(60));
+    let b = generate_oauth_access_token("service-b", &mut rng(60));
+    // Same seed but different labels → different payload → different token
+    assert_ne!(a, b);
+}

--- a/crates/uselesskey-core-x509-negative/tests/x509_negative_integration.rs
+++ b/crates/uselesskey-core-x509-negative/tests/x509_negative_integration.rs
@@ -1,0 +1,222 @@
+//! Integration tests for X.509 negative-fixture policies — covers all
+//! variants, spec mutation safety, and stable metadata.
+
+use uselesskey_core_x509_negative::{ChainNegative, X509Negative};
+use uselesskey_core_x509_spec::{ChainSpec, KeyUsage, NotBeforeOffset, X509Spec};
+
+// ── X509Negative: each variant produces a distinct mutation ──────────
+
+#[test]
+fn all_x509_negative_variants_differ_from_base() {
+    let base = X509Spec::self_signed("neg.example.com");
+    let variants = [
+        X509Negative::Expired,
+        X509Negative::NotYetValid,
+        X509Negative::WrongKeyUsage,
+        X509Negative::SelfSignedButClaimsCA,
+    ];
+
+    for v in &variants {
+        let mutated = v.apply_to_spec(&base);
+        assert_ne!(
+            mutated.stable_bytes(),
+            base.stable_bytes(),
+            "variant {v:?} should differ from base"
+        );
+    }
+}
+
+#[test]
+fn all_x509_negative_variants_differ_from_each_other() {
+    let base = X509Spec::self_signed("neg.example.com");
+    let variants = [
+        X509Negative::Expired,
+        X509Negative::NotYetValid,
+        X509Negative::WrongKeyUsage,
+        X509Negative::SelfSignedButClaimsCA,
+    ];
+
+    for (i, vi) in variants.iter().enumerate() {
+        for (j, vj) in variants.iter().enumerate() {
+            if i != j {
+                let si = vi.apply_to_spec(&base);
+                let sj = vj.apply_to_spec(&base);
+                assert_ne!(
+                    si.stable_bytes(),
+                    sj.stable_bytes(),
+                    "{vi:?} and {vj:?} should produce different specs"
+                );
+            }
+        }
+    }
+}
+
+// ── X509Negative: mutation doesn't corrupt unrelated fields ──────────
+
+#[test]
+fn expired_preserves_cn() {
+    let base = X509Spec::self_signed("preserve.example.com");
+    let mutated = X509Negative::Expired.apply_to_spec(&base);
+    assert_eq!(mutated.subject_cn, base.subject_cn);
+}
+
+#[test]
+fn not_yet_valid_preserves_key_usage() {
+    let base = X509Spec::self_signed("preserve.example.com");
+    let mutated = X509Negative::NotYetValid.apply_to_spec(&base);
+    assert_eq!(mutated.key_usage, KeyUsage::leaf());
+    assert!(!mutated.is_ca);
+}
+
+#[test]
+fn wrong_key_usage_exact_flags() {
+    let base = X509Spec::self_signed("flags.example.com");
+    let mutated = X509Negative::WrongKeyUsage.apply_to_spec(&base);
+    assert!(mutated.is_ca);
+    assert!(!mutated.key_usage.key_cert_sign);
+    assert!(!mutated.key_usage.crl_sign);
+    assert!(mutated.key_usage.digital_signature);
+    assert!(mutated.key_usage.key_encipherment);
+}
+
+#[test]
+fn self_signed_ca_sets_ca_key_usage() {
+    let base = X509Spec::self_signed("ca.example.com");
+    let mutated = X509Negative::SelfSignedButClaimsCA.apply_to_spec(&base);
+    assert!(mutated.is_ca);
+    assert_eq!(mutated.key_usage, KeyUsage::ca());
+}
+
+// ── X509Negative: metadata stability ─────────────────────────────────
+
+#[test]
+fn variant_names_are_unique() {
+    let names: Vec<&str> = [
+        X509Negative::Expired,
+        X509Negative::NotYetValid,
+        X509Negative::WrongKeyUsage,
+        X509Negative::SelfSignedButClaimsCA,
+    ]
+    .iter()
+    .map(|v| v.variant_name())
+    .collect();
+
+    let unique: std::collections::HashSet<&&str> = names.iter().collect();
+    assert_eq!(unique.len(), names.len());
+}
+
+#[test]
+fn descriptions_are_non_empty() {
+    for v in [
+        X509Negative::Expired,
+        X509Negative::NotYetValid,
+        X509Negative::WrongKeyUsage,
+        X509Negative::SelfSignedButClaimsCA,
+    ] {
+        assert!(!v.description().is_empty(), "{v:?} has empty description");
+    }
+}
+
+// ── ChainNegative: all variants produce valid mutations ──────────────
+
+#[test]
+fn chain_hostname_mismatch_replaces_leaf_cn_and_sans() {
+    let base = ChainSpec::new("api.example.com");
+    let neg = ChainNegative::HostnameMismatch {
+        wrong_hostname: "evil.example.com".to_string(),
+    };
+    let mutated = neg.apply_to_spec(&base);
+    assert_eq!(mutated.leaf_cn, "evil.example.com");
+    assert_eq!(mutated.leaf_sans, vec!["evil.example.com"]);
+    // Root and intermediate should be preserved
+    assert_eq!(mutated.root_cn, base.root_cn);
+    assert_eq!(mutated.intermediate_cn, base.intermediate_cn);
+}
+
+#[test]
+fn chain_unknown_ca_modifies_root_cn_only() {
+    let base = ChainSpec::new("api.example.com");
+    let mutated = ChainNegative::UnknownCa.apply_to_spec(&base);
+    assert!(mutated.root_cn.contains("Unknown"));
+    assert_ne!(mutated.root_cn, base.root_cn);
+    assert_eq!(mutated.leaf_cn, base.leaf_cn);
+    assert_eq!(mutated.intermediate_cn, base.intermediate_cn);
+}
+
+#[test]
+fn chain_expired_leaf_sets_short_validity_and_past_offset() {
+    let base = ChainSpec::new("api.example.com");
+    let mutated = ChainNegative::ExpiredLeaf.apply_to_spec(&base);
+    assert_eq!(mutated.leaf_validity_days, 1);
+    assert_eq!(mutated.leaf_not_before_offset_days, Some(730));
+    // Intermediate should be unchanged
+    assert_eq!(
+        mutated.intermediate_validity_days,
+        base.intermediate_validity_days
+    );
+}
+
+#[test]
+fn chain_expired_intermediate_sets_short_validity_and_past_offset() {
+    let base = ChainSpec::new("api.example.com");
+    let mutated = ChainNegative::ExpiredIntermediate.apply_to_spec(&base);
+    assert_eq!(mutated.intermediate_validity_days, 1);
+    assert_eq!(mutated.intermediate_not_before_offset_days, Some(730));
+    // Leaf should be unchanged
+    assert_eq!(mutated.leaf_validity_days, base.leaf_validity_days);
+}
+
+#[test]
+fn chain_revoked_leaf_does_not_mutate_spec() {
+    let base = ChainSpec::new("api.example.com");
+    let mutated = ChainNegative::RevokedLeaf.apply_to_spec(&base);
+    assert_eq!(mutated.leaf_cn, base.leaf_cn);
+    assert_eq!(mutated.leaf_validity_days, base.leaf_validity_days);
+    assert_eq!(mutated.root_cn, base.root_cn);
+}
+
+// ── ChainNegative: variant name stability ────────────────────────────
+
+#[test]
+fn chain_variant_names_are_unique() {
+    let names: Vec<String> = vec![
+        ChainNegative::HostnameMismatch {
+            wrong_hostname: "test.com".to_string(),
+        }
+        .variant_name(),
+        ChainNegative::UnknownCa.variant_name(),
+        ChainNegative::ExpiredLeaf.variant_name(),
+        ChainNegative::ExpiredIntermediate.variant_name(),
+        ChainNegative::RevokedLeaf.variant_name(),
+    ];
+
+    let unique: std::collections::HashSet<&String> = names.iter().collect();
+    assert_eq!(unique.len(), names.len());
+}
+
+#[test]
+fn chain_hostname_mismatch_variant_name_includes_hostname() {
+    let neg = ChainNegative::HostnameMismatch {
+        wrong_hostname: "wrong.example.com".to_string(),
+    };
+    let name = neg.variant_name();
+    assert!(name.contains("hostname_mismatch"));
+    assert!(name.contains("wrong.example.com"));
+}
+
+// ── X509Negative: timing values ──────────────────────────────────────
+
+#[test]
+fn expired_has_not_before_in_the_past() {
+    let base = X509Spec::self_signed("timing.example.com");
+    let mutated = X509Negative::Expired.apply_to_spec(&base);
+    assert_eq!(mutated.not_before_offset, NotBeforeOffset::DaysAgo(395));
+    assert_eq!(mutated.validity_days, 365);
+}
+
+#[test]
+fn not_yet_valid_has_not_before_in_the_future() {
+    let base = X509Spec::self_signed("timing.example.com");
+    let mutated = X509Negative::NotYetValid.apply_to_spec(&base);
+    assert_eq!(mutated.not_before_offset, NotBeforeOffset::DaysFromNow(30));
+}


### PR DESCRIPTION
## Summary

Adds integration test suites for 8 core microcrates that had thin or no integration test coverage, bringing ~111 new test cases across the workspace.

## New test files

| Crate | File | Tests | Coverage areas |
|-------|------|-------|---------------|
| core-factory | factory_concurrency.rs | 8 | Concurrent get_or_init, clone cache sharing, deterministic reproducibility, random mode, Debug |
| core-hash | edge_cases.rs | 10 | Empty input, single byte, boundary conditions, re-exports, determinism |
| core-jwk-shape | jwk_shape_integration.rs | 16 | All JWK type variants, Debug safety, JWKS serialization, From conversions, kid accessors |
| core-jwks-order | edge_cases.rs | 13 | Lexicographic ordering, stable tie-breaking, unicode, empty/large collections |
| core-keypair-material | negative_fixtures.rs | 17 | Corrupt PEM/DER, deterministic corruption, truncation, tempfile round-trips, kid stability, Debug safety |
| core-token | token_integration.rs | 16 | All token kinds, structural invariants, base64/JSON validation, authorization_scheme, determinism |
| core-token-shape | edge_cases.rs | 13 | Constants, TokenKind derives, random_base62 edge cases, cross-kind uniqueness, auth schemes |
| core-x509-negative | x509_negative_integration.rs | 18 | All X509Negative/ChainNegative variants, mutation safety, metadata stability, timing values |

## Validation

- cargo test --workspace --all-features: all new tests pass
- cargo fmt: clean
- cargo clippy --workspace --all-features --tests -- -D warnings: clean

## Notes

- No source code changes; test-only additions
- Pre-existing doctest failure in uselesskey-x509 (ChainSpec::default example) is unrelated to this PR
