### PR TITLE
test: expand BDD scenarios for under-covered features

### DIFF
--- a/crates/uselesskey-bdd-steps/src/lib.rs
+++ b/crates/uselesskey-bdd-steps/src/lib.rs
@@ -369,6 +369,9 @@ struct UselessWorld {
     // JWT recorded token for stability tests
     #[cfg(feature = "uk-jwt")]
     jwt_recorded_token: Option<String>,
+
+    // Generic DER recording for determinism-across-instances tests
+    recorded_der: Option<Vec<u8>>,
 }
 
 #[cfg(feature = "uk-jwt")]
@@ -5937,6 +5940,241 @@ fn rustcrypto_signature_identical_to_recorded(world: &mut UselessWorld) {
         .as_ref()
         .expect("recorded signature not set");
     assert_eq!(current, recorded, "signatures should be identical");
+}
+
+// =============================================================================
+// Additional HMAC steps
+// =============================================================================
+
+#[when(regex = r#"^I generate another HMAC HS256 secret for label "([^"]+)"$"#)]
+fn gen_hmac_hs256_second(world: &mut UselessWorld, label: String) {
+    let fx = world.factory.as_ref().expect("factory not set");
+    let secret = fx.hmac(&label, HmacSpec::hs256());
+    world.hmac_secret_2 = Some(secret.secret_bytes().to_vec());
+    world.hmac = Some(secret);
+}
+
+// =============================================================================
+// Additional token assertion steps
+// =============================================================================
+
+#[cfg(feature = "uk-token")]
+#[then("the token value should contain only printable ASCII")]
+fn token_value_printable_ascii(world: &mut UselessWorld) {
+    let value = world.token_value_1.as_ref().expect("token_value_1 not set");
+    assert!(
+        value.chars().all(|c| c.is_ascii_graphic()),
+        "token value should contain only printable ASCII characters, got: {value}"
+    );
+}
+
+#[cfg(feature = "uk-token")]
+#[then("the OAuth payload should contain an exp claim")]
+fn oauth_payload_has_exp(world: &mut UselessWorld) {
+    let value = world.token_value_1.as_ref().expect("token_value_1 not set");
+    let payload = value.split('.').nth(1).expect("payload segment");
+    let decoded = URL_SAFE_NO_PAD
+        .decode(payload)
+        .expect("payload base64url decode");
+    let json: Value = serde_json::from_slice(&decoded).expect("payload JSON parse");
+    assert!(
+        json.get("exp").is_some(),
+        "OAuth payload should contain exp claim"
+    );
+}
+
+#[cfg(feature = "uk-token")]
+#[then("the OAuth payload should contain a scope claim")]
+fn oauth_payload_has_scope(world: &mut UselessWorld) {
+    let value = world.token_value_1.as_ref().expect("token_value_1 not set");
+    let payload = value.split('.').nth(1).expect("payload segment");
+    let decoded = URL_SAFE_NO_PAD
+        .decode(payload)
+        .expect("payload base64url decode");
+    let json: Value = serde_json::from_slice(&decoded).expect("payload JSON parse");
+    assert!(
+        json.get("scope").is_some(),
+        "OAuth payload should contain scope claim"
+    );
+}
+
+// =============================================================================
+// Additional RSA assertion steps
+// =============================================================================
+
+#[then("the PKCS8 PEM should differ")]
+fn pem_should_differ(world: &mut UselessWorld) {
+    assert_ne!(
+        world.pkcs8_pem_1.as_deref(),
+        world.pkcs8_pem_2.as_deref(),
+        "PKCS8 PEMs should differ"
+    );
+}
+
+// =============================================================================
+// X.509 negative variant recording steps
+// =============================================================================
+
+#[when("I record the expired X.509 certificate DER")]
+fn record_expired_x509_der(world: &mut UselessWorld) {
+    let expired = world.x509_expired.as_ref().expect("x509_expired not set");
+    world.recorded_der = Some(expired.cert_der().to_vec());
+}
+
+#[then("the expired X.509 certificate DER should match the recorded one")]
+fn expired_x509_der_matches_recorded(world: &mut UselessWorld) {
+    let expired = world.x509_expired.as_ref().expect("x509_expired not set");
+    let recorded = world.recorded_der.as_ref().expect("recorded_der not set");
+    assert_eq!(
+        expired.cert_der(),
+        recorded.as_slice(),
+        "expired X.509 DER should match recorded"
+    );
+}
+
+#[when("I record the not-yet-valid X.509 certificate DER")]
+fn record_not_yet_valid_x509_der(world: &mut UselessWorld) {
+    let nyv = world
+        .x509_not_yet_valid
+        .as_ref()
+        .expect("x509_not_yet_valid not set");
+    world.recorded_der = Some(nyv.cert_der().to_vec());
+}
+
+#[then("the not-yet-valid X.509 certificate DER should match the recorded one")]
+fn not_yet_valid_x509_der_matches_recorded(world: &mut UselessWorld) {
+    let nyv = world
+        .x509_not_yet_valid
+        .as_ref()
+        .expect("x509_not_yet_valid not set");
+    let recorded = world.recorded_der.as_ref().expect("recorded_der not set");
+    assert_eq!(
+        nyv.cert_der(),
+        recorded.as_slice(),
+        "not-yet-valid X.509 DER should match recorded"
+    );
+}
+
+#[when("I record the wrong-key-usage X.509 certificate DER")]
+fn record_wrong_key_usage_x509_der(world: &mut UselessWorld) {
+    let wku = world
+        .x509_wrong_key_usage
+        .as_ref()
+        .expect("x509_wrong_key_usage not set");
+    world.recorded_der = Some(wku.cert_der().to_vec());
+}
+
+#[then("the wrong-key-usage X.509 certificate DER should match the recorded one")]
+fn wrong_key_usage_x509_der_matches_recorded(world: &mut UselessWorld) {
+    let wku = world
+        .x509_wrong_key_usage
+        .as_ref()
+        .expect("x509_wrong_key_usage not set");
+    let recorded = world.recorded_der.as_ref().expect("recorded_der not set");
+    assert_eq!(
+        wku.cert_der(),
+        recorded.as_slice(),
+        "wrong-key-usage X.509 DER should match recorded"
+    );
+}
+
+#[then("the not-yet-valid X.509 certificate DER should differ from the expired one")]
+fn not_yet_valid_differs_from_expired(world: &mut UselessWorld) {
+    let nyv = world
+        .x509_not_yet_valid
+        .as_ref()
+        .expect("x509_not_yet_valid not set");
+    let recorded = world.recorded_der.as_ref().expect("recorded_der not set");
+    assert_ne!(
+        nyv.cert_der(),
+        recorded.as_slice(),
+        "not-yet-valid and expired X.509 DER should differ"
+    );
+}
+
+#[then("the wrong-key-usage X.509 certificate DER should differ from the expired one")]
+fn wrong_key_usage_differs_from_expired(world: &mut UselessWorld) {
+    let wku = world
+        .x509_wrong_key_usage
+        .as_ref()
+        .expect("x509_wrong_key_usage not set");
+    let recorded = world.recorded_der.as_ref().expect("recorded_der not set");
+    assert_ne!(
+        wku.cert_der(),
+        recorded.as_slice(),
+        "wrong-key-usage and expired X.509 DER should differ"
+    );
+}
+
+// --- Chain negative variant recording steps ---
+
+#[when("I record the unknown CA root DER")]
+fn record_unknown_ca_root_der(world: &mut UselessWorld) {
+    let chain = world
+        .x509_chain_unknown_ca
+        .as_ref()
+        .expect("x509_chain_unknown_ca not set");
+    world.recorded_der = Some(chain.root_cert_der().to_vec());
+}
+
+#[then("the unknown CA root DER should match the recorded one")]
+fn unknown_ca_root_der_matches_recorded(world: &mut UselessWorld) {
+    let chain = world
+        .x509_chain_unknown_ca
+        .as_ref()
+        .expect("x509_chain_unknown_ca not set");
+    let recorded = world.recorded_der.as_ref().expect("recorded_der not set");
+    assert_eq!(
+        chain.root_cert_der(),
+        recorded.as_slice(),
+        "unknown CA root DER should match recorded"
+    );
+}
+
+#[when("I record the revoked leaf DER")]
+fn record_revoked_leaf_der(world: &mut UselessWorld) {
+    let chain = world
+        .x509_chain_revoked_leaf
+        .as_ref()
+        .expect("x509_chain_revoked_leaf not set");
+    world.recorded_der = Some(chain.leaf_cert_der().to_vec());
+}
+
+#[then("the revoked leaf DER should match the recorded one")]
+fn revoked_leaf_der_matches_recorded(world: &mut UselessWorld) {
+    let chain = world
+        .x509_chain_revoked_leaf
+        .as_ref()
+        .expect("x509_chain_revoked_leaf not set");
+    let recorded = world.recorded_der.as_ref().expect("recorded_der not set");
+    assert_eq!(
+        chain.leaf_cert_der(),
+        recorded.as_slice(),
+        "revoked leaf DER should match recorded"
+    );
+}
+
+#[when("I record the hostname mismatch leaf DER")]
+fn record_hostname_mismatch_leaf_der(world: &mut UselessWorld) {
+    let chain = world
+        .x509_chain_hostname_mismatch
+        .as_ref()
+        .expect("x509_chain_hostname_mismatch not set");
+    world.recorded_der = Some(chain.leaf_cert_der().to_vec());
+}
+
+#[then("the hostname mismatch leaf DER should match the recorded one")]
+fn hostname_mismatch_leaf_der_matches_recorded(world: &mut UselessWorld) {
+    let chain = world
+        .x509_chain_hostname_mismatch
+        .as_ref()
+        .expect("x509_chain_hostname_mismatch not set");
+    let recorded = world.recorded_der.as_ref().expect("recorded_der not set");
+    assert_eq!(
+        chain.leaf_cert_der(),
+        recorded.as_slice(),
+        "hostname mismatch leaf DER should match recorded"
+    );
 }
 
 /// Execute the BDD suite from the selected test harness.

