### PR TITLE
test: add integration tests for core-jwk, core-negative, core-keypair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,6 +3500,7 @@ dependencies = [
 name = "uselesskey-core-jwk"
 version = "0.3.0"
 dependencies = [
+ "serde_json",
  "uselesskey-core-jwk-builder",
  "uselesskey-core-jwk-shape",
 ]
@@ -3535,6 +3536,7 @@ name = "uselesskey-core-keypair"
 version = "0.3.0"
 dependencies = [
  "uselesskey-core-keypair-material",
+ "uselesskey-core-negative",
 ]
 
 [[package]]

--- a/crates/uselesskey-core-jwk/Cargo.toml
+++ b/crates/uselesskey-core-jwk/Cargo.toml
@@ -18,5 +18,8 @@ authors.workspace = true
 uselesskey-core-jwk-shape = { path = "../uselesskey-core-jwk-shape", version = "0.3.0" }
 uselesskey-core-jwk-builder = { path = "../uselesskey-core-jwk-builder", version = "0.3.0" }
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-jwk/tests/integration.rs
+++ b/crates/uselesskey-core-jwk/tests/integration.rs
@@ -1,0 +1,320 @@
+//! Integration tests for `uselesskey-core-jwk`.
+//!
+//! Covers: JWK type construction, serialization round-trips, kid accessors,
+//! JwksBuilder ordering, Display/Debug output, clone semantics, and
+//! private-material-safety in Debug output.
+
+use serde_json::Value;
+use uselesskey_core_jwk::{
+    AnyJwk, EcPrivateJwk, EcPublicJwk, Jwks, JwksBuilder, OctJwk, OkpPrivateJwk, OkpPublicJwk,
+    PrivateJwk, PublicJwk, RsaPrivateJwk, RsaPublicJwk,
+};
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+fn rsa_public(kid: &str) -> PublicJwk {
+    PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.to_string(),
+        n: "test-n".to_string(),
+        e: "AQAB".to_string(),
+    })
+}
+
+fn ec_public(kid: &str) -> PublicJwk {
+    PublicJwk::Ec(EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.to_string(),
+        x: "test-x".to_string(),
+        y: "test-y".to_string(),
+    })
+}
+
+fn okp_public(kid: &str) -> PublicJwk {
+    PublicJwk::Okp(OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.to_string(),
+        x: "test-x".to_string(),
+    })
+}
+
+fn oct_private(kid: &str) -> PrivateJwk {
+    PrivateJwk::Oct(OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: kid.to_string(),
+        k: "test-secret".to_string(),
+    })
+}
+
+fn rsa_private(kid: &str) -> PrivateJwk {
+    PrivateJwk::Rsa(RsaPrivateJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.to_string(),
+        n: "n".to_string(),
+        e: "e".to_string(),
+        d: "secret-d".to_string(),
+        p: "secret-p".to_string(),
+        q: "secret-q".to_string(),
+        dp: "secret-dp".to_string(),
+        dq: "secret-dq".to_string(),
+        qi: "secret-qi".to_string(),
+    })
+}
+
+fn ec_private(kid: &str) -> PrivateJwk {
+    PrivateJwk::Ec(EcPrivateJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.to_string(),
+        x: "x".to_string(),
+        y: "y".to_string(),
+        d: "secret-d".to_string(),
+    })
+}
+
+fn okp_private(kid: &str) -> PrivateJwk {
+    PrivateJwk::Okp(OkpPrivateJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.to_string(),
+        x: "x".to_string(),
+        d: "secret-d".to_string(),
+    })
+}
+
+// ── construction & kid ───────────────────────────────────────────────
+
+#[test]
+fn rsa_public_jwk_kid_accessor() {
+    let jwk = rsa_public("rsa-kid-1");
+    assert_eq!(jwk.kid(), "rsa-kid-1");
+}
+
+#[test]
+fn ec_public_jwk_kid_accessor() {
+    let jwk = ec_public("ec-kid-1");
+    assert_eq!(jwk.kid(), "ec-kid-1");
+}
+
+#[test]
+fn okp_public_jwk_kid_accessor() {
+    let jwk = okp_public("okp-kid-1");
+    assert_eq!(jwk.kid(), "okp-kid-1");
+}
+
+#[test]
+fn private_jwk_kid_all_variants() {
+    assert_eq!(rsa_private("rsa").kid(), "rsa");
+    assert_eq!(ec_private("ec").kid(), "ec");
+    assert_eq!(okp_private("okp").kid(), "okp");
+    assert_eq!(oct_private("oct").kid(), "oct");
+}
+
+// ── serialization round-trips ────────────────────────────────────────
+
+#[test]
+fn public_jwk_to_value_contains_kty() {
+    let rsa = rsa_public("k1");
+    assert_eq!(rsa.to_value()["kty"], "RSA");
+
+    let ec = ec_public("k2");
+    assert_eq!(ec.to_value()["kty"], "EC");
+
+    let okp = okp_public("k3");
+    assert_eq!(okp.to_value()["kty"], "OKP");
+}
+
+#[test]
+fn public_jwk_display_is_valid_json() {
+    let jwk = rsa_public("display-test");
+    let json_str = jwk.to_string();
+    let parsed: Value = serde_json::from_str(&json_str).expect("Display should produce valid JSON");
+    assert_eq!(parsed["kid"], "display-test");
+    assert_eq!(parsed["kty"], "RSA");
+}
+
+#[test]
+fn private_jwk_to_value_round_trip() {
+    let jwk = oct_private("oct-rt");
+    let val = jwk.to_value();
+    assert_eq!(val["kty"], "oct");
+    assert_eq!(val["kid"], "oct-rt");
+    assert_eq!(val["alg"], "HS256");
+}
+
+#[test]
+fn private_jwk_display_is_valid_json() {
+    let jwk = ec_private("ec-display");
+    let json_str = jwk.to_string();
+    let parsed: Value = serde_json::from_str(&json_str).expect("Display should produce valid JSON");
+    assert_eq!(parsed["kid"], "ec-display");
+    assert_eq!(parsed["crv"], "P-256");
+}
+
+#[test]
+fn rsa_public_serializes_use_as_use() {
+    let jwk = rsa_public("use-test");
+    let val = jwk.to_value();
+    assert_eq!(val["use"], "sig");
+    assert!(val.get("use_").is_none());
+}
+
+// ── AnyJwk conversion and kid ────────────────────────────────────────
+
+#[test]
+fn any_jwk_from_public_preserves_kid() {
+    let pub_jwk = rsa_public("any-pub");
+    let any: AnyJwk = pub_jwk.into();
+    assert_eq!(any.kid(), "any-pub");
+}
+
+#[test]
+fn any_jwk_from_private_preserves_kid() {
+    let priv_jwk = oct_private("any-priv");
+    let any: AnyJwk = priv_jwk.into();
+    assert_eq!(any.kid(), "any-priv");
+}
+
+#[test]
+fn any_jwk_to_value_and_display_agree() {
+    let any = AnyJwk::from(okp_public("agree-test"));
+    let from_value = any.to_value();
+    let from_display: Value =
+        serde_json::from_str(&any.to_string()).expect("Display should produce valid JSON");
+    assert_eq!(from_value, from_display);
+}
+
+// ── Jwks and JwksBuilder ─────────────────────────────────────────────
+
+#[test]
+fn jwks_direct_construction_serializes_keys_array() {
+    let jwks = Jwks {
+        keys: vec![
+            AnyJwk::from(rsa_public("k1")),
+            AnyJwk::from(ec_public("k2")),
+        ],
+    };
+    let val = jwks.to_value();
+    let keys = val["keys"].as_array().expect("should have keys array");
+    assert_eq!(keys.len(), 2);
+}
+
+#[test]
+fn jwks_display_produces_valid_json() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(okp_public("disp-jwks"))],
+    };
+    let json_str = jwks.to_string();
+    let parsed: Value =
+        serde_json::from_str(&json_str).expect("JWKS Display should produce valid JSON");
+    assert_eq!(parsed["keys"][0]["kid"], "disp-jwks");
+}
+
+#[test]
+fn jwks_builder_sorts_by_kid() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_public("charlie"))
+        .add_public(ec_public("alice"))
+        .add_public(okp_public("bob"))
+        .build();
+
+    assert_eq!(jwks.keys.len(), 3);
+    assert_eq!(jwks.keys[0].kid(), "alice");
+    assert_eq!(jwks.keys[1].kid(), "bob");
+    assert_eq!(jwks.keys[2].kid(), "charlie");
+}
+
+#[test]
+fn jwks_builder_preserves_insertion_order_for_same_kid() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_public("same-kid"))
+        .add_public(ec_public("same-kid"))
+        .build();
+
+    assert_eq!(jwks.keys.len(), 2);
+    assert_eq!(jwks.keys[0].to_value()["kty"], "RSA");
+    assert_eq!(jwks.keys[1].to_value()["kty"], "EC");
+}
+
+#[test]
+fn jwks_builder_add_private_and_add_any() {
+    let jwks = JwksBuilder::new()
+        .add_private(oct_private("priv-kid"))
+        .add_any(AnyJwk::from(rsa_public("any-kid")))
+        .build();
+
+    assert_eq!(jwks.keys.len(), 2);
+}
+
+#[test]
+fn jwks_builder_push_methods_return_self() {
+    let mut builder = JwksBuilder::new();
+    builder
+        .push_public(rsa_public("a"))
+        .push_private(oct_private("b"))
+        .push_any(AnyJwk::from(ec_public("c")));
+    let jwks = builder.build();
+    assert_eq!(jwks.keys.len(), 3);
+}
+
+// ── Debug safety ─────────────────────────────────────────────────────
+
+#[test]
+fn debug_rsa_private_does_not_leak_material() {
+    let jwk = rsa_private("safe-rsa");
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("RsaPrivateJwk"));
+    assert!(!dbg.contains("secret-d"));
+    assert!(!dbg.contains("secret-p"));
+    assert!(!dbg.contains("secret-q"));
+}
+
+#[test]
+fn debug_ec_private_does_not_leak_material() {
+    let jwk = ec_private("safe-ec");
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("EcPrivateJwk"));
+    assert!(!dbg.contains("secret-d"));
+}
+
+#[test]
+fn debug_okp_private_does_not_leak_material() {
+    let jwk = okp_private("safe-okp");
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("OkpPrivateJwk"));
+    assert!(!dbg.contains("secret-d"));
+}
+
+#[test]
+fn debug_oct_does_not_leak_k_value() {
+    let jwk = oct_private("safe-oct");
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("OctJwk"));
+    assert!(!dbg.contains("test-secret"));
+}
+
+// ── clone ────────────────────────────────────────────────────────────
+
+#[test]
+fn public_jwk_clone_is_equal_by_serialization() {
+    let original = rsa_public("clone-test");
+    let cloned = original.clone();
+    assert_eq!(original.to_value(), cloned.to_value());
+    assert_eq!(original.kid(), cloned.kid());
+}

