### PR TITLE
test: harden adapter test coverage for aws-lc-rs, ring, tonic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ version = "0.3.0"
 dependencies = [
  "hex",
  "insta",
+ "proptest",
  "ring",
  "serde",
  "uselesskey-core",

--- a/crates/uselesskey-aws-lc-rs/tests/integration_aws.rs
+++ b/crates/uselesskey-aws-lc-rs/tests/integration_aws.rs
@@ -1,0 +1,576 @@
+//! Integration tests for uselesskey-aws-lc-rs adapter.
+//!
+//! Covers key conversion, signing/verification round-trips, error handling for
+//! invalid inputs, and all supported algorithms (RSA, ECDSA P-256/P-384, Ed25519).
+
+mod testutil;
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm)))]
+use testutil::fx;
+
+// =========================================================================
+// RSA integration
+// =========================================================================
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "rsa"))]
+mod rsa_integration {
+    use super::*;
+    use aws_lc_rs::{
+        rand::SystemRandom,
+        signature::{self, KeyPair},
+    };
+    use uselesskey_aws_lc_rs::AwsLcRsRsaKeyPairExt;
+    use uselesskey_core::{Factory, Seed};
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn rsa_2048_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.rsa("int-rsa-2048", RsaSpec::new(2048));
+        let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+
+        let msg = b"rsa 2048 integration roundtrip";
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+        aws_kp
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            aws_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify");
+    }
+
+    #[test]
+    fn rsa_3072_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.rsa("int-rsa-3072", RsaSpec::new(3072));
+        let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+
+        let msg = b"rsa 3072 integration roundtrip";
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+        aws_kp
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            aws_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify");
+    }
+
+    #[test]
+    fn rsa_4096_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.rsa("int-rsa-4096", RsaSpec::new(4096));
+        let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+
+        let msg = b"rsa 4096 integration roundtrip";
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+        aws_kp
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            aws_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify");
+    }
+
+    #[test]
+    fn rsa_pss_sha256_sign_verify() {
+        let fx = fx();
+        let kp = fx.rsa("int-rsa-pss", RsaSpec::rs256());
+        let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+
+        let msg = b"rsa pss integration";
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+        aws_kp
+            .sign(&signature::RSA_PSS_SHA256, &rng, msg, &mut sig)
+            .expect("sign with PSS");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PSS_2048_8192_SHA256,
+            aws_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify PSS");
+    }
+
+    #[test]
+    fn rsa_modulus_len_matches_spec() {
+        let fx = fx();
+        for (bits, label) in [(2048, "int-mod-2k"), (4096, "int-mod-4k")] {
+            let kp = fx.rsa(label, RsaSpec::new(bits));
+            let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+            assert_eq!(
+                aws_kp.public_modulus_len(),
+                bits / 8,
+                "modulus_len should match {bits}-bit spec"
+            );
+        }
+    }
+
+    #[test]
+    fn rsa_deterministic_conversion_is_stable() {
+        let seed = Seed::from_env_value("int-aws-rsa-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.rsa("int-det-rsa", RsaSpec::rs256());
+        let kp2 = fx2.rsa("int-det-rsa", RsaSpec::rs256());
+
+        let aws1 = kp1.rsa_key_pair_aws_lc_rs();
+        let aws2 = kp2.rsa_key_pair_aws_lc_rs();
+
+        assert_eq!(
+            aws1.public_key().as_ref(),
+            aws2.public_key().as_ref(),
+            "Deterministic keys should yield identical aws-lc-rs public keys"
+        );
+    }
+
+    #[test]
+    fn rsa_empty_message_sign_verify() {
+        let fx = fx();
+        let kp = fx.rsa("int-rsa-empty", RsaSpec::rs256());
+        let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+
+        let msg = b"";
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+        aws_kp
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("sign empty msg");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            aws_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify empty msg");
+    }
+
+    #[test]
+    fn rsa_large_message_sign_verify() {
+        let fx = fx();
+        let kp = fx.rsa("int-rsa-large", RsaSpec::rs256());
+        let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+
+        let msg = vec![0xABu8; 64 * 1024];
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+        aws_kp
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, &msg, &mut sig)
+            .expect("sign large msg");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            aws_kp.public_key().as_ref(),
+        );
+        pk.verify(&msg, &sig).expect("verify large msg");
+    }
+
+    #[test]
+    fn rsa_invalid_signature_rejected() {
+        let fx = fx();
+        let kp = fx.rsa("int-rsa-invalid-sig", RsaSpec::rs256());
+        let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            aws_kp.public_key().as_ref(),
+        );
+        // All-zeros is not a valid signature
+        let bad_sig = vec![0u8; aws_kp.public_modulus_len()];
+        assert!(
+            pk.verify(b"any message", &bad_sig).is_err(),
+            "All-zero signature should be rejected"
+        );
+    }
+
+    #[test]
+    fn rsa_truncated_signature_rejected() {
+        let fx = fx();
+        let kp = fx.rsa("int-rsa-trunc-sig", RsaSpec::rs256());
+        let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+
+        let msg = b"truncation test";
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+        aws_kp
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("sign");
+
+        // Truncate the signature
+        let truncated = &sig[..sig.len() / 2];
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            aws_kp.public_key().as_ref(),
+        );
+        assert!(
+            pk.verify(msg, truncated).is_err(),
+            "Truncated signature should be rejected"
+        );
+    }
+}
+
+// =========================================================================
+// ECDSA integration
+// =========================================================================
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "ecdsa"))]
+mod ecdsa_integration {
+    use super::*;
+    use aws_lc_rs::{
+        rand::SystemRandom,
+        signature::{self, KeyPair},
+    };
+    use uselesskey_aws_lc_rs::AwsLcRsEcdsaKeyPairExt;
+    use uselesskey_core::{Factory, Seed};
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    #[test]
+    fn ecdsa_p256_roundtrip() {
+        let fx = fx();
+        let kp = fx.ecdsa("int-ec-p256", EcdsaSpec::es256());
+        let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+
+        let msg = b"ecdsa p256 integration";
+        let rng = SystemRandom::new();
+        let sig = aws_kp.sign(&rng, msg).expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            aws_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, sig.as_ref()).expect("verify");
+    }
+
+    #[test]
+    fn ecdsa_p384_roundtrip() {
+        let fx = fx();
+        let kp = fx.ecdsa("int-ec-p384", EcdsaSpec::es384());
+        let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+
+        let msg = b"ecdsa p384 integration";
+        let rng = SystemRandom::new();
+        let sig = aws_kp.sign(&rng, msg).expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P384_SHA384_ASN1,
+            aws_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, sig.as_ref()).expect("verify");
+    }
+
+    #[test]
+    fn ecdsa_deterministic_conversion_is_stable() {
+        let seed = Seed::from_env_value("int-aws-ecdsa-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ecdsa("int-det-ec", EcdsaSpec::es256());
+        let kp2 = fx2.ecdsa("int-det-ec", EcdsaSpec::es256());
+
+        let aws1 = kp1.ecdsa_key_pair_aws_lc_rs();
+        let aws2 = kp2.ecdsa_key_pair_aws_lc_rs();
+
+        assert_eq!(
+            aws1.public_key().as_ref(),
+            aws2.public_key().as_ref(),
+            "Deterministic ECDSA keys should yield identical aws-lc-rs public keys"
+        );
+    }
+
+    #[test]
+    fn ecdsa_empty_message_sign_verify() {
+        let fx = fx();
+        let kp = fx.ecdsa("int-ec-empty", EcdsaSpec::es256());
+        let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+
+        let msg = b"";
+        let rng = SystemRandom::new();
+        let sig = aws_kp.sign(&rng, msg).expect("sign empty msg");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            aws_kp.public_key().as_ref(),
+        );
+        pk.verify(msg, sig.as_ref()).expect("verify empty msg");
+    }
+
+    #[test]
+    fn ecdsa_p256_wrong_key_rejects() {
+        let fx = fx();
+        let kp_a = fx.ecdsa("int-ec-a", EcdsaSpec::es256());
+        let kp_b = fx.ecdsa("int-ec-b", EcdsaSpec::es256());
+
+        let aws_a = kp_a.ecdsa_key_pair_aws_lc_rs();
+        let aws_b = kp_b.ecdsa_key_pair_aws_lc_rs();
+
+        let rng = SystemRandom::new();
+        let sig = aws_a.sign(&rng, b"cross-key test").unwrap();
+
+        let pk_b = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            aws_b.public_key().as_ref(),
+        );
+        assert!(pk_b.verify(b"cross-key test", sig.as_ref()).is_err());
+    }
+
+    #[test]
+    fn ecdsa_p384_wrong_key_rejects() {
+        let fx = fx();
+        let kp_a = fx.ecdsa("int-ec384-a", EcdsaSpec::es384());
+        let kp_b = fx.ecdsa("int-ec384-b", EcdsaSpec::es384());
+
+        let aws_a = kp_a.ecdsa_key_pair_aws_lc_rs();
+        let aws_b = kp_b.ecdsa_key_pair_aws_lc_rs();
+
+        let rng = SystemRandom::new();
+        let sig = aws_a.sign(&rng, b"cross-key p384").unwrap();
+
+        let pk_b = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P384_SHA384_ASN1,
+            aws_b.public_key().as_ref(),
+        );
+        assert!(pk_b.verify(b"cross-key p384", sig.as_ref()).is_err());
+    }
+
+    #[test]
+    fn ecdsa_tampered_message_rejected() {
+        let fx = fx();
+        let kp = fx.ecdsa("int-ec-tamper", EcdsaSpec::es256());
+        let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+
+        let rng = SystemRandom::new();
+        let sig = aws_kp.sign(&rng, b"original").unwrap();
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            aws_kp.public_key().as_ref(),
+        );
+        assert!(pk.verify(b"tampered", sig.as_ref()).is_err());
+    }
+}
+
+// =========================================================================
+// Ed25519 integration
+// =========================================================================
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "ed25519"))]
+mod ed25519_integration {
+    use super::*;
+    use aws_lc_rs::signature::{self, KeyPair};
+    use uselesskey_aws_lc_rs::AwsLcRsEd25519KeyPairExt;
+    use uselesskey_core::{Factory, Seed};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    #[test]
+    fn ed25519_sign_verify_roundtrip() {
+        let fx = fx();
+        let kp = fx.ed25519("int-ed-rt", Ed25519Spec::new());
+        let aws_kp = kp.ed25519_key_pair_aws_lc_rs();
+
+        let msg = b"ed25519 integration roundtrip";
+        let sig = aws_kp.sign(msg);
+
+        let pk =
+            signature::UnparsedPublicKey::new(&signature::ED25519, aws_kp.public_key().as_ref());
+        pk.verify(msg, sig.as_ref()).expect("verify");
+    }
+
+    #[test]
+    fn ed25519_deterministic_signatures_identical() {
+        let seed = Seed::from_env_value("int-aws-ed-det").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ed25519("int-ed-sig-det", Ed25519Spec::new());
+        let kp2 = fx2.ed25519("int-ed-sig-det", Ed25519Spec::new());
+
+        let aws1 = kp1.ed25519_key_pair_aws_lc_rs();
+        let aws2 = kp2.ed25519_key_pair_aws_lc_rs();
+
+        let msg = b"deterministic ed25519 signature";
+        let sig1 = aws1.sign(msg);
+        let sig2 = aws2.sign(msg);
+
+        assert_eq!(
+            sig1.as_ref(),
+            sig2.as_ref(),
+            "Ed25519 signatures should be deterministic for same key+message"
+        );
+    }
+
+    #[test]
+    fn ed25519_empty_message_sign_verify() {
+        let fx = fx();
+        let kp = fx.ed25519("int-ed-empty", Ed25519Spec::new());
+        let aws_kp = kp.ed25519_key_pair_aws_lc_rs();
+
+        let sig = aws_kp.sign(b"");
+        let pk =
+            signature::UnparsedPublicKey::new(&signature::ED25519, aws_kp.public_key().as_ref());
+        pk.verify(b"", sig.as_ref()).expect("verify empty msg");
+    }
+
+    #[test]
+    fn ed25519_wrong_key_rejects() {
+        let fx = fx();
+        let kp_a = fx.ed25519("int-ed-a", Ed25519Spec::new());
+        let kp_b = fx.ed25519("int-ed-b", Ed25519Spec::new());
+
+        let aws_a = kp_a.ed25519_key_pair_aws_lc_rs();
+        let aws_b = kp_b.ed25519_key_pair_aws_lc_rs();
+
+        let sig = aws_a.sign(b"cross-key ed25519");
+        let pk_b =
+            signature::UnparsedPublicKey::new(&signature::ED25519, aws_b.public_key().as_ref());
+        assert!(pk_b.verify(b"cross-key ed25519", sig.as_ref()).is_err());
+    }
+
+    #[test]
+    fn ed25519_tampered_message_rejected() {
+        let fx = fx();
+        let kp = fx.ed25519("int-ed-tamper", Ed25519Spec::new());
+        let aws_kp = kp.ed25519_key_pair_aws_lc_rs();
+
+        let sig = aws_kp.sign(b"original");
+        let pk =
+            signature::UnparsedPublicKey::new(&signature::ED25519, aws_kp.public_key().as_ref());
+        pk.verify(b"original", sig.as_ref()).expect("verify ok");
+        assert!(pk.verify(b"tampered", sig.as_ref()).is_err());
+    }
+
+    #[test]
+    fn ed25519_large_message_sign_verify() {
+        let fx = fx();
+        let kp = fx.ed25519("int-ed-large", Ed25519Spec::new());
+        let aws_kp = kp.ed25519_key_pair_aws_lc_rs();
+
+        let msg = vec![0xCDu8; 64 * 1024];
+        let sig = aws_kp.sign(&msg);
+        let pk =
+            signature::UnparsedPublicKey::new(&signature::ED25519, aws_kp.public_key().as_ref());
+        pk.verify(&msg, sig.as_ref()).expect("verify large msg");
+    }
+}
+
+// =========================================================================
+// Cross-algorithm: all key types in one test
+// =========================================================================
+
+#[cfg(all(
+    feature = "native",
+    any(not(windows), has_nasm),
+    feature = "rsa",
+    feature = "ecdsa",
+    feature = "ed25519"
+))]
+mod all_algorithms {
+    use super::*;
+    use aws_lc_rs::{
+        rand::SystemRandom,
+        signature::{self, KeyPair},
+    };
+    use uselesskey_aws_lc_rs::{
+        AwsLcRsEcdsaKeyPairExt, AwsLcRsEd25519KeyPairExt, AwsLcRsRsaKeyPairExt,
+    };
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn all_key_types_from_same_factory() {
+        let fx = fx();
+        let rng = SystemRandom::new();
+        let msg = b"all key types test";
+
+        // RSA
+        let rsa_kp = fx.rsa("int-all-rsa", RsaSpec::rs256());
+        let aws_rsa = rsa_kp.rsa_key_pair_aws_lc_rs();
+        let mut rsa_sig = vec![0u8; aws_rsa.public_modulus_len()];
+        aws_rsa
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut rsa_sig)
+            .expect("rsa sign");
+        let rsa_pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            aws_rsa.public_key().as_ref(),
+        );
+        rsa_pk.verify(msg, &rsa_sig).expect("rsa verify");
+
+        // ECDSA P-256
+        let ec_kp = fx.ecdsa("int-all-ec256", EcdsaSpec::es256());
+        let aws_ec = ec_kp.ecdsa_key_pair_aws_lc_rs();
+        let ec_sig = aws_ec.sign(&rng, msg).expect("ecdsa sign");
+        let ec_pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            aws_ec.public_key().as_ref(),
+        );
+        ec_pk.verify(msg, ec_sig.as_ref()).expect("ecdsa verify");
+
+        // ECDSA P-384
+        let ec384_kp = fx.ecdsa("int-all-ec384", EcdsaSpec::es384());
+        let aws_ec384 = ec384_kp.ecdsa_key_pair_aws_lc_rs();
+        let ec384_sig = aws_ec384.sign(&rng, msg).expect("ecdsa384 sign");
+        let ec384_pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P384_SHA384_ASN1,
+            aws_ec384.public_key().as_ref(),
+        );
+        ec384_pk
+            .verify(msg, ec384_sig.as_ref())
+            .expect("ecdsa384 verify");
+
+        // Ed25519
+        let ed_kp = fx.ed25519("int-all-ed", Ed25519Spec::new());
+        let aws_ed = ed_kp.ed25519_key_pair_aws_lc_rs();
+        let ed_sig = aws_ed.sign(msg);
+        let ed_pk =
+            signature::UnparsedPublicKey::new(&signature::ED25519, aws_ed.public_key().as_ref());
+        ed_pk.verify(msg, ed_sig.as_ref()).expect("ed25519 verify");
+    }
+
+    #[test]
+    fn cross_algorithm_verification_always_fails() {
+        let fx = fx();
+        let rng = SystemRandom::new();
+
+        let rsa_kp = fx
+            .rsa("int-cross-rsa", RsaSpec::rs256())
+            .rsa_key_pair_aws_lc_rs();
+        let ec_kp = fx
+            .ecdsa("int-cross-ec", EcdsaSpec::es256())
+            .ecdsa_key_pair_aws_lc_rs();
+        let ed_kp = fx
+            .ed25519("int-cross-ed", Ed25519Spec::new())
+            .ed25519_key_pair_aws_lc_rs();
+
+        // RSA sig with ECDSA verifier
+        let mut rsa_sig = vec![0u8; rsa_kp.public_modulus_len()];
+        rsa_kp
+            .sign(&signature::RSA_PKCS1_SHA256, &rng, b"msg", &mut rsa_sig)
+            .unwrap();
+        let ec_pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            ec_kp.public_key().as_ref(),
+        );
+        assert!(ec_pk.verify(b"msg", &rsa_sig).is_err());
+
+        // Ed25519 sig with ECDSA verifier
+        let ed_sig = ed_kp.sign(b"msg");
+        assert!(ec_pk.verify(b"msg", ed_sig.as_ref()).is_err());
+
+        // ECDSA sig with Ed25519 verifier
+        let ec_sig = ec_kp.sign(&rng, b"msg").unwrap();
+        let ed_pk =
+            signature::UnparsedPublicKey::new(&signature::ED25519, ed_kp.public_key().as_ref());
+        assert!(ed_pk.verify(b"msg", ec_sig.as_ref()).is_err());
+    }
+}