--- a/crates/uselesskey-bdd/features/cache_behavior.feature
+++ b/crates/uselesskey-bdd/features/cache_behavior.feature
@@ -1,0 +1,87 @@
+Feature: Cache behavior
+  As a test author
+  I want to verify factory cache hit and miss behavior
+  So that I can rely on correct caching across different seeds, labels, and specs
+
+  # --- Cache hit: same label same spec returns cached value ---
+
+  Scenario: RSA cache hit returns identical key material
+    Given a deterministic factory seeded with "cache-hit-rsa"
+    When I generate an RSA key for label "cached-rsa"
+    And I generate an RSA key for label "cached-rsa" again
+    Then the PKCS8 PEM should be identical
+
+  Scenario: ECDSA cache hit returns identical key material
+    Given a deterministic factory seeded with "cache-hit-ecdsa"
+    When I generate an ECDSA ES256 key for label "cached-ecdsa"
+    And I generate an ECDSA ES256 key for label "cached-ecdsa" again
+    Then the ECDSA PKCS8 PEM should be identical
+
+  # --- Cache miss: different labels get different keys ---
+
+  Scenario: different labels are cache-isolated for RSA
+    Given a deterministic factory seeded with "cache-miss-label-rsa"
+    When I generate an RSA key for label "label-alpha"
+    And I generate another RSA key for label "label-beta"
+    Then the keys should have different moduli
+
+  Scenario: different labels are cache-isolated for ECDSA
+    Given a deterministic factory seeded with "cache-miss-label-ecdsa"
+    When I generate an ECDSA ES256 key for label "label-alpha"
+    And I generate another ECDSA ES256 key for label "label-beta"
+    Then the ECDSA keys should have different public keys
+
+  # --- Cache miss: different specs for same label ---
+
+  Scenario: same label different HMAC specs produce different secrets
+    Given a deterministic factory seeded with "cache-miss-spec-hmac"
+    When I generate an HMAC HS256 secret for label "shared-hmac"
+    And I generate another HMAC HS384 secret for label "shared-hmac"
+    Then the HMAC secrets should be different
+
+  # --- Cache clear then re-derive: determinism preserved ---
+
+  Scenario: cache clear followed by re-derive gives identical RSA key
+    Given a deterministic factory seeded with "cache-clear-rsa"
+    When I generate an RSA key for label "clear-test"
+    And I clear the factory cache
+    And I generate an RSA key for label "clear-test" again
+    Then the PKCS8 PEM should be identical
+
+  Scenario: cache clear followed by re-derive gives identical HMAC secret
+    Given a deterministic factory seeded with "cache-clear-hmac"
+    When I generate an HMAC HS256 secret for label "clear-hmac"
+    And I clear the factory cache
+    And I generate an HMAC HS256 secret for label "clear-hmac" again
+    Then the HMAC secrets should be identical
+
+  Scenario: cache clear followed by re-derive gives identical token
+    Given a deterministic factory seeded with "cache-clear-token"
+    When I generate an API key token for label "clear-token"
+    And I clear the factory cache
+    And I generate an API key token for label "clear-token" again
+    Then the token values should be identical
+
+  # --- New factory instance: cache is empty but determinism holds ---
+
+  Scenario: new factory instance gets cache miss but same deterministic value
+    Given a deterministic factory seeded with "cache-new-factory"
+    When I generate an RSA key for label "new-factory-test"
+    And I switch to a deterministic factory seeded with "cache-new-factory"
+    And I generate an RSA key for label "new-factory-test" again
+    Then the PKCS8 PEM should be identical
+
+  # --- Random mode cache behavior ---
+
+  Scenario: random factory caches within session
+    Given a random factory
+    When I generate an RSA key for label "random-cached"
+    And I generate an RSA key for label "random-cached" again
+    Then the PKCS8 PEM should be identical
+
+  Scenario: random factory cache clear produces different key
+    Given a random factory
+    When I generate an RSA key for label "random-clear"
+    And I clear the factory cache
+    And I generate an RSA key for label "random-clear" again
+    Then the PKCS8 PEM should differ

