### PR TITLE
test: add determinism regression tests

### DIFF
--- a/crates/uselesskey-core/tests/determinism_regression.rs
+++ b/crates/uselesskey-core/tests/determinism_regression.rs
@@ -24,33 +24,25 @@ fn determinism_blake3_derivation_produces_stable_rng() {
     use rand_core::RngCore;
 
     let fx = fx42();
-    let bytes: Arc<Vec<u8>> = fx.get_or_init(
-        "test:derive-pin",
-        "label",
-        b"spec",
-        "good",
-        |rng| {
-            let mut buf = vec![0u8; 16];
-            rng.fill_bytes(&mut buf);
-            buf
-        },
-    );
+    let bytes: Arc<Vec<u8>> = fx.get_or_init("test:derive-pin", "label", b"spec", "good", |rng| {
+        let mut buf = vec![0u8; 16];
+        rng.fill_bytes(&mut buf);
+        buf
+    });
 
     // A second factory with the same seed must produce identical bytes.
     let fx2 = fx42();
-    let bytes2: Arc<Vec<u8>> = fx2.get_or_init(
-        "test:derive-pin",
-        "label",
-        b"spec",
-        "good",
-        |rng| {
+    let bytes2: Arc<Vec<u8>> =
+        fx2.get_or_init("test:derive-pin", "label", b"spec", "good", |rng| {
             let mut buf = vec![0u8; 16];
             rng.fill_bytes(&mut buf);
             buf
-        },
-    );
+        });
 
-    assert_eq!(*bytes, *bytes2, "derived RNG output must be stable across factory instances");
+    assert_eq!(
+        *bytes, *bytes2,
+        "derived RNG output must be stable across factory instances"
+    );
 
     // Pin the first 4 bytes so any derivation algorithm change is caught.
     let pinned_prefix = [bytes[0], bytes[1], bytes[2], bytes[3]];
@@ -78,7 +70,10 @@ fn determinism_blake3_different_domains_produce_different_output() {
 
     let a = make_bytes("test:domain-a");
     let b = make_bytes("test:domain-b");
-    assert_ne!(a, b, "different domains must produce different derived output");
+    assert_ne!(
+        a, b,
+        "different domains must produce different derived output"
+    );
 }
 
 #[test]
@@ -99,7 +94,10 @@ fn determinism_blake3_different_labels_produce_different_output() {
 
     let a = make_bytes("label-a");
     let b = make_bytes("label-b");
-    assert_ne!(a, b, "different labels must produce different derived output");
+    assert_ne!(
+        a, b,
+        "different labels must produce different derived output"
+    );
 }
 
 #[test]
@@ -119,7 +117,10 @@ fn determinism_blake3_different_specs_produce_different_output() {
 
     let a = make_bytes(b"spec-a");
     let b = make_bytes(b"spec-b");
-    assert_ne!(a, b, "different spec bytes must produce different derived output");
+    assert_ne!(
+        a, b,
+        "different spec bytes must produce different derived output"
+    );
 }
 
 #[test]
@@ -129,31 +130,41 @@ fn determinism_blake3_different_variants_produce_different_output() {
     let fx = fx42();
 
     let make_bytes = |variant: &str| -> Vec<u8> {
-        let arc: Arc<Vec<u8>> = fx.get_or_init(
-            "test:variant-test",
-            "label",
-            b"spec",
-            variant,
-            |rng| {
+        let arc: Arc<Vec<u8>> =
+            fx.get_or_init("test:variant-test", "label", b"spec", variant, |rng| {
                 let mut buf = vec![0u8; 16];
                 rng.fill_bytes(&mut buf);
                 buf
-            },
-        );
+            });
         (*arc).clone()
     };
 
     let a = make_bytes("good");
     let b = make_bytes("mismatch");
-    assert_ne!(a, b, "different variants must produce different derived output");
+    assert_ne!(
+        a, b,
+        "different variants must produce different derived output"
+    );
 }
 
 // ── 2. ArtifactId fingerprint pinning ─────────────────────────────────────
 
 #[test]
 fn determinism_artifact_id_fingerprint_is_stable() {
-    let id1 = ArtifactId::new("domain", "label", b"spec-bytes", "good", DerivationVersion::V1);
-    let id2 = ArtifactId::new("domain", "label", b"spec-bytes", "good", DerivationVersion::V1);
+    let id1 = ArtifactId::new(
+        "domain",
+        "label",
+        b"spec-bytes",
+        "good",
+        DerivationVersion::V1,
+    );
+    let id2 = ArtifactId::new(
+        "domain",
+        "label",
+        b"spec-bytes",
+        "good",
+        DerivationVersion::V1,
+    );
 
     // Fingerprints must be identical for identical inputs.
     assert_eq!(id1.spec_fingerprint, id2.spec_fingerprint);
@@ -178,7 +189,13 @@ fn determinism_artifact_id_fingerprint_changes_with_spec() {
 
 #[test]
 fn determinism_artifact_id_fields_preserved() {
-    let id = ArtifactId::new("my:domain", "my-label", b"s", "my-variant", DerivationVersion::V1);
+    let id = ArtifactId::new(
+        "my:domain",
+        "my-label",
+        b"s",
+        "my-variant",
+        DerivationVersion::V1,
+    );
     assert_eq!(id.domain, "my:domain");
     assert_eq!(id.label, "my-label");
     assert_eq!(id.variant, "my-variant");
@@ -192,8 +209,7 @@ fn determinism_cache_returns_same_arc_pointer() {
     let fx = fx42();
 
     let first: Arc<u64> = fx.get_or_init("test:cache-id", "label", b"spec", "good", |_rng| 42u64);
-    let second: Arc<u64> =
-        fx.get_or_init("test:cache-id", "label", b"spec", "good", |_rng| 99u64);
+    let second: Arc<u64> = fx.get_or_init("test:cache-id", "label", b"spec", "good", |_rng| 99u64);
 
     // Must return the same Arc — the init closure should not run a second time.
     assert!(

--- a/crates/uselesskey/tests/determinism_regression.rs
+++ b/crates/uselesskey/tests/determinism_regression.rs
@@ -218,7 +218,13 @@ fn spec_sensitivity_hmac_lengths() {
 // ── 6. Multi-algorithm stability ─────────────────────────────────────────
 
 #[test]
-#[cfg(all(feature = "rsa", feature = "ecdsa", feature = "ed25519", feature = "hmac", feature = "jwk"))]
+#[cfg(all(
+    feature = "rsa",
+    feature = "ecdsa",
+    feature = "ed25519",
+    feature = "hmac",
+    feature = "jwk"
+))]
 fn multi_algorithm_kid_regression() {
     let fx = fx42();
     let rsa = fx.rsa("multi", RsaSpec::rs256());
@@ -306,8 +312,14 @@ fn factory_equality_all_algorithms() {
 fn determinism_pem_header_rsa() {
     let fx = fx42();
     let kp = fx.rsa("test", RsaSpec::rs256());
-    assert!(kp.private_key_pkcs8_pem().starts_with("-----BEGIN PRIVATE KEY-----"));
-    assert!(kp.public_key_spki_pem().starts_with("-----BEGIN PUBLIC KEY-----"));
+    assert!(
+        kp.private_key_pkcs8_pem()
+            .starts_with("-----BEGIN PRIVATE KEY-----")
+    );
+    assert!(
+        kp.public_key_spki_pem()
+            .starts_with("-----BEGIN PUBLIC KEY-----")
+    );
 }
 
 #[test]
@@ -315,8 +327,14 @@ fn determinism_pem_header_rsa() {
 fn determinism_pem_header_ecdsa() {
     let fx = fx42();
     let kp = fx.ecdsa("test", EcdsaSpec::es256());
-    assert!(kp.private_key_pkcs8_pem().starts_with("-----BEGIN PRIVATE KEY-----"));
-    assert!(kp.public_key_spki_pem().starts_with("-----BEGIN PUBLIC KEY-----"));
+    assert!(
+        kp.private_key_pkcs8_pem()
+            .starts_with("-----BEGIN PRIVATE KEY-----")
+    );
+    assert!(
+        kp.public_key_spki_pem()
+            .starts_with("-----BEGIN PUBLIC KEY-----")
+    );
 }
 
 #[test]
@@ -324,8 +342,14 @@ fn determinism_pem_header_ecdsa() {
 fn determinism_pem_header_ed25519() {
     let fx = fx42();
     let kp = fx.ed25519("test", Ed25519Spec::new());
-    assert!(kp.private_key_pkcs8_pem().starts_with("-----BEGIN PRIVATE KEY-----"));
-    assert!(kp.public_key_spki_pem().starts_with("-----BEGIN PUBLIC KEY-----"));
+    assert!(
+        kp.private_key_pkcs8_pem()
+            .starts_with("-----BEGIN PRIVATE KEY-----")
+    );
+    assert!(
+        kp.public_key_spki_pem()
+            .starts_with("-----BEGIN PUBLIC KEY-----")
+    );
 }
 
 // ── 10. DER length pinning ────────────────────────────────────────────────
@@ -446,8 +470,14 @@ fn determinism_variant_independence_token() {
 fn determinism_seed_sensitivity_token() {
     let fx_42 = fx42();
     let fx_43 = Factory::deterministic(Seed::from_env_value("43").unwrap());
-    let t42 = fx_42.token("test", TokenSpec::api_key()).value().to_string();
-    let t43 = fx_43.token("test", TokenSpec::api_key()).value().to_string();
+    let t42 = fx_42
+        .token("test", TokenSpec::api_key())
+        .value()
+        .to_string();
+    let t43 = fx_43
+        .token("test", TokenSpec::api_key())
+        .value()
+        .to_string();
     assert_ne!(t42, t43);
 }
 
@@ -470,8 +500,14 @@ fn determinism_seed_sensitivity_rsa() {
 fn determinism_seed_sensitivity_ecdsa() {
     let fx_42 = fx42();
     let fx_43 = Factory::deterministic(Seed::from_env_value("43").unwrap());
-    let pem42 = fx_42.ecdsa("test", EcdsaSpec::es256()).private_key_pkcs8_pem().to_string();
-    let pem43 = fx_43.ecdsa("test", EcdsaSpec::es256()).private_key_pkcs8_pem().to_string();
+    let pem42 = fx_42
+        .ecdsa("test", EcdsaSpec::es256())
+        .private_key_pkcs8_pem()
+        .to_string();
+    let pem43 = fx_43
+        .ecdsa("test", EcdsaSpec::es256())
+        .private_key_pkcs8_pem()
+        .to_string();
     assert_ne!(pem42, pem43);
 }
 
@@ -480,8 +516,14 @@ fn determinism_seed_sensitivity_ecdsa() {
 fn determinism_seed_sensitivity_ed25519() {
     let fx_42 = fx42();
     let fx_43 = Factory::deterministic(Seed::from_env_value("43").unwrap());
-    let der42 = fx_42.ed25519("test", Ed25519Spec::new()).private_key_pkcs8_der().to_vec();
-    let der43 = fx_43.ed25519("test", Ed25519Spec::new()).private_key_pkcs8_der().to_vec();
+    let der42 = fx_42
+        .ed25519("test", Ed25519Spec::new())
+        .private_key_pkcs8_der()
+        .to_vec();
+    let der43 = fx_43
+        .ed25519("test", Ed25519Spec::new())
+        .private_key_pkcs8_der()
+        .to_vec();
     assert_ne!(der42, der43);
 }
 
@@ -490,8 +532,14 @@ fn determinism_seed_sensitivity_ed25519() {
 fn determinism_seed_sensitivity_hmac() {
     let fx_42 = fx42();
     let fx_43 = Factory::deterministic(Seed::from_env_value("43").unwrap());
-    let s42 = fx_42.hmac("test", HmacSpec::hs256()).secret_bytes().to_vec();
-    let s43 = fx_43.hmac("test", HmacSpec::hs256()).secret_bytes().to_vec();
+    let s42 = fx_42
+        .hmac("test", HmacSpec::hs256())
+        .secret_bytes()
+        .to_vec();
+    let s43 = fx_43
+        .hmac("test", HmacSpec::hs256())
+        .secret_bytes()
+        .to_vec();
     assert_ne!(s42, s43);
 }
 
@@ -525,9 +573,18 @@ fn determinism_order_independence_all_key_types() {
     let ecdsa_second = fx2.ecdsa("beta", EcdsaSpec::es256());
     let rsa_second = fx2.rsa("alpha", RsaSpec::rs256());
 
-    assert_eq!(rsa_first.private_key_pkcs8_pem(), rsa_second.private_key_pkcs8_pem());
-    assert_eq!(ecdsa_first.private_key_pkcs8_pem(), ecdsa_second.private_key_pkcs8_pem());
-    assert_eq!(ed_first.private_key_pkcs8_pem(), ed_second.private_key_pkcs8_pem());
+    assert_eq!(
+        rsa_first.private_key_pkcs8_pem(),
+        rsa_second.private_key_pkcs8_pem()
+    );
+    assert_eq!(
+        ecdsa_first.private_key_pkcs8_pem(),
+        ecdsa_second.private_key_pkcs8_pem()
+    );
+    assert_eq!(
+        ed_first.private_key_pkcs8_pem(),
+        ed_second.private_key_pkcs8_pem()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Adds regression tests pinning specific deterministic outputs for all key types, ensuring derivation stability.