### PR TITLE
test: add property-based tests for core microcrates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,6 +3383,7 @@ dependencies = [
 name = "uselesskey-core-base62"
 version = "0.3.0"
 dependencies = [
+ "proptest",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rstest",
@@ -3488,6 +3489,7 @@ version = "0.3.0"
 dependencies = [
  "base64",
  "blake3",
+ "proptest",
  "rstest",
 ]
 

--- a/crates/uselesskey-core-base62/Cargo.toml
+++ b/crates/uselesskey-core-base62/Cargo.toml
@@ -18,6 +18,7 @@ authors.workspace = true
 rand_core.workspace = true
 
 [dev-dependencies]
+proptest.workspace = true
 rand_chacha.workspace = true
 rstest.workspace = true
 

--- a/crates/uselesskey-core-base62/tests/prop_base62.rs
+++ b/crates/uselesskey-core-base62/tests/prop_base62.rs
@@ -1,0 +1,52 @@
+use proptest::prelude::*;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use uselesskey_core_base62::{BASE62_ALPHABET, random_base62};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn output_length_matches_requested(seed in any::<[u8; 32]>(), len in 0usize..256) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let out = random_base62(&mut rng, len);
+        prop_assert_eq!(out.len(), len);
+    }
+
+    #[test]
+    fn output_contains_only_base62_chars(seed in any::<[u8; 32]>(), len in 1usize..256) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let out = random_base62(&mut rng, len);
+        for b in out.bytes() {
+            prop_assert!(
+                BASE62_ALPHABET.contains(&b),
+                "byte {} is not in BASE62_ALPHABET",
+                b
+            );
+        }
+    }
+
+    #[test]
+    fn deterministic_for_same_seed(seed in any::<[u8; 32]>(), len in 1usize..128) {
+        let a = random_base62(&mut ChaCha20Rng::from_seed(seed), len);
+        let b = random_base62(&mut ChaCha20Rng::from_seed(seed), len);
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_seeds_produce_different_output(
+        seed_a in any::<[u8; 32]>(),
+        seed_b in any::<[u8; 32]>(),
+    ) {
+        prop_assume!(seed_a != seed_b);
+        let a = random_base62(&mut ChaCha20Rng::from_seed(seed_a), 64);
+        let b = random_base62(&mut ChaCha20Rng::from_seed(seed_b), 64);
+        prop_assert_ne!(a, b);
+    }
+
+    #[test]
+    fn zero_length_produces_empty_string(seed in any::<[u8; 32]>()) {
+        let out = random_base62(&mut ChaCha20Rng::from_seed(seed), 0);
+        prop_assert!(out.is_empty());
+    }
+}

--- a/crates/uselesskey-core-hash/tests/prop_hash.rs
+++ b/crates/uselesskey-core-hash/tests/prop_hash.rs
@@ -1,0 +1,64 @@
+use proptest::prelude::*;
+use uselesskey_core_hash::{Hasher, hash32, write_len_prefixed};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn hash32_deterministic(data in any::<Vec<u8>>()) {
+        prop_assert_eq!(hash32(&data), hash32(&data));
+    }
+
+    #[test]
+    fn hash32_different_inputs_differ(
+        a in proptest::collection::vec(any::<u8>(), 1..64),
+        b in proptest::collection::vec(any::<u8>(), 1..64),
+    ) {
+        prop_assume!(a != b);
+        prop_assert_ne!(hash32(&a), hash32(&b));
+    }
+
+    #[test]
+    fn write_len_prefixed_matches_manual(data in any::<Vec<u8>>()) {
+        let len = u32::try_from(data.len()).unwrap_or(u32::MAX);
+
+        let mut manual = Hasher::new();
+        manual.update(&len.to_be_bytes());
+        manual.update(&data);
+
+        let mut prefixed = Hasher::new();
+        write_len_prefixed(&mut prefixed, &data);
+
+        prop_assert_eq!(manual.finalize(), prefixed.finalize());
+    }
+
+    #[test]
+    fn len_prefix_prevents_boundary_confusion(
+        left in proptest::collection::vec(any::<u8>(), 1..32),
+        right in proptest::collection::vec(any::<u8>(), 1..32),
+    ) {
+        prop_assume!(left.len() > 1 || right.len() > 1);
+
+        // Split at a different boundary
+        let combined: Vec<u8> = left.iter().chain(right.iter()).copied().collect();
+        let split_at = if left.len() > 1 { left.len() - 1 } else { left.len() + 1 };
+        prop_assume!(split_at < combined.len());
+        let (alt_left, alt_right) = combined.split_at(split_at);
+        prop_assume!(alt_left != left.as_slice() || alt_right != right.as_slice());
+
+        let mut original = Hasher::new();
+        write_len_prefixed(&mut original, &left);
+        write_len_prefixed(&mut original, &right);
+
+        let mut alternate = Hasher::new();
+        write_len_prefixed(&mut alternate, alt_left);
+        write_len_prefixed(&mut alternate, alt_right);
+
+        prop_assert_ne!(original.finalize(), alternate.finalize());
+    }
+
+    #[test]
+    fn hash32_output_is_32_bytes(data in any::<Vec<u8>>()) {
+        prop_assert_eq!(hash32(&data).as_bytes().len(), 32);
+    }
+}

