### PR TITLE
test: add tests for core-sink, core-x509-derive, core-x509-spec

### DIFF
--- a/crates/uselesskey-core-sink/tests/integration.rs
+++ b/crates/uselesskey-core-sink/tests/integration.rs
@@ -116,3 +116,66 @@ fn large_content_round_trip() {
     let read_back = temp.read_to_bytes().unwrap();
     assert_eq!(read_back, data);
 }
+
+// ── multiple artifacts coexist ───────────────────────────────────────
+
+#[test]
+fn multiple_artifacts_have_distinct_paths() {
+    let a = TempArtifact::new_string("uk-a-", ".pem", "artifact-a").unwrap();
+    let b = TempArtifact::new_string("uk-b-", ".pem", "artifact-b").unwrap();
+
+    assert_ne!(a.path(), b.path());
+    assert_eq!(a.read_to_string().unwrap(), "artifact-a");
+    assert_eq!(b.read_to_string().unwrap(), "artifact-b");
+}
+
+// ── Debug safety with binary content ─────────────────────────────────
+
+#[test]
+fn debug_does_not_leak_binary_content() {
+    let secret = vec![0xDE, 0xAD, 0xBE, 0xEF];
+    let temp = TempArtifact::new_bytes("uk-test-", ".bin", &secret).unwrap();
+    let dbg = format!("{temp:?}");
+    assert!(dbg.contains("TempArtifact"));
+    // Debug should only show path, not file content
+    assert!(!dbg.contains("DEAD"));
+    assert!(!dbg.contains("BEEF"));
+}
+
+// ── null bytes in binary content ─────────────────────────────────────
+
+#[test]
+fn binary_content_with_null_bytes() {
+    let data = vec![0x00, 0x01, 0x00, 0xFF, 0x00];
+    let temp = TempArtifact::new_bytes("uk-null-", ".bin", &data).unwrap();
+    assert_eq!(temp.read_to_bytes().unwrap(), data);
+}
+
+// ── write operations ─────────────────────────────────────────────────
+
+#[test]
+fn new_bytes_creates_readable_file() {
+    let data = b"test data for write op";
+    let temp = TempArtifact::new_bytes("uk-write-", ".dat", data).unwrap();
+    let content = std::fs::read(temp.path()).unwrap();
+    assert_eq!(content, data);
+}
+
+#[test]
+fn new_string_creates_readable_file() {
+    let text = "hello from new_string";
+    let temp = TempArtifact::new_string("uk-write-", ".txt", text).unwrap();
+    let content = std::fs::read_to_string(temp.path()).unwrap();
+    assert_eq!(content, text);
+}
+
+// ── Debug shows path but uses finish_non_exhaustive ──────────────────
+
+#[test]
+fn debug_shows_path_field() {
+    let temp = TempArtifact::new_string("uk-test-", ".txt", "data").unwrap();
+    let dbg = format!("{temp:?}");
+    assert!(dbg.contains("path"));
+    // finish_non_exhaustive appends ".."
+    assert!(dbg.contains(".."));
+}