--- a/crates/uselesskey-bdd/features/cross_adapter.feature
+++ b/crates/uselesskey-bdd/features/cross_adapter.feature
@@ -1,0 +1,76 @@
+Feature: Cross-adapter fixture sharing
+  As a test author
+  I want to verify the same deterministic fixture works across multiple adapter crates
+  So that I can mix and match adapters in the same test suite
+
+  # --- RSA key used in JWT then ring ---
+
+  @jsonwebtoken @ring
+  Scenario: same RSA key signs JWT and ring message
+    Given a deterministic factory seeded with "cross-adapter-rsa"
+    When I generate an RSA key for label "cross-rsa"
+    And I sign a JWT with the RSA key
+    Then the JWT should be valid
+    And the JWT header should have alg "RS256"
+    When I sign a message with the ring RSA key
+    Then the ring RSA signature should verify
+
+  # --- ECDSA key used in JWT then RustCrypto ---
+
+  @jsonwebtoken @rustcrypto
+  Scenario: same ECDSA key signs JWT and RustCrypto message
+    Given a deterministic factory seeded with "cross-adapter-ecdsa"
+    When I generate an ECDSA ES256 key for label "cross-ecdsa"
+    And I sign a JWT with the ECDSA key
+    Then the JWT should be valid
+    And the JWT header should have alg "ES256"
+    When I sign a message with the RustCrypto P-256 key
+    Then the RustCrypto P-256 signature should verify
+
+  # --- Ed25519 key used in JWT then ring ---
+
+  @jsonwebtoken @ring
+  Scenario: same Ed25519 key signs JWT and ring message
+    Given a deterministic factory seeded with "cross-adapter-ed25519"
+    When I generate an Ed25519 key for label "cross-ed25519"
+    And I sign a JWT with the Ed25519 key
+    Then the JWT should be valid
+    And the JWT header should have alg "EdDSA"
+    When I sign a message with the ring Ed25519 key
+    Then the ring Ed25519 signature should verify
+
+  # --- HMAC key used in JWT then RustCrypto ---
+
+  @jsonwebtoken @rustcrypto
+  Scenario: same HMAC key signs JWT and RustCrypto HMAC tag
+    Given a deterministic factory seeded with "cross-adapter-hmac"
+    When I generate an HMAC HS256 secret for label "cross-hmac"
+    And I sign a JWT with the HMAC key
+    Then the JWT should be valid
+    And the JWT header should have alg "HS256"
+    When I compute a RustCrypto HMAC-SHA256 tag
+    Then the RustCrypto HMAC-SHA256 tag should verify
+
+  # --- X.509 chain used in rustls ServerConfig then ClientConfig ---
+
+  @rustls
+  Scenario: same X.509 chain works for rustls server and client config
+    Given a deterministic factory seeded with "cross-adapter-rustls"
+    When I generate a certificate chain for domain "example.com" with label "cross-rustls"
+    And I build a rustls ServerConfig from the chain
+    Then the rustls ServerConfig should be valid
+    When I build a rustls ClientConfig from the chain
+    Then the rustls ClientConfig should be valid
+
+  # --- Deterministic key stability across adapters ---
+
+  @jsonwebtoken @ring
+  Scenario: deterministic RSA key produces same JWT across factory instances
+    Given a deterministic factory seeded with "cross-adapter-det-rsa"
+    When I generate an RSA key for label "det-cross-rsa"
+    And I sign a JWT with the RSA key
+    And I record the JWT token
+    And I switch to a deterministic factory seeded with "cross-adapter-det-rsa"
+    And I generate an RSA key for label "det-cross-rsa"
+    And I sign a JWT with the RSA key
+    Then the JWT token should be identical to the recorded one