--- a/crates/uselesskey-core-id/tests/prop_id.rs
+++ b/crates/uselesskey-core-id/tests/prop_id.rs
@@ -1,0 +1,98 @@
+use proptest::prelude::*;
+use uselesskey_core_id::{ArtifactId, DerivationVersion, Seed, derive_seed};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn derive_seed_is_deterministic(
+        master in any::<[u8; 32]>(),
+        label in "[a-z0-9_-]{1,16}",
+        spec in any::<Vec<u8>>(),
+        variant in "[a-z0-9_-]{1,16}",
+    ) {
+        let master = Seed::new(master);
+        let id = ArtifactId::new("domain:test", &label, &spec, &variant, DerivationVersion::V1);
+        let a = derive_seed(&master, &id);
+        let b = derive_seed(&master, &id);
+        prop_assert_eq!(a.bytes(), b.bytes());
+    }
+
+    #[test]
+    fn different_labels_produce_different_seeds(
+        master in any::<[u8; 32]>(),
+        label_a in "[a-z]{1,8}",
+        label_b in "[a-z]{1,8}",
+    ) {
+        prop_assume!(label_a != label_b);
+        let master = Seed::new(master);
+        let id_a = ArtifactId::new("d", &label_a, b"spec", "v", DerivationVersion::V1);
+        let id_b = ArtifactId::new("d", &label_b, b"spec", "v", DerivationVersion::V1);
+        let sa = derive_seed(&master, &id_a);
+        let sb = derive_seed(&master, &id_b);
+        prop_assert_ne!(sa.bytes(), sb.bytes());
+    }
+
+    #[test]
+    fn different_variants_produce_different_seeds(
+        master in any::<[u8; 32]>(),
+        var_a in "[a-z]{1,8}",
+        var_b in "[a-z]{1,8}",
+    ) {
+        prop_assume!(var_a != var_b);
+        let master = Seed::new(master);
+        let id_a = ArtifactId::new("d", "label", b"spec", &var_a, DerivationVersion::V1);
+        let id_b = ArtifactId::new("d", "label", b"spec", &var_b, DerivationVersion::V1);
+        let sa = derive_seed(&master, &id_a);
+        let sb = derive_seed(&master, &id_b);
+        prop_assert_ne!(sa.bytes(), sb.bytes());
+    }
+
+    #[test]
+    fn different_specs_produce_different_seeds(
+        master in any::<[u8; 32]>(),
+        spec_a in proptest::collection::vec(any::<u8>(), 1..32),
+        spec_b in proptest::collection::vec(any::<u8>(), 1..32),
+    ) {
+        prop_assume!(spec_a != spec_b);
+        let master = Seed::new(master);
+        let id_a = ArtifactId::new("d", "label", &spec_a, "v", DerivationVersion::V1);
+        let id_b = ArtifactId::new("d", "label", &spec_b, "v", DerivationVersion::V1);
+        let sa = derive_seed(&master, &id_a);
+        let sb = derive_seed(&master, &id_b);
+        prop_assert_ne!(sa.bytes(), sb.bytes());
+    }
+
+    #[test]
+    fn different_masters_produce_different_seeds(
+        master_a in any::<[u8; 32]>(),
+        master_b in any::<[u8; 32]>(),
+    ) {
+        prop_assume!(master_a != master_b);
+        let id = ArtifactId::new("d", "label", b"spec", "v", DerivationVersion::V1);
+        let a = derive_seed(&Seed::new(master_a), &id);
+        let b = derive_seed(&Seed::new(master_b), &id);
+        prop_assert_ne!(a.bytes(), b.bytes());
+    }
+
+    #[test]
+    fn spec_fingerprint_is_stable(spec in any::<Vec<u8>>()) {
+        let id_a = ArtifactId::new("d", "l", &spec, "v", DerivationVersion::V1);
+        let id_b = ArtifactId::new("d", "l", &spec, "v", DerivationVersion::V1);
+        prop_assert_eq!(id_a.spec_fingerprint, id_b.spec_fingerprint);
+    }
+
+    #[test]
+    fn derivation_version_affects_output(
+        master in any::<[u8; 32]>(),
+        v1 in 1u16..100,
+        v2 in 100u16..200,
+    ) {
+        let master = Seed::new(master);
+        let id_a = ArtifactId::new("d", "l", b"s", "v", DerivationVersion(v1));
+        let id_b = ArtifactId::new("d", "l", b"s", "v", DerivationVersion(v2));
+        let sa = derive_seed(&master, &id_a);
+        let sb = derive_seed(&master, &id_b);
+        prop_assert_ne!(sa.bytes(), sb.bytes());
+    }
+}