--- a/crates/uselesskey-core-keypair/Cargo.toml
+++ b/crates/uselesskey-core-keypair/Cargo.toml
@@ -17,5 +17,8 @@ authors.workspace = true
 [dependencies]
 uselesskey-core-keypair-material.workspace = true
 
+[dev-dependencies]
+uselesskey-core-negative.workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-keypair/tests/integration.rs
+++ b/crates/uselesskey-core-keypair/tests/integration.rs
@@ -1,0 +1,187 @@
+//! Integration tests for `uselesskey-core-keypair`.
+//!
+//! Covers: Pkcs8SpkiKeyMaterial construction, all accessors, kid determinism,
+//! Debug safety (no key-material leakage), Clone semantics, negative-fixture
+//! helpers (corrupt PEM/DER), and tempfile writers.
+
+use uselesskey_core_keypair::Pkcs8SpkiKeyMaterial;
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+fn material_a() -> Pkcs8SpkiKeyMaterial {
+    Pkcs8SpkiKeyMaterial::new(
+        vec![0x30, 0x82, 0x01, 0x22],
+        "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n",
+        vec![0x30, 0x59, 0x30, 0x13],
+        "-----BEGIN PUBLIC KEY-----\nBBBB\n-----END PUBLIC KEY-----\n",
+    )
+}
+
+fn material_b() -> Pkcs8SpkiKeyMaterial {
+    Pkcs8SpkiKeyMaterial::new(
+        vec![0xFF, 0xFE, 0xFD],
+        "-----BEGIN PRIVATE KEY-----\nXXXX\n-----END PRIVATE KEY-----\n",
+        vec![0xAA, 0xBB, 0xCC],
+        "-----BEGIN PUBLIC KEY-----\nYYYY\n-----END PUBLIC KEY-----\n",
+    )
+}
+
+// ── construction & accessors ─────────────────────────────────────────
+
+#[test]
+fn private_key_pkcs8_der_returns_expected_bytes() {
+    let m = material_a();
+    assert_eq!(m.private_key_pkcs8_der(), &[0x30, 0x82, 0x01, 0x22]);
+}
+
+#[test]
+fn private_key_pkcs8_pem_contains_private_key_header() {
+    let m = material_a();
+    assert!(m.private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    assert!(m.private_key_pkcs8_pem().contains("END PRIVATE KEY"));
+}
+
+#[test]
+fn public_key_spki_der_returns_expected_bytes() {
+    let m = material_a();
+    assert_eq!(m.public_key_spki_der(), &[0x30, 0x59, 0x30, 0x13]);
+}
+
+#[test]
+fn public_key_spki_pem_contains_public_key_header() {
+    let m = material_a();
+    assert!(m.public_key_spki_pem().contains("BEGIN PUBLIC KEY"));
+    assert!(m.public_key_spki_pem().contains("END PUBLIC KEY"));
+}
+
+// ── kid ──────────────────────────────────────────────────────────────
+
+#[test]
+fn kid_is_deterministic() {
+    let m = material_a();
+    assert_eq!(m.kid(), m.kid());
+}
+
+#[test]
+fn kid_is_non_empty() {
+    assert!(!material_a().kid().is_empty());
+}
+
+#[test]
+fn kid_differs_for_different_spki_bytes() {
+    let a = material_a();
+    let b = material_b();
+    assert_ne!(a.kid(), b.kid());
+}
+
+#[test]
+fn kid_depends_only_on_spki_not_pkcs8() {
+    let m1 = Pkcs8SpkiKeyMaterial::new(
+        vec![0x01],
+        "different-private-pem",
+        vec![0x30, 0x59, 0x30, 0x13],
+        "-----BEGIN PUBLIC KEY-----\nBBBB\n-----END PUBLIC KEY-----\n",
+    );
+    let m2 = Pkcs8SpkiKeyMaterial::new(
+        vec![0x02],
+        "another-private-pem",
+        vec![0x30, 0x59, 0x30, 0x13],
+        "-----BEGIN PUBLIC KEY-----\nBBBB\n-----END PUBLIC KEY-----\n",
+    );
+    assert_eq!(m1.kid(), m2.kid());
+}
+
+// ── Debug safety ─────────────────────────────────────────────────────
+
+#[test]
+fn debug_does_not_leak_private_pem() {
+    let m = material_a();
+    let dbg = format!("{m:?}");
+    assert!(dbg.contains("Pkcs8SpkiKeyMaterial"));
+    assert!(!dbg.contains("BEGIN PRIVATE KEY"));
+    assert!(!dbg.contains("AAAA"));
+}
+
+#[test]
+fn debug_does_not_leak_public_pem() {
+    let m = material_a();
+    let dbg = format!("{m:?}");
+    assert!(!dbg.contains("BEGIN PUBLIC KEY"));
+    assert!(!dbg.contains("BBBB"));
+}
+
+#[test]
+fn debug_shows_lengths_not_content() {
+    let m = material_a();
+    let dbg = format!("{m:?}");
+    assert!(dbg.contains("pkcs8_der_len"));
+    assert!(dbg.contains("spki_der_len"));
+}
+
+// ── Clone ────────────────────────────────────────────────────────────
+
+#[test]
+fn clone_preserves_all_accessors() {
+    let m = material_a();
+    let c = m.clone();
+    assert_eq!(m.private_key_pkcs8_der(), c.private_key_pkcs8_der());
+    assert_eq!(m.private_key_pkcs8_pem(), c.private_key_pkcs8_pem());
+    assert_eq!(m.public_key_spki_der(), c.public_key_spki_der());
+    assert_eq!(m.public_key_spki_pem(), c.public_key_spki_pem());
+    assert_eq!(m.kid(), c.kid());
+}
+
+// ── negative fixture helpers ─────────────────────────────────────────
+
+#[test]
+fn corrupt_pem_bad_header_via_keypair() {
+    use uselesskey_core_negative::CorruptPem;
+    let m = material_a();
+    let corrupted = m.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+    assert!(corrupted.contains("CORRUPTED KEY"));
+    assert!(!corrupted.contains("BEGIN PRIVATE KEY"));
+}
+
+#[test]
+fn deterministic_pem_corruption_is_stable() {
+    let m = material_a();
+    let a = m.private_key_pkcs8_pem_corrupt_deterministic("test:v1");
+    let b = m.private_key_pkcs8_pem_corrupt_deterministic("test:v1");
+    assert_eq!(a, b);
+    assert_ne!(a, m.private_key_pkcs8_pem());
+}
+
+#[test]
+fn der_truncation_respects_length() {
+    let m = material_a();
+    let truncated = m.private_key_pkcs8_der_truncated(2);
+    assert_eq!(truncated.len(), 2);
+    assert_eq!(truncated, &m.private_key_pkcs8_der()[..2]);
+}
+
+#[test]
+fn der_corrupt_deterministic_is_stable() {
+    let m = material_a();
+    let a = m.private_key_pkcs8_der_corrupt_deterministic("der:v1");
+    let b = m.private_key_pkcs8_der_corrupt_deterministic("der:v1");
+    assert_eq!(a, b);
+    assert_ne!(a.as_slice(), m.private_key_pkcs8_der());
+}
+
+// ── tempfile writers ─────────────────────────────────────────────────
+
+#[test]
+fn write_private_key_creates_readable_tempfile() {
+    let m = material_a();
+    let tmp = m.write_private_key_pkcs8_pem().expect("write private pem");
+    let content = tmp.read_to_string().expect("read tempfile");
+    assert!(content.contains("BEGIN PRIVATE KEY"));
+}
+
+#[test]
+fn write_public_key_creates_readable_tempfile() {
+    let m = material_a();
+    let tmp = m.write_public_key_spki_pem().expect("write public pem");
+    let content = tmp.read_to_string().expect("read tempfile");
+    assert!(content.contains("BEGIN PUBLIC KEY"));
+}

--- a/crates/uselesskey-core-negative/tests/integration_core.rs
+++ b/crates/uselesskey-core-negative/tests/integration_core.rs
@@ -1,0 +1,225 @@
+//! Integration tests for `uselesskey-core-negative`.
+//!
+//! Covers: CorruptPem variant construction, Debug output, all-variant coverage,
+//! fingerprint stability for deterministic corruption, DER helpers, and
+//! edge cases for both PEM and DER corruption paths.
+
+use std::collections::HashSet;
+
+use uselesskey_core_negative::{
+    CorruptPem, corrupt_der_deterministic, corrupt_pem, corrupt_pem_deterministic, flip_byte,
+    truncate_der,
+};
+
+// ── sample data ──────────────────────────────────────────────────────
+
+const SAMPLE_PEM: &str =
+    "-----BEGIN EC PRIVATE KEY-----\nTWF0dGVyIGlzIG1hZGU=\n-----END EC PRIVATE KEY-----\n";
+
+fn sample_der() -> Vec<u8> {
+    vec![
+        0x30, 0x82, 0x01, 0x22, 0x30, 0x0D, 0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01,
+        0x01,
+    ]
+}
+
+// ── CorruptPem construction & Debug ──────────────────────────────────
+
+#[test]
+fn corrupt_pem_variants_are_constructible() {
+    let _a = CorruptPem::BadHeader;
+    let _b = CorruptPem::BadFooter;
+    let _c = CorruptPem::BadBase64;
+    let _d = CorruptPem::Truncate { bytes: 5 };
+    let _e = CorruptPem::ExtraBlankLine;
+}
+
+#[test]
+fn corrupt_pem_debug_output_contains_variant_name() {
+    assert!(format!("{:?}", CorruptPem::BadHeader).contains("BadHeader"));
+    assert!(format!("{:?}", CorruptPem::BadFooter).contains("BadFooter"));
+    assert!(format!("{:?}", CorruptPem::BadBase64).contains("BadBase64"));
+    assert!(format!("{:?}", CorruptPem::Truncate { bytes: 7 }).contains("Truncate"));
+    assert!(format!("{:?}", CorruptPem::ExtraBlankLine).contains("ExtraBlankLine"));
+}
+
+#[test]
+fn corrupt_pem_clone_and_copy() {
+    let v = CorruptPem::BadHeader;
+    let cloned = v;
+    let _copied = cloned;
+    // CorruptPem is Copy, so all three should be valid
+    let _ = format!("{v:?}");
+}
+
+// ── all-variant coverage ─────────────────────────────────────────────
+
+#[test]
+fn every_variant_corrupts_pem_differently() {
+    let variants = [
+        CorruptPem::BadHeader,
+        CorruptPem::BadFooter,
+        CorruptPem::BadBase64,
+        CorruptPem::ExtraBlankLine,
+        CorruptPem::Truncate { bytes: 12 },
+    ];
+
+    let outputs: HashSet<String> = variants
+        .iter()
+        .map(|v| corrupt_pem(SAMPLE_PEM, *v))
+        .collect();
+    assert_eq!(
+        outputs.len(),
+        variants.len(),
+        "each variant should produce a distinct output"
+    );
+}
+
+#[test]
+fn no_variant_returns_original() {
+    let variants = [
+        CorruptPem::BadHeader,
+        CorruptPem::BadFooter,
+        CorruptPem::BadBase64,
+        CorruptPem::ExtraBlankLine,
+        CorruptPem::Truncate { bytes: 12 },
+    ];
+
+    for v in &variants {
+        let out = corrupt_pem(SAMPLE_PEM, *v);
+        assert_ne!(out, SAMPLE_PEM, "{v:?} must differ from original");
+    }
+}
+
+// ── specific variant behavior ────────────────────────────────────────
+
+#[test]
+fn bad_header_replaces_begin_line() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::BadHeader);
+    assert!(out.starts_with("-----BEGIN CORRUPTED KEY-----"));
+    assert!(!out.contains("-----BEGIN EC PRIVATE KEY-----"));
+}
+
+#[test]
+fn bad_footer_replaces_end_line() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::BadFooter);
+    assert!(out.contains("-----END CORRUPTED KEY-----"));
+    assert!(!out.contains("-----END EC PRIVATE KEY-----"));
+}
+
+#[test]
+fn bad_base64_injects_invalid_chars() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::BadBase64);
+    assert!(out.contains("THIS_IS_NOT_BASE64!!!"));
+    assert!(out.contains("-----BEGIN EC PRIVATE KEY-----"));
+}
+
+#[test]
+fn truncate_limits_to_exact_byte_count() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::Truncate { bytes: 8 });
+    assert_eq!(out.len(), 8);
+}
+
+#[test]
+fn extra_blank_line_inserts_empty_line() {
+    let out = corrupt_pem(SAMPLE_PEM, CorruptPem::ExtraBlankLine);
+    assert!(out.contains("\n\n"));
+}
+
+// ── deterministic PEM fingerprint stability ──────────────────────────
+
+#[test]
+fn deterministic_pem_is_reproducible() {
+    let a = corrupt_pem_deterministic(SAMPLE_PEM, "fingerprint:v1");
+    let b = corrupt_pem_deterministic(SAMPLE_PEM, "fingerprint:v1");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn deterministic_pem_differs_for_different_variants() {
+    let a = corrupt_pem_deterministic(SAMPLE_PEM, "variant-alpha");
+    let b = corrupt_pem_deterministic(SAMPLE_PEM, "variant-beta");
+    let c = corrupt_pem_deterministic(SAMPLE_PEM, "variant-gamma");
+    let d = corrupt_pem_deterministic(SAMPLE_PEM, "variant-delta");
+    let outputs: HashSet<_> = [a, b, c, d].into_iter().collect();
+    assert!(
+        outputs.len() >= 2,
+        "different variant strings should (very likely) produce distinct corruptions"
+    );
+}
+
+#[test]
+fn deterministic_pem_always_differs_from_original() {
+    for i in 0..10 {
+        let variant = format!("stability-{i}");
+        let out = corrupt_pem_deterministic(SAMPLE_PEM, &variant);
+        assert_ne!(
+            out, SAMPLE_PEM,
+            "variant '{variant}' must differ from original"
+        );
+    }
+}
+
+// ── DER helpers ──────────────────────────────────────────────────────
+
+#[test]
+fn truncate_der_at_various_lengths() {
+    let der = sample_der();
+    assert_eq!(truncate_der(&der, 4).len(), 4);
+    assert_eq!(truncate_der(&der, 0).len(), 0);
+    assert_eq!(truncate_der(&der, 100), der); // beyond length
+}
+
+#[test]
+fn flip_byte_changes_exactly_one_byte() {
+    let der = sample_der();
+    for offset in 0..der.len() {
+        let flipped = flip_byte(&der, offset);
+        assert_eq!(flipped.len(), der.len());
+        let diff_count = flipped
+            .iter()
+            .zip(der.iter())
+            .filter(|(a, b)| a != b)
+            .count();
+        assert_eq!(
+            diff_count, 1,
+            "exactly one byte should differ at offset {offset}"
+        );
+    }
+}
+
+#[test]
+fn flip_byte_out_of_bounds_is_identity() {
+    let der = sample_der();
+    let result = flip_byte(&der, 1000);
+    assert_eq!(result, der);
+}
+
+// ── deterministic DER fingerprint stability ──────────────────────────
+
+#[test]
+fn deterministic_der_is_reproducible() {
+    let der = sample_der();
+    let a = corrupt_der_deterministic(&der, "der-fp:v1");
+    let b = corrupt_der_deterministic(&der, "der-fp:v1");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn deterministic_der_differs_from_original() {
+    let der = sample_der();
+    let out = corrupt_der_deterministic(&der, "der-must-differ");
+    assert_ne!(out, der);
+}
+
+#[test]
+fn deterministic_der_different_variants_produce_variety() {
+    let der = sample_der();
+    let outputs: HashSet<Vec<u8>> = (0..10)
+        .map(|i| corrupt_der_deterministic(&der, &format!("var-{i}")))
+        .collect();
+    assert!(
+        outputs.len() >= 2,
+        "different variant strings should produce varied corruptions"
+    );
+}


### PR DESCRIPTION
Adds comprehensive integration tests to 3 core crates.

## Changes
- core-jwk: JWK/JWKS construction, serialization, ordering tests
- core-negative: CorruptPem variant coverage, display, fingerprint tests
- core-keypair: Keypair construction, trait impl, debug safety tests

## CI
- cargo test passes for all 3 crates
- cargo clippy clean
- cargo fmt clean