### PR TITLE
test: add doc-test examples to algorithm crate public APIs

### DIFF
--- a/crates/uselesskey-ecdsa/src/keypair.rs
+++ b/crates/uselesskey-ecdsa/src/keypair.rs
@@ -123,6 +123,19 @@ impl EcdsaKeyPair {
     }
 
     /// PKCS#8 PEM-encoded private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("test", EcdsaSpec::es256());
+    /// let pem = kp.private_key_pkcs8_pem();
+    /// assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    /// assert!(pem.ends_with("-----END PRIVATE KEY-----\n"));
+    /// ```
     pub fn private_key_pkcs8_pem(&self) -> &str {
         self.inner.material.private_key_pkcs8_pem()
     }
@@ -133,6 +146,19 @@ impl EcdsaKeyPair {
     }
 
     /// SPKI PEM-encoded public key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("test", EcdsaSpec::es256());
+    /// let pem = kp.public_key_spki_pem();
+    /// assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    /// assert!(pem.ends_with("-----END PUBLIC KEY-----\n"));
+    /// ```
     pub fn public_key_spki_pem(&self) -> &str {
         self.inner.material.public_key_spki_pem()
     }
@@ -172,6 +198,19 @@ impl EcdsaKeyPair {
     }
 
     /// Return a valid (parseable) public key that does *not* match this private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("test", EcdsaSpec::es256());