--- a/crates/uselesskey-core-jwks-order/tests/prop_jwks_order.rs
+++ b/crates/uselesskey-core-jwks-order/tests/prop_jwks_order.rs
@@ -1,0 +1,84 @@
+use proptest::prelude::*;
+use uselesskey_core_jwks_order::{HasKid, KidSorted};
+
+#[derive(Debug, Clone)]
+struct TestKey {
+    kid: String,
+    index: usize,
+}
+
+impl HasKid for TestKey {
+    fn kid(&self) -> &str {
+        &self.kid
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn output_is_sorted_by_kid(kids in proptest::collection::vec("[a-z]{1,8}", 0..32)) {
+        let mut sorter = KidSorted::new();
+        for (i, kid) in kids.iter().enumerate() {
+            sorter.push(TestKey { kid: kid.clone(), index: i });
+        }
+        let result = sorter.build();
+        for window in result.windows(2) {
+            prop_assert!(
+                window[0].kid() <= window[1].kid(),
+                "not sorted: {:?} > {:?}",
+                window[0].kid(),
+                window[1].kid()
+            );
+        }
+    }
+
+    #[test]
+    fn stable_sort_preserves_insertion_order(
+        count in 2usize..16,
+        kid in "[a-z]{1,4}",
+    ) {
+        let mut sorter = KidSorted::new();
+        for i in 0..count {
+            sorter.push(TestKey { kid: kid.clone(), index: i });
+        }
+        let result = sorter.build();
+        for (pos, item) in result.iter().enumerate() {
+            prop_assert_eq!(
+                item.index, pos,
+                "insertion order not preserved at position {}",
+                pos
+            );
+        }
+    }
+
+    #[test]
+    fn build_preserves_all_items(kids in proptest::collection::vec("[a-z]{1,8}", 0..32)) {
+        let mut sorter = KidSorted::new();
+        for (i, kid) in kids.iter().enumerate() {
+            sorter.push(TestKey { kid: kid.clone(), index: i });
+        }
+        let result = sorter.build();
+        prop_assert_eq!(result.len(), kids.len());
+    }
+
+    #[test]
+    fn ordering_is_deterministic(kids in proptest::collection::vec("[a-z]{1,8}", 0..32)) {
+        let build = |kids: &[String]| {
+            let mut sorter = KidSorted::new();
+            for (i, kid) in kids.iter().enumerate() {
+                sorter.push(TestKey { kid: kid.clone(), index: i });
+            }
+            sorter.build().into_iter().map(|k| (k.kid, k.index)).collect::<Vec<_>>()
+        };
+        prop_assert_eq!(build(&kids), build(&kids));
+    }
+
+    #[test]
+    fn empty_collection_builds_empty(dummy in 0u8..1) {
+        let _ = dummy;
+        let sorter: KidSorted<TestKey> = KidSorted::new();
+        let result = sorter.build();
+        prop_assert!(result.is_empty());
+    }
+}

--- a/crates/uselesskey-core-kid/Cargo.toml
+++ b/crates/uselesskey-core-kid/Cargo.toml
@@ -19,6 +19,7 @@ blake3.workspace = true
 base64.workspace = true
 
 [dev-dependencies]
+proptest.workspace = true
 rstest.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-core-kid/tests/prop_kid.rs
+++ b/crates/uselesskey-core-kid/tests/prop_kid.rs
@@ -1,0 +1,62 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use proptest::prelude::*;
+use uselesskey_core_kid::{DEFAULT_KID_PREFIX_BYTES, kid_from_bytes, kid_from_bytes_with_prefix};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn kid_is_deterministic(input in any::<Vec<u8>>()) {
+        let a = kid_from_bytes(&input);
+        let b = kid_from_bytes(&input);
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn kid_is_valid_base64url(input in any::<Vec<u8>>()) {
+        let kid = kid_from_bytes(&input);
+        let decoded = URL_SAFE_NO_PAD.decode(kid.as_bytes());
+        prop_assert!(decoded.is_ok(), "kid should be valid base64url");
+    }
+
+    #[test]
+    fn kid_default_decodes_to_expected_length(input in any::<Vec<u8>>()) {
+        let kid = kid_from_bytes(&input);
+        let decoded = URL_SAFE_NO_PAD.decode(kid.as_bytes()).unwrap();
+        prop_assert_eq!(decoded.len(), DEFAULT_KID_PREFIX_BYTES);
+    }
+
+    #[test]
+    fn kid_custom_prefix_decodes_to_requested_length(
+        input in any::<Vec<u8>>(),
+        prefix_bytes in 1usize..=32,
+    ) {
+        let kid = kid_from_bytes_with_prefix(&input, prefix_bytes);
+        let decoded = URL_SAFE_NO_PAD.decode(kid.as_bytes()).unwrap();
+        prop_assert_eq!(decoded.len(), prefix_bytes);
+    }
+
+    #[test]
+    fn different_inputs_produce_different_kids(
+        a in proptest::collection::vec(any::<u8>(), 1..64),
+        b in proptest::collection::vec(any::<u8>(), 1..64),
+    ) {
+        prop_assume!(a != b);
+        let kid_a = kid_from_bytes(&a);
+        let kid_b = kid_from_bytes(&b);
+        prop_assert_ne!(kid_a, kid_b);
+    }
+
+    #[test]
+    fn kid_contains_only_url_safe_chars(input in any::<Vec<u8>>()) {
+        let kid = kid_from_bytes(&input);
+        for ch in kid.chars() {
+            prop_assert!(
+                ch.is_ascii_alphanumeric() || ch == '-' || ch == '_',
+                "unexpected char in kid: {:?}",
+                ch
+            );
+        }
+    }
+}

--- a/crates/uselesskey-core-negative-pem/tests/prop_negative_pem.rs
+++ b/crates/uselesskey-core-negative-pem/tests/prop_negative_pem.rs
@@ -1,0 +1,63 @@
+use proptest::prelude::*;
+use uselesskey_core_negative_pem::{CorruptPem, corrupt_pem, corrupt_pem_deterministic};
+
+const SAMPLE_PEM: &str =
+    "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALRiMLAH\n-----END RSA PRIVATE KEY-----\n";
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn bad_header_always_corrupts_header(input in "[A-Z ]{3,20}") {
+        let pem = format!("-----BEGIN {input}-----\nDATA=\n-----END {input}-----\n");
+        let out = corrupt_pem(&pem, CorruptPem::BadHeader);
+        prop_assert!(out.starts_with("-----BEGIN CORRUPTED KEY-----"));
+        let expected_start = format!("-----BEGIN {input}-----");
+        prop_assert!(!out.starts_with(&expected_start));
+    }
+
+    #[test]
+    fn bad_footer_always_corrupts_footer(input in "[A-Z ]{3,20}") {
+        let pem = format!("-----BEGIN {input}-----\nDATA=\n-----END {input}-----\n");
+        let out = corrupt_pem(&pem, CorruptPem::BadFooter);
+        prop_assert!(out.contains("-----END CORRUPTED KEY-----"));
+        let expected_end = format!("-----END {input}-----\n");
+        prop_assert!(!out.ends_with(&expected_end));
+    }
+
+    #[test]
+    fn bad_base64_injects_invalid_data(input in "[A-Z ]{3,20}") {
+        let pem = format!("-----BEGIN {input}-----\nDATA=\n-----END {input}-----\n");
+        let out = corrupt_pem(&pem, CorruptPem::BadBase64);
+        prop_assert!(out.contains("THIS_IS_NOT_BASE64!!!"));
+    }
+
+    #[test]
+    fn truncate_produces_exact_length(bytes in 0usize..50) {
+        let out = corrupt_pem(SAMPLE_PEM, CorruptPem::Truncate { bytes });
+        prop_assert_eq!(out.chars().count(), bytes.min(SAMPLE_PEM.chars().count()));
+    }
+
+    #[test]
+    fn extra_blank_line_adds_empty_line(input in "[A-Z ]{3,20}") {
+        let pem = format!("-----BEGIN {input}-----\nDATA=\n-----END {input}-----\n");
+        let out = corrupt_pem(&pem, CorruptPem::ExtraBlankLine);
+        let lines: Vec<&str> = out.lines().collect();
+        let orig_lines: Vec<&str> = pem.lines().collect();
+        prop_assert!(lines.len() > orig_lines.len());
+        prop_assert!(lines.contains(&""));
+    }
+
+    #[test]
+    fn deterministic_corruption_is_stable(variant in "[a-z0-9:_-]{1,32}") {
+        let a = corrupt_pem_deterministic(SAMPLE_PEM, &variant);
+        let b = corrupt_pem_deterministic(SAMPLE_PEM, &variant);
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn corrupt_output_differs_from_original(variant in "[a-z0-9:_-]{1,32}") {
+        let out = corrupt_pem_deterministic(SAMPLE_PEM, &variant);
+        prop_assert_ne!(out, SAMPLE_PEM);
+    }
+}

--- a/crates/uselesskey-core-seed/tests/prop_seed.rs
+++ b/crates/uselesskey-core-seed/tests/prop_seed.rs
@@ -1,0 +1,71 @@
+use proptest::prelude::*;
+use uselesskey_core_seed::Seed;
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn seed_roundtrip_bytes(bytes in any::<[u8; 32]>()) {
+        let seed = Seed::new(bytes);
+        prop_assert_eq!(*seed.bytes(), bytes);
+    }
+
+    #[test]
+    fn seed_debug_never_leaks_bytes(bytes in any::<[u8; 32]>()) {
+        let seed = Seed::new(bytes);
+        let debug = format!("{:?}", seed);
+        prop_assert_eq!(debug, "Seed(**redacted**)");
+    }
+
+    #[test]
+    fn seed_from_hex_is_deterministic(bytes in any::<[u8; 32]>()) {
+        let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+        let a = Seed::from_env_value(&hex).unwrap();
+        let b = Seed::from_env_value(&hex).unwrap();
+        prop_assert_eq!(a.bytes(), b.bytes());
+    }
+
+    #[test]
+    fn seed_from_hex_with_0x_prefix(bytes in any::<[u8; 32]>()) {
+        let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+        let without = Seed::from_env_value(&hex).unwrap();
+        let with = Seed::from_env_value(&format!("0x{hex}")).unwrap();
+        prop_assert_eq!(without.bytes(), with.bytes());
+    }
+
+    #[test]
+    fn seed_from_string_is_deterministic(s in "[a-zA-Z0-9_]{1,63}") {
+        let a = Seed::from_env_value(&s).unwrap();
+        let b = Seed::from_env_value(&s).unwrap();
+        prop_assert_eq!(a.bytes(), b.bytes());
+    }
+
+    #[test]
+    fn seed_from_different_strings_differ(
+        s1 in "[a-zA-Z]{1,32}",
+        s2 in "[a-zA-Z]{1,32}",
+    ) {
+        prop_assume!(s1 != s2);
+        let a = Seed::from_env_value(&s1).unwrap();
+        let b = Seed::from_env_value(&s2).unwrap();
+        prop_assert_ne!(a.bytes(), b.bytes());
+    }
+
+    #[test]
+    fn seed_from_hex_case_insensitive(bytes in any::<[u8; 32]>()) {
+        let lower: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+        let upper: String = bytes.iter().map(|b| format!("{b:02X}")).collect();
+        let a = Seed::from_env_value(&lower).unwrap();
+        let b = Seed::from_env_value(&upper).unwrap();
+        prop_assert_eq!(a.bytes(), b.bytes());
+    }
+
+    #[test]
+    fn seed_from_hex_trims_whitespace(bytes in any::<[u8; 32]>()) {
+        let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+        let padded = format!("  {hex}  ");
+        let a = Seed::from_env_value(&hex).unwrap();
+        let b = Seed::from_env_value(&padded).unwrap();
+        prop_assert_eq!(a.bytes(), b.bytes());
+    }
+}