--- a/crates/uselesskey-ring/Cargo.toml
+++ b/crates/uselesskey-ring/Cargo.toml
@@ -37,3 +37,4 @@ uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true
+proptest.workspace = true

--- a/crates/uselesskey-ring/tests/prop_tests_ring.rs
+++ b/crates/uselesskey-ring/tests/prop_tests_ring.rs
@@ -1,0 +1,259 @@
+//! Property-based tests for uselesskey-ring adapter.
+//!
+//! Covers:
+//! - Random label generation doesn't panic
+//! - Key generation is deterministic from seed
+//! - Signing produces valid signatures
+
+use proptest::prelude::*;
+use uselesskey_core::{Factory, Seed};
+
+// =========================================================================
+// RSA property-based tests
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_props {
+    use super::*;
+    use ring::{rand::SystemRandom, signature};
+    use uselesskey_ring::RingRsaKeyPairExt;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    proptest! {
+        // RSA keygen is very expensive; keep case count minimal.
+        #![proptest_config(ProptestConfig { cases: 5, ..ProptestConfig::default() })]
+
+        /// Arbitrary labels never panic during key generation + ring conversion.
+        #[test]
+        fn random_label_does_not_panic(label in "[a-z][a-z0-9-]{0,30}") {
+            let fx = Factory::random();
+            let kp = fx.rsa(&label, RsaSpec::rs256());
+            let _ring_kp = kp.rsa_key_pair_ring();
+        }
+
+        /// Deterministic factories with the same seed produce identical ring keys.
+        #[test]
+        fn deterministic_rsa_from_seed(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.rsa("prop-det-rsa", RsaSpec::rs256());
+            let kp2 = fx2.rsa("prop-det-rsa", RsaSpec::rs256());
+
+            prop_assert_eq!(
+                kp1.private_key_pkcs8_der(),
+                kp2.private_key_pkcs8_der(),
+                "Deterministic RSA keys should be identical"
+            );
+
+            let ring1 = kp1.rsa_key_pair_ring();
+            let ring2 = kp2.rsa_key_pair_ring();
+            prop_assert_eq!(
+                ring1.public().as_ref(),
+                ring2.public().as_ref(),
+                "Ring public keys should match"
+            );
+        }
+
+        /// Signing with a random message always produces a verifiable signature.
+        #[test]
+        fn signing_produces_valid_signature(msg in prop::collection::vec(any::<u8>(), 0..1024)) {
+            let fx = Factory::random();
+            let kp = fx.rsa("prop-rsa-sign", RsaSpec::rs256());
+            let ring_kp = kp.rsa_key_pair_ring();
+
+            let rng = SystemRandom::new();
+            let mut sig = vec![0u8; ring_kp.public().modulus_len()];
+            ring_kp
+                .sign(&signature::RSA_PKCS1_SHA256, &rng, &msg, &mut sig)
+                .expect("sign should succeed");
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::RSA_PKCS1_2048_8192_SHA256,
+                ring_kp.public().as_ref(),
+            );
+            prop_assert!(
+                pk.verify(&msg, &sig).is_ok(),
+                "Signature should verify for the same message"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// ECDSA property-based tests
+// =========================================================================
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_props {
+    use super::*;
+    use ring::{
+        rand::SystemRandom,
+        signature::{self, KeyPair},
+    };
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ring::RingEcdsaKeyPairExt;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 16, ..ProptestConfig::default() })]
+
+        /// Arbitrary labels never panic during ECDSA key generation + ring conversion.
+        #[test]
+        fn random_label_does_not_panic(label in "[a-z][a-z0-9-]{0,30}") {
+            let fx = Factory::random();
+            let kp = fx.ecdsa(&label, EcdsaSpec::es256());
+            let _ring_kp = kp.ecdsa_key_pair_ring();
+        }
+
+        /// Deterministic factories produce identical ECDSA ring keys.
+        #[test]
+        fn deterministic_ecdsa_from_seed(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.ecdsa("prop-det-ec", EcdsaSpec::es256());
+            let kp2 = fx2.ecdsa("prop-det-ec", EcdsaSpec::es256());
+
+            prop_assert_eq!(
+                kp1.private_key_pkcs8_der(),
+                kp2.private_key_pkcs8_der(),
+                "Deterministic ECDSA keys should be identical"
+            );
+
+            let ring1 = kp1.ecdsa_key_pair_ring();
+            let ring2 = kp2.ecdsa_key_pair_ring();
+            prop_assert_eq!(
+                ring1.public_key().as_ref(),
+                ring2.public_key().as_ref(),
+                "Ring ECDSA public keys should match"
+            );
+        }
+
+        /// ECDSA P-256 signing always produces a verifiable signature.
+        #[test]
+        fn p256_signing_produces_valid_signature(msg in prop::collection::vec(any::<u8>(), 0..1024)) {
+            let fx = Factory::random();
+            let kp = fx.ecdsa("prop-ec-sign", EcdsaSpec::es256());
+            let ring_kp = kp.ecdsa_key_pair_ring();
+
+            let rng = SystemRandom::new();
+            let sig = ring_kp.sign(&rng, &msg).expect("sign should succeed");
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::ECDSA_P256_SHA256_ASN1,
+                ring_kp.public_key().as_ref(),
+            );
+            prop_assert!(
+                pk.verify(&msg, sig.as_ref()).is_ok(),
+                "ECDSA P-256 signature should verify"
+            );
+        }
+
+        /// ECDSA P-384 signing always produces a verifiable signature.
+        #[test]
+        fn p384_signing_produces_valid_signature(msg in prop::collection::vec(any::<u8>(), 0..512)) {
+            let fx = Factory::random();
+            let kp = fx.ecdsa("prop-ec384-sign", EcdsaSpec::es384());
+            let ring_kp = kp.ecdsa_key_pair_ring();
+
+            let rng = SystemRandom::new();
+            let sig = ring_kp.sign(&rng, &msg).expect("sign should succeed");
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::ECDSA_P384_SHA384_ASN1,
+                ring_kp.public_key().as_ref(),
+            );
+            prop_assert!(
+                pk.verify(&msg, sig.as_ref()).is_ok(),
+                "ECDSA P-384 signature should verify"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// Ed25519 property-based tests
+// =========================================================================
+
+#[cfg(feature = "ed25519")]
+mod ed25519_props {
+    use super::*;
+    use ring::signature::{self, KeyPair};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_ring::RingEd25519KeyPairExt;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 32, ..ProptestConfig::default() })]
+
+        /// Arbitrary labels never panic during Ed25519 key generation + ring conversion.
+        #[test]
+        fn random_label_does_not_panic(label in "[a-z][a-z0-9-]{0,30}") {
+            let fx = Factory::random();
+            let kp = fx.ed25519(&label, Ed25519Spec::new());
+            let _ring_kp = kp.ed25519_key_pair_ring();
+        }
+
+        /// Deterministic factories produce identical Ed25519 ring keys.
+        #[test]
+        fn deterministic_ed25519_from_seed(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.ed25519("prop-det-ed", Ed25519Spec::new());
+            let kp2 = fx2.ed25519("prop-det-ed", Ed25519Spec::new());
+
+            prop_assert_eq!(
+                kp1.private_key_pkcs8_der(),
+                kp2.private_key_pkcs8_der(),
+                "Deterministic Ed25519 keys should be identical"
+            );
+
+            let ring1 = kp1.ed25519_key_pair_ring();
+            let ring2 = kp2.ed25519_key_pair_ring();
+            prop_assert_eq!(
+                ring1.public_key().as_ref(),
+                ring2.public_key().as_ref(),
+                "Ring Ed25519 public keys should match"
+            );
+        }
+
+        /// Ed25519 signing always produces a verifiable signature.
+        #[test]
+        fn signing_produces_valid_signature(msg in prop::collection::vec(any::<u8>(), 0..2048)) {
+            let fx = Factory::random();
+            let kp = fx.ed25519("prop-ed-sign", Ed25519Spec::new());
+            let ring_kp = kp.ed25519_key_pair_ring();
+
+            let sig = ring_kp.sign(&msg);
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::ED25519,
+                ring_kp.public_key().as_ref(),
+            );
+            prop_assert!(
+                pk.verify(&msg, sig.as_ref()).is_ok(),
+                "Ed25519 signature should verify"
+            );
+        }
+
+        /// Ed25519 signatures are deterministic for the same key and message.
+        #[test]
+        fn ed25519_signatures_are_deterministic(
+            seed in any::<[u8; 32]>(),
+            msg in prop::collection::vec(any::<u8>(), 0..512),
+        ) {
+            let fx = Factory::deterministic(Seed::new(seed));
+            let kp = fx.ed25519("prop-ed-det-sig", Ed25519Spec::new());
+            let ring_kp = kp.ed25519_key_pair_ring();
+
+            let sig1 = ring_kp.sign(&msg);
+            let sig2 = ring_kp.sign(&msg);
+
+            prop_assert_eq!(
+                sig1.as_ref(),
+                sig2.as_ref(),
+                "Ed25519 signatures should be deterministic"
+            );
+        }
+    }
+}

