### PR TITLE
refactor(pgp): extract `PgpSpec` into a dedicated core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "uselesskey-core-pgp-spec"
+version = "0.3.0"
+
+[[package]]
 name = "uselesskey-core-seed"
 version = "0.3.0"
 dependencies = [
@@ -3716,6 +3720,7 @@ dependencies = [
  "pgp",
  "proptest",
  "uselesskey-core",
+ "uselesskey-core-pgp-spec",
 ]
 
 [[package]]
@@ -3820,12 +3825,14 @@ name = "uselesskey-x509"
 version = "0.3.0"
 dependencies = [
  "base64",
+ "insta",
  "proptest",
  "rand_chacha 0.3.1",
  "rcgen",
  "rsa",
  "rstest",
  "rustls-pki-types",
+ "serde",
  "time",
  "uselesskey-core",
  "uselesskey-core-x509",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crates/uselesskey-core-sink",
   "crates/uselesskey-core-token",
   "crates/uselesskey-core-token-shape",
+  "crates/uselesskey-core-pgp-spec",
   "crates/uselesskey-core-jwk-builder",
   "crates/uselesskey-core-jwks-order",
   "crates/uselesskey-core-jwk",

--- a/crates/uselesskey-core-pgp-spec/Cargo.toml
+++ b/crates/uselesskey-core-pgp-spec/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "uselesskey-core-pgp-spec"
+version = "0.3.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "Core OpenPGP fixture spec model and stable encoding helpers."
+categories.workspace = true
+keywords = ["openpgp", "pgp", "fixtures", "testing", "deterministic"]
+readme = "README.md"
+homepage.workspace = true
+documentation = "https://docs.rs/uselesskey-core-pgp-spec"
+authors.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/uselesskey-core-pgp-spec/README.md
+++ b/crates/uselesskey-core-pgp-spec/README.md
@@ -1,0 +1,5 @@
+# uselesskey-core-pgp-spec
+
+Core OpenPGP fixture spec model plus stable byte encoding for deterministic derivation/cache keys.
+
+This is a low-level crate; most users should use `uselesskey-pgp`.

--- a/crates/uselesskey-core-pgp-spec/src/lib.rs
+++ b/crates/uselesskey-core-pgp-spec/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 /// Specification for OpenPGP fixture generation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum PgpSpec {

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -16,6 +16,7 @@ authors.workspace = true
 
 [dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core-pgp-spec = { path = "../uselesskey-core-pgp-spec", version = "0.3.0" }
 pgp = { version = "0.19.0", default-features = false }
 
 [dev-dependencies]

--- a/crates/uselesskey-pgp/src/lib.rs
+++ b/crates/uselesskey-pgp/src/lib.rs
@@ -6,7 +6,6 @@
 //! [`Factory`](uselesskey_core::Factory).
 
 mod keypair;
-mod spec;
 
 pub use keypair::{DOMAIN_PGP_KEYPAIR, PgpFactoryExt, PgpKeyPair};
-pub use spec::PgpSpec;
+pub use uselesskey_core_pgp_spec::PgpSpec;


### PR DESCRIPTION
### Motivation
- Separate a small, stable spec model from runtime fixture logic so other crates can reuse the OpenPGP spec without pulling in full keygen dependencies.
- Keep `uselesskey-pgp` focused on generation and I/O while moving stable encoding semantics into a tiny core microcrate.
- Follow the existing workspace pattern of small `core-*-spec` microcrates for stable encoding/cache keys.

### Description
- Added a new crate `crates/uselesskey-core-pgp-spec` containing `PgpSpec` and its stability tests, and a README describing its purpose.
- Removed the local `spec.rs` from `crates/uselesskey-pgp` and re-exported `PgpSpec` from `uselesskey_core_pgp_spec` via `pub use uselesskey_core_pgp_spec::PgpSpec;` in `crates/uselesskey-pgp/src/lib.rs`.
- Wired the new crate into the workspace `Cargo.toml` and updated `crates/uselesskey-pgp/Cargo.toml` to depend on `uselesskey-core-pgp-spec`.
- Updated lockfile metadata so the new workspace crate resolves correctly and formatted sources with `cargo fmt`.

### Testing
- Ran `cargo fmt` to normalize formatting and succeeded.
- Ran `cargo test -p uselesskey-core-pgp-spec -p uselesskey-pgp` and all tests in those crates passed.
- Ran `cargo test -p uselesskey --all-features` and the full test-suite passed under `--all-features`.
- Observed an expected failure when running `cargo test -p uselesskey --features pgp` because existing tests assume `ecdsa` symbols while only `pgp` was enabled; this is a pre-existing test assumption and not caused by the split.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d67091608333a73a15d85d298e56)