--- a/crates/uselesskey-core-token-shape/tests/prop_token_shape.rs
+++ b/crates/uselesskey-core-token-shape/tests/prop_token_shape.rs
@@ -1,0 +1,77 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use proptest::prelude::*;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use uselesskey_core_token_shape::{
+    API_KEY_PREFIX, API_KEY_RANDOM_LEN, BEARER_RANDOM_BYTES, TokenKind, generate_api_key,
+    generate_bearer_token, generate_oauth_access_token, generate_token,
+};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    #[test]
+    fn api_key_has_correct_prefix_and_length(seed in any::<[u8; 32]>()) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let key = generate_api_key(&mut rng);
+        prop_assert!(key.starts_with(API_KEY_PREFIX));
+        let suffix = &key[API_KEY_PREFIX.len()..];
+        prop_assert_eq!(suffix.len(), API_KEY_RANDOM_LEN);
+        prop_assert!(suffix.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    #[test]
+    fn bearer_decodes_to_expected_bytes(seed in any::<[u8; 32]>()) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let token = generate_bearer_token(&mut rng);
+        let decoded = URL_SAFE_NO_PAD.decode(token.as_bytes());
+        prop_assert!(decoded.is_ok());
+        prop_assert_eq!(decoded.unwrap().len(), BEARER_RANDOM_BYTES);
+    }
+
+    #[test]
+    fn oauth_has_three_jwt_segments(
+        seed in any::<[u8; 32]>(),
+        label in "[a-z0-9_-]{1,16}",
+    ) {
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let token = generate_oauth_access_token(&label, &mut rng);
+        prop_assert_eq!(token.matches('.').count(), 2);
+
+        let parts: Vec<&str> = token.split('.').collect();
+        // Header segment is valid base64url
+        prop_assert!(URL_SAFE_NO_PAD.decode(parts[0]).is_ok());
+        // Payload segment contains the label as sub
+        let payload = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        prop_assert_eq!(json["sub"].as_str().unwrap(), label.as_str());
+        prop_assert_eq!(json["iss"].as_str().unwrap(), "uselesskey");
+    }
+
+    #[test]
+    fn generate_token_deterministic(seed in any::<[u8; 32]>(), label in "[a-z]{1,8}") {
+        let a = generate_token(&label, TokenKind::ApiKey, &mut ChaCha20Rng::from_seed(seed));
+        let b = generate_token(&label, TokenKind::ApiKey, &mut ChaCha20Rng::from_seed(seed));
+        prop_assert_eq!(a, b);
+
+        let a = generate_token(&label, TokenKind::Bearer, &mut ChaCha20Rng::from_seed(seed));
+        let b = generate_token(&label, TokenKind::Bearer, &mut ChaCha20Rng::from_seed(seed));
+        prop_assert_eq!(a, b);
+
+        let a = generate_token(&label, TokenKind::OAuthAccessToken, &mut ChaCha20Rng::from_seed(seed));
+        let b = generate_token(&label, TokenKind::OAuthAccessToken, &mut ChaCha20Rng::from_seed(seed));
+        prop_assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_seeds_produce_different_api_keys(
+        seed_a in any::<[u8; 32]>(),
+        seed_b in any::<[u8; 32]>(),
+    ) {
+        prop_assume!(seed_a != seed_b);
+        let a = generate_api_key(&mut ChaCha20Rng::from_seed(seed_a));
+        let b = generate_api_key(&mut ChaCha20Rng::from_seed(seed_b));
+        prop_assert_ne!(a, b);
+    }
+}


### PR DESCRIPTION
Adds proptest-based property tests for 8 core microcrates covering determinism, uniqueness, format validity, and stability invariants.

**Crates covered:**
- uselesskey-core-base62: output length, charset validity, determinism
- uselesskey-core-kid: determinism, base64url validity, prefix length
- uselesskey-core-seed: hex roundtrip, BLAKE3 hashing, Debug redaction
- uselesskey-core-id: seed derivation determinism, field sensitivity
- uselesskey-core-token-shape: API key/bearer/OAuth format constraints
- uselesskey-core-negative-pem: corruption strategies, deterministic corruption
- uselesskey-core-hash: determinism, length-prefix boundary separation
- uselesskey-core-jwks-order: lexicographic sorting, stable insertion order