--- a/crates/uselesskey-bdd/features/determinism_edge_cases.feature
+++ b/crates/uselesskey-bdd/features/determinism_edge_cases.feature
@@ -1,0 +1,89 @@
+Feature: Determinism edge cases
+  As a test author
+  I want to verify determinism holds under unusual combinations
+  So that I can trust fixture stability across seed, label, and spec permutations
+
+  # --- Same seed, same label, different key types produce different material ---
+
+  Scenario: same seed and label across RSA and Ed25519 produce different kids
+    Given a deterministic factory seeded with "det-edge-type-diff"
+    When I generate an RSA key for label "shared" with spec RS256
+    And I generate an ECDSA ES256 key for label "shared"
+    And I generate an Ed25519 key for label "shared"
+    And I generate an HMAC HS256 secret for label "shared"
+    Then each key should have a unique kid
+
+  # --- Same seed, different labels, same key type ---
+
+  Scenario: same seed different labels produce different Ed25519 keys
+    Given a deterministic factory seeded with "det-edge-label-ed"
+    When I generate an Ed25519 key for label "label-alpha"
+    And I generate another Ed25519 key for label "label-beta"
+    Then the Ed25519 keys should have different public keys
+
+  Scenario: same seed different labels produce different HMAC secrets
+    Given a deterministic factory seeded with "det-edge-label-hmac"
+    When I generate an HMAC HS256 secret for label "label-alpha"
+    And I generate another HMAC HS256 secret for label "label-beta"
+    Then the HMAC secrets should be different
+
+  # --- Deterministic order independence: interleaved generation ---
+
+  Scenario: interleaved key generation preserves determinism
+    Given a deterministic factory seeded with "det-edge-interleave"
+    When I generate an RSA key for label "rsa-first" with spec RS256
+    And I generate an ECDSA ES256 key for label "ecdsa-first"
+    And I generate an HMAC HS256 secret for label "hmac-first"
+    And I generate an Ed25519 key for label "ed-first"
+    And I clear the factory cache
+    And I generate an Ed25519 key for label "ed-first" again
+    Then the Ed25519 PKCS8 PEM should be identical
+
+  Scenario: interleaved generation does not perturb token values
+    Given a deterministic factory seeded with "det-edge-token-interleave"
+    When I generate an API key token for label "token-first"
+    And I generate an RSA key for label "interleave-rsa"
+    And I generate an ECDSA ES256 key for label "interleave-ecdsa"
+    And I clear the factory cache
+    And I generate an API key token for label "token-first" again
+    Then the token values should be identical
+
+  # --- Same label with different variant strings ---
+
+  Scenario: different variants produce different corrupted PEMs
+    Given a deterministic factory seeded with "det-edge-variant-diff"
+    When I generate an RSA key for label "variant-test"
+    And I deterministically corrupt the RSA PKCS8 PEM with variant "alpha"
+    And I deterministically corrupt the RSA PKCS8 PEM with variant "beta" again
+    Then the deterministic text artifacts should differ
+
+  # --- X.509 determinism with same domain different labels ---
+
+  Scenario: same domain different labels produce different X.509 certificates
+    Given a deterministic factory seeded with "det-edge-x509-labels"
+    When I generate an X.509 certificate for domain "shared.example.com" with label "cert-a"
+    And I generate another X.509 certificate for domain "shared.example.com" with label "cert-b"
+    Then the X.509 certificates should have different DER
+
+  # --- Token determinism: same label across all token types ---
+
+  Scenario: same label across API key and bearer produces different values
+    Given a deterministic factory seeded with "det-edge-token-types-ab"
+    When I generate an API key token for label "same-label"
+    And I generate another bearer token for label "same-label"
+    Then the token values should be different
+
+  Scenario: same label across bearer and OAuth produces different values
+    Given a deterministic factory seeded with "det-edge-token-types-bo"
+    When I generate a bearer token for label "same-label"
+    And I generate another OAuth access token for label "same-label"
+    Then the token values should be different
+
+  # --- Factory recreation determinism for X.509 ---
+
+  Scenario: recreating factory with same seed yields identical X.509 certificate
+    Given a deterministic factory seeded with "det-edge-x509-recreate"
+    When I generate an X.509 certificate for domain "test.example.com" with label "stable-cert"
+    And I switch to a deterministic factory seeded with "det-edge-x509-recreate"
+    And I generate an X.509 certificate for domain "test.example.com" with label "stable-cert" again
+    Then the X.509 certificate PEM should be identical

