### PR TITLE
test: comprehensive error handling and edge case tests

### DIFF
--- a/crates/uselesskey-core/tests/edge_cases.rs
+++ b/crates/uselesskey-core/tests/edge_cases.rs
@@ -1,0 +1,350 @@
+//! Edge-case tests for uselesskey-core internals.
+//!
+//! Covers concurrent cache access, cache clearing under contention,
+//! large cache populations, and factory behavior with extreme inputs.
+
+#![cfg(feature = "std")]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use uselesskey_core::{Factory, Mode, Seed};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn det_factory(byte: u8) -> Factory {
+    Factory::deterministic(Seed::new([byte; 32]))
+}
+
+// ===========================================================================
+// 1. Concurrent cache access — many threads reading/writing same key
+// ===========================================================================
+
+#[test]
+fn concurrent_get_or_init_same_key_calls_init_once() {
+    let fx = det_factory(0x01);
+    let init_count = Arc::new(AtomicUsize::new(0));
+    let barrier = Arc::new(Barrier::new(8));
+
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let fx = fx.clone();
+            let count = init_count.clone();
+            let bar = barrier.clone();
+            thread::spawn(move || {
+                bar.wait();
+                let v = fx.get_or_init("domain:conc", "shared", b"spec", "good", |_rng| {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    42u64
+                });
+                assert_eq!(*v, 42u64);
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // init should be called a small number of times (ideally 1, but DashMap
+    // may race on insert; the important thing is all threads see the same value)
+    let count = init_count.load(Ordering::SeqCst);
+    assert!((1..=8).contains(&count), "init called {count} times");
+}
+
+// ===========================================================================
+// 2. Concurrent access with different keys
+// ===========================================================================
+
+#[test]
+fn concurrent_get_or_init_different_keys_all_succeed() {
+    let fx = det_factory(0x02);
+    let barrier = Arc::new(Barrier::new(16));
+
+    let handles: Vec<_> = (0..16)
+        .map(|i| {
+            let fx = fx.clone();
+            let bar = barrier.clone();
+            thread::spawn(move || {
+                bar.wait();
+                let label = format!("thread-{i}");
+                let v = fx.get_or_init("domain:multi", &label, b"spec", "good", |_rng| i as u64);
+                assert_eq!(*v, i as u64);
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+}
+
+// ===========================================================================
+// 3. Cache clear while other threads are reading
+// ===========================================================================
+
+#[test]
+fn cache_clear_while_readers_active_does_not_panic() {
+    let fx = det_factory(0x03);
+
+    // Pre-populate cache
+    for i in 0..10 {
+        let label = format!("pre-{i}");
+        let _ = fx.get_or_init("domain:clear", &label, b"spec", "good", |_rng| i as u32);
+    }
+
+    let barrier = Arc::new(Barrier::new(9));
+
+    // 8 reader threads
+    let mut handles: Vec<_> = (0..8)
+        .map(|i| {
+            let fx = fx.clone();
+            let bar = barrier.clone();
+            thread::spawn(move || {
+                bar.wait();
+                for _ in 0..100 {
+                    let label = format!("pre-{}", i % 10);
+                    let _ =
+                        fx.get_or_init("domain:clear", &label, b"spec", "good", |_rng| i as u32);
+                }
+            })
+        })
+        .collect();
+
+    // 1 clearer thread
+    {
+        let fx = fx.clone();
+        let bar = barrier.clone();
+        handles.push(thread::spawn(move || {
+            bar.wait();
+            for _ in 0..50 {
+                fx.clear_cache();
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().unwrap();
+    }
+}
+
+// ===========================================================================
+// 4. Large number of cache entries
+// ===========================================================================
+
+#[test]
+fn cache_handles_many_entries() {
+    let fx = det_factory(0x04);
+    let entry_count = 500;
+
+    for i in 0..entry_count {
+        let label = format!("entry-{i}");
+        let _ = fx.get_or_init("domain:many", &label, b"spec", "good", |_rng| i as u64);
+    }
+
+    // Verify all entries are retrievable (init closure returns a sentinel;
+    // since the entry already exists the closure is never called)
+    for i in 0..entry_count {
+        let label = format!("entry-{i}");
+        let v = fx.get_or_init("domain:many", &label, b"spec", "good", |_rng| 999_999u64);
+        assert_eq!(*v, i as u64);
+    }
+}
+
+// ===========================================================================
+// 5. Cache clear actually evicts entries
+// ===========================================================================
+
+#[test]
+fn clear_cache_forces_reinit_with_new_values() {
+    let fx = det_factory(0x05);
+    let init_count = AtomicUsize::new(0);
+
+    let first = fx.get_or_init("domain:reinit", "label", b"spec", "good", |_rng| {
+        init_count.fetch_add(1, Ordering::SeqCst);
+        100u32
+    });
+    assert_eq!(*first, 100);
+    assert_eq!(init_count.load(Ordering::SeqCst), 1);
+
+    fx.clear_cache();
+
+    let second = fx.get_or_init("domain:reinit", "label", b"spec", "good", |_rng| {
+        init_count.fetch_add(1, Ordering::SeqCst);
+        200u32
+    });
+    // In deterministic mode, the RNG produces the same value, but our
+    // closure explicitly returns a different value to prove reinit happened
+    assert_eq!(init_count.load(Ordering::SeqCst), 2);
+    assert_eq!(*second, 200);
+}
+
+// ===========================================================================
+// 6. Factory mode accessors
+// ===========================================================================
+
+#[test]
+fn random_factory_mode_is_random() {
+    let fx = Factory::random();
+    assert!(matches!(fx.mode(), Mode::Random));
+}
+
+#[test]
+fn deterministic_factory_mode_contains_seed() {
+    let seed = Seed::new([0xAA; 32]);
+    let fx = Factory::deterministic(seed);
+    match fx.mode() {
+        Mode::Deterministic { master } => {
+            assert_eq!(master.bytes(), &[0xAA; 32]);
+        }
+        Mode::Random => panic!("expected deterministic mode"),
+    }
+}
+
+// ===========================================================================
+// 7. Empty and unusual domain/label/variant/spec combinations
+// ===========================================================================
+
+#[test]
+fn empty_domain_label_variant_spec_does_not_panic() {
+    let fx = det_factory(0x07);
+    // All-empty should still work
+    let v = fx.get_or_init("", "", b"", "", |_rng| 99u8);
+    assert_eq!(*v, 99);
+}
+
+#[test]
+fn unicode_label_and_variant_work() {
+    let fx = det_factory(0x08);
+    let v = fx.get_or_init(
+        "domain:unicode",
+        "日本語ラベル",
+        b"spec",
+        "変体",
+        |_rng| 77u16,
+    );
+    assert_eq!(*v, 77);
+}
+
+#[test]
+fn very_long_spec_bytes_work() {
+    let fx = det_factory(0x09);
+    let big_spec = vec![0xFFu8; 10_000];
+    let v = fx.get_or_init("domain:bigspec", "label", &big_spec, "good", |_rng| 55u32);
+    assert_eq!(*v, 55);
+}
+
+// ===========================================================================
+// 8. Deterministic derivation produces distinct values for different inputs
+// ===========================================================================
+
+#[test]
+fn different_domains_produce_different_values() {
+    let fx = det_factory(0x0A);
+    let spec = b"same-spec";
+
+    let a = fx.get_or_init("domain:a", "label", spec, "good", |rng| {
+        use rand_core::RngCore;
+        let mut buf = [0u8; 8];
+        rng.fill_bytes(&mut buf);
+        u64::from_le_bytes(buf)
+    });
+    let b = fx.get_or_init("domain:b", "label", spec, "good", |rng| {
+        use rand_core::RngCore;
+        let mut buf = [0u8; 8];
+        rng.fill_bytes(&mut buf);
+        u64::from_le_bytes(buf)
+    });
+    assert_ne!(*a, *b);
+}
+
+#[test]
+fn different_labels_produce_different_values() {
+    let fx = det_factory(0x0B);
+    let make = |label: &str| -> Arc<u64> {
+        fx.get_or_init("domain:lbl", label, b"spec", "good", |rng| {
+            use rand_core::RngCore;
+            let mut buf = [0u8; 8];
+            rng.fill_bytes(&mut buf);
+            u64::from_le_bytes(buf)
+        })
+    };
+    assert_ne!(*make("alpha"), *make("beta"));
+}
+
+#[test]
+fn different_variants_produce_different_values() {
+    // Need separate factories to avoid cache hits
+    let fx1 = det_factory(0x0C);
+    let fx2 = det_factory(0x0C);
+
+    let a = fx1.get_or_init("domain:var", "label", b"spec", "good", |rng| {
+        use rand_core::RngCore;
+        let mut buf = [0u8; 8];
+        rng.fill_bytes(&mut buf);
+        u64::from_le_bytes(buf)
+    });
+    let b = fx2.get_or_init("domain:var", "label", b"spec", "other", |rng| {
+        use rand_core::RngCore;
+        let mut buf = [0u8; 8];
+        rng.fill_bytes(&mut buf);
+        u64::from_le_bytes(buf)
+    });
+    assert_ne!(*a, *b);
+}
+
+// ===========================================================================
+// 9. Seed::from_env_value edge cases
+// ===========================================================================
+
+#[test]
+fn seed_from_env_value_empty_string_is_ok() {
+    assert!(Seed::from_env_value("").is_ok());
+}
+
+#[test]
+fn seed_from_env_value_exactly_64_hex_chars() {
+    let hex = "a".repeat(64);
+    let result = Seed::from_env_value(&hex);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn seed_from_env_value_64_chars_invalid_hex_is_err() {
+    // 64 chars but contains invalid hex -> Err
+    let mut bad = "0".repeat(63);
+    bad.push('g');
+    let result = Seed::from_env_value(&bad);
+    assert!(result.is_err());
+}
+
+#[test]
+fn seed_from_env_value_with_0x_prefix() {
+    let hex = format!("0x{}", "b".repeat(64));
+    let result = Seed::from_env_value(&hex);
+    assert!(result.is_ok());
+}
+
+// ===========================================================================
+// 10. Debug formatting
+// ===========================================================================
+
+#[test]
+fn factory_debug_includes_cache_size() {
+    let fx = det_factory(0x10);
+    let dbg = format!("{:?}", fx);
+    assert!(dbg.contains("Factory"));
+    assert!(dbg.contains("cache_size"));
+}
+
+#[test]
+fn seed_debug_never_leaks_bytes() {
+    let seed = Seed::new([0xFF; 32]);
+    let dbg = format!("{:?}", seed);
+    assert!(dbg.contains("redacted"));
+    // Ensure no hex of the actual bytes appears
+    assert!(!dbg.to_lowercase().contains("ff"));
+}

--- a/crates/uselesskey/tests/error_paths.rs
+++ b/crates/uselesskey/tests/error_paths.rs
@@ -1,0 +1,500 @@
+//! Error-path and edge-case tests for the uselesskey facade crate.
+//!
+//! Exercises boundary inputs (empty labels, very long labels, extreme seeds),
+//! negative fixture variants (mismatch, corrupt:*), and factory isolation.
+//! No key material appears in assertions — only shapes, lengths, and non-empty
+//! checks.
+
+mod testutil;
+
+use uselesskey::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn fx() -> Factory {
+    testutil::fx()
+}
+
+fn fx_with_seed(seed_bytes: [u8; 32]) -> Factory {
+    Factory::deterministic(Seed::new(seed_bytes))
+}
+
+// ===========================================================================
+// 1. Empty labels — factory should accept "" without panicking
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "rsa")]
+fn rsa_empty_label_produces_valid_key() {
+    let kp = fx().rsa("", RsaSpec::rs256());
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(!kp.private_key_pkcs8_der().is_empty());
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_empty_label_produces_valid_key() {
+    let kp = fx().ecdsa("", EcdsaSpec::es256());
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(!kp.private_key_pkcs8_der().is_empty());
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_empty_label_produces_valid_key() {
+    let kp = fx().ed25519("", Ed25519Spec::new());
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(!kp.private_key_pkcs8_der().is_empty());
+}
+
+#[test]
+#[cfg(feature = "hmac")]
+fn hmac_empty_label_produces_valid_secret() {
+    let secret = fx().hmac("", HmacSpec::hs256());
+    assert_eq!(secret.secret_bytes().len(), 32);
+}
+
+// ===========================================================================
+// 2. Very long labels — 1000+ chars should work without panic
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_very_long_label_does_not_panic() {
+    let long_label = "x".repeat(2000);
+    let kp = fx().ecdsa(&long_label, EcdsaSpec::es256());
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_very_long_label_does_not_panic() {
+    let long_label = "y".repeat(2000);
+    let kp = fx().ed25519(&long_label, Ed25519Spec::new());
+    assert!(!kp.public_key_spki_der().is_empty());
+}
+
+#[test]
+#[cfg(feature = "hmac")]
+fn hmac_very_long_label_does_not_panic() {
+    let long_label = "z".repeat(2000);
+    let secret = fx().hmac(&long_label, HmacSpec::hs512());
+    assert_eq!(secret.secret_bytes().len(), 64);
+}
+
+// ===========================================================================
+// 3. Extreme seed values — zero seed and max seed
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn deterministic_zero_seed_produces_valid_ecdsa_key() {
+    let fx = fx_with_seed([0x00; 32]);
+    let kp = fx.ecdsa("zero-seed", EcdsaSpec::es256());
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(!kp.public_key_spki_der().is_empty());
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn deterministic_max_seed_produces_valid_ecdsa_key() {
+    let fx = fx_with_seed([0xFF; 32]);
+    let kp = fx.ecdsa("max-seed", EcdsaSpec::es384());
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(!kp.public_key_spki_der().is_empty());
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn deterministic_zero_seed_produces_valid_ed25519_key() {
+    let fx = fx_with_seed([0x00; 32]);
+    let kp = fx.ed25519("zero-seed", Ed25519Spec::new());
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn deterministic_max_seed_produces_valid_ed25519_key() {
+    let fx = fx_with_seed([0xFF; 32]);
+    let kp = fx.ed25519("max-seed", Ed25519Spec::new());
+    assert!(!kp.public_key_spki_pem().is_empty());
+}
+
+#[test]
+#[cfg(feature = "hmac")]
+fn deterministic_zero_seed_produces_valid_hmac_secret() {
+    let fx = fx_with_seed([0x00; 32]);
+    let s = fx.hmac("zero-seed", HmacSpec::hs256());
+    assert_eq!(s.secret_bytes().len(), 32);
+}
+
+#[test]
+#[cfg(feature = "hmac")]
+fn deterministic_max_seed_produces_valid_hmac_secret() {
+    let fx = fx_with_seed([0xFF; 32]);
+    let s = fx.hmac("max-seed", HmacSpec::hs512());
+    assert_eq!(s.secret_bytes().len(), 64);
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn zero_seed_and_max_seed_produce_different_ecdsa_keys() {
+    let fx_zero = fx_with_seed([0x00; 32]);
+    let fx_max = fx_with_seed([0xFF; 32]);
+
+    let kp_zero = fx_zero.ecdsa("seed-cmp", EcdsaSpec::es256());
+    let kp_max = fx_max.ecdsa("seed-cmp", EcdsaSpec::es256());
+    assert_ne!(
+        kp_zero.private_key_pkcs8_der(),
+        kp_max.private_key_pkcs8_der()
+    );
+}
+
+// ===========================================================================
+// 4. Mismatch variant for all asymmetric key types
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_es256_mismatch_differs_from_original() {
+    let kp = fx().ecdsa("mismatch-es256", EcdsaSpec::es256());
+    let original = kp.public_key_spki_der();
+    let mismatched = kp.mismatched_public_key_spki_der();
+    assert_ne!(original, mismatched.as_slice());
+    assert!(!mismatched.is_empty());
+    assert_eq!(mismatched[0], 0x30); // DER SEQUENCE tag
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_es384_mismatch_differs_from_original() {
+    let kp = fx().ecdsa("mismatch-es384", EcdsaSpec::es384());
+    let original = kp.public_key_spki_der();
+    let mismatched = kp.mismatched_public_key_spki_der();
+    assert_ne!(original, mismatched.as_slice());
+    assert!(!mismatched.is_empty());
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_mismatch_differs_from_original() {
+    let kp = fx().ed25519("mismatch-ed25519", Ed25519Spec::new());
+    let original = kp.public_key_spki_der();
+    let mismatched = kp.mismatched_public_key_spki_der();
+    assert_ne!(original, mismatched.as_slice());
+    assert!(!mismatched.is_empty());
+    assert_eq!(mismatched[0], 0x30);
+}
+
+// ===========================================================================
+// 5. Corrupt:* variants — deterministic corruption for all key types
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_corrupt_pem_all_variants_differ_from_original() {
+    let kp = fx().ecdsa("corrupt-all", EcdsaSpec::es256());
+    let original = kp.private_key_pkcs8_pem();
+    let variants = [
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader),
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadFooter),
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadBase64),
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::Truncate { bytes: 20 }),
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::ExtraBlankLine),
+    ];
+    for (i, v) in variants.iter().enumerate() {
+        assert_ne!(v, original, "ecdsa corrupt variant {i} should differ");
+    }
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_corrupt_pem_all_variants_differ_from_original() {
+    let kp = fx().ed25519("corrupt-all", Ed25519Spec::new());
+    let original = kp.private_key_pkcs8_pem();
+    let variants = [
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader),
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadFooter),
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadBase64),
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::Truncate { bytes: 10 }),
+        kp.private_key_pkcs8_pem_corrupt(CorruptPem::ExtraBlankLine),
+    ];
+    for (i, v) in variants.iter().enumerate() {
+        assert_ne!(v, original, "ed25519 corrupt variant {i} should differ");
+    }
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_deterministic_pem_corruption_is_stable() {
+    let kp = fx().ecdsa("corrupt-stable-ecdsa", EcdsaSpec::es256());
+    let a = kp.private_key_pkcs8_pem_corrupt_deterministic("corrupt:edge-v1");
+    let b = kp.private_key_pkcs8_pem_corrupt_deterministic("corrupt:edge-v1");
+    assert_eq!(a, b);
+    assert_ne!(a, kp.private_key_pkcs8_pem());
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_deterministic_pem_corruption_is_stable() {
+    let kp = fx().ed25519("corrupt-stable-ed25519", Ed25519Spec::new());
+    let a = kp.private_key_pkcs8_pem_corrupt_deterministic("corrupt:edge-v1");
+    let b = kp.private_key_pkcs8_pem_corrupt_deterministic("corrupt:edge-v1");
+    assert_eq!(a, b);
+    assert_ne!(a, kp.private_key_pkcs8_pem());
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_deterministic_der_corruption_is_stable() {
+    let kp = fx().ecdsa("der-corrupt-ecdsa", EcdsaSpec::es256());
+    let a = kp.private_key_pkcs8_der_corrupt_deterministic("corrupt:der-edge-v1");
+    let b = kp.private_key_pkcs8_der_corrupt_deterministic("corrupt:der-edge-v1");
+    assert_eq!(a, b);
+    assert_ne!(a, kp.private_key_pkcs8_der());
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_deterministic_der_corruption_is_stable() {
+    let kp = fx().ed25519("der-corrupt-ed25519", Ed25519Spec::new());
+    let a = kp.private_key_pkcs8_der_corrupt_deterministic("corrupt:der-edge-v1");
+    let b = kp.private_key_pkcs8_der_corrupt_deterministic("corrupt:der-edge-v1");
+    assert_eq!(a, b);
+    assert_ne!(a, kp.private_key_pkcs8_der());
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_truncated_der_at_zero_is_empty() {
+    let kp = fx().ecdsa("trunc-zero-ecdsa", EcdsaSpec::es256());
+    let truncated = kp.private_key_pkcs8_der_truncated(0);
+    assert!(truncated.is_empty());
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_truncated_der_at_zero_is_empty() {
+    let kp = fx().ed25519("trunc-zero-ed25519", Ed25519Spec::new());
+    let truncated = kp.private_key_pkcs8_der_truncated(0);
+    assert!(truncated.is_empty());
+}
+
+// ===========================================================================
+// 6. Multiple factories with same seed don't interfere
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn two_factories_same_seed_produce_identical_ecdsa_keys() {
+    let seed_bytes = [0x42; 32];
+    let fx1 = fx_with_seed(seed_bytes);
+    let fx2 = fx_with_seed(seed_bytes);
+
+    let kp1 = fx1.ecdsa("shared-label", EcdsaSpec::es256());
+    let kp2 = fx2.ecdsa("shared-label", EcdsaSpec::es256());
+    assert_eq!(kp1.private_key_pkcs8_pem(), kp2.private_key_pkcs8_pem());
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn two_factories_same_seed_produce_identical_ed25519_keys() {
+    let seed_bytes = [0x42; 32];
+    let fx1 = fx_with_seed(seed_bytes);
+    let fx2 = fx_with_seed(seed_bytes);
+
+    let kp1 = fx1.ed25519("shared-label", Ed25519Spec::new());
+    let kp2 = fx2.ed25519("shared-label", Ed25519Spec::new());
+    assert_eq!(kp1.private_key_pkcs8_pem(), kp2.private_key_pkcs8_pem());
+}
+
+#[test]
+#[cfg(feature = "hmac")]
+fn two_factories_same_seed_produce_identical_hmac_secrets() {
+    let seed_bytes = [0x42; 32];
+    let fx1 = fx_with_seed(seed_bytes);
+    let fx2 = fx_with_seed(seed_bytes);
+
+    let s1 = fx1.hmac("shared-label", HmacSpec::hs256());
+    let s2 = fx2.hmac("shared-label", HmacSpec::hs256());
+    assert_eq!(s1.secret_bytes(), s2.secret_bytes());
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn two_factories_same_seed_have_independent_caches() {
+    let seed_bytes = [0x42; 32];
+    let fx1 = fx_with_seed(seed_bytes);
+    let fx2 = fx_with_seed(seed_bytes);
+
+    // Both factories produce identical keys from same seed
+    let kp1 = fx1.ed25519("iso-test", Ed25519Spec::new());
+    fx1.clear_cache();
+
+    // fx2's cache should be unaffected by fx1.clear_cache()
+    let kp2 = fx2.ed25519("iso-test", Ed25519Spec::new());
+    assert_eq!(kp1.private_key_pkcs8_pem(), kp2.private_key_pkcs8_pem());
+}
+
+// ===========================================================================
+// 7. Factory clones share cache
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn cloned_factory_shares_cache() {
+    let fx1 = fx_with_seed([0x10; 32]);
+    let fx2 = fx1.clone();
+
+    let kp1 = fx1.ed25519("clone-test", Ed25519Spec::new());
+    let kp2 = fx2.ed25519("clone-test", Ed25519Spec::new());
+    assert_eq!(kp1.private_key_pkcs8_pem(), kp2.private_key_pkcs8_pem());
+}
+
+// ===========================================================================
+// 8. Random mode produces non-empty outputs
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn random_mode_ecdsa_produces_valid_key() {
+    let fx = Factory::random();
+    let kp = fx.ecdsa("random-test", EcdsaSpec::es256());
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(!kp.public_key_spki_der().is_empty());
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn random_mode_ed25519_produces_valid_key() {
+    let fx = Factory::random();
+    let kp = fx.ed25519("random-test", Ed25519Spec::new());
+    assert!(kp.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+}
+
+#[test]
+#[cfg(feature = "hmac")]
+fn random_mode_hmac_produces_valid_secret() {
+    let fx = Factory::random();
+    let s = fx.hmac("random-test", HmacSpec::hs256());
+    assert_eq!(s.secret_bytes().len(), 32);
+}
+
+// ===========================================================================
+// 9. Error::deterministic_from_env with missing var
+// ===========================================================================
+
+#[test]
+fn deterministic_from_env_missing_var_returns_error() {
+    let result = Factory::deterministic_from_env("USELESSKEY_NONEXISTENT_VAR_12345");
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("USELESSKEY_NONEXISTENT_VAR_12345"));
+}
+
+// ===========================================================================
+// 10. Seed::from_env_value edge cases
+// ===========================================================================
+
+#[test]
+fn seed_from_empty_string_is_ok() {
+    let result = Seed::from_env_value("");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn seed_from_whitespace_only_is_ok() {
+    let result = Seed::from_env_value("   ");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn seed_from_unicode_is_ok() {
+    let result = Seed::from_env_value("🔑🔒🗝️");
+    assert!(result.is_ok());
+}
+
+// ===========================================================================
+// 11. Debug output never leaks key material
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_debug_does_not_contain_begin_private() {
+    let kp = fx().ecdsa("debug-check", EcdsaSpec::es256());
+    let dbg = format!("{:?}", kp);
+    assert!(!dbg.contains("BEGIN PRIVATE KEY"));
+    assert!(!dbg.contains("BEGIN PUBLIC KEY"));
+    assert!(dbg.contains("EcdsaKeyPair"));
+}
+
+#[test]
+#[cfg(feature = "hmac")]
+fn hmac_debug_does_not_contain_secret_bytes() {
+    let s = fx().hmac("debug-check", HmacSpec::hs256());
+    let dbg = format!("{:?}", s);
+    assert!(!dbg.contains("secret_bytes"));
+    assert!(dbg.contains("HmacSecret"));
+}
+
+#[test]
+fn seed_debug_is_redacted() {
+    let seed = Seed::new([0xAB; 32]);
+    let dbg = format!("{:?}", seed);
+    assert!(dbg.contains("redacted"));
+    assert!(!dbg.contains("ab"));
+}
+
+// ===========================================================================
+// 12. Multiple HMAC specs produce different lengths
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "hmac")]
+fn hmac_all_specs_produce_correct_lengths() {
+    let fx = fx();
+    let hs256 = fx.hmac("spec-len-256", HmacSpec::hs256());
+    let hs384 = fx.hmac("spec-len-384", HmacSpec::hs384());
+    let hs512 = fx.hmac("spec-len-512", HmacSpec::hs512());
+    assert_eq!(hs256.secret_bytes().len(), 32);
+    assert_eq!(hs384.secret_bytes().len(), 48);
+    assert_eq!(hs512.secret_bytes().len(), 64);
+}
+
+// ===========================================================================
+// 13. ECDSA both curves produce valid distinct keys
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_es256_and_es384_produce_different_keys() {
+    let fx = fx();
+    let es256 = fx.ecdsa("curve-cmp", EcdsaSpec::es256());
+    let es384 = fx.ecdsa("curve-cmp", EcdsaSpec::es384());
+    assert_ne!(es256.private_key_pkcs8_der(), es384.private_key_pkcs8_der());
+}
+
+// ===========================================================================
+// 14. Truncation larger than DER returns full DER
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_truncated_der_larger_than_original_returns_full() {
+    let kp = fx().ecdsa("trunc-full", EcdsaSpec::es256());
+    let full = kp.private_key_pkcs8_der();
+    let truncated = kp.private_key_pkcs8_der_truncated(full.len() + 100);
+    assert_eq!(truncated, full);
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_truncated_der_larger_than_original_returns_full() {
+    let kp = fx().ed25519("trunc-full", Ed25519Spec::new());
+    let full = kp.private_key_pkcs8_der();
+    let truncated = kp.private_key_pkcs8_der_truncated(full.len() + 100);
+    assert_eq!(truncated, full);
+}


### PR DESCRIPTION
## Summary

Add comprehensive error-path and edge-case tests across the workspace, replacing the stale PR #50.

### New test files

**`crates/uselesskey/tests/error_paths.rs`** (43 tests):
- Empty labels (`""`) for RSA, ECDSA, Ed25519, HMAC
- Very long labels (2000 chars) for ECDSA, Ed25519, HMAC
- Zero seed (`[0x00; 32]`) and max seed (`[0xFF; 32]`) boundary values
- Mismatch variants for ECDSA (ES256, ES384) and Ed25519
- All 5 CorruptPem variants for ECDSA and Ed25519
- Deterministic PEM and DER corruption stability
- DER truncation edge cases (zero length, larger than original)
- Factory isolation (independent caches, clone sharing)
- Random mode produces valid outputs
- `Factory::deterministic_from_env` error path
- `Seed::from_env_value` edge cases (empty, whitespace, unicode)
- Debug output never leaks key material
- HMAC all specs produce correct lengths
- ECDSA ES256 vs ES384 produce different keys

**`crates/uselesskey-core/tests/edge_cases.rs`** (19 tests):
- Concurrent cache access (8 threads with barrier)
- Concurrent access with 16 threads on different keys
- Cache clear under read contention
- Large cache (500 entries)
- Cache clear forces reinit
- Factory mode accessors
- Empty domain/label/variant/spec
- Unicode labels and variants
- Very large spec bytes (10KB)
- Different domains/labels/variants produce different values
- Seed edge cases and Debug redaction

### Validation
- All 62 new tests pass
- `cargo fmt` clean
- `cargo clippy --workspace --all-features --tests -- -D warnings` clean
- Full workspace test suite passes