### PR TITLE
docs: add doc-test examples to core microcrates

### DIFF
--- a/crates/uselesskey-core-cache/src/lib.rs
+++ b/crates/uselesskey-core-cache/src/lib.rs
@@ -37,6 +37,22 @@ type Cache = DashMap<ArtifactId, CacheValue>;
 type Cache = Mutex<BTreeMap<ArtifactId, CacheValue>>;
 
 /// Cache keyed by [`ArtifactId`] that stores typed values behind `Arc<dyn Any>`.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use uselesskey_core_cache::ArtifactCache;
+/// use uselesskey_core_id::{ArtifactId, DerivationVersion};
+///
+/// let cache = ArtifactCache::new();
+/// let id = ArtifactId::new("domain:rsa", "issuer", b"RS256", "good", DerivationVersion::V1);
+///
+/// // Insert once, retrieve many times
+/// cache.insert_if_absent_typed(id.clone(), Arc::new(42u32));
+/// let value = cache.get_typed::<u32>(&id).unwrap();
+/// assert_eq!(*value, 42);
+/// ```
 pub struct ArtifactCache {
     inner: Cache,
 }

--- a/crates/uselesskey-core-jwk/src/lib.rs
+++ b/crates/uselesskey-core-jwk/src/lib.rs
@@ -4,6 +4,46 @@
 //!
 //! This crate is a thin compatibility façade over
 //! `uselesskey-core-jwk-shape` for API stability.
+//!
+//! # Examples
+//!
+//! Build an Ed25519 public JWK:
+//!
+//! ```
+//! use uselesskey_core_jwk::{OkpPublicJwk, PublicJwk};
+//!
+//! let jwk = OkpPublicJwk {
+//!     kty: "OKP",
+//!     use_: "sig",
+//!     alg: "EdDSA",
+//!     crv: "Ed25519",
+//!     kid: "my-key-1".into(),
+//!     x: "dGVzdC1wdWJsaWMta2V5".into(),
+//! };
+//! let public = PublicJwk::Okp(jwk);
+//! assert_eq!(public.to_value()["kty"], "OKP");
+//! ```
+//!
+//! Assemble a JWKS with deterministic ordering via [`JwksBuilder`]:
+//!
+//! ```
+//! use uselesskey_core_jwk::{JwksBuilder, RsaPublicJwk, PublicJwk};
+//!
+//! let jwks = JwksBuilder::new()
+//!     .add_public(PublicJwk::Rsa(RsaPublicJwk {
+//!         kty: "RSA", use_: "sig", alg: "RS256",
+//!         kid: "b-key".into(), n: "modulus".into(), e: "AQAB".into(),
+//!     }))
+//!     .add_public(PublicJwk::Rsa(RsaPublicJwk {
+//!         kty: "RSA", use_: "sig", alg: "RS256",
+//!         kid: "a-key".into(), n: "modulus".into(), e: "AQAB".into(),
+//!     }))
+//!     .build();
+//!
+//! // Keys are sorted by kid
+//! assert_eq!(jwks.keys[0].kid(), "a-key");
+//! assert_eq!(jwks.keys[1].kid(), "b-key");
+//! ```
 
 pub use uselesskey_core_jwk_builder::JwksBuilder;
 pub use uselesskey_core_jwk_shape::*;

--- a/crates/uselesskey-core-keypair/src/lib.rs
+++ b/crates/uselesskey-core-keypair/src/lib.rs
@@ -5,5 +5,25 @@
 //! The actual implementation lives in
 //! [`uselesskey_core_keypair_material`]; this crate keeps the existing public path
 //! stable for downstream users and internal integrations.
+//!
+//! # Examples
+//!
+//! Create key material and access encodings:
+//!
+//! ```
+//! use uselesskey_core_keypair::Pkcs8SpkiKeyMaterial;
+//!
+//! let material = Pkcs8SpkiKeyMaterial::new(
+//!     vec![0x30, 0x82],                        // PKCS#8 DER (placeholder)
+//!     "-----BEGIN PRIVATE KEY-----\nAA==\n-----END PRIVATE KEY-----\n",
+//!     vec![0x30, 0x59],                        // SPKI DER (placeholder)
+//!     "-----BEGIN PUBLIC KEY-----\nAA==\n-----END PUBLIC KEY-----\n",
+//! );
+//!
+//! assert_eq!(material.private_key_pkcs8_der(), &[0x30, 0x82]);
+//! assert!(material.public_key_spki_pem().contains("PUBLIC KEY"));
+//! // kid is deterministic from the SPKI bytes
+//! assert_eq!(material.kid(), material.kid());
+//! ```
 
 pub use uselesskey_core_keypair_material::Pkcs8SpkiKeyMaterial;