--- a/crates/uselesskey-bdd/features/token_edge_cases.feature
+++ b/crates/uselesskey-bdd/features/token_edge_cases.feature
@@ -1,0 +1,101 @@
+Feature: Token fixture edge cases
+  As a test author
+  I want to verify token fixtures handle edge cases correctly
+  So that tokens are robust across unusual inputs and usage patterns
+
+  # --- Empty and special label edge cases ---
+
+  Scenario: API key with minimal label generates valid token
+    Given a deterministic factory seeded with "token-minimal-label"
+    When I generate an API key token for label "x"
+    Then the token value should start with "uk_test_"
+    And the token value should have length 40
+
+  Scenario: bearer token with minimal label generates valid token
+    Given a deterministic factory seeded with "bearer-minimal-label"
+    When I generate a bearer token for label "x"
+    Then the token value should be valid base64url
+    And the token value should have length 43
+
+  Scenario: OAuth token with minimal label generates valid token
+    Given a deterministic factory seeded with "oauth-minimal-label"
+    When I generate an OAuth access token for label "x"
+    Then the token value should have three dot-separated segments
+    And the token value header should decode to valid JSON
+
+  Scenario: API key with unicode label generates valid token
+    Given a deterministic factory seeded with "token-unicode-label"
+    When I generate an API key token for label "日本語テスト-🔑"
+    Then the token value should start with "uk_test_"
+    And the token value should have length 40
+
+  Scenario: bearer token with very long label generates valid token
+    Given a deterministic factory seeded with "token-long-label"
+    When I generate a bearer token for label "this-is-a-very-long-label-that-exceeds-normal-lengths-for-testing"
+    Then the token value should be valid base64url
+    And the token value should have length 43
+
+  # --- API key format validation ---
+
+  Scenario: API key contains only printable ASCII
+    Given a deterministic factory seeded with "apikey-printable-ascii"
+    When I generate an API key token for label "ascii-check"
+    Then the token value should contain only printable ASCII
+
+  Scenario: API key prefix is consistent across labels
+    Given a deterministic factory seeded with "apikey-prefix-consistency"
+    When I generate an API key token for label "first-service"
+    Then the token value should start with "uk_test_"
+    When I generate an API key token for label "second-service"
+    Then the token value should start with "uk_test_"
+
+  # --- OAuth payload edge cases ---
+
+  Scenario: OAuth access token payload contains exp claim
+    Given a deterministic factory seeded with "oauth-exp-check"
+    When I generate an OAuth access token for label "exp-test"
+    Then the OAuth payload should contain an exp claim
+
+  Scenario: OAuth access token payload contains scope claim
+    Given a deterministic factory seeded with "oauth-scope-check"
+    When I generate an OAuth access token for label "scope-test"
+    Then the OAuth payload should contain a scope claim
+
+  # --- Deterministic recreation across factory instances ---
+
+  Scenario: recreating factory with same seed yields identical API key
+    Given a deterministic factory seeded with "token-recreation-apikey"
+    When I generate an API key token for label "stable-api"
+    And I switch to a deterministic factory seeded with "token-recreation-apikey"
+    And I generate an API key token for label "stable-api" again
+    Then the token values should be identical
+
+  Scenario: recreating factory with same seed yields identical bearer token
+    Given a deterministic factory seeded with "token-recreation-bearer"
+    When I generate a bearer token for label "stable-bearer"
+    And I switch to a deterministic factory seeded with "token-recreation-bearer"
+    And I generate a bearer token for label "stable-bearer" again
+    Then the token values should be identical
+
+  Scenario: recreating factory with same seed yields identical OAuth token
+    Given a deterministic factory seeded with "token-recreation-oauth"
+    When I generate an OAuth access token for label "stable-oauth"
+    And I switch to a deterministic factory seeded with "token-recreation-oauth"
+    And I generate an OAuth access token for label "stable-oauth" again
+    Then the token values should be identical
+
+  # --- Different seeds produce different tokens for bearer and OAuth ---
+
+  Scenario: different seeds produce different bearer tokens
+    Given a deterministic factory seeded with "bearer-seed-one"
+    When I generate a bearer token for label "service"
+    And I switch to a deterministic factory seeded with "bearer-seed-two"
+    And I generate another bearer token for label "service"
+    Then the token values should be different
+
+  Scenario: different seeds produce different OAuth tokens
+    Given a deterministic factory seeded with "oauth-seed-one"
+    When I generate an OAuth access token for label "service"
+    And I switch to a deterministic factory seeded with "oauth-seed-two"
+    And I generate another OAuth access token for label "service"
+    Then the token values should be different

