### PR TITLE
docs: add module-level documentation to all crates

### DIFF
--- a/crates/uselesskey-core-negative-der/src/lib.rs
+++ b/crates/uselesskey-core-negative-der/src/lib.rs
@@ -2,6 +2,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 //! DER corruption helpers for negative test fixtures.
+//!
+//! Provides deterministic truncation, byte-flipping, and combined corruption
+//! strategies for DER-encoded blobs. Used by higher-level negative fixture
+//! crates (`uselesskey-core-negative`) to generate invalid DER artifacts
+//! that exercise parser error paths in tests.
 
 extern crate alloc;
 

--- a/crates/uselesskey-core-x509-chain-negative/src/lib.rs
+++ b/crates/uselesskey-core-x509-chain-negative/src/lib.rs
@@ -2,6 +2,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 //! X.509 chain-level negative-fixture policy helpers.
+//!
+//! Defines [`ChainNegative`] variants (hostname mismatch, unknown CA,
+//! expired leaf/intermediate, revoked leaf) and provides
+//! [`ChainNegative::apply_to_spec`] to derive a modified [`ChainSpec`]
+//! for each scenario. Used by `uselesskey-x509` to produce invalid
+//! certificate chains for TLS error-handling tests.
 
 extern crate alloc;
 

--- a/crates/uselesskey-token-spec/src/lib.rs
+++ b/crates/uselesskey-token-spec/src/lib.rs
@@ -1,6 +1,11 @@
 #![forbid(unsafe_code)]
 
 //! Stable token fixture specification shared across token-generation crates.
+//!
+//! Defines [`TokenSpec`], the enum of supported token shapes (API key,
+//! bearer, OAuth/JWT-shape) used by `uselesskey-token` and related crates.
+//! Kept in a separate micro-crate so that spec types can be depended on
+//! without pulling in the full token generation machinery.
 
 /// Specification for token fixture generation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]


### PR DESCRIPTION
Expands single-line \//!\ module doc comments to the multi-line format with workspace context for three crates that were missing detailed descriptions:

- **uselesskey-core-negative-der**: Added detail about DER corruption strategies and workspace role
- **uselesskey-core-x509-chain-negative**: Added \ChainNegative\ variant overview and workspace role
- **uselesskey-token-spec**: Added \TokenSpec\ description and rationale for separate micro-crate

All other 45 crates in the workspace already had multi-line \//!\ documentation.