--- a/crates/uselesskey-core-kid/src/lib.rs
+++ b/crates/uselesskey-core-kid/src/lib.rs
@@ -23,6 +23,17 @@ pub const DEFAULT_KID_PREFIX_BYTES: usize = 12;
 ///
 /// Uses BLAKE3 and base64url (no padding), truncating to
 /// [`DEFAULT_KID_PREFIX_BYTES`].
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_core_kid::kid_from_bytes;
+///
+/// let kid = kid_from_bytes(b"my-public-key-bytes");
+/// assert!(!kid.is_empty());
+/// // Same input always produces the same kid
+/// assert_eq!(kid, kid_from_bytes(b"my-public-key-bytes"));
+/// ```
 pub fn kid_from_bytes(bytes: &[u8]) -> String {
     kid_from_bytes_with_prefix(bytes, DEFAULT_KID_PREFIX_BYTES)
 }
@@ -30,6 +41,17 @@ pub fn kid_from_bytes(bytes: &[u8]) -> String {
 /// Generate a deterministic key ID from key bytes with a custom hash prefix length.
 ///
 /// `prefix_bytes` must be in `1..=32`.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_core_kid::kid_from_bytes_with_prefix;
+///
+/// // Shorter prefix = shorter kid string
+/// let short = kid_from_bytes_with_prefix(b"my-key", 4);
+/// let long  = kid_from_bytes_with_prefix(b"my-key", 16);
+/// assert!(short.len() < long.len());
+/// ```
 pub fn kid_from_bytes_with_prefix(bytes: &[u8], prefix_bytes: usize) -> String {
     assert!(
         (1..=blake3::OUT_LEN).contains(&prefix_bytes),

--- a/crates/uselesskey-core-negative/src/lib.rs
+++ b/crates/uselesskey-core-negative/src/lib.rs
@@ -7,6 +7,29 @@
 //! delegating to focused microcrates:
 //! - [`uselesskey_core_negative_der`] for DER corruption helpers.
 //! - [`uselesskey_core_negative_pem`] for PEM corruption helpers.
+//!
+//! # Examples
+//!
+//! Corrupt a PEM string with a specific strategy:
+//!
+//! ```
+//! use uselesskey_core_negative::{corrupt_pem, CorruptPem};
+//!
+//! let pem = "-----BEGIN PUBLIC KEY-----\nABC=\n-----END PUBLIC KEY-----\n";
+//! let bad = corrupt_pem(pem, CorruptPem::BadHeader);
+//! assert!(bad.starts_with("-----BEGIN CORRUPTED KEY-----"));
+//! ```
+//!
+//! Deterministic DER corruption from a variant string:
+//!
+//! ```
+//! use uselesskey_core_negative::corrupt_der_deterministic;
+//!
+//! let der = vec![0x30, 0x82, 0x01, 0x22, 0x10, 0x20];
+//! let a = corrupt_der_deterministic(&der, "corrupt:test-v1");
+//! let b = corrupt_der_deterministic(&der, "corrupt:test-v1");
+//! assert_eq!(a, b); // same variant ⇒ same corruption
+//! ```
 
 pub use uselesskey_core_negative_der::{corrupt_der_deterministic, flip_byte, truncate_der};
 pub use uselesskey_core_negative_pem::{CorruptPem, corrupt_pem, corrupt_pem_deterministic};


### PR DESCRIPTION
Adds doc-test examples to five core microcrates that are most likely to be used directly by consumers:

- **uselesskey-core-jwk** — JWK construction and JwksBuilder usage
- **uselesskey-core-negative** — CorruptPem and DER corruption usage
- **uselesskey-core-keypair** — Pkcs8SpkiKeyMaterial accessor usage
- **uselesskey-core-kid** — kid_from_bytes and prefix configuration
- **uselesskey-core-cache** — ArtifactCache insert/retrieve pattern

All doc-tests compile and pass.