### PR TITLE
Split TokenSpec into new core microcrate (uselesskey-core-token-spec)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,6 +3537,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "uselesskey-core-token-spec"
+version = "0.3.0"
+
+[[package]]
 name = "uselesskey-core-x509"
 version = "0.3.0"
 dependencies = [
@@ -3803,6 +3807,7 @@ dependencies = [
  "serde_json",
  "uselesskey-core",
  "uselesskey-core-token",
+ "uselesskey-core-token-spec",
 ]
 
 [[package]]
@@ -3820,12 +3825,14 @@ name = "uselesskey-x509"
 version = "0.3.0"
 dependencies = [
  "base64",
+ "insta",
  "proptest",
  "rand_chacha 0.3.1",
  "rcgen",
  "rsa",
  "rstest",
  "rustls-pki-types",
+ "serde",
  "time",
  "uselesskey-core",
  "uselesskey-core-x509",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/uselesskey-core-negative-pem",
   "crates/uselesskey-core-sink",
   "crates/uselesskey-core-token",
+  "crates/uselesskey-core-token-spec",
   "crates/uselesskey-core-token-shape",
   "crates/uselesskey-core-jwk-builder",
   "crates/uselesskey-core-jwks-order",
@@ -76,6 +77,7 @@ uselesskey-core-keypair-material = { path = "crates/uselesskey-core-keypair-mate
 uselesskey-core-negative = { path = "crates/uselesskey-core-negative", version = "0.3.0", default-features = false }
 uselesskey-core-negative-pem = { path = "crates/uselesskey-core-negative-pem", version = "0.3.0", default-features = false }
 uselesskey-core-token = { path = "crates/uselesskey-core-token", version = "0.3.0" }
+uselesskey-core-token-spec = { path = "crates/uselesskey-core-token-spec", version = "0.3.0", default-features = false }
 uselesskey-core-jwk-builder = { path = "crates/uselesskey-core-jwk-builder", version = "0.3.0" }
 uselesskey-core-jwk = { path = "crates/uselesskey-core-jwk", version = "0.3.0" }
 uselesskey-core-jwk-shape = { path = "crates/uselesskey-core-jwk-shape", version = "0.3.0" }

--- a/crates/uselesskey-core-token-spec/Cargo.toml
+++ b/crates/uselesskey-core-token-spec/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uselesskey-core-token-spec"
+version = "0.3.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "Stable token fixture specification model shared by uselesskey token crates."
+categories.workspace = true
+keywords = ["token", "fixtures", "testing"]
+readme = "README.md"
+exclude = ["fuzz/**", "corpus/**", "**/*.der", "**/*.pem"]
+homepage.workspace = true
+documentation = "https://docs.rs/uselesskey-core-token-spec"
+authors.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/uselesskey-core-token-spec/README.md
+++ b/crates/uselesskey-core-token-spec/README.md
@@ -1,0 +1,5 @@
+# uselesskey-core-token-spec
+
+Stable token fixture specification type used by `uselesskey-token` and related crates.
+
+This crate isolates the token fixture *spec model* from fixture generation so spec stability can evolve independently.

--- a/crates/uselesskey-core-token-spec/src/lib.rs
+++ b/crates/uselesskey-core-token-spec/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 /// Specification for token fixture generation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum TokenSpec {

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -17,6 +17,7 @@ authors.workspace = true
 [dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
 uselesskey-core-token.workspace = true
+uselesskey-core-token-spec.workspace = true
 
 [dev-dependencies]
 base64.workspace = true

--- a/crates/uselesskey-token/src/lib.rs
+++ b/crates/uselesskey-token/src/lib.rs
@@ -22,8 +22,7 @@
 //! assert!(!value.is_empty());
 //! ```
 
-mod spec;
 mod token;
 
-pub use spec::TokenSpec;
 pub use token::{DOMAIN_TOKEN_FIXTURE, TokenFactoryExt, TokenFixture};
+pub use uselesskey_core_token_spec::TokenSpec;


### PR DESCRIPTION
### Motivation
- Isolate the stable token fixture specification type from runtime token generation to provide a small SRP microcrate that can be reused independently. 
- Make the spec's stable encoding and invariants easy to version and maintain without touching generation code.

### Description
- Added a new crate `crates/uselesskey-core-token-spec` containing `TokenSpec` and its unit tests, moving the former `spec.rs` into the new crate. 
- Updated the workspace `Cargo.toml` to include the new microcrate and added it to workspace dependencies, and updated relevant lockfile entries. 
- Kept the public API stable by re-exporting `TokenSpec` from `uselesskey-token` (`pub use uselesskey_core_token_spec::TokenSpec;`) and removed the old local `spec.rs`. 
- Minor formatting cleanup applied to affected files.

### Testing
- Ran `cargo fmt` to ensure formatting changes were applied and it completed successfully. 
- Ran `cargo test -p uselesskey-core-token-spec -p uselesskey-token` and all unit tests in those crates passed. 
- Ran `cargo test -p uselesskey --test facade` to validate the facade integration and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d67413fc8333aa6ffcc3ea89884e)