--- a/crates/uselesskey-bdd/features/x509_negative_edge_cases.feature
+++ b/crates/uselesskey-bdd/features/x509_negative_edge_cases.feature
@@ -1,0 +1,94 @@
+Feature: X.509 negative fixture edge cases
+  As a test author
+  I want to verify X.509 negative fixtures cover additional invalid certificate scenarios
+  So that I can test comprehensive certificate validation error paths
+
+  # --- Self-signed expired is deterministic ---
+
+  Scenario: expired self-signed X.509 is deterministic across factory instances
+    Given a deterministic factory seeded with "x509-neg-expired-det"
+    When I generate an X.509 certificate for domain "test.example.com" with label "exp-det"
+    And I get the expired variant of the X.509 certificate
+    And I record the expired X.509 certificate DER
+    And I switch to a deterministic factory seeded with "x509-neg-expired-det"
+    And I generate an X.509 certificate for domain "test.example.com" with label "exp-det"
+    And I get the expired variant of the X.509 certificate
+    Then the expired X.509 certificate DER should match the recorded one
+
+  # --- Not-yet-valid is deterministic ---
+
+  Scenario: not-yet-valid X.509 is deterministic across factory instances
+    Given a deterministic factory seeded with "x509-neg-future-det"
+    When I generate an X.509 certificate for domain "test.example.com" with label "fut-det"
+    And I get the not-yet-valid variant of the X.509 certificate
+    And I record the not-yet-valid X.509 certificate DER
+    And I switch to a deterministic factory seeded with "x509-neg-future-det"
+    And I generate an X.509 certificate for domain "test.example.com" with label "fut-det"
+    And I get the not-yet-valid variant of the X.509 certificate
+    Then the not-yet-valid X.509 certificate DER should match the recorded one
+
+  # --- Wrong key usage is deterministic ---
+
+  Scenario: wrong-key-usage X.509 is deterministic across factory instances
+    Given a deterministic factory seeded with "x509-neg-wku-det"
+    When I generate an X.509 certificate for domain "test.example.com" with label "wku-det"
+    And I get the wrong-key-usage variant of the X.509 certificate
+    And I record the wrong-key-usage X.509 certificate DER
+    And I switch to a deterministic factory seeded with "x509-neg-wku-det"
+    And I generate an X.509 certificate for domain "test.example.com" with label "wku-det"
+    And I get the wrong-key-usage variant of the X.509 certificate
+    Then the wrong-key-usage X.509 certificate DER should match the recorded one
+
+  # --- Multiple negative variants differ from each other ---
+
+  Scenario: expired and not-yet-valid variants differ
+    Given a deterministic factory seeded with "x509-neg-variants-differ"
+    When I generate an X.509 certificate for domain "test.example.com" with label "variant-diff"
+    And I get the expired variant of the X.509 certificate
+    And I record the expired X.509 certificate DER
+    And I get the not-yet-valid variant of the X.509 certificate
+    Then the not-yet-valid X.509 certificate DER should differ from the expired one
+
+  Scenario: expired and wrong-key-usage variants differ
+    Given a deterministic factory seeded with "x509-neg-exp-vs-wku"
+    When I generate an X.509 certificate for domain "test.example.com" with label "exp-wku-diff"
+    And I get the expired variant of the X.509 certificate
+    And I record the expired X.509 certificate DER
+    And I get the wrong-key-usage variant of the X.509 certificate
+    Then the wrong-key-usage X.509 certificate DER should differ from the expired one
+
+  # --- Chain negative variants: unknown CA is deterministic ---
+
+  Scenario: unknown CA chain variant is deterministic
+    Given a deterministic factory seeded with "x509-neg-unknown-ca-det"
+    When I generate a certificate chain for domain "test.example.com" with label "unknown-det"
+    And I get the unknown CA variant of the certificate chain
+    And I record the unknown CA root DER
+    And I switch to a deterministic factory seeded with "x509-neg-unknown-ca-det"
+    And I generate a certificate chain for domain "test.example.com" with label "unknown-det"
+    And I get the unknown CA variant of the certificate chain
+    Then the unknown CA root DER should match the recorded one
+
+  # --- Chain negative variants: revoked is deterministic ---
+
+  Scenario: revoked leaf chain variant is deterministic
+    Given a deterministic factory seeded with "x509-neg-revoked-det"
+    When I generate a certificate chain for domain "test.example.com" with label "revoked-det"
+    And I get the revoked leaf variant of the certificate chain
+    And I record the revoked leaf DER
+    And I switch to a deterministic factory seeded with "x509-neg-revoked-det"
+    And I generate a certificate chain for domain "test.example.com" with label "revoked-det"
+    And I get the revoked leaf variant of the certificate chain
+    Then the revoked leaf DER should match the recorded one
+
+  # --- Chain negative variants: hostname mismatch is deterministic ---
+
+  Scenario: hostname mismatch chain variant is deterministic
+    Given a deterministic factory seeded with "x509-neg-hostname-det"
+    When I generate a certificate chain for domain "test.example.com" with label "hostname-det"
+    And I get the hostname mismatch variant with "wrong.example.com"
+    And I record the hostname mismatch leaf DER
+    And I switch to a deterministic factory seeded with "x509-neg-hostname-det"
+    And I generate a certificate chain for domain "test.example.com" with label "hostname-det"
+    And I get the hostname mismatch variant with "wrong.example.com"
+    Then the hostname mismatch leaf DER should match the recorded one


