### PR TITLE
test: add insta snapshot tests for tonic and pgp adapter crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,8 +3763,10 @@ dependencies = [
 name = "uselesskey-pgp"
 version = "0.3.0"
 dependencies = [
+ "insta",
  "pgp",
  "proptest",
+ "serde",
  "uselesskey-core",
 ]
 
@@ -3865,7 +3867,9 @@ version = "0.3.0"
 name = "uselesskey-tonic"
 version = "0.3.0"
 dependencies = [
+ "insta",
  "proptest",
+ "serde",
  "tonic",
  "uselesskey-core",
  "uselesskey-x509",

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -20,6 +20,8 @@ pgp = { version = "0.19.0", default-features = false }
 
 [dev-dependencies]
 proptest.workspace = true
+serde.workspace = true
+insta.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__all_specs_snapshots__pgp_all_specs_comparison.snap
+++ b/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__all_specs_snapshots__pgp_all_specs_comparison.snap
@@ -1,0 +1,17 @@
+---
+source: crates/uselesskey-pgp/tests/snapshots_pgp.rs
+assertion_line: 313
+expression: cases
+---
+- spec_name: ed25519
+  private_binary_len: 268
+  public_binary_len: 233
+  fingerprint_len: 40
+- spec_name: rsa2048
+  private_binary_len: 1311
+  public_binary_len: 660
+  fingerprint_len: 40
+- spec_name: rsa3072
+  private_binary_len: 1887
+  public_binary_len: 916
+  fingerprint_len: 40

--- a/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__ed25519_snapshots__pgp_ed25519_key_metadata.snap
+++ b/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__ed25519_snapshots__pgp_ed25519_key_metadata.snap
@@ -1,0 +1,17 @@
+---
+source: crates/uselesskey-pgp/tests/snapshots_pgp.rs
+assertion_line: 64
+expression: result
+---
+spec: ed25519
+user_id: snapshot-ed25519 <snapshot-ed25519@uselesskey.test>
+fingerprint_len: 40
+private_armor_has_begin: true
+private_armor_has_end: true
+public_armor_has_begin: true
+public_armor_has_end: true
+private_binary_len: 260
+public_binary_len: 225
+private_armor: "[REDACTED]"
+public_armor: "[REDACTED]"
+fingerprint: "[REDACTED]"

--- a/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__negative_snapshots__pgp_corrupt_armor.snap
+++ b/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__negative_snapshots__pgp_corrupt_armor.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-pgp/tests/snapshots_pgp.rs
+assertion_line: 273
+expression: result
+---
+original_starts_with_dash: true
+corrupt_differs_from_original: true
+corrupt_deterministic_is_stable: true

--- a/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__negative_snapshots__pgp_mismatch_metadata.snap
+++ b/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__negative_snapshots__pgp_mismatch_metadata.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-pgp/tests/snapshots_pgp.rs
+assertion_line: 230
+expression: result
+---
+original_public_binary_len: 227
+mismatched_public_binary_len: 227
+keys_differ: true
+mismatched_armor_has_begin: true

--- a/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__negative_snapshots__pgp_truncated_binary.snap
+++ b/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__negative_snapshots__pgp_truncated_binary.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-pgp/tests/snapshots_pgp.rs
+assertion_line: 249
+expression: result
+---
+original_len: 264
+truncated_len: 32

--- a/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__rsa_2048_snapshots__pgp_rsa_2048_key_metadata.snap
+++ b/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__rsa_2048_snapshots__pgp_rsa_2048_key_metadata.snap
@@ -1,0 +1,15 @@
+---
+source: crates/uselesskey-pgp/tests/snapshots_pgp.rs
+assertion_line: 115
+expression: result
+---
+spec: rsa2048
+user_id: snapshot-rsa-2048 <snapshot-rsa-2048@uselesskey.test>
+fingerprint_len: 40
+private_armor_has_begin: true
+public_armor_has_begin: true
+private_binary_len: 1305
+public_binary_len: 654
+private_armor: "[REDACTED]"
+public_armor: "[REDACTED]"
+fingerprint: "[REDACTED]"

--- a/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__rsa_3072_snapshots__pgp_rsa_3072_key_metadata.snap
+++ b/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__rsa_3072_snapshots__pgp_rsa_3072_key_metadata.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uselesskey-pgp/tests/snapshots_pgp.rs
+assertion_line: 156
+expression: result
+---
+spec: rsa3072
+user_id: snapshot-rsa-3072 <snapshot-rsa-3072@uselesskey.test>
+fingerprint_len: 40
+private_binary_len: 1881
+public_binary_len: 910
+private_armor: "[REDACTED]"
+fingerprint: "[REDACTED]"

--- a/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__user_id_snapshots__pgp_user_id_formats.snap
+++ b/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__user_id_snapshots__pgp_user_id_formats.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uselesskey-pgp/tests/snapshots_pgp.rs
+assertion_line: 196
+expression: cases
+---
+- label: simple-label
+  user_id: simple-label <simple-label@uselesskey.test>
+- label: "Test User!@#"
+  user_id: "Test User!@# <test-user@uselesskey.test>"
+- label: ALL CAPS
+  user_id: ALL CAPS <all-caps@uselesskey.test>
+- label: with spaces
+  user_id: with spaces <with-spaces@uselesskey.test>

--- a/crates/uselesskey-pgp/tests/snapshots_pgp.rs
+++ b/crates/uselesskey-pgp/tests/snapshots_pgp.rs
@@ -1,0 +1,310 @@
+//! Insta snapshot tests for uselesskey-pgp.
+//!
+//! These tests snapshot PGP key metadata produced by deterministic fixtures
+//! to detect unintended changes in output shape.
+//! CRITICAL: No actual key bytes appear in snapshots — all crypto material is redacted.
+
+mod testutil;
+
+use serde::Serialize;
+use testutil::fx;
+use uselesskey_pgp::{PgpFactoryExt, PgpSpec};
+
+// =========================================================================
+// Ed25519 PGP snapshots
+// =========================================================================
+
+mod ed25519_snapshots {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct PgpKeySnapshot {
+        spec: &'static str,
+        user_id: String,
+        fingerprint_len: usize,
+        private_armor_has_begin: bool,
+        private_armor_has_end: bool,
+        public_armor_has_begin: bool,
+        public_armor_has_end: bool,
+        private_binary_len: usize,
+        public_binary_len: usize,
+        private_armor: String,
+        public_armor: String,
+        fingerprint: String,
+    }
+
+    #[test]
+    fn snapshot_pgp_ed25519_key_metadata() {
+        let fx = fx();
+        let key = fx.pgp("snapshot-ed25519", PgpSpec::ed25519());
+
+        let result = PgpKeySnapshot {
+            spec: "ed25519",
+            user_id: key.user_id().to_string(),
+            fingerprint_len: key.fingerprint().len(),
+            private_armor_has_begin: key
+                .private_key_armored()
+                .contains("BEGIN PGP PRIVATE KEY BLOCK"),
+            private_armor_has_end: key
+                .private_key_armored()
+                .contains("END PGP PRIVATE KEY BLOCK"),
+            public_armor_has_begin: key
+                .public_key_armored()
+                .contains("BEGIN PGP PUBLIC KEY BLOCK"),
+            public_armor_has_end: key
+                .public_key_armored()
+                .contains("END PGP PUBLIC KEY BLOCK"),
+            private_binary_len: key.private_key_binary().len(),
+            public_binary_len: key.public_key_binary().len(),
+            private_armor: key.private_key_armored().to_string(),
+            public_armor: key.public_key_armored().to_string(),
+            fingerprint: key.fingerprint().to_string(),
+        };
+
+        insta::assert_yaml_snapshot!("pgp_ed25519_key_metadata", result, {
+            ".private_armor" => "[REDACTED]",
+            ".public_armor" => "[REDACTED]",
+            ".fingerprint" => "[REDACTED]",
+        });
+    }
+}
+
+// =========================================================================
+// RSA 2048 PGP snapshots
+// =========================================================================
+
+mod rsa_2048_snapshots {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct PgpKeySnapshot {
+        spec: &'static str,
+        user_id: String,
+        fingerprint_len: usize,
+        private_armor_has_begin: bool,
+        public_armor_has_begin: bool,
+        private_binary_len: usize,
+        public_binary_len: usize,
+        private_armor: String,
+        public_armor: String,
+        fingerprint: String,
+    }
+
+    #[test]
+    fn snapshot_pgp_rsa_2048_key_metadata() {
+        let fx = fx();
+        let key = fx.pgp("snapshot-rsa-2048", PgpSpec::rsa_2048());
+
+        let result = PgpKeySnapshot {
+            spec: "rsa2048",
+            user_id: key.user_id().to_string(),
+            fingerprint_len: key.fingerprint().len(),
+            private_armor_has_begin: key
+                .private_key_armored()
+                .contains("BEGIN PGP PRIVATE KEY BLOCK"),
+            public_armor_has_begin: key
+                .public_key_armored()
+                .contains("BEGIN PGP PUBLIC KEY BLOCK"),
+            private_binary_len: key.private_key_binary().len(),
+            public_binary_len: key.public_key_binary().len(),
+            private_armor: key.private_key_armored().to_string(),
+            public_armor: key.public_key_armored().to_string(),
+            fingerprint: key.fingerprint().to_string(),
+        };
+
+        insta::assert_yaml_snapshot!("pgp_rsa_2048_key_metadata", result, {
+            ".private_armor" => "[REDACTED]",
+            ".public_armor" => "[REDACTED]",
+            ".fingerprint" => "[REDACTED]",
+        });
+    }
+}
+
+// =========================================================================
+// RSA 3072 PGP snapshots
+// =========================================================================
+
+mod rsa_3072_snapshots {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct PgpKeySnapshot {
+        spec: &'static str,
+        user_id: String,
+        fingerprint_len: usize,
+        private_binary_len: usize,
+        public_binary_len: usize,
+        private_armor: String,
+        fingerprint: String,
+    }
+
+    #[test]
+    fn snapshot_pgp_rsa_3072_key_metadata() {
+        let fx = fx();
+        let key = fx.pgp("snapshot-rsa-3072", PgpSpec::rsa_3072());
+
+        let result = PgpKeySnapshot {
+            spec: "rsa3072",
+            user_id: key.user_id().to_string(),
+            fingerprint_len: key.fingerprint().len(),
+            private_binary_len: key.private_key_binary().len(),
+            public_binary_len: key.public_key_binary().len(),
+            private_armor: key.private_key_armored().to_string(),
+            fingerprint: key.fingerprint().to_string(),
+        };
+
+        insta::assert_yaml_snapshot!("pgp_rsa_3072_key_metadata", result, {
+            ".private_armor" => "[REDACTED]",
+            ".fingerprint" => "[REDACTED]",
+        });
+    }
+}
+
+// =========================================================================
+// User ID sanitization snapshots
+// =========================================================================
+
+mod user_id_snapshots {
+    use super::*;
+
+    #[test]
+    fn snapshot_pgp_user_id_formats() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct UserIdEntry {
+            label: String,
+            user_id: String,
+        }
+
+        let cases: Vec<UserIdEntry> = ["simple-label", "Test User!@#", "ALL CAPS", "with spaces"]
+            .into_iter()
+            .map(|label| {
+                let key = fx.pgp(label, PgpSpec::ed25519());
+                UserIdEntry {
+                    label: label.to_string(),
+                    user_id: key.user_id().to_string(),
+                }
+            })
+            .collect();
+
+        insta::assert_yaml_snapshot!("pgp_user_id_formats", cases);
+    }
+}
+
+// =========================================================================
+// Negative fixture snapshots
+// =========================================================================
+
+mod negative_snapshots {
+    use super::*;
+
+    #[test]
+    fn snapshot_pgp_mismatch_metadata() {
+        let fx = fx();
+        let key = fx.pgp("snapshot-mismatch", PgpSpec::ed25519());
+
+        #[derive(Serialize)]
+        struct MismatchSnapshot {
+            original_public_binary_len: usize,
+            mismatched_public_binary_len: usize,
+            keys_differ: bool,
+            mismatched_armor_has_begin: bool,
+        }
+
+        let mismatch_bin = key.mismatched_public_key_binary();
+        let mismatch_arm = key.mismatched_public_key_armored();
+
+        let result = MismatchSnapshot {
+            original_public_binary_len: key.public_key_binary().len(),
+            mismatched_public_binary_len: mismatch_bin.len(),
+            keys_differ: mismatch_bin != key.public_key_binary(),
+            mismatched_armor_has_begin: mismatch_arm.contains("BEGIN PGP PUBLIC KEY BLOCK"),
+        };
+
+        insta::assert_yaml_snapshot!("pgp_mismatch_metadata", result);
+    }
+
+    #[test]
+    fn snapshot_pgp_truncated_binary() {
+        let fx = fx();
+        let key = fx.pgp("snapshot-truncated", PgpSpec::ed25519());
+
+        #[derive(Serialize)]
+        struct TruncatedSnapshot {
+            original_len: usize,
+            truncated_len: usize,
+        }
+
+        let result = TruncatedSnapshot {
+            original_len: key.private_key_binary().len(),
+            truncated_len: key.private_key_binary_truncated(32).len(),
+        };
+
+        insta::assert_yaml_snapshot!("pgp_truncated_binary", result);
+    }
+
+    #[test]
+    fn snapshot_pgp_corrupt_armor() {
+        let fx = fx();
+        let key = fx.pgp("snapshot-corrupt", PgpSpec::ed25519());
+
+        #[derive(Serialize)]
+        struct CorruptArmorSnapshot {
+            original_starts_with_dash: bool,
+            corrupt_differs_from_original: bool,
+            corrupt_deterministic_is_stable: bool,
+        }
+
+        let det_a = key.private_key_armored_corrupt_deterministic("corrupt:snap-v1");
+        let det_b = key.private_key_armored_corrupt_deterministic("corrupt:snap-v1");
+
+        let result = CorruptArmorSnapshot {
+            original_starts_with_dash: key.private_key_armored().starts_with('-'),
+            corrupt_differs_from_original: det_a != key.private_key_armored(),
+            corrupt_deterministic_is_stable: det_a == det_b,
+        };
+
+        insta::assert_yaml_snapshot!("pgp_corrupt_armor", result);
+    }
+}
+
+// =========================================================================
+// All specs comparison snapshot
+// =========================================================================
+
+mod all_specs_snapshots {
+    use super::*;
+
+    #[test]
+    fn snapshot_pgp_all_specs_comparison() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct SpecInfo {
+            spec_name: &'static str,
+            private_binary_len: usize,
+            public_binary_len: usize,
+            fingerprint_len: usize,
+        }
+
+        let cases: Vec<SpecInfo> = [
+            ("ed25519", PgpSpec::ed25519()),
+            ("rsa2048", PgpSpec::rsa_2048()),
+            ("rsa3072", PgpSpec::rsa_3072()),
+        ]
+        .into_iter()
+        .map(|(name, spec)| {
+            let key = fx.pgp(format!("snapshot-all-{name}"), spec);
+            SpecInfo {
+                spec_name: name,
+                private_binary_len: key.private_key_binary().len(),
+                public_binary_len: key.public_key_binary().len(),
+                fingerprint_len: key.fingerprint().len(),
+            }
+        })
+        .collect();
+
+        insta::assert_yaml_snapshot!("pgp_all_specs_comparison", cases);
+    }
+}

