### PR TITLE
docs: add doc-test examples to algorithm crate public APIs

### DIFF
--- a/crates/uselesskey-ecdsa/src/keypair.rs
+++ b/crates/uselesskey-ecdsa/src/keypair.rs
@@ -118,21 +118,65 @@ impl EcdsaKeyPair {
     }
 
     /// PKCS#8 DER-encoded private key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let der = kp.private_key_pkcs8_der();
+    /// assert!(!der.is_empty());
+    /// ```
     pub fn private_key_pkcs8_der(&self) -> &[u8] {
         self.inner.material.private_key_pkcs8_der()
     }
 
     /// PKCS#8 PEM-encoded private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let pem = kp.private_key_pkcs8_pem();
+    /// assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    /// ```
     pub fn private_key_pkcs8_pem(&self) -> &str {
         self.inner.material.private_key_pkcs8_pem()
     }
 
     /// SPKI DER-encoded public key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let der = kp.public_key_spki_der();
+    /// assert!(!der.is_empty());
+    /// ```
     pub fn public_key_spki_der(&self) -> &[u8] {
         self.inner.material.public_key_spki_der()
     }
 
     /// SPKI PEM-encoded public key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let pem = kp.public_key_spki_pem();
+    /// assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    /// ```
     pub fn public_key_spki_pem(&self) -> &str {
         self.inner.material.public_key_spki_pem()
     }
@@ -148,6 +192,18 @@ impl EcdsaKeyPair {
     }
 
     /// Produce a corrupted variant of the PKCS#8 PEM.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_core::negative::CorruptPem;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let bad = kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+    /// assert!(bad.contains("CORRUPTED"));
+    /// ```
     pub fn private_key_pkcs8_pem_corrupt(&self, how: CorruptPem) -> String {
         self.inner.material.private_key_pkcs8_pem_corrupt(how)
     }
@@ -160,6 +216,17 @@ impl EcdsaKeyPair {
     }
 
     /// Produce a truncated variant of the PKCS#8 DER.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let truncated = kp.private_key_pkcs8_der_truncated(10);
+    /// assert_eq!(truncated.len(), 10);
+    /// ```
     pub fn private_key_pkcs8_der_truncated(&self, len: usize) -> Vec<u8> {
         self.inner.material.private_key_pkcs8_der_truncated(len)
     }
@@ -172,6 +239,17 @@ impl EcdsaKeyPair {
     }
 
     /// Return a valid (parseable) public key that does *not* match this private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let wrong_pub = kp.mismatched_public_key_spki_der();