### PR DESCRIPTION
## Wave 82: Expand BDD scenarios for under-covered features

### Summary
Add **49 new BDD scenarios** across **5 new feature files** covering under-tested areas:

| Feature File | Scenarios | Coverage Area |
|---|---|---|
| \	oken_edge_cases.feature\ | 14 | Minimal/unicode/long labels, ASCII validation, OAuth claims, factory recreation, seed isolation |
| \x509_negative_edge_cases.feature\ | 8 | Expired/not-yet-valid/wrong-key-usage determinism, variant differentiation, chain negative variants |
| \cache_behavior.feature\ | 11 | Cache hit/miss for RSA/ECDSA/HMAC, spec isolation, cache clear, random mode |
| \cross_adapter.feature\ | 6 | JWT+ring, JWT+RustCrypto, rustls server+client, deterministic JWT stability |
| \determinism_edge_cases.feature\ | 10 | Cross-type kid uniqueness, interleaved generation, variant differences, token type isolation |

### Step definitions added
- HMAC HS256 second-label generation (\gen_hmac_hs256_second\)
- Token printable ASCII validation
- OAuth payload claim assertions (exp, scope)
- PKCS8 PEM differ check (for random-mode cache clear)
- X.509/chain DER recording and comparison (12 steps)

### Test results
- **394 scenarios** (345 existing + 49 new), **1905 steps** — all passing
- No existing tests broken
- No Cargo.toml or feature flag changes

### Determinism / policy impact
- No derivation algorithm changes
- No new dependencies
- No secret material in feature files