### PR TITLE
refactor(core): extract shared core error type into `uselesskey-core-error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,8 +3371,8 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rstest",
- "thiserror",
  "uselesskey-core-cache",
+ "uselesskey-core-error",
  "uselesskey-core-factory",
  "uselesskey-core-id",
  "uselesskey-core-negative",
@@ -3388,6 +3388,13 @@ dependencies = [
  "rstest",
  "spin",
  "uselesskey-core-id",
+]
+
+[[package]]
+name = "uselesskey-core-error"
+version = "0.3.0"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -3820,12 +3827,14 @@ name = "uselesskey-x509"
 version = "0.3.0"
 dependencies = [
  "base64",
+ "insta",
  "proptest",
  "rand_chacha 0.3.1",
  "rcgen",
  "rsa",
  "rstest",
  "rustls-pki-types",
+ "serde",
  "time",
  "uselesskey-core",
  "uselesskey-core-x509",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,9 @@ members = [
   "crates/uselesskey-test-grid",
   "crates/uselesskey-feature-grid",
   "crates/uselesskey",
-"crates/uselesskey-core",
-    "crates/uselesskey-core-factory",
+  "crates/uselesskey-core",
+  "crates/uselesskey-core-error",
+  "crates/uselesskey-core-factory",
   "crates/uselesskey-core-cache",
   "crates/uselesskey-core-hash",
   "crates/uselesskey-core-id",
@@ -64,6 +65,7 @@ thiserror = "2.0.18"
 uselesskey-test-grid = { path = "crates/uselesskey-test-grid", version = "0.3.0" }
 uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid", version = "0.3.0" }
 uselesskey-core-cache = { path = "crates/uselesskey-core-cache", version = "0.3.0", default-features = false }
+uselesskey-core-error = { path = "crates/uselesskey-core-error", version = "0.3.0", default-features = false }
 uselesskey-core-factory = { path = "crates/uselesskey-core-factory", version = "0.3.0" }
 uselesskey-core-jwks-order = { path = "crates/uselesskey-core-jwks-order", version = "0.3.0" }
 uselesskey-core-hash = { path = "crates/uselesskey-core-hash", version = "0.3.0", default-features = false }

--- a/crates/uselesskey-core-error/Cargo.toml
+++ b/crates/uselesskey-core-error/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "uselesskey-core-error"
+version = "0.3.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "Shared error types for uselesskey core crates."
+categories.workspace = true
+keywords = ["errors", "fixtures", "testing", "core"]
+readme = "README.md"
+exclude = ["fuzz/**", "corpus/**", "**/*.der", "**/*.pem"]
+homepage.workspace = true
+documentation = "https://docs.rs/uselesskey-core-error"
+authors.workspace = true
+
+[features]
+default = ["std"]
+std = ["thiserror/std"]
+
+[dependencies]
+thiserror = { version = "2.0.18", default-features = false }
+
+[dev-dependencies]
+
+[package.metadata.docs.rs]
+features = ["std"]

--- a/crates/uselesskey-core-error/README.md
+++ b/crates/uselesskey-core-error/README.md
@@ -1,0 +1,6 @@
+# uselesskey-core-error
+
+Shared error types for `uselesskey` core crates.
+
+This crate provides the canonical `Error` enum used by higher-level crates for
+seed/env parsing and IO operations.

--- a/crates/uselesskey-core-error/src/lib.rs
+++ b/crates/uselesskey-core-error/src/lib.rs
@@ -1,11 +1,16 @@
-use alloc::string::String;
+#![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
+use alloc::string::String;
 use thiserror::Error;
 
-/// Errors for `uselesskey-core`.
+/// Errors for `uselesskey` core crates.
 ///
-/// This crate is deliberately “test-first”: many operations are infallible by design.
-/// We still surface IO and environment errors because those are common in test harnesses.
+/// These crates are deliberately test-first: many operations are infallible by
+/// design. We still surface IO and environment errors because those are common
+/// in test harnesses.
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("environment variable `{var}` is not set")]
@@ -42,10 +47,7 @@ mod tests {
             "failed to parse seed from environment variable `MY_VAR`: bad seed"
         );
 
-        #[cfg(feature = "std")]
-        {
-            let io_err: Error = std::io::Error::other("io-fail").into();
-            assert_eq!(io_err.to_string(), "io-fail");
-        }
+        let io_err: Error = std::io::Error::other("io-fail").into();
+        assert_eq!(io_err.to_string(), "io-fail");
     }
 }

--- a/crates/uselesskey-core/Cargo.toml
+++ b/crates/uselesskey-core/Cargo.toml
@@ -18,7 +18,7 @@ authors.workspace = true
 default = ["std"]
 std = [
     "dep:uselesskey-core-sink",
-    "thiserror/std",
+    "uselesskey-core-error/std",
     "rand_chacha/std",
     "uselesskey-core-factory/std",
     "uselesskey-core-cache/std",
@@ -27,7 +27,7 @@ std = [
 ]
 
 [dependencies]
-thiserror = { version = "2.0.18", default-features = false }
+uselesskey-core-error = { path = "../uselesskey-core-error", version = "0.3.0", default-features = false }
 rand_chacha = { workspace = true }
 uselesskey-core-factory = { path = "../uselesskey-core-factory", version = "0.3.0", default-features = false }
 uselesskey-core-sink = { path = "../uselesskey-core-sink", version = "0.3.0", optional = true }

--- a/crates/uselesskey-core/src/lib.rs
+++ b/crates/uselesskey-core/src/lib.rs
@@ -32,15 +32,14 @@
 //! // Extension crates add methods like: fx.rsa("label", spec)
 //! ```
 
-mod error;
 mod factory;
 mod id;
 pub mod negative;
 #[cfg(feature = "std")]
 pub mod sink;
 
-pub use crate::error::Error;
 pub use crate::factory::{Factory, Mode};
 pub use crate::id::{ArtifactDomain, ArtifactId, DerivationVersion, Seed};
 
 extern crate alloc;
+pub use uselesskey_core_error::Error;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -30,6 +30,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +189,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +244,29 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -198,6 +293,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +315,31 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -245,7 +376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -263,6 +394,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -478,6 +615,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +655,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -521,6 +690,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -567,6 +745,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +783,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -678,6 +872,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +901,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -717,6 +938,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,7 +965,16 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -865,6 +1113,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,7 +1133,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -898,6 +1157,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,13 +1206,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "uselesskey"
 version = "0.3.0"
 dependencies = [
  "uselesskey-core",
  "uselesskey-ecdsa",
+ "uselesskey-ed25519",
+ "uselesskey-hmac",
  "uselesskey-rsa",
  "uselesskey-token",
+ "uselesskey-x509",
 ]
 
 [[package]]
@@ -1063,6 +1362,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "uselesskey-core-x509"
+version = "0.3.0"
+dependencies = [
+ "uselesskey-core-x509-derive",
+ "uselesskey-core-x509-negative",
+ "uselesskey-core-x509-spec",
+]
+
+[[package]]
+name = "uselesskey-core-x509-derive"
+version = "0.3.0"
+dependencies = [
+ "rand_core",
+ "rcgen",
+ "time",
+ "uselesskey-core-hash",
+]
+
+[[package]]
 name = "uselesskey-core-x509-negative"
 version = "0.3.0"
 dependencies = [
@@ -1086,11 +1404,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "uselesskey-ed25519"
+version = "0.3.0"
+dependencies = [
+ "ed25519-dalek",
+ "pkcs8",
+ "rand_core",
+ "uselesskey-core",
+ "uselesskey-core-keypair-material",
+]
+
+[[package]]
 name = "uselesskey-fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
  "blake3",
+ "ed25519-dalek",
  "libfuzzer-sys",
  "p256",
  "rand_chacha",
@@ -1108,7 +1438,20 @@ dependencies = [
  "uselesskey-core-token-shape",
  "uselesskey-core-x509-negative",
  "uselesskey-core-x509-spec",
+ "uselesskey-ecdsa",
+ "uselesskey-ed25519",
+ "uselesskey-hmac",
  "uselesskey-jwk",
+ "uselesskey-x509",
+]
+
+[[package]]
+name = "uselesskey-hmac"
+version = "0.3.0"
+dependencies = [
+ "rand_core",
+ "uselesskey-core",
+ "uselesskey-core-kid",
 ]
 
 [[package]]
@@ -1123,9 +1466,12 @@ dependencies = [
 name = "uselesskey-rsa"
 version = "0.3.0"
 dependencies = [
+ "base64",
  "rsa",
+ "serde_json",
  "uselesskey-core",
  "uselesskey-core-keypair-material",
+ "uselesskey-jwk",
 ]
 
 [[package]]
@@ -1134,6 +1480,22 @@ version = "0.3.0"
 dependencies = [
  "uselesskey-core",
  "uselesskey-core-token",
+]
+
+[[package]]
+name = "uselesskey-x509"
+version = "0.3.0"
+dependencies = [
+ "base64",
+ "rcgen",
+ "rsa",
+ "rustls-pki-types",
+ "time",
+ "uselesskey-core",
+ "uselesskey-core-x509",
+ "uselesskey-jwk",
+ "uselesskey-rsa",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1208,12 +1570,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1301,6 +1736,32 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation
- Reduce coupling in the core layer by moving the shared `Error` enum out of `uselesskey-core` into a focused SRP microcrate so error responsibilities are isolated.
- Make `uselesskey-core` narrower and easier to evolve while preserving the public API surface for downstream consumers.

### Description
- Add a new crate `crates/uselesskey-core-error` that defines the canonical `Error` enum (env/seed parsing and IO variants) and unit tests. 
- Move the former `error.rs` implementation into `crates/uselesskey-core-error/src/lib.rs` and update its crate metadata and docs.
- Rewire `crates/uselesskey-core` to depend on `uselesskey-core-error`, propagate the `std` feature, and re-export `Error` as `pub use uselesskey_core_error::Error;` so existing consumers keep the same symbol.
- Update workspace membership and workspace-level dependencies in `Cargo.toml` and refresh lockfiles so the new microcrate builds in the workspace.

### Testing
- Ran `cargo fmt` to ensure formatting; the command completed successfully.
- Ran `cargo test -p uselesskey-core-error -p uselesskey-core -p uselesskey-core-keypair-material` and all unit tests passed.
- Ran `cargo check -p uselesskey-core -p uselesskey-core-keypair-material -p uselesskey` and the workspace packages type-checked successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d69d81fc83339ea783783a37bda5)