--- a/crates/uselesskey-tonic/tests/extended_tonic.rs
+++ b/crates/uselesskey-tonic/tests/extended_tonic.rs
@@ -1,0 +1,360 @@
+//! Extended tests for uselesskey-tonic adapter.
+//!
+//! Covers:
+//! - TLS config construction (server and client)
+//! - Certificate chain building and PEM structure
+//! - mTLS setup with separate server/client chains
+//! - Edge cases: multiple SANs, custom validity, domain name variants
+
+#[cfg(feature = "x509")]
+mod tls_config {
+    use uselesskey_core::{Factory, Seed};
+    use uselesskey_tonic::{TonicClientTlsExt, TonicIdentityExt, TonicServerTlsExt};
+    use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+    fn fx() -> Factory {
+        let seed = Seed::from_env_value("uselesskey-tonic-extended-test-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    }
+
+    #[test]
+    fn server_tls_from_self_signed_builds() {
+        let fx = fx();
+        let cert = fx.x509_self_signed("ext-srv-ss", X509Spec::self_signed("localhost"));
+        let _server = cert.server_tls_config_tonic();
+    }
+
+    #[test]
+    fn server_tls_from_chain_builds() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-srv-chain", ChainSpec::new("srv.example.com"));
+        let _server = chain.server_tls_config_tonic();
+    }
+
+    #[test]
+    fn client_tls_from_self_signed_builds() {
+        let fx = fx();
+        let cert = fx.x509_self_signed("ext-cli-ss", X509Spec::self_signed("localhost"));
+        let _client = cert.client_tls_config_tonic("localhost");
+    }
+
+    #[test]
+    fn client_tls_from_chain_builds() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-cli-chain", ChainSpec::new("cli.example.com"));
+        let _client = chain.client_tls_config_tonic("cli.example.com");
+    }
+
+    #[test]
+    fn client_tls_accepts_string_domain() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-cli-str", ChainSpec::new("grpc.example.com"));
+        let domain = String::from("grpc.example.com");
+        let _client = chain.client_tls_config_tonic(domain);
+    }
+
+    #[test]
+    fn server_and_client_from_same_chain() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-both", ChainSpec::new("both.example.com"));
+        let _server = chain.server_tls_config_tonic();
+        let _client = chain.client_tls_config_tonic("both.example.com");
+    }
+
+    #[test]
+    fn random_factory_builds_tls_configs() {
+        let fx = Factory::random();
+        let chain = fx.x509_chain("ext-random", ChainSpec::new("random.example.com"));
+        let _server = chain.server_tls_config_tonic();
+        let _client = chain.client_tls_config_tonic("random.example.com");
+        let _identity = chain.identity_tonic();
+    }
+}
+
+// =========================================================================
+// Certificate chain building
+// =========================================================================
+
+#[cfg(feature = "x509")]
+mod chain_building {
+    use uselesskey_core::{Factory, Seed};
+    use uselesskey_tonic::TonicIdentityExt;
+    use uselesskey_x509::{ChainSpec, X509FactoryExt};
+
+    fn fx() -> Factory {
+        let seed = Seed::from_env_value("uselesskey-tonic-extended-chain-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    }
+
+    #[test]
+    fn chain_pem_has_two_certs() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-chain-cnt", ChainSpec::new("chain.example.com"));
+        let count = chain
+            .chain_pem()
+            .matches("-----BEGIN CERTIFICATE-----")
+            .count();
+        assert_eq!(count, 2, "chain_pem should contain leaf + intermediate");
+    }
+
+    #[test]
+    fn full_chain_pem_has_three_certs() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-full-chain", ChainSpec::new("chain.example.com"));
+        let count = chain
+            .full_chain_pem()
+            .matches("-----BEGIN CERTIFICATE-----")
+            .count();
+        assert_eq!(
+            count, 3,
+            "full_chain_pem should contain leaf + intermediate + root"
+        );
+    }
+
+    #[test]
+    fn root_cert_pem_is_single() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-root-single", ChainSpec::new("chain.example.com"));
+        let count = chain
+            .root_cert_pem()
+            .matches("-----BEGIN CERTIFICATE-----")
+            .count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn leaf_cert_pem_is_single() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-leaf-single", ChainSpec::new("chain.example.com"));
+        let count = chain
+            .leaf_cert_pem()
+            .matches("-----BEGIN CERTIFICATE-----")
+            .count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn leaf_key_pem_has_correct_header() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-key-hdr", ChainSpec::new("chain.example.com"));
+        assert!(
+            chain
+                .leaf_private_key_pkcs8_pem()
+                .starts_with("-----BEGIN PRIVATE KEY-----")
+        );
+    }
+
+    #[test]
+    fn der_outputs_are_nonempty() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-der-ne", ChainSpec::new("chain.example.com"));
+        assert!(!chain.root_cert_der().is_empty());
+        assert!(!chain.intermediate_cert_der().is_empty());
+        assert!(!chain.leaf_cert_der().is_empty());
+        assert!(!chain.leaf_private_key_pkcs8_der().is_empty());
+    }
+
+    #[test]
+    fn identity_from_chain_succeeds() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-id-chain", ChainSpec::new("chain.example.com"));
+        let _identity = chain.identity_tonic();
+    }
+
+    #[test]
+    fn chain_with_custom_cn_names() {
+        let fx = fx();
+        let chain = fx.x509_chain(
+            "ext-custom-cn",
+            ChainSpec::new("leaf.example.com")
+                .with_root_cn("Custom Root CA")
+                .with_intermediate_cn("Custom Intermediate CA"),
+        );
+        let _identity = chain.identity_tonic();
+    }
+
+    #[test]
+    fn chain_with_multiple_sans() {
+        let fx = fx();
+        let chain = fx.x509_chain(
+            "ext-multi-sans",
+            ChainSpec::new("primary.example.com").with_sans(vec![
+                "alt1.example.com".into(),
+                "alt2.example.com".into(),
+                "alt3.example.com".into(),
+            ]),
+        );
+        let _identity = chain.identity_tonic();
+    }
+
+    #[test]
+    fn chain_with_custom_validity_days() {
+        let fx = fx();
+        let chain = fx.x509_chain(
+            "ext-validity",
+            ChainSpec::new("validity.example.com")
+                .with_root_validity_days(7300)
+                .with_intermediate_validity_days(3650)
+                .with_leaf_validity_days(365),
+        );
+        let _identity = chain.identity_tonic();
+    }
+
+    #[test]
+    fn different_labels_produce_different_chains() {
+        let fx = fx();
+        let chain_a = fx.x509_chain("ext-diff-a", ChainSpec::new("a.example.com"));
+        let chain_b = fx.x509_chain("ext-diff-b", ChainSpec::new("b.example.com"));
+        assert_ne!(chain_a.leaf_cert_der(), chain_b.leaf_cert_der());
+    }
+
+    #[test]
+    fn different_rsa_sizes_produce_different_chains() {
+        let fx = fx();
+        let chain_2k = fx.x509_chain(
+            "ext-rsa-2k",
+            ChainSpec::new("rsa.example.com").with_rsa_bits(2048),
+        );
+        let chain_4k = fx.x509_chain(
+            "ext-rsa-4k",
+            ChainSpec::new("rsa.example.com").with_rsa_bits(4096),
+        );
+        assert_ne!(chain_2k.leaf_cert_der(), chain_4k.leaf_cert_der());
+    }
+}
+
+// =========================================================================
+// mTLS setup tests
+// =========================================================================
+
+#[cfg(feature = "x509")]
+mod mtls_setup {
+    use uselesskey_core::{Factory, Seed};
+    use uselesskey_tonic::{TonicClientTlsExt, TonicMtlsExt, TonicServerTlsExt};
+    use uselesskey_x509::{ChainSpec, X509FactoryExt};
+
+    fn fx() -> Factory {
+        let seed = Seed::from_env_value("uselesskey-tonic-extended-mtls-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    }
+
+    #[test]
+    fn mtls_server_from_chain() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-mtls-srv", ChainSpec::new("mtls.example.com"));
+        let _server = chain.server_tls_config_mtls_tonic();
+    }
+
+    #[test]
+    fn mtls_client_from_chain() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-mtls-cli", ChainSpec::new("mtls.example.com"));
+        let _client = chain.client_tls_config_mtls_tonic("mtls.example.com");
+    }
+
+    #[test]
+    fn mtls_server_and_client_from_same_chain() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-mtls-both", ChainSpec::new("mtls.example.com"));
+        let _server = chain.server_tls_config_mtls_tonic();
+        let _client = chain.client_tls_config_mtls_tonic("mtls.example.com");
+    }
+
+    #[test]
+    fn mtls_separate_server_and_client_chains() {
+        let fx = fx();
+        let server_chain = fx.x509_chain("ext-mtls-srv-sep", ChainSpec::new("server.example.com"));
+        let client_chain = fx.x509_chain("ext-mtls-cli-sep", ChainSpec::new("client.example.com"));
+
+        let _server = server_chain.server_tls_config_mtls_tonic();
+        let _client = client_chain.client_tls_config_mtls_tonic("server.example.com");
+    }
+
+    #[test]
+    fn mtls_with_4096_bit_keys() {
+        let fx = fx();
+        let chain = fx.x509_chain(
+            "ext-mtls-4096",
+            ChainSpec::new("mtls-4096.example.com").with_rsa_bits(4096),
+        );
+        let _server = chain.server_tls_config_mtls_tonic();
+        let _client = chain.client_tls_config_mtls_tonic("mtls-4096.example.com");
+    }
+
+    #[test]
+    fn mtls_random_factory() {
+        let fx = Factory::random();
+        let chain = fx.x509_chain("ext-mtls-rand", ChainSpec::new("random.example.com"));
+        let _server = chain.server_tls_config_mtls_tonic();
+        let _client = chain.client_tls_config_mtls_tonic("random.example.com");
+    }
+
+    #[test]
+    fn mtls_with_sans() {
+        let fx = fx();
+        let chain = fx.x509_chain(
+            "ext-mtls-sans",
+            ChainSpec::new("mtls.example.com")
+                .with_sans(vec!["alt.example.com".into(), "other.example.com".into()]),
+        );
+        let _server = chain.server_tls_config_mtls_tonic();
+        let _client = chain.client_tls_config_mtls_tonic("mtls.example.com");
+    }
+
+    #[test]
+    fn mtls_deterministic_produces_consistent_configs() {
+        let seed = Seed::from_env_value("ext-mtls-det").expect("seed");
+        let fx = Factory::deterministic(seed);
+
+        let chain_a = fx.x509_chain("ext-mtls-det", ChainSpec::new("det.example.com"));
+        fx.clear_cache();
+        let chain_b = fx.x509_chain("ext-mtls-det", ChainSpec::new("det.example.com"));
+
+        assert_eq!(chain_a.chain_pem(), chain_b.chain_pem());
+        assert_eq!(chain_a.root_cert_pem(), chain_b.root_cert_pem());
+        assert_eq!(
+            chain_a.leaf_private_key_pkcs8_pem(),
+            chain_b.leaf_private_key_pkcs8_pem()
+        );
+
+        // Both should build mTLS configs without panicking
+        let _srv_a = chain_a.server_tls_config_mtls_tonic();
+        let _srv_b = chain_b.server_tls_config_mtls_tonic();
+        let _cli_a = chain_a.client_tls_config_mtls_tonic("det.example.com");
+        let _cli_b = chain_b.client_tls_config_mtls_tonic("det.example.com");
+    }
+
+    #[test]
+    fn multiple_mtls_pairs_from_same_factory() {
+        let fx = fx();
+        for i in 0..3 {
+            let chain = fx.x509_chain(
+                format!("ext-mtls-multi-{i}"),
+                ChainSpec::new(format!("svc{i}.example.com")),
+            );
+            let _server = chain.server_tls_config_mtls_tonic();
+            let _client = chain.client_tls_config_mtls_tonic(format!("svc{i}.example.com"));
+        }
+    }
+
+    /// Verify that standard (non-mTLS) server TLS and mTLS server TLS both build from the same chain.
+    #[test]
+    fn standard_and_mtls_server_from_same_chain() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-std-mtls", ChainSpec::new("both.example.com"));
+        let _standard = chain.server_tls_config_tonic();
+        let _mtls = chain.server_tls_config_mtls_tonic();
+    }
+
+    /// Verify that standard (non-mTLS) client TLS and mTLS client TLS both build from the same chain.
+    #[test]
+    fn standard_and_mtls_client_from_same_chain() {
+        let fx = fx();
+        let chain = fx.x509_chain("ext-std-mtls-cli", ChainSpec::new("both.example.com"));
+        let _standard = chain.client_tls_config_tonic("both.example.com");
+        let _mtls = chain.client_tls_config_mtls_tonic("both.example.com");
+    }
+}


### PR DESCRIPTION
## Changes
- aws-lc-rs: Integration tests for key conversion and signing round-trips
- ring: Property-based tests for determinism and signature validity
- tonic: Extended tests for TLS config and mTLS

All tests pass. No new blobs.