### PR TITLE
chore: handle unpublished workspace deps in publish-check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3820,12 +3820,14 @@ name = "uselesskey-x509"
 version = "0.3.0"
 dependencies = [
  "base64",
+ "insta",
  "proptest",
  "rand_chacha 0.3.1",
  "rcgen",
  "rsa",
  "rstest",
  "rustls-pki-types",
+ "serde",
  "time",
  "uselesskey-core",
  "uselesskey-core-x509",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -284,7 +284,22 @@ const PUBLISH_CRATES: &[&str] = &[
 
 fn publish_check() -> Result<()> {
     for name in PUBLISH_CRATES {
-        run(Command::new("cargo").args(["publish", "--dry-run", "-p", name]))?;
+        let output = Command::new("cargo")
+            .args(["publish", "--dry-run", "-p", name])
+            .output()
+            .with_context(|| format!("failed to spawn cargo publish --dry-run for {name}"))?;
+
+        if output.status.success() {
+            continue;
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("no matching package named") {
+            eprintln!(
+                "  [warn] {name} publish check: skipped (workspace dep not yet on crates.io)"
+            );
+            continue;
+        }
+        bail!("cargo publish --dry-run -p {name} failed:\n{stderr}");
     }
     Ok(())
 }


### PR DESCRIPTION
Updated `xtask/src/main.rs` to handle local workspace dependencies that aren't yet published to crates.io. This prevents `cargo xtask publish-check` from failing when running `cargo publish --dry-run` on crates that depend on sibling crates that are also unpublished. This perfectly aligns with how `publish_preflight` currently skips unpublished dependencies.

---
*PR created automatically by Jules for task [5917203308848645294](https://jules.google.com/task/5917203308848645294) started by @EffortlessSteven*