--- a/crates/uselesskey-core-x509-derive/tests/integration.rs
+++ b/crates/uselesskey-core-x509-derive/tests/integration.rs
@@ -1,0 +1,154 @@
+//! Integration tests for `uselesskey-core-x509-derive`.
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use uselesskey_core_x509_derive::{
+    BASE_TIME_EPOCH_UNIX, BASE_TIME_WINDOW_DAYS, SERIAL_NUMBER_BYTES,
+    deterministic_base_time_from_parts, deterministic_serial_number, write_len_prefixed,
+};
+
+// ── deterministic_base_time_from_parts ───────────────────────────────
+
+#[test]
+fn base_time_within_epoch_window() {
+    let epoch = time::OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).unwrap();
+    let max = epoch + time::Duration::days(i64::from(BASE_TIME_WINDOW_DAYS));
+
+    let t = deterministic_base_time_from_parts(&[b"some-label"]);
+    assert!(t >= epoch && t < max);
+}
+
+#[test]
+fn base_time_deterministic_for_same_input() {
+    let a = deterministic_base_time_from_parts(&[b"label", b"leaf"]);
+    let b = deterministic_base_time_from_parts(&[b"label", b"leaf"]);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn base_time_differs_for_different_input() {
+    let a = deterministic_base_time_from_parts(&[b"label-a"]);
+    let b = deterministic_base_time_from_parts(&[b"label-b"]);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn base_time_boundary_safe_avoids_collisions() {
+    // "ab" + "c" must differ from "a" + "bc" due to length-prefixed hashing
+    let a = deterministic_base_time_from_parts(&[b"ab", b"c"]);
+    let b = deterministic_base_time_from_parts(&[b"a", b"bc"]);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn base_time_empty_parts_is_deterministic() {
+    let a = deterministic_base_time_from_parts(&[]);
+    let b = deterministic_base_time_from_parts(&[]);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn base_time_single_empty_part_differs_from_no_parts() {
+    let no_parts = deterministic_base_time_from_parts(&[]);
+    let empty_part = deterministic_base_time_from_parts(&[b""]);
+    // Length-prefixed encoding: zero parts vs one zero-length part
+    assert_ne!(no_parts, empty_part);
+}
+
+#[test]
+fn base_time_many_parts() {
+    let data: Vec<Vec<u8>> = (0..20).map(|i| vec![i as u8]).collect();
+    let refs: Vec<&[u8]> = data.iter().map(|v| v.as_slice()).collect();
+    let a = deterministic_base_time_from_parts(&refs);
+    let b = deterministic_base_time_from_parts(&refs);
+    assert_eq!(a, b);
+}
+
+// ── deterministic_serial_number ──────────────────────────────────────
+
+#[test]
+fn serial_number_is_positive() {
+    let mut rng = ChaCha20Rng::from_seed([7u8; 32]);
+    let serial = deterministic_serial_number(&mut rng);
+    let bytes = serial.to_bytes();
+    assert_eq!(
+        bytes[0] & 0x80,
+        0,
+        "high bit must be cleared for positive serial"
+    );
+}
+
+#[test]
+fn serial_number_correct_length() {
+    let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+    let serial = deterministic_serial_number(&mut rng);
+    assert_eq!(serial.to_bytes().len(), SERIAL_NUMBER_BYTES);
+}
+
+#[test]
+fn serial_number_deterministic_from_same_seed() {
+    let mut a = ChaCha20Rng::from_seed([99u8; 32]);
+    let mut b = ChaCha20Rng::from_seed([99u8; 32]);
+    assert_eq!(
+        deterministic_serial_number(&mut a).to_bytes(),
+        deterministic_serial_number(&mut b).to_bytes()
+    );
+}
+
+#[test]
+fn serial_number_varies_across_seeds() {
+    let mut a = ChaCha20Rng::from_seed([1u8; 32]);
+    let mut b = ChaCha20Rng::from_seed([2u8; 32]);
+    assert_ne!(
+        deterministic_serial_number(&mut a).to_bytes(),
+        deterministic_serial_number(&mut b).to_bytes()
+    );
+}
+
+#[test]
+fn serial_number_all_zero_seed() {
+    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+    let serial = deterministic_serial_number(&mut rng);
+    let bytes = serial.to_bytes();
+    assert_eq!(bytes.len(), SERIAL_NUMBER_BYTES);
+    assert_eq!(bytes[0] & 0x80, 0);
+}
+
+#[test]
+fn serial_number_all_ones_seed() {
+    let mut rng = ChaCha20Rng::from_seed([0xFF; 32]);
+    let serial = deterministic_serial_number(&mut rng);
+    let bytes = serial.to_bytes();
+    assert_eq!(bytes.len(), SERIAL_NUMBER_BYTES);
+    assert_eq!(bytes[0] & 0x80, 0);
+}
+
+// ── constants ────────────────────────────────────────────────────────
+
+#[test]
+fn epoch_is_2025_01_01() {
+    let epoch = time::OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).unwrap();
+    assert_eq!(epoch.year(), 2025);
+    assert_eq!(epoch.month(), time::Month::January);
+    assert_eq!(epoch.day(), 1);
+}
+
+#[test]
+fn window_days_constant() {
+    assert_eq!(BASE_TIME_WINDOW_DAYS, 365);
+}
+
+#[test]
+fn serial_bytes_constant() {
+    assert_eq!(SERIAL_NUMBER_BYTES, 16);
+}
+
+// ── write_len_prefixed re-export ─────────────────────────────────────
+
+#[test]
+fn write_len_prefixed_is_accessible() {
+    let mut hasher = uselesskey_core_hash::Hasher::new();
+    write_len_prefixed(&mut hasher, b"test-data");
+    // Should not panic; the hasher accepted the input
+    let _hash = hasher.finalize();
+}

--- a/crates/uselesskey-core-x509-spec/tests/spec_integration_tests.rs
+++ b/crates/uselesskey-core-x509-spec/tests/spec_integration_tests.rs
@@ -111,3 +111,183 @@ fn chain_spec_not_before_offsets() {
     let bytes = spec.stable_bytes();
     assert!(!bytes.is_empty());
 }
+
+// ---------------------------------------------------------------------------
+// Trait implementations — Clone, Debug, PartialEq, Hash
+// ---------------------------------------------------------------------------
+
+#[test]
+fn x509_spec_clone_equals_original() {
+    let spec = X509Spec::self_signed("clone-test")
+        .with_validity_days(90)
+        .with_sans(vec!["a.test".into()]);
+    let cloned = spec.clone();
+    assert_eq!(spec, cloned);
+    assert_eq!(spec.stable_bytes(), cloned.stable_bytes());
+}
+
+#[test]
+fn x509_spec_debug_contains_type_name() {
+    let spec = X509Spec::self_signed("debug-test");
+    let dbg = format!("{spec:?}");
+    assert!(dbg.contains("X509Spec"));
+    assert!(dbg.contains("debug-test"));
+}
+
+#[test]
+fn x509_spec_ne_for_different_cn() {
+    let a = X509Spec::self_signed("alpha");
+    let b = X509Spec::self_signed("beta");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn x509_spec_hash_equal_for_equal_specs() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let a = X509Spec::self_signed("hash-test");
+    let b = X509Spec::self_signed("hash-test");
+
+    let mut ha = DefaultHasher::new();
+    a.hash(&mut ha);
+    let mut hb = DefaultHasher::new();
+    b.hash(&mut hb);
+    assert_eq!(ha.finish(), hb.finish());
+}
+
+#[test]
+fn chain_spec_clone_equals_original() {
+    let spec = ChainSpec::new("clone.example.com")
+        .with_rsa_bits(4096)
+        .with_sans(vec!["a.com".into()]);
+    let cloned = spec.clone();
+    assert_eq!(spec, cloned);
+    assert_eq!(spec.stable_bytes(), cloned.stable_bytes());
+}
+
+#[test]
+fn chain_spec_debug_contains_type_name() {
+    let spec = ChainSpec::new("debug.example.com");
+    let dbg = format!("{spec:?}");
+    assert!(dbg.contains("ChainSpec"));
+    assert!(dbg.contains("debug.example.com"));
+}
+
+#[test]
+fn chain_spec_ne_for_different_leaf_cn() {
+    let a = ChainSpec::new("alpha.example.com");
+    let b = ChainSpec::new("beta.example.com");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn chain_spec_hash_equal_for_equal_specs() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let a = ChainSpec::new("hash.example.com");
+    let b = ChainSpec::new("hash.example.com");
+
+    let mut ha = DefaultHasher::new();
+    a.hash(&mut ha);
+    let mut hb = DefaultHasher::new();
+    b.hash(&mut hb);
+    assert_eq!(ha.finish(), hb.finish());
+}
+
+#[test]
+fn key_usage_clone_equals_original() {
+    let leaf = KeyUsage::leaf();
+    let cloned = leaf;
+    assert_eq!(leaf, cloned);
+
+    let ca = KeyUsage::ca();
+    let cloned = ca;
+    assert_eq!(ca, cloned);
+}
+
+#[test]
+fn key_usage_debug_contains_type_name() {
+    let ku = KeyUsage::leaf();
+    let dbg = format!("{ku:?}");
+    assert!(dbg.contains("KeyUsage"));
+}
+
+#[test]
+fn key_usage_hash_equal_for_equal_values() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let a = KeyUsage::leaf();
+    let b = KeyUsage::leaf();
+
+    let mut ha = DefaultHasher::new();
+    a.hash(&mut ha);
+    let mut hb = DefaultHasher::new();
+    b.hash(&mut hb);
+    assert_eq!(ha.finish(), hb.finish());
+}
+
+#[test]
+fn not_before_offset_clone_equals_original() {
+    let ago = NotBeforeOffset::DaysAgo(5);
+    let cloned = ago;
+    assert_eq!(ago, cloned);
+
+    let future = NotBeforeOffset::DaysFromNow(10);
+    let cloned = future;
+    assert_eq!(future, cloned);
+}
+
+#[test]
+fn not_before_offset_debug_contains_variant() {
+    let ago = NotBeforeOffset::DaysAgo(5);
+    let dbg = format!("{ago:?}");
+    assert!(dbg.contains("DaysAgo"));
+    assert!(dbg.contains("5"));
+
+    let future = NotBeforeOffset::DaysFromNow(10);
+    let dbg = format!("{future:?}");
+    assert!(dbg.contains("DaysFromNow"));
+    assert!(dbg.contains("10"));
+}
+
+#[test]
+fn not_before_offset_ne_across_variants() {
+    assert_ne!(NotBeforeOffset::DaysAgo(1), NotBeforeOffset::DaysFromNow(1));
+}
+
+#[test]
+fn not_before_offset_ne_different_values() {
+    assert_ne!(NotBeforeOffset::DaysAgo(1), NotBeforeOffset::DaysAgo(2));
+    assert_ne!(
+        NotBeforeOffset::DaysFromNow(1),
+        NotBeforeOffset::DaysFromNow(2)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprint stability — snapshot values
+// ---------------------------------------------------------------------------
+
+#[test]
+fn x509_spec_stable_bytes_starts_with_version_4() {
+    let spec = X509Spec::self_signed("test");
+    assert_eq!(spec.stable_bytes()[0], 4);
+}
+
+#[test]
+fn chain_spec_stable_bytes_starts_with_version_2() {
+    let spec = ChainSpec::new("test.example.com");
+    assert_eq!(spec.stable_bytes()[0], 2);
+}
+
+#[test]
+fn x509_spec_stable_bytes_snapshot() {
+    let spec = X509Spec::self_signed("snapshot.test").with_validity_days(365);
+    let bytes = spec.stable_bytes();
+    let again = spec.stable_bytes();
+    assert_eq!(bytes, again);
+    assert!(bytes.len() > 10);
+}


### PR DESCRIPTION
Adds integration tests for 3 previously untested core crates.