+    /// let wrong_pub = kp.mismatched_public_key_spki_der();
+    /// assert!(!wrong_pub.is_empty());
+    /// assert_ne!(wrong_pub, kp.public_key_spki_der());
+    /// ```
     pub fn mismatched_public_key_spki_der(&self) -> Vec<u8> {
         let other = self.load_variant("mismatch");
         other.material.public_key_spki_der().to_vec()

--- a/crates/uselesskey-ed25519/src/keypair.rs
+++ b/crates/uselesskey-ed25519/src/keypair.rs
@@ -117,6 +117,19 @@ impl Ed25519KeyPair {
     }
 
     /// PKCS#8 PEM-encoded private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    ///
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("test", Ed25519Spec::new());
+    /// let pem = kp.private_key_pkcs8_pem();
+    /// assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    /// assert!(pem.ends_with("-----END PRIVATE KEY-----\n"));
+    /// ```
     pub fn private_key_pkcs8_pem(&self) -> &str {
         self.inner.material.private_key_pkcs8_pem()
     }
@@ -127,6 +140,19 @@ impl Ed25519KeyPair {
     }
 
     /// SPKI PEM-encoded public key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    ///
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("test", Ed25519Spec::new());
+    /// let pem = kp.public_key_spki_pem();
+    /// assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    /// assert!(pem.ends_with("-----END PUBLIC KEY-----\n"));
+    /// ```
     pub fn public_key_spki_pem(&self) -> &str {
         self.inner.material.public_key_spki_pem()
     }
@@ -166,6 +192,19 @@ impl Ed25519KeyPair {
     }
 
     /// Return a valid (parseable) public key that does *not* match this private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    ///
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("test", Ed25519Spec::new());
+    /// let wrong_pub = kp.mismatched_public_key_spki_der();
+    /// assert!(!wrong_pub.is_empty());
+    /// assert_ne!(wrong_pub, kp.public_key_spki_der());
+    /// ```
     pub fn mismatched_public_key_spki_der(&self) -> Vec<u8> {
         let other = self.load_variant("mismatch");
         other.material.public_key_spki_der().to_vec()

--- a/crates/uselesskey-hmac/src/secret.rs
+++ b/crates/uselesskey-hmac/src/secret.rs
@@ -97,6 +97,18 @@ impl HmacSecret {
     }
 
     /// Access raw secret bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let secret = fx.hmac("signing", HmacSpec::hs256());
+    /// let bytes = secret.secret_bytes();
+    /// assert_eq!(bytes.len(), 32);
+    /// ```
     pub fn secret_bytes(&self) -> &[u8] {
         &self.inner.secret
     }

--- a/crates/uselesskey-rsa/src/keypair.rs
+++ b/crates/uselesskey-rsa/src/keypair.rs
@@ -123,6 +123,19 @@ impl RsaKeyPair {
     }
 
     /// PKCS#8 PEM-encoded private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let kp = fx.rsa("test", RsaSpec::rs256());
+    /// let pem = kp.private_key_pkcs8_pem();
+    /// assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    /// assert!(pem.ends_with("-----END PRIVATE KEY-----\n"));
+    /// ```
     pub fn private_key_pkcs8_pem(&self) -> &str {
         self.inner.material.private_key_pkcs8_pem()
     }
@@ -133,6 +146,19 @@ impl RsaKeyPair {
     }
 
     /// SPKI PEM-encoded public key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let kp = fx.rsa("test", RsaSpec::rs256());
+    /// let pem = kp.public_key_spki_pem();
+    /// assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    /// assert!(pem.ends_with("-----END PUBLIC KEY-----\n"));
+    /// ```
     pub fn public_key_spki_pem(&self) -> &str {
         self.inner.material.public_key_spki_pem()
     }
@@ -172,6 +198,19 @@ impl RsaKeyPair {
     }
 
     /// Return a valid (parseable) public key that does *not* match this private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let kp = fx.rsa("test", RsaSpec::rs256());
+    /// let wrong_pub = kp.mismatched_public_key_spki_der();
+    /// assert!(!wrong_pub.is_empty());
+    /// assert_ne!(wrong_pub, kp.public_key_spki_der());
+    /// ```
     pub fn mismatched_public_key_spki_der(&self) -> Vec<u8> {
         let other = self.load_variant("mismatch");
         other.material.public_key_spki_der().to_vec()

--- a/crates/uselesskey-token/src/lib.rs
+++ b/crates/uselesskey-token/src/lib.rs
@@ -21,6 +21,19 @@
 //! let value = tok.value();
 //! assert!(!value.is_empty());
 //! ```
+//!
+//! # Deterministic mode
+//!
+//! ```
+//! use uselesskey_core::{Factory, Seed};
+//! use uselesskey_token::{TokenFactoryExt, TokenSpec};
+//!
+//! let seed = Seed::from_env_value("test-seed").unwrap();
+//! let fx = Factory::deterministic(seed);
+//! let a = fx.token("key", TokenSpec::api_key());
+//! let b = fx.token("key", TokenSpec::api_key());
+//! assert_eq!(a.value(), b.value()); // same seed + label → same value
+//! ```
 
 mod spec;
 mod token;

--- a/crates/uselesskey-token/src/token.rs
+++ b/crates/uselesskey-token/src/token.rs
@@ -11,6 +11,18 @@ use crate::TokenSpec;
 /// Keep this stable: changing it changes deterministic outputs.
 pub const DOMAIN_TOKEN_FIXTURE: &str = "uselesskey:token:fixture";
 
+/// A generated token fixture.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_core::Factory;
+/// use uselesskey_token::{TokenFactoryExt, TokenSpec};
+///
+/// let fx = Factory::random();
+/// let tok = fx.token("api-key", TokenSpec::api_key());
+/// assert!(!tok.value().is_empty());
+/// ```
 #[derive(Clone)]
 pub struct TokenFixture {
     factory: Factory,
@@ -34,7 +46,33 @@ impl fmt::Debug for TokenFixture {
 
 /// Extension trait to hang token helpers off the core [`Factory`].
 pub trait TokenFactoryExt {
+    /// Generate a token fixture for the given label and spec.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_token::{TokenFactoryExt, TokenSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let tok = fx.token("my-api-key", TokenSpec::api_key());
+    /// assert!(!tok.value().is_empty());
+    /// ```
     fn token(&self, label: impl AsRef<str>, spec: TokenSpec) -> TokenFixture;
+
+    /// Generate a token fixture with a specific variant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_token::{TokenFactoryExt, TokenSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let a = fx.token_with_variant("svc", TokenSpec::bearer(), "v1");
+    /// let b = fx.token_with_variant("svc", TokenSpec::bearer(), "v2");
+    /// assert_ne!(a.value(), b.value());
+    /// ```
     fn token_with_variant(
         &self,
         label: impl AsRef<str>,
@@ -84,6 +122,18 @@ impl TokenFixture {
     }
 
     /// Access the token value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_token::{TokenFactoryExt, TokenSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let tok = fx.token("key", TokenSpec::bearer());
+    /// let val = tok.value();
+    /// assert!(!val.is_empty());
+    /// ```
     pub fn value(&self) -> &str {
         &self.inner.value
     }
@@ -92,6 +142,18 @@ impl TokenFixture {
     ///
     /// - API keys use `ApiKey <token>`
     /// - Bearer and OAuth access tokens use `Bearer <token>`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_token::{TokenFactoryExt, TokenSpec};
+    ///
+    /// let fx = Factory::random();
+    /// let tok = fx.token("key", TokenSpec::api_key());
+    /// let hdr = tok.authorization_header();
+    /// assert!(hdr.starts_with("ApiKey "));
+    /// ```
     pub fn authorization_header(&self) -> String {
         let scheme = authorization_scheme(token_kind(self.spec));
         format!("{scheme} {}", self.value())

--- a/crates/uselesskey-x509/src/cert.rs
+++ b/crates/uselesskey-x509/src/cert.rs
@@ -30,6 +30,18 @@ use crate::negative::{
 pub const DOMAIN_X509_CERT: &str = "uselesskey:x509:cert";
 
 /// An X.509 certificate fixture.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_core::Factory;
+/// use uselesskey_x509::X509FactoryExt;
+/// use uselesskey_core_x509::X509Spec;
+///
+/// let fx = Factory::random();
+/// let cert = fx.x509_self_signed("test", X509Spec::default());
+/// assert!(cert.cert_pem().starts_with("-----BEGIN CERTIFICATE-----"));
+/// ```
 #[derive(Clone)]
 pub struct X509Cert {
     factory: Factory,
@@ -60,12 +72,38 @@ pub trait X509FactoryExt {
     ///
     /// The certificate is cached by `(label, spec)` and will be reused on subsequent calls
     /// with the same parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_x509::X509FactoryExt;
+    /// use uselesskey_core_x509::X509Spec;
+    ///
+    /// let fx = Factory::random();
+    /// let cert = fx.x509_self_signed("server", X509Spec::default());
+    /// assert!(!cert.cert_der().is_empty());
+    /// assert!(cert.cert_pem().contains("CERTIFICATE"));
+    /// ```
     fn x509_self_signed(&self, label: impl AsRef<str>, spec: X509Spec) -> X509Cert;
 
     /// Generate a three-level X.509 certificate chain (root CA → intermediate CA → leaf).
     ///
     /// The chain is cached by `(label, spec)` and will be reused on subsequent calls
     /// with the same parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_x509::X509FactoryExt;
+    /// use uselesskey_core_x509::ChainSpec;
+    ///
+    /// let fx = Factory::random();
+    /// let chain = fx.x509_chain("my-chain", ChainSpec::new("leaf.example.com"));
+    /// assert!(chain.leaf_cert_pem().contains("CERTIFICATE"));
+    /// assert!(chain.root_cert_pem().contains("CERTIFICATE"));
+    /// ```
     fn x509_chain(&self, label: impl AsRef<str>, spec: ChainSpec) -> X509Chain;
 }
 
@@ -123,6 +161,20 @@ impl X509Cert {
     ///
     /// This is a common format for TLS server configuration where
     /// a single file holds the server identity (cert + key).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_x509::X509FactoryExt;
+    /// use uselesskey_core_x509::X509Spec;
+    ///
+    /// let fx = Factory::random();
+    /// let cert = fx.x509_self_signed("server", X509Spec::default());
+    /// let id = cert.identity_pem();
+    /// assert!(id.contains("CERTIFICATE"));
+    /// assert!(id.contains("PRIVATE KEY"));
+    /// ```
     pub fn identity_pem(&self) -> String {
         format!("{}\n{}", self.cert_pem(), self.private_key_pkcs8_pem())
     }
@@ -192,11 +244,37 @@ impl X509Cert {
     }
 
     /// Get a certificate that is already expired.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_x509::X509FactoryExt;
+    /// use uselesskey_core_x509::X509Spec;
+    ///
+    /// let fx = Factory::random();
+    /// let cert = fx.x509_self_signed("test", X509Spec::default());
+    /// let exp = cert.expired();
+    /// assert!(exp.cert_pem().contains("CERTIFICATE"));
+    /// ```
     pub fn expired(&self) -> X509Cert {
         self.negative(X509Negative::Expired)
     }
 
     /// Get a certificate that is not yet valid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core::Factory;
+    /// use uselesskey_x509::X509FactoryExt;
+    /// use uselesskey_core_x509::X509Spec;
+    ///
+    /// let fx = Factory::random();
+    /// let cert = fx.x509_self_signed("test", X509Spec::default());
+    /// let future = cert.not_yet_valid();
+    /// assert!(future.cert_pem().contains("CERTIFICATE"));
+    /// ```
     pub fn not_yet_valid(&self) -> X509Cert {
         self.negative(X509Negative::NotYetValid)
     }


### PR DESCRIPTION
## Summary

Add method-level doc-tests to 6 algorithm crates, verifying output shapes (PEM headers, lengths, non-empty assertions) without embedding actual key material.

## Changes

### RSA, ECDSA, Ed25519 (keypair.rs each)
- `private_key_pkcs8_pem()` — asserts PEM header/footer
- `public_key_spki_pem()` — asserts PEM header/footer
- `mismatched_public_key_spki_der()` — asserts non-empty and different from real pubkey

### HMAC (secret.rs)
- `secret_bytes()` — asserts expected length for HS256 (32 bytes)

### Token (token.rs + lib.rs)
- `TokenFixture` struct — basic creation example
- `token()` — trait method example
- `token_with_variant()` — shows different variants produce different values
- `value()` — basic accessor example
- `authorization_header()` — asserts correct scheme prefix
- Deterministic mode — shows `Seed` + `Factory::deterministic()` usage

### X.509 (cert.rs)
- `X509Cert` struct — basic creation example
- `x509_self_signed()` — asserts DER non-empty, PEM contains CERTIFICATE
- `x509_chain()` — leaf and root cert PEM assertions
- `identity_pem()` — asserts contains both CERTIFICATE and PRIVATE KEY
- `expired()` — asserts still produces valid PEM
- `not_yet_valid()` — asserts still produces valid PEM

## Test results
All doc-tests pass across all 6 crates. `cargo fmt --check` and `cargo clippy` clean.