### PR TITLE
test: harden mutation test coverage

### DIFF
--- a/crates/uselesskey-ecdsa/tests/mutation_hardening.rs
+++ b/crates/uselesskey-ecdsa/tests/mutation_hardening.rs
@@ -1,0 +1,258 @@
+//! Mutation-hardening tests for uselesskey-ecdsa JWK methods.
+//!
+//! Targets surviving mutants in `EcdsaKeyPair::kid()`, `public_key_jwk()`,
+//! `public_jwk()`, `private_key_jwk()`, `public_jwks()`, JSON helpers,
+//! and arithmetic mutations in EC coordinate slicing.
+
+#[allow(dead_code)]
+mod testutil;
+
+#[cfg(feature = "jwk")]
+mod jwk_mutation_hardening {
+    use crate::testutil::fx;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    // ── kid() must return non-empty, non-trivial string ──────────────────
+
+    #[test]
+    fn kid_is_non_empty_and_non_trivial_es256() {
+        let fx = fx();
+        let kp = fx.ecdsa("kid-mut-256", EcdsaSpec::es256());
+        let kid = kp.kid();
+        assert!(!kid.is_empty(), "kid must not be empty");
+        assert_ne!(kid, "xyzzy", "kid must not be trivial placeholder");
+    }
+
+    #[test]
+    fn kid_is_non_empty_and_non_trivial_es384() {
+        let fx = fx();
+        let kp = fx.ecdsa("kid-mut-384", EcdsaSpec::es384());
+        let kid = kp.kid();
+        assert!(!kid.is_empty());
+        assert_ne!(kid, "xyzzy");
+    }
+
+    #[test]
+    fn kid_is_deterministic() {
+        let fx = fx();
+        let k1 = fx.ecdsa("kid-det", EcdsaSpec::es256());
+        let k2 = fx.ecdsa("kid-det", EcdsaSpec::es256());
+        assert_eq!(k1.kid(), k2.kid());
+    }
+
+    // ── public_key_jwk() alias must match public_jwk() ─────────────────
+
+    #[test]
+    fn public_key_jwk_matches_public_jwk() {
+        let fx = fx();
+        for spec in [EcdsaSpec::es256(), EcdsaSpec::es384()] {
+            let kp = fx.ecdsa("alias-mut", spec);
+            assert_eq!(
+                kp.public_key_jwk().to_value(),
+                kp.public_jwk().to_value(),
+                "alias must match for {spec:?}"
+            );
+        }
+    }
+
+    // ── public_jwk() must return well-formed EC JWK with correct coords ─
+
+    #[test]
+    fn public_jwk_has_expected_fields_es256() {
+        let fx = fx();
+        let kp = fx.ecdsa("pub-jwk-256", EcdsaSpec::es256());
+        let jwk = kp.public_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "EC");
+        assert_eq!(jwk["crv"], "P-256");
+        assert_eq!(jwk["use"], "sig");
+        assert_eq!(jwk["alg"], "ES256");
+        assert!(jwk["kid"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(jwk["x"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(jwk["y"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    #[test]
+    fn public_jwk_has_expected_fields_es384() {
+        let fx = fx();
+        let kp = fx.ecdsa("pub-jwk-384", EcdsaSpec::es384());
+        let jwk = kp.public_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "EC");
+        assert_eq!(jwk["crv"], "P-384");
+        assert_eq!(jwk["alg"], "ES384");
+        assert!(jwk["x"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(jwk["y"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    // ── Coordinate lengths must match curve size (kills arithmetic mutants) ─
+
+    #[test]
+    fn public_jwk_x_y_decode_to_32_bytes_for_p256() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = fx();
+        let kp = fx.ecdsa("coord-p256", EcdsaSpec::es256());
+        let jwk = kp.public_jwk().to_value();
+        let x = URL_SAFE_NO_PAD.decode(jwk["x"].as_str().unwrap()).unwrap();
+        let y = URL_SAFE_NO_PAD.decode(jwk["y"].as_str().unwrap()).unwrap();
+        assert_eq!(x.len(), 32, "P-256 x coordinate must be 32 bytes");
+        assert_eq!(y.len(), 32, "P-256 y coordinate must be 32 bytes");
+    }
+
+    #[test]
+    fn public_jwk_x_y_decode_to_48_bytes_for_p384() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = fx();
+        let kp = fx.ecdsa("coord-p384", EcdsaSpec::es384());
+        let jwk = kp.public_jwk().to_value();
+        let x = URL_SAFE_NO_PAD.decode(jwk["x"].as_str().unwrap()).unwrap();
+        let y = URL_SAFE_NO_PAD.decode(jwk["y"].as_str().unwrap()).unwrap();
+        assert_eq!(x.len(), 48, "P-384 x coordinate must be 48 bytes");
+        assert_eq!(y.len(), 48, "P-384 y coordinate must be 48 bytes");
+    }
+
+    // ── x and y must differ (catches swapped/duplicated slicing) ────────
+
+    #[test]
+    fn public_jwk_x_and_y_differ() {
+        let fx = fx();
+        for spec in [EcdsaSpec::es256(), EcdsaSpec::es384()] {
+            let kp = fx.ecdsa("xy-diff", spec);
+            let jwk = kp.public_jwk().to_value();
+            assert_ne!(
+                jwk["x"].as_str().unwrap(),
+                jwk["y"].as_str().unwrap(),
+                "x and y must differ for {spec:?}"
+            );
+        }
+    }
+
+    // ── private_key_jwk() must have d field with correct coords ─────────
+
+    #[test]
+    fn private_key_jwk_has_d_and_coords_es256() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = fx();
+        let kp = fx.ecdsa("priv-jwk-256", EcdsaSpec::es256());
+        let jwk = kp.private_key_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "EC");
+        assert_eq!(jwk["crv"], "P-256");
+        assert_eq!(jwk["alg"], "ES256");
+        assert!(jwk["d"].as_str().is_some_and(|s| !s.is_empty()));
+
+        let x = URL_SAFE_NO_PAD.decode(jwk["x"].as_str().unwrap()).unwrap();
+        let y = URL_SAFE_NO_PAD.decode(jwk["y"].as_str().unwrap()).unwrap();
+        assert_eq!(x.len(), 32);
+        assert_eq!(y.len(), 32);
+        assert_ne!(
+            jwk["x"].as_str().unwrap(),
+            jwk["y"].as_str().unwrap(),
+            "private JWK x and y must differ"
+        );
+    }
+
+    #[test]
+    fn private_key_jwk_has_d_and_coords_es384() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = fx();
+        let kp = fx.ecdsa("priv-jwk-384", EcdsaSpec::es384());
+        let jwk = kp.private_key_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "EC");
+        assert_eq!(jwk["crv"], "P-384");
+        assert_eq!(jwk["alg"], "ES384");
+
+        let x = URL_SAFE_NO_PAD.decode(jwk["x"].as_str().unwrap()).unwrap();
+        let y = URL_SAFE_NO_PAD.decode(jwk["y"].as_str().unwrap()).unwrap();
+        let d = URL_SAFE_NO_PAD.decode(jwk["d"].as_str().unwrap()).unwrap();
+        assert_eq!(x.len(), 48);
+        assert_eq!(y.len(), 48);
+        assert_eq!(d.len(), 48);
+        assert_ne!(
+            jwk["x"].as_str().unwrap(),
+            jwk["y"].as_str().unwrap(),
+            "private JWK x and y must differ"
+        );
+    }
+
+    // ── public_jwks() must wrap a single public key ─────────────────────
+
+    #[test]
+    fn public_jwks_contains_one_ec_key() {
+        let fx = fx();
+        for (spec, crv) in [(EcdsaSpec::es256(), "P-256"), (EcdsaSpec::es384(), "P-384")] {
+            let kp = fx.ecdsa("jwks-mut", spec);
+            let jwks = kp.public_jwks().to_value();
+            let keys = jwks["keys"].as_array().expect("keys array");
+            assert_eq!(keys.len(), 1, "jwks must have one key for {spec:?}");
+            assert_eq!(keys[0]["kty"], "EC");
+            assert_eq!(keys[0]["crv"], crv);
+        }
+    }
+
+    // ── JSON helpers must return non-null, non-empty objects ─────────────
+
+    #[test]
+    fn public_jwk_json_has_kty() {
+        let fx = fx();
+        for spec in [EcdsaSpec::es256(), EcdsaSpec::es384()] {
+            let kp = fx.ecdsa("pub-json", spec);
+            let val = kp.public_jwk_json();
+            assert_eq!(
+                val["kty"], "EC",
+                "public_jwk_json must have kty for {spec:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn public_jwks_json_has_keys_array() {
+        let fx = fx();
+        for spec in [EcdsaSpec::es256(), EcdsaSpec::es384()] {
+            let kp = fx.ecdsa("jwks-json", spec);
+            let val = kp.public_jwks_json();
+            assert!(
+                val["keys"].as_array().is_some_and(|a| !a.is_empty()),
+                "public_jwks_json must have keys for {spec:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn private_key_jwk_json_has_d_field() {
+        let fx = fx();
+        for spec in [EcdsaSpec::es256(), EcdsaSpec::es384()] {
+            let kp = fx.ecdsa("priv-json", spec);
+            let val = kp.private_key_jwk_json();
+            assert!(
+                val["d"].as_str().is_some_and(|s| !s.is_empty()),
+                "private_key_jwk_json must have d for {spec:?}"
+            );
+        }
+    }
+
+    // ── kid embedded in JWKs matches standalone kid() ───────────────────
+
+    #[test]
+    fn jwk_kid_matches_standalone_kid() {
+        let fx = fx();
+        for spec in [EcdsaSpec::es256(), EcdsaSpec::es384()] {
+            let kp = fx.ecdsa("kid-embed", spec);
+            let jwk = kp.public_jwk().to_value();
+            assert_eq!(
+                jwk["kid"].as_str().unwrap(),
+                kp.kid(),
+                "JWK kid must match standalone kid for {spec:?}"
+            );
+        }
+    }
+}

--- a/crates/uselesskey-ed25519/tests/mutation_hardening.rs
+++ b/crates/uselesskey-ed25519/tests/mutation_hardening.rs
@@ -1,0 +1,153 @@
+//! Mutation-hardening tests for uselesskey-ed25519 JWK methods.
+//!
+//! Targets surviving mutants in `Ed25519KeyPair::kid()`, `public_key_jwk()`,
+//! `public_jwk()`, `private_key_jwk()`, `public_jwks()`, and the JSON helpers.
+
+#[allow(dead_code)]
+mod testutil;
+
+#[cfg(feature = "jwk")]
+mod jwk_mutation_hardening {
+    use crate::testutil::fx;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    // ── kid() must return non-empty, non-trivial string ──────────────────
+
+    #[test]
+    fn kid_is_non_empty_and_non_trivial() {
+        let fx = fx();
+        let kp = fx.ed25519("kid-mut", Ed25519Spec::new());
+        let kid = kp.kid();
+        assert!(!kid.is_empty(), "kid must not be empty");
+        assert_ne!(kid, "xyzzy", "kid must not be trivial placeholder");
+    }
+
+    #[test]
+    fn kid_is_deterministic() {
+        let fx = fx();
+        let k1 = fx.ed25519("kid-det", Ed25519Spec::new());
+        let k2 = fx.ed25519("kid-det", Ed25519Spec::new());
+        assert_eq!(k1.kid(), k2.kid());
+    }
+
+    // ── public_key_jwk() alias must match public_jwk() ─────────────────
+
+    #[test]
+    fn public_key_jwk_matches_public_jwk() {
+        let fx = fx();
+        let kp = fx.ed25519("alias-mut", Ed25519Spec::new());
+        assert_eq!(kp.public_key_jwk().to_value(), kp.public_jwk().to_value());
+    }
+
+    // ── public_jwk() must return well-formed OKP JWK ────────────────────
+
+    #[test]
+    fn public_jwk_has_expected_fields() {
+        let fx = fx();
+        let kp = fx.ed25519("pub-jwk-mut", Ed25519Spec::new());
+        let jwk = kp.public_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "OKP");
+        assert_eq!(jwk["crv"], "Ed25519");
+        assert_eq!(jwk["use"], "sig");
+        assert_eq!(jwk["alg"], "EdDSA");
+        assert!(jwk["kid"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(jwk["x"].as_str().is_some_and(|s| !s.is_empty()));
+        // Public JWK must NOT have "d"
+        assert!(jwk.get("d").is_none(), "public JWK must not contain d");
+    }
+
+    #[test]
+    fn public_jwk_x_decodes_to_32_bytes() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = fx();
+        let kp = fx.ed25519("pub-x-len", Ed25519Spec::new());
+        let jwk = kp.public_jwk().to_value();
+        let x = URL_SAFE_NO_PAD
+            .decode(jwk["x"].as_str().unwrap())
+            .expect("valid base64url");
+        assert_eq!(x.len(), 32, "Ed25519 public key x must be 32 bytes");
+    }
+
+    // ── private_key_jwk() must return well-formed OKP private JWK ───────
+
+    #[test]
+    fn private_key_jwk_has_expected_fields() {
+        let fx = fx();
+        let kp = fx.ed25519("priv-jwk-mut", Ed25519Spec::new());
+        let jwk = kp.private_key_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "OKP");
+        assert_eq!(jwk["crv"], "Ed25519");
+        assert_eq!(jwk["use"], "sig");
+        assert_eq!(jwk["alg"], "EdDSA");
+        assert!(jwk["kid"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(jwk["x"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(jwk["d"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    #[test]
+    fn private_key_jwk_d_decodes_to_32_bytes() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+
+        let fx = fx();
+        let kp = fx.ed25519("priv-d-len", Ed25519Spec::new());
+        let jwk = kp.private_key_jwk().to_value();
+        let d = URL_SAFE_NO_PAD
+            .decode(jwk["d"].as_str().unwrap())
+            .expect("valid base64url");
+        assert_eq!(d.len(), 32, "Ed25519 private key d must be 32 bytes");
+    }
+
+    // ── public_jwks() must wrap a single public key ─────────────────────
+
+    #[test]
+    fn public_jwks_contains_one_okp_key() {
+        let fx = fx();
+        let kp = fx.ed25519("jwks-mut", Ed25519Spec::new());
+        let jwks = kp.public_jwks().to_value();
+        let keys = jwks["keys"].as_array().expect("keys array");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0]["kty"], "OKP");
+        assert_eq!(keys[0]["crv"], "Ed25519");
+    }
+
+    // ── JSON helpers must return non-null, non-empty objects ─────────────
+
+    #[test]
+    fn public_jwk_json_has_kty() {
+        let fx = fx();
+        let kp = fx.ed25519("pub-json-mut", Ed25519Spec::new());
+        let val = kp.public_jwk_json();
+        assert_eq!(val["kty"], "OKP");
+    }
+
+    #[test]
+    fn public_jwks_json_has_keys_array() {
+        let fx = fx();
+        let kp = fx.ed25519("jwks-json-mut", Ed25519Spec::new());
+        let val = kp.public_jwks_json();
+        assert!(val["keys"].as_array().is_some_and(|a| !a.is_empty()));
+    }
+
+    #[test]
+    fn private_key_jwk_json_has_d_field() {
+        let fx = fx();
+        let kp = fx.ed25519("priv-json-mut", Ed25519Spec::new());
+        let val = kp.private_key_jwk_json();
+        assert!(val["d"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    // ── kid embedded in JWKs matches standalone kid() ───────────────────
+
+    #[test]
+    fn jwk_kid_matches_standalone_kid() {
+        let fx = fx();
+        let kp = fx.ed25519("kid-embed", Ed25519Spec::new());
+        let jwk = kp.public_jwk().to_value();
+        assert_eq!(jwk["kid"].as_str().unwrap(), kp.kid());
+    }
+}

--- a/crates/uselesskey-hmac/tests/mutation_hardening.rs
+++ b/crates/uselesskey-hmac/tests/mutation_hardening.rs
@@ -1,0 +1,103 @@
+//! Mutation-hardening tests for uselesskey-hmac JWK methods.
+//!
+//! These tests target surviving mutants in `HmacSecret::kid()`, `jwk()`, and `jwks()`.
+//! Each test asserts concrete field values so that replacing the return with
+//! `Default::default()`, `String::new()`, or `"xyzzy"` will fail.
+
+#[allow(dead_code)]
+mod testutil;
+
+#[cfg(feature = "jwk")]
+mod jwk_mutation_hardening {
+    use crate::testutil::fx;
+    use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+
+    // ── kid() must return non-empty, non-trivial string ──────────────────
+
+    #[test]
+    fn kid_is_non_empty_and_non_trivial() {
+        let fx = fx();
+        for spec in [HmacSpec::hs256(), HmacSpec::hs384(), HmacSpec::hs512()] {
+            let secret = fx.hmac("kid-mut", spec);
+            let kid = secret.kid();
+            assert!(!kid.is_empty(), "kid must not be empty for {spec:?}");
+            assert_ne!(kid, "xyzzy", "kid must not be trivial for {spec:?}");
+        }
+    }
+
+    #[test]
+    fn kid_is_deterministic() {
+        let fx = fx();
+        let s1 = fx.hmac("kid-det", HmacSpec::hs256());
+        let s2 = fx.hmac("kid-det", HmacSpec::hs256());
+        assert_eq!(s1.kid(), s2.kid());
+    }
+
+    // ── jwk() must return well-formed octet JWK ─────────────────────────
+
+    #[test]
+    fn jwk_has_expected_fields_hs256() {
+        let fx = fx();
+        let secret = fx.hmac("jwk-mut-256", HmacSpec::hs256());
+        let jwk = secret.jwk().to_value();
+
+        assert_eq!(jwk["kty"], "oct");
+        assert_eq!(jwk["use"], "sig");
+        assert_eq!(jwk["alg"], "HS256");
+        assert!(jwk["kid"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(jwk["k"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    #[test]
+    fn jwk_has_expected_fields_hs384() {
+        let fx = fx();
+        let secret = fx.hmac("jwk-mut-384", HmacSpec::hs384());
+        let jwk = secret.jwk().to_value();
+
+        assert_eq!(jwk["kty"], "oct");
+        assert_eq!(jwk["alg"], "HS384");
+        assert!(jwk["k"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    #[test]
+    fn jwk_has_expected_fields_hs512() {
+        let fx = fx();
+        let secret = fx.hmac("jwk-mut-512", HmacSpec::hs512());
+        let jwk = secret.jwk().to_value();
+
+        assert_eq!(jwk["kty"], "oct");
+        assert_eq!(jwk["alg"], "HS512");
+        assert!(jwk["k"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    // ── jwks() must wrap a single key ───────────────────────────────────
+
+    #[test]
+    fn jwks_contains_one_key_with_correct_alg() {
+        let fx = fx();
+        for (spec, expected_alg) in [
+            (HmacSpec::hs256(), "HS256"),
+            (HmacSpec::hs384(), "HS384"),
+            (HmacSpec::hs512(), "HS512"),
+        ] {
+            let secret = fx.hmac("jwks-mut", spec);
+            let jwks = secret.jwks().to_value();
+            let keys = jwks["keys"].as_array().expect("keys array");
+            assert_eq!(keys.len(), 1, "jwks should have one key for {spec:?}");
+            assert_eq!(
+                keys[0]["alg"], expected_alg,
+                "wrong alg in jwks for {spec:?}"
+            );
+        }
+    }
+
+    // ── kid embedded in jwk matches standalone kid() ────────────────────
+
+    #[test]
+    fn jwk_kid_matches_standalone_kid() {
+        let fx = fx();
+        let secret = fx.hmac("kid-embed", HmacSpec::hs256());
+        let jwk = secret.jwk().to_value();
+        assert_eq!(jwk["kid"].as_str().unwrap(), secret.kid());
+    }
+}

--- a/crates/uselesskey-rsa/tests/mutation_hardening.rs
+++ b/crates/uselesskey-rsa/tests/mutation_hardening.rs
@@ -1,0 +1,181 @@
+//! Mutation-hardening tests for uselesskey-rsa JWK methods.
+//!
+//! Targets surviving mutants in `RsaKeyPair::jwk_alg()`, `kid()`,
+//! `public_key_jwk()`, `public_jwk()`, `private_key_jwk()`, `public_jwks()`,
+//! and the JSON helpers.
+
+#[allow(dead_code)]
+mod testutil;
+
+#[cfg(feature = "jwk")]
+mod jwk_mutation_hardening {
+    use crate::testutil::fx;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    // ── jwk_alg() match arms: each bit size must map correctly ──────────
+
+    #[test]
+    fn jwk_alg_rs256_for_2048() {
+        let fx = fx();
+        let kp = fx.rsa("alg-2048", RsaSpec::new(2048));
+        let jwk = kp.public_jwk().to_value();
+        assert_eq!(jwk["alg"], "RS256", "2048-bit RSA must use RS256");
+    }
+
+    #[test]
+    fn jwk_alg_rs384_for_3072() {
+        let fx = fx();
+        let kp = fx.rsa("alg-3072", RsaSpec::new(3072));
+        let jwk = kp.public_jwk().to_value();
+        assert_eq!(jwk["alg"], "RS384", "3072-bit RSA must use RS384");
+    }
+
+    #[test]
+    fn jwk_alg_rs512_for_4096() {
+        let fx = fx();
+        let kp = fx.rsa("alg-4096", RsaSpec::new(4096));
+        let jwk = kp.public_jwk().to_value();
+        assert_eq!(jwk["alg"], "RS512", "4096-bit RSA must use RS512");
+    }
+
+    #[test]
+    fn jwk_alg_values_are_all_distinct() {
+        let fx = fx();
+        let alg_2048 = fx
+            .rsa("alg-dist-2048", RsaSpec::new(2048))
+            .public_jwk()
+            .to_value()["alg"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let alg_3072 = fx
+            .rsa("alg-dist-3072", RsaSpec::new(3072))
+            .public_jwk()
+            .to_value()["alg"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let alg_4096 = fx
+            .rsa("alg-dist-4096", RsaSpec::new(4096))
+            .public_jwk()
+            .to_value()["alg"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        assert_ne!(alg_2048, alg_3072, "2048 and 3072 alg must differ");
+        assert_ne!(alg_2048, alg_4096, "2048 and 4096 alg must differ");
+        assert_ne!(alg_3072, alg_4096, "3072 and 4096 alg must differ");
+    }
+
+    // ── kid() must return non-empty, non-trivial string ─────────────────
+
+    #[test]
+    fn kid_is_non_empty_and_non_trivial() {
+        let fx = fx();
+        let kp = fx.rsa("kid-mut", RsaSpec::rs256());
+        let kid = kp.kid();
+        assert!(!kid.is_empty(), "kid must not be empty");
+        assert_ne!(kid, "xyzzy", "kid must not be trivial placeholder");
+    }
+
+    #[test]
+    fn kid_is_deterministic() {
+        let fx = fx();
+        let k1 = fx.rsa("kid-det", RsaSpec::rs256());
+        let k2 = fx.rsa("kid-det", RsaSpec::rs256());
+        assert_eq!(k1.kid(), k2.kid());
+    }
+
+    // ── public_key_jwk() alias must match public_jwk() ─────────────────
+
+    #[test]
+    fn public_key_jwk_matches_public_jwk() {
+        let fx = fx();
+        let kp = fx.rsa("alias-mut", RsaSpec::rs256());
+        assert_eq!(kp.public_key_jwk().to_value(), kp.public_jwk().to_value());
+    }
+
+    // ── public_jwk() must return well-formed RSA JWK ────────────────────
+
+    #[test]
+    fn public_jwk_has_expected_fields() {
+        let fx = fx();
+        let kp = fx.rsa("pub-jwk-mut", RsaSpec::rs256());
+        let jwk = kp.public_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "RSA");
+        assert_eq!(jwk["use"], "sig");
+        assert_eq!(jwk["alg"], "RS256");
+        assert!(jwk["kid"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(jwk["n"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(jwk["e"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    // ── private_key_jwk() must have all RSA CRT fields ──────────────────
+
+    #[test]
+    fn private_key_jwk_has_all_crt_fields() {
+        let fx = fx();
+        let kp = fx.rsa("priv-jwk-mut", RsaSpec::rs256());
+        let jwk = kp.private_key_jwk().to_value();
+
+        assert_eq!(jwk["kty"], "RSA");
+        assert_eq!(jwk["use"], "sig");
+        assert_eq!(jwk["alg"], "RS256");
+        for field in ["n", "e", "d", "p", "q", "dp", "dq", "qi"] {
+            assert!(
+                jwk[field].as_str().is_some_and(|s| !s.is_empty()),
+                "Missing or empty field: {field}"
+            );
+        }
+    }
+
+    // ── public_jwks() must wrap a single public key ─────────────────────
+
+    #[test]
+    fn public_jwks_contains_one_rsa_key() {
+        let fx = fx();
+        let kp = fx.rsa("jwks-mut", RsaSpec::rs256());
+        let jwks = kp.public_jwks().to_value();
+        let keys = jwks["keys"].as_array().expect("keys array");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0]["kty"], "RSA");
+    }
+
+    // ── JSON helpers must return non-null, non-empty objects ─────────────
+
+    #[test]
+    fn public_jwk_json_has_kty() {
+        let fx = fx();
+        let kp = fx.rsa("pub-json-mut", RsaSpec::rs256());
+        let val = kp.public_jwk_json();
+        assert_eq!(val["kty"], "RSA");
+    }
+
+    #[test]
+    fn public_jwks_json_has_keys_array() {
+        let fx = fx();
+        let kp = fx.rsa("jwks-json-mut", RsaSpec::rs256());
+        let val = kp.public_jwks_json();
+        assert!(val["keys"].as_array().is_some_and(|a| !a.is_empty()));
+    }
+
+    #[test]
+    fn private_key_jwk_json_has_d_field() {
+        let fx = fx();
+        let kp = fx.rsa("priv-json-mut", RsaSpec::rs256());
+        let val = kp.private_key_jwk_json();
+        assert!(val["d"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+
+    // ── kid embedded in JWKs matches standalone kid() ───────────────────
+
+    #[test]
+    fn jwk_kid_matches_standalone_kid() {
+        let fx = fx();
+        let kp = fx.rsa("kid-embed", RsaSpec::rs256());
+        let jwk = kp.public_jwk().to_value();
+        assert_eq!(jwk["kid"].as_str().unwrap(), kp.kid());
+    }
+}


### PR DESCRIPTION
## Summary

Add targeted tests to kill 43 surviving mutants across 4 crates, improving mutation test coverage for JWK-related methods.

### Surviving mutants killed

| Crate | Mutants killed | Categories |
|-------|---------------|------------|
| uselesskey-rsa | 13 | jwk_alg match arms, kid(), public/private JWK, JWKS, JSON helpers |
| uselesskey-ecdsa | 17 | kid(), EC coordinate arithmetic, public/private JWK, JWKS, JSON helpers |
| uselesskey-ed25519 | 9 | kid(), public/private JWK, JWKS, JSON helpers |
| uselesskey-hmac | 4 | kid(), jwk(), jwks() |

### Approach

Each test asserts concrete field values (kty, alg, crv, coordinate lengths, kid non-emptiness) so that replacing return values with Default::default(), String::new(), or arithmetic operator swaps will cause test failures.

### What changed
- New mutation_hardening.rs test files in 4 crates

### Determinism impact: none
### Policy impact: none

### Risks
- None; test-only changes with no library code modifications

### Recommended triage: A