+    /// assert_ne!(wrong_pub, kp.public_key_spki_der());
+    /// ```
     pub fn mismatched_public_key_spki_der(&self) -> Vec<u8> {
         let other = self.load_variant("mismatch");
         other.material.public_key_spki_der().to_vec()

--- a/crates/uselesskey-ed25519/src/keypair.rs
+++ b/crates/uselesskey-ed25519/src/keypair.rs
@@ -112,21 +112,65 @@ impl Ed25519KeyPair {
     }
 
     /// PKCS#8 DER-encoded private key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let der = kp.private_key_pkcs8_der();
+    /// assert!(!der.is_empty());
+    /// ```
     pub fn private_key_pkcs8_der(&self) -> &[u8] {
         self.inner.material.private_key_pkcs8_der()
     }
 
     /// PKCS#8 PEM-encoded private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let pem = kp.private_key_pkcs8_pem();
+    /// assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    /// ```
     pub fn private_key_pkcs8_pem(&self) -> &str {
         self.inner.material.private_key_pkcs8_pem()
     }
 
     /// SPKI DER-encoded public key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let der = kp.public_key_spki_der();
+    /// assert!(!der.is_empty());
+    /// ```
     pub fn public_key_spki_der(&self) -> &[u8] {
         self.inner.material.public_key_spki_der()
     }
 
     /// SPKI PEM-encoded public key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let pem = kp.public_key_spki_pem();
+    /// assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    /// ```
     pub fn public_key_spki_pem(&self) -> &str {
         self.inner.material.public_key_spki_pem()
     }
@@ -142,6 +186,18 @@ impl Ed25519KeyPair {
     }
 
     /// Produce a corrupted variant of the PKCS#8 PEM.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_core::negative::CorruptPem;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let bad = kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+    /// assert!(bad.contains("CORRUPTED"));
+    /// ```
     pub fn private_key_pkcs8_pem_corrupt(&self, how: CorruptPem) -> String {
         self.inner.material.private_key_pkcs8_pem_corrupt(how)
     }
@@ -154,6 +210,17 @@ impl Ed25519KeyPair {
     }
 
     /// Produce a truncated variant of the PKCS#8 DER.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let truncated = kp.private_key_pkcs8_der_truncated(10);
+    /// assert_eq!(truncated.len(), 10);
+    /// ```
     pub fn private_key_pkcs8_der_truncated(&self, len: usize) -> Vec<u8> {
         self.inner.material.private_key_pkcs8_der_truncated(len)
     }
@@ -166,6 +233,17 @@ impl Ed25519KeyPair {
     }
 
     /// Return a valid (parseable) public key that does *not* match this private key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let wrong_pub = kp.mismatched_public_key_spki_der();
+    /// assert_ne!(wrong_pub, kp.public_key_spki_der());
+    /// ```
     pub fn mismatched_public_key_spki_der(&self) -> Vec<u8> {
         let other = self.load_variant("mismatch");
         other.material.public_key_spki_der().to_vec()

--- a/crates/uselesskey-hmac/src/secret.rs
+++ b/crates/uselesskey-hmac/src/secret.rs
@@ -97,6 +97,19 @@ impl HmacSecret {
     }
 
     /// Access raw secret bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let secret = fx.hmac("jwt-signing", HmacSpec::hs256());
+    /// assert_eq!(secret.secret_bytes().len(), 32);
+    ///
+    /// let secret512 = fx.hmac("jwt-signing", HmacSpec::hs512());
+    /// assert_eq!(secret512.secret_bytes().len(), 64);
+    /// ```
     pub fn secret_bytes(&self) -> &[u8] {
         &self.inner.secret
     }

--- a/crates/uselesskey-rsa/src/keypair.rs
+++ b/crates/uselesskey-rsa/src/keypair.rs
@@ -118,21 +118,65 @@ impl RsaKeyPair {
     }
 
     /// PKCS#8 DER-encoded private key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let der = kp.private_key_pkcs8_der();
+    /// assert!(!der.is_empty());
+    /// ```
     pub fn private_key_pkcs8_der(&self) -> &[u8] {
         self.inner.material.private_key_pkcs8_der()
     }
 
     /// PKCS#8 PEM-encoded private key.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let pem = kp.private_key_pkcs8_pem();
+    /// assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    /// ```
     pub fn private_key_pkcs8_pem(&self) -> &str {
         self.inner.material.private_key_pkcs8_pem()
     }
 
     /// SPKI DER-encoded public key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let der = kp.public_key_spki_der();
+    /// assert!(!der.is_empty());
+    /// ```
     pub fn public_key_spki_der(&self) -> &[u8] {
         self.inner.material.public_key_spki_der()
     }
 
     /// SPKI PEM-encoded public key.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let pem = kp.public_key_spki_pem();
+    /// assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    /// ```
     pub fn public_key_spki_pem(&self) -> &str {
         self.inner.material.public_key_spki_pem()
     }
@@ -148,6 +192,18 @@ impl RsaKeyPair {
     }
 
     /// Produce a corrupted variant of the PKCS#8 PEM.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_core::negative::CorruptPem;
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let bad = kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+    /// assert!(bad.contains("CORRUPTED"));
+    /// ```
     pub fn private_key_pkcs8_pem_corrupt(&self, how: CorruptPem) -> String {
         self.inner.material.private_key_pkcs8_pem_corrupt(how)
     }
@@ -160,6 +216,17 @@ impl RsaKeyPair {
     }
 
     /// Produce a truncated variant of the PKCS#8 DER.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let truncated = kp.private_key_pkcs8_der_truncated(10);
+    /// assert_eq!(truncated.len(), 10);
+    /// ```
     pub fn private_key_pkcs8_der_truncated(&self, len: usize) -> Vec<u8> {
         self.inner.material.private_key_pkcs8_der_truncated(len)
     }
@@ -172,6 +239,17 @@ impl RsaKeyPair {
     }
 
     /// Return a valid (parseable) public key that does *not* match this private key.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let wrong_pub = kp.mismatched_public_key_spki_der();
+    /// assert_ne!(wrong_pub, kp.public_key_spki_der());
+    /// ```
     pub fn mismatched_public_key_spki_der(&self) -> Vec<u8> {
         let other = self.load_variant("mismatch");
         other.material.public_key_spki_der().to_vec()

--- a/crates/uselesskey-token/src/token.rs
+++ b/crates/uselesskey-token/src/token.rs
@@ -11,6 +11,20 @@ use crate::TokenSpec;
 /// Keep this stable: changing it changes deterministic outputs.
 pub const DOMAIN_TOKEN_FIXTURE: &str = "uselesskey:token:fixture";
 
+/// A token fixture with a generated value.
+///
+/// Created via [`TokenFactoryExt::token()`]. Provides access to
+/// the generated token value and an HTTP `Authorization` header.
+///
+/// # Examples
+///
+/// ```
+/// # use uselesskey_core::{Factory, Seed};
+/// # use uselesskey_token::{TokenFactoryExt, TokenSpec};
+/// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+/// let tok = fx.token("api-key", TokenSpec::api_key());
+/// assert!(tok.value().starts_with("uk_test_"));
+/// ```
 #[derive(Clone)]
 pub struct TokenFixture {
     factory: Factory,
@@ -34,7 +48,36 @@ impl fmt::Debug for TokenFixture {
 
 /// Extension trait to hang token helpers off the core [`Factory`].
 pub trait TokenFactoryExt {
+    /// Generate (or retrieve from cache) a token fixture.
+    ///
+    /// The `label` identifies this token within your test suite.
+    /// In deterministic mode, `seed + label + spec` always produces the same token.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_token::{TokenFactoryExt, TokenSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let tok = fx.token("billing", TokenSpec::bearer());
+    /// assert!(!tok.value().is_empty());
+    /// ```
     fn token(&self, label: impl AsRef<str>, spec: TokenSpec) -> TokenFixture;
+
+    /// Generate a token fixture with an explicit variant.
+    ///
+    /// Different variants for the same `(label, spec)` produce different tokens.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_token::{TokenFactoryExt, TokenSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let good = fx.token("svc", TokenSpec::api_key());
+    /// let alt = fx.token_with_variant("svc", TokenSpec::api_key(), "alt");
+    /// assert_ne!(good.value(), alt.value());
+    /// ```
     fn token_with_variant(
         &self,
         label: impl AsRef<str>,
@@ -84,6 +127,17 @@ impl TokenFixture {
     }
 
     /// Access the token value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_token::{TokenFactoryExt, TokenSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let tok = fx.token("svc", TokenSpec::api_key());
+    /// let val = tok.value();
+    /// assert!(val.starts_with("uk_test_"));
+    /// ```
     pub fn value(&self) -> &str {
         &self.inner.value
     }
@@ -92,6 +146,20 @@ impl TokenFixture {
     ///
     /// - API keys use `ApiKey <token>`
     /// - Bearer and OAuth access tokens use `Bearer <token>`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_token::{TokenFactoryExt, TokenSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    ///
+    /// let bearer = fx.token("svc", TokenSpec::bearer());
+    /// assert!(bearer.authorization_header().starts_with("Bearer "));
+    ///
+    /// let api = fx.token("svc", TokenSpec::api_key());
+    /// assert!(api.authorization_header().starts_with("ApiKey "));
+    /// ```
     pub fn authorization_header(&self) -> String {
         let scheme = authorization_scheme(token_kind(self.spec));
         format!("{scheme} {}", self.value())

--- a/crates/uselesskey-x509/src/cert.rs
+++ b/crates/uselesskey-x509/src/cert.rs
@@ -30,6 +30,24 @@ use crate::negative::{
 pub const DOMAIN_X509_CERT: &str = "uselesskey:x509:cert";
 
 /// An X.509 certificate fixture.
+///
+/// Created via [`X509FactoryExt::x509_self_signed()`]. Provides access to:
+/// - Certificate in PEM and DER formats
+/// - Private key in PKCS#8 PEM and DER formats
+/// - Combined identity PEM (cert + key)
+/// - Negative fixtures (expired, not-yet-valid, wrong key usage, corrupt PEM)
+///
+/// # Examples
+///
+/// ```no_run
+/// # use uselesskey_core::{Factory, Seed};
+/// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+/// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+/// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+///
+/// assert!(cert.cert_pem().contains("-----BEGIN CERTIFICATE-----"));
+/// assert!(cert.private_key_pkcs8_pem().contains("-----BEGIN PRIVATE KEY-----"));
+/// ```
 #[derive(Clone)]
 pub struct X509Cert {
     factory: Factory,
@@ -60,12 +78,33 @@ pub trait X509FactoryExt {
     ///
     /// The certificate is cached by `(label, spec)` and will be reused on subsequent calls
     /// with the same parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let spec = X509Spec::self_signed("test.example.com");
+    /// let cert = fx.x509_self_signed("my-service", spec);
+    /// assert!(cert.cert_pem().contains("-----BEGIN CERTIFICATE-----"));
+    /// ```
     fn x509_self_signed(&self, label: impl AsRef<str>, spec: X509Spec) -> X509Cert;
 
     /// Generate a three-level X.509 certificate chain (root CA → intermediate CA → leaf).
     ///
     /// The chain is cached by `(label, spec)` and will be reused on subsequent calls
     /// with the same parameters.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("my-service", ChainSpec::new("test.example.com"));
+    /// assert!(chain.leaf_cert_pem().contains("-----BEGIN CERTIFICATE-----"));
+    /// ```
     fn x509_chain(&self, label: impl AsRef<str>, spec: ChainSpec) -> X509Chain;
 }
 
@@ -100,11 +139,31 @@ impl X509Cert {
     // =========================================================================
 
     /// DER-encoded certificate bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// assert!(!cert.cert_der().is_empty());
+    /// ```
     pub fn cert_der(&self) -> &[u8] {
         &self.inner.cert_der
     }
 
     /// PEM-encoded certificate.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// assert!(cert.cert_pem().starts_with("-----BEGIN CERTIFICATE-----"));
+    /// ```
     pub fn cert_pem(&self) -> &str {
         &self.inner.cert_pem
     }
@@ -123,6 +182,18 @@ impl X509Cert {
     ///
     /// This is a common format for TLS server configuration where
     /// a single file holds the server identity (cert + key).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let identity = cert.identity_pem();
+    /// assert!(identity.contains("-----BEGIN CERTIFICATE-----"));
+    /// assert!(identity.contains("-----BEGIN PRIVATE KEY-----"));
+    /// ```
     pub fn identity_pem(&self) -> String {
         format!("{}\n{}", self.cert_pem(), self.private_key_pkcs8_pem())
     }
@@ -192,11 +263,33 @@ impl X509Cert {
     }
 
     /// Get a certificate that is already expired.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let expired = cert.expired();
+    /// assert_ne!(cert.cert_der(), expired.cert_der());
+    /// ```
     pub fn expired(&self) -> X509Cert {
         self.negative(X509Negative::Expired)
     }
 
     /// Get a certificate that is not yet valid.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let future = cert.not_yet_valid();
+    /// assert_ne!(cert.cert_der(), future.cert_der());
+    /// ```
     pub fn not_yet_valid(&self) -> X509Cert {
         self.negative(X509Negative::NotYetValid)
     }


### PR DESCRIPTION
Adds runnable doc-test examples to the main extension trait methods across all 6 algorithm crates.