--- a/crates/uselesskey-tonic/Cargo.toml
+++ b/crates/uselesskey-tonic/Cargo.toml
@@ -29,3 +29,5 @@ x509 = ["dep:uselesskey-x509"]
 uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
 uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0" }
 proptest.workspace = true
+serde.workspace = true
+insta.workspace = true

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_all_configs_build.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_all_configs_build.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+assertion_line: 180
+expression: result
+---
+domain: grpc.example.com
+identity_built: true
+server_tls_built: true
+client_tls_built: true

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_tls_metadata.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_tls_metadata.snap
@@ -1,0 +1,17 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+assertion_line: 149
+expression: result
+---
+domain: test.example.com
+chain_pem_cert_count: 2
+full_chain_pem_cert_count: 3
+root_cert_pem_cert_count: 1
+leaf_cert_pem_cert_count: 1
+root_cert_der_len: 794
+intermediate_cert_der_len: 802
+leaf_cert_der_len: 803
+leaf_private_key_der_len: 1217
+chain_pem: "[REDACTED]"
+root_cert_pem: "[REDACTED]"
+leaf_private_key_pem: "[REDACTED]"

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__key_size_snapshots__tonic_chain_key_sizes.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__key_size_snapshots__tonic_chain_key_sizes.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+assertion_line: 258
+expression: cases
+---
+- rsa_bits: 2048
+  leaf_cert_der_len: 815
+  leaf_private_key_der_len: 1216
+  root_cert_der_len: 802
+- rsa_bits: 4096
+  leaf_cert_der_len: 1327
+  leaf_private_key_der_len: 2374
+  root_cert_der_len: 1314

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__mtls_snapshots__tonic_mtls_configs_build.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__mtls_snapshots__tonic_mtls_configs_build.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+assertion_line: 219
+expression: result
+---
+domain: mtls.example.com
+server_mtls_built: true
+client_mtls_built: true
+chain_pem_cert_count: 2
+root_cert_der_len: 794

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_identity_builds.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_identity_builds.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+assertion_line: 88
+expression: result
+---
+domain: localhost
+identity_built: true
+server_tls_built: true
+client_tls_built: true

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_tls_metadata.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_tls_metadata.snap
@@ -1,0 +1,15 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+assertion_line: 56
+expression: result
+---
+domain: localhost
+cert_pem_lines: 18
+cert_pem_has_begin: true
+cert_pem_has_end: true
+private_key_pem_has_begin: true
+private_key_pem_has_end: true
+cert_der_len: 744
+private_key_der_len: 1217
+cert_pem: "[REDACTED]"
+private_key_pem: "[REDACTED]"

--- a/crates/uselesskey-tonic/tests/snapshots_tonic.rs
+++ b/crates/uselesskey-tonic/tests/snapshots_tonic.rs
@@ -1,0 +1,254 @@
+//! Insta snapshot tests for uselesskey-tonic adapter.
+//!
+//! These tests snapshot TLS configuration metadata produced by deterministic
+//! X.509 fixtures to detect unintended changes in adapter output.
+//! CRITICAL: No actual key bytes appear in snapshots — all crypto material is redacted.
+
+mod testutil;
+
+use serde::Serialize;
+use testutil::fx;
+use uselesskey_tonic::{TonicClientTlsExt, TonicIdentityExt, TonicMtlsExt, TonicServerTlsExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+// =========================================================================
+// Self-signed certificate snapshots
+// =========================================================================
+
+mod self_signed_snapshots {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct SelfSignedTlsSnapshot {
+        domain: &'static str,
+        cert_pem_lines: usize,
+        cert_pem_has_begin: bool,
+        cert_pem_has_end: bool,
+        private_key_pem_has_begin: bool,
+        private_key_pem_has_end: bool,
+        cert_der_len: usize,
+        private_key_der_len: usize,
+        cert_pem: String,
+        private_key_pem: String,
+    }
+
+    #[test]
+    fn snapshot_self_signed_tls_metadata() {
+        let fx = fx();
+        let cert = fx.x509_self_signed("snapshot-ss", X509Spec::self_signed("localhost"));
+
+        let cert_pem = cert.cert_pem().to_string();
+        let key_pem = cert.private_key_pkcs8_pem().to_string();
+
+        let result = SelfSignedTlsSnapshot {
+            domain: "localhost",
+            cert_pem_lines: cert_pem.lines().count(),
+            cert_pem_has_begin: cert_pem.contains("-----BEGIN CERTIFICATE-----"),
+            cert_pem_has_end: cert_pem.contains("-----END CERTIFICATE-----"),
+            private_key_pem_has_begin: key_pem.contains("-----BEGIN PRIVATE KEY-----"),
+            private_key_pem_has_end: key_pem.contains("-----END PRIVATE KEY-----"),
+            cert_der_len: cert.cert_der().len(),
+            private_key_der_len: cert.private_key_pkcs8_der().len(),
+            cert_pem,
+            private_key_pem: key_pem,
+        };
+
+        insta::assert_yaml_snapshot!("tonic_self_signed_tls_metadata", result, {
+            ".cert_pem" => "[REDACTED]",
+            ".private_key_pem" => "[REDACTED]",
+        });
+    }
+
+    #[test]
+    fn snapshot_self_signed_identity_builds() {
+        let fx = fx();
+        let cert = fx.x509_self_signed("snapshot-ss-id", X509Spec::self_signed("localhost"));
+
+        // Identity creation is infallible — snapshot that it succeeds with metadata
+        let _identity = cert.identity_tonic();
+
+        #[derive(Serialize)]
+        struct IdentityBuildResult {
+            domain: &'static str,
+            identity_built: bool,
+            server_tls_built: bool,
+            client_tls_built: bool,
+        }
+
+        let _server = cert.server_tls_config_tonic();
+        let _client = cert.client_tls_config_tonic("localhost");
+
+        let result = IdentityBuildResult {
+            domain: "localhost",
+            identity_built: true,
+            server_tls_built: true,
+            client_tls_built: true,
+        };
+
+        insta::assert_yaml_snapshot!("tonic_self_signed_identity_builds", result);
+    }
+}
+
+// =========================================================================
+// Chain certificate snapshots
+// =========================================================================
+
+mod chain_snapshots {
+    use super::*;
+
+    #[derive(Serialize)]
+    struct ChainTlsSnapshot {
+        domain: &'static str,
+        chain_pem_cert_count: usize,
+        full_chain_pem_cert_count: usize,
+        root_cert_pem_cert_count: usize,
+        leaf_cert_pem_cert_count: usize,
+        root_cert_der_len: usize,
+        intermediate_cert_der_len: usize,
+        leaf_cert_der_len: usize,
+        leaf_private_key_der_len: usize,
+        chain_pem: String,
+        root_cert_pem: String,
+        leaf_private_key_pem: String,
+    }
+
+    #[test]
+    fn snapshot_chain_tls_metadata() {
+        let fx = fx();
+        let chain = fx.x509_chain("snapshot-chain", ChainSpec::new("test.example.com"));
+
+        let chain_pem = chain.chain_pem().to_string();
+        let full_chain_pem = chain.full_chain_pem();
+        let root_pem = chain.root_cert_pem().to_string();
+        let leaf_pem = chain.leaf_cert_pem();
+        let key_pem = chain.leaf_private_key_pkcs8_pem().to_string();
+
+        let result = ChainTlsSnapshot {
+            domain: "test.example.com",
+            chain_pem_cert_count: chain_pem.matches("-----BEGIN CERTIFICATE-----").count(),
+            full_chain_pem_cert_count: full_chain_pem
+                .matches("-----BEGIN CERTIFICATE-----")
+                .count(),
+            root_cert_pem_cert_count: root_pem.matches("-----BEGIN CERTIFICATE-----").count(),
+            leaf_cert_pem_cert_count: leaf_pem.matches("-----BEGIN CERTIFICATE-----").count(),
+            root_cert_der_len: chain.root_cert_der().len(),
+            intermediate_cert_der_len: chain.intermediate_cert_der().len(),
+            leaf_cert_der_len: chain.leaf_cert_der().len(),
+            leaf_private_key_der_len: chain.leaf_private_key_pkcs8_der().len(),
+            chain_pem,
+            root_cert_pem: root_pem,
+            leaf_private_key_pem: key_pem,
+        };
+
+        insta::assert_yaml_snapshot!("tonic_chain_tls_metadata", result, {
+            ".chain_pem" => "[REDACTED]",
+            ".root_cert_pem" => "[REDACTED]",
+            ".leaf_private_key_pem" => "[REDACTED]",
+        });
+    }
+
+    #[test]
+    fn snapshot_chain_all_configs_build() {
+        let fx = fx();
+        let chain = fx.x509_chain("snapshot-chain-cfg", ChainSpec::new("grpc.example.com"));
+
+        let _identity = chain.identity_tonic();
+        let _server = chain.server_tls_config_tonic();
+        let _client = chain.client_tls_config_tonic("grpc.example.com");
+
+        #[derive(Serialize)]
+        struct ChainConfigResult {
+            domain: &'static str,
+            identity_built: bool,
+            server_tls_built: bool,
+            client_tls_built: bool,
+        }
+
+        let result = ChainConfigResult {
+            domain: "grpc.example.com",
+            identity_built: true,
+            server_tls_built: true,
+            client_tls_built: true,
+        };
+
+        insta::assert_yaml_snapshot!("tonic_chain_all_configs_build", result);
+    }
+}
+
+// =========================================================================
+// mTLS snapshots
+// =========================================================================
+
+mod mtls_snapshots {
+    use super::*;
+
+    #[test]
+    fn snapshot_mtls_configs_build() {
+        let fx = fx();
+        let chain = fx.x509_chain("snapshot-mtls", ChainSpec::new("mtls.example.com"));
+
+        let _server = chain.server_tls_config_mtls_tonic();
+        let _client = chain.client_tls_config_mtls_tonic("mtls.example.com");
+
+        #[derive(Serialize)]
+        struct MtlsConfigResult {
+            domain: &'static str,
+            server_mtls_built: bool,
+            client_mtls_built: bool,
+            chain_pem_cert_count: usize,
+            root_cert_der_len: usize,
+        }
+
+        let result = MtlsConfigResult {
+            domain: "mtls.example.com",
+            server_mtls_built: true,
+            client_mtls_built: true,
+            chain_pem_cert_count: chain
+                .chain_pem()
+                .matches("-----BEGIN CERTIFICATE-----")
+                .count(),
+            root_cert_der_len: chain.root_cert_der().len(),
+        };
+
+        insta::assert_yaml_snapshot!("tonic_mtls_configs_build", result);
+    }
+}
+
+// =========================================================================
+// RSA key size snapshots
+// =========================================================================
+
+mod key_size_snapshots {
+    use super::*;
+
+    #[test]
+    fn snapshot_chain_key_sizes() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct KeySizeInfo {
+            rsa_bits: usize,
+            leaf_cert_der_len: usize,
+            leaf_private_key_der_len: usize,
+            root_cert_der_len: usize,
+        }
+
+        let cases: Vec<KeySizeInfo> = [2048, 4096]
+            .into_iter()
+            .map(|bits| {
+                let chain = fx.x509_chain(
+                    format!("snapshot-bits-{bits}"),
+                    ChainSpec::new(format!("bits{bits}.example.com")).with_rsa_bits(bits),
+                );
+                KeySizeInfo {
+                    rsa_bits: bits,
+                    leaf_cert_der_len: chain.leaf_cert_der().len(),
+                    leaf_private_key_der_len: chain.leaf_private_key_pkcs8_der().len(),
+                    root_cert_der_len: chain.root_cert_der().len(),
+                }
+            })
+            .collect();
+
+        insta::assert_yaml_snapshot!("tonic_chain_key_sizes", cases);
+    }
+}

--- a/crates/uselesskey-tonic/tests/testutil.rs
+++ b/crates/uselesskey-tonic/tests/testutil.rs
@@ -1,0 +1,16 @@
+#![allow(unused)]
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+pub(crate) fn fx() -> Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-tonic-test-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+    .clone()
+}


### PR DESCRIPTION
Add metadata-only insta snapshot tests for the **uselesskey-tonic** (6 tests) and **uselesskey-pgp** (8 tests) adapter crates, matching the existing pattern used by jsonwebtoken, rustls, ring, and aws-lc-rs adapters.

### Tonic tests (6)
- Self-signed cert metadata and identity building
- Certificate chain TLS metadata and all config building
- mTLS config building
- Key size variations (RSA-2048 vs RSA-4096)

### PGP tests (8)
- Ed25519, RSA-2048, RSA-3072 key metadata
- User ID format sanitization
- Negative fixtures: mismatch, truncated binary, corrupt armor
- All-specs comparison

### Pattern
All tests follow the established snapshot pattern:
- Deterministic factory with fixed seed
- \Serialize\ structs capturing metadata only
- Key material redacted via insta redactions
- Snapshot files checked in for CI regression detection