### PR TITLE
Split TokenSpec into dedicated token-spec microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,7 +3803,12 @@ dependencies = [
  "serde_json",
  "uselesskey-core",
  "uselesskey-core-token",
+ "uselesskey-token-spec",
 ]
+
+[[package]]
+name = "uselesskey-token-spec"
+version = "0.3.0"
 
 [[package]]
 name = "uselesskey-tonic"
@@ -3820,12 +3825,14 @@ name = "uselesskey-x509"
 version = "0.3.0"
 dependencies = [
  "base64",
+ "insta",
  "proptest",
  "rand_chacha 0.3.1",
  "rcgen",
  "rsa",
  "rstest",
  "rustls-pki-types",
+ "serde",
  "time",
  "uselesskey-core",
  "uselesskey-core-x509",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
   "crates/uselesskey-ed25519",
   "crates/uselesskey-hmac",
   "crates/uselesskey-token",
+  "crates/uselesskey-token-spec",
   "crates/uselesskey-pgp",
   "crates/uselesskey-x509",
   "crates/uselesskey-jsonwebtoken",
@@ -76,6 +77,7 @@ uselesskey-core-keypair-material = { path = "crates/uselesskey-core-keypair-mate
 uselesskey-core-negative = { path = "crates/uselesskey-core-negative", version = "0.3.0", default-features = false }
 uselesskey-core-negative-pem = { path = "crates/uselesskey-core-negative-pem", version = "0.3.0", default-features = false }
 uselesskey-core-token = { path = "crates/uselesskey-core-token", version = "0.3.0" }
+uselesskey-token-spec = { path = "crates/uselesskey-token-spec", version = "0.3.0" }
 uselesskey-core-jwk-builder = { path = "crates/uselesskey-core-jwk-builder", version = "0.3.0" }
 uselesskey-core-jwk = { path = "crates/uselesskey-core-jwk", version = "0.3.0" }
 uselesskey-core-jwk-shape = { path = "crates/uselesskey-core-jwk-shape", version = "0.3.0" }

--- a/crates/uselesskey-token-spec/Cargo.toml
+++ b/crates/uselesskey-token-spec/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uselesskey-token-spec"
+version = "0.3.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "Stable token fixture specification shared across token generators."
+categories.workspace = true
+keywords = ["token", "spec", "fixtures", "testing"]
+readme = "README.md"
+exclude = ["fuzz/**", "corpus/**", "**/*.der", "**/*.pem"]
+homepage.workspace = true
+documentation = "https://docs.rs/uselesskey-token-spec"
+authors.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/uselesskey-token-spec/README.md
+++ b/crates/uselesskey-token-spec/README.md
@@ -1,0 +1,6 @@
+# uselesskey-token-spec
+
+Stable token fixture specification used by token-generation crates.
+
+This crate contains the `TokenSpec` enum and its stable encoding for cache keys
+and deterministic derivation.

--- a/crates/uselesskey-token-spec/src/lib.rs
+++ b/crates/uselesskey-token-spec/src/lib.rs
@@ -1,3 +1,7 @@
+#![forbid(unsafe_code)]
+
+//! Stable token fixture specification shared across token-generation crates.
+
 /// Specification for token fixture generation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum TokenSpec {
@@ -10,19 +14,19 @@ pub enum TokenSpec {
 }
 
 impl TokenSpec {
-    pub fn api_key() -> Self {
+    pub const fn api_key() -> Self {
         Self::ApiKey
     }
 
-    pub fn bearer() -> Self {
+    pub const fn bearer() -> Self {
         Self::Bearer
     }
 
-    pub fn oauth_access_token() -> Self {
+    pub const fn oauth_access_token() -> Self {
         Self::OAuthAccessToken
     }
 
-    pub fn kind_name(&self) -> &'static str {
+    pub const fn kind_name(&self) -> &'static str {
         match self {
             Self::ApiKey => "api_key",
             Self::Bearer => "bearer",
@@ -33,7 +37,7 @@ impl TokenSpec {
     /// Stable encoding for cache keys / deterministic derivation.
     ///
     /// If you change this, bump the derivation version in `uselesskey-core`.
-    pub fn stable_bytes(&self) -> [u8; 4] {
+    pub const fn stable_bytes(&self) -> [u8; 4] {
         match self {
             Self::ApiKey => [0, 0, 0, 1],
             Self::Bearer => [0, 0, 0, 2],

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -17,6 +17,7 @@ authors.workspace = true
 [dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
 uselesskey-core-token.workspace = true
+uselesskey-token-spec.workspace = true
 
 [dev-dependencies]
 base64.workspace = true

--- a/crates/uselesskey-token/src/lib.rs
+++ b/crates/uselesskey-token/src/lib.rs
@@ -22,8 +22,7 @@
 //! assert!(!value.is_empty());
 //! ```
 
-mod spec;
 mod token;
 
-pub use spec::TokenSpec;
 pub use token::{DOMAIN_TOKEN_FIXTURE, TokenFactoryExt, TokenFixture};
+pub use uselesskey_token_spec::TokenSpec;


### PR DESCRIPTION
### Motivation

- Reduce single-responsibility surface by extracting the small, stable `TokenSpec` API into its own SRP microcrate so it can be reused independently. 
- Keep `uselesskey-token` focused on factory integration and fixture behaviour while isolating the stable encoding used for deterministic derivation.

### Description

- Added a new crate `crates/uselesskey-token-spec` that implements `TokenSpec`, its stable encoding (`stable_bytes`) and unit tests. 
- Moved the previous `spec.rs` implementation into `crates/uselesskey-token-spec/src/lib.rs` and added `README.md`. 
- Updated the workspace `Cargo.toml` to include `crates/uselesskey-token-spec` and added a workspace dependency entry for `uselesskey-token-spec`. 
- Changed `crates/uselesskey-token` to depend on and re-export `TokenSpec` from `uselesskey-token-spec` so the public API remains unchanged (calls like `use uselesskey_token::TokenSpec` still work). 
- Updated lockfile entries to reflect the new crate and dependency edge.

### Testing

- Ran formatting with `cargo fmt` and applied formatting successfully. 
- Ran unit/integration tests with `cargo test -p uselesskey-token-spec -p uselesskey-token -p uselesskey-core-token` and all selected test suites passed. 
- Verified the re-exported public API by building and running doctests for `uselesskey-token` which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d67091608333a73a15d85d298e56)