### PR TITLE
test: add new fuzz targets for parsing paths

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -122,6 +122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +554,32 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -978,6 +1010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1109,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -1238,6 +1288,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "uselesskey-core-base62"
+version = "0.3.0"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "uselesskey-core-cache"
 version = "0.3.0"
 dependencies = [
@@ -1262,6 +1319,10 @@ version = "0.3.0"
 dependencies = [
  "blake3",
 ]
+
+[[package]]
+name = "uselesskey-core-hmac-spec"
+version = "0.3.0"
 
 [[package]]
 name = "uselesskey-core-id"
@@ -1320,8 +1381,15 @@ dependencies = [
 name = "uselesskey-core-negative"
 version = "0.3.0"
 dependencies = [
- "uselesskey-core-hash",
+ "uselesskey-core-negative-der",
  "uselesskey-core-negative-pem",
+]
+
+[[package]]
+name = "uselesskey-core-negative-der"
+version = "0.3.0"
+dependencies = [
+ "uselesskey-core-hash",
 ]
 
 [[package]]
@@ -1329,6 +1397,16 @@ name = "uselesskey-core-negative-pem"
 version = "0.3.0"
 dependencies = [
  "uselesskey-core-hash",
+]
+
+[[package]]
+name = "uselesskey-core-rustls-pki"
+version = "0.3.0"
+dependencies = [
+ "rustls-pki-types",
+ "uselesskey-ecdsa",
+ "uselesskey-ed25519",
+ "uselesskey-x509",
 ]
 
 [[package]]
@@ -1359,6 +1437,7 @@ dependencies = [
  "base64",
  "rand_core",
  "serde_json",
+ "uselesskey-core-base62",
 ]
 
 [[package]]
@@ -1367,6 +1446,13 @@ version = "0.3.0"
 dependencies = [
  "uselesskey-core-x509-derive",
  "uselesskey-core-x509-negative",
+ "uselesskey-core-x509-spec",
+]
+
+[[package]]
+name = "uselesskey-core-x509-chain-negative"
+version = "0.3.0"
+dependencies = [
  "uselesskey-core-x509-spec",
 ]
 
@@ -1384,6 +1470,7 @@ dependencies = [
 name = "uselesskey-core-x509-negative"
 version = "0.3.0"
 dependencies = [
+ "uselesskey-core-x509-chain-negative",
  "uselesskey-core-x509-spec",
 ]
 
@@ -1425,7 +1512,9 @@ dependencies = [
  "p256",
  "rand_chacha",
  "rand_core",
+ "ring",
  "rsa",
+ "rustls-pki-types",
  "serde_json",
  "uselesskey",
  "uselesskey-core-factory",
@@ -1441,7 +1530,10 @@ dependencies = [
  "uselesskey-ecdsa",
  "uselesskey-ed25519",
  "uselesskey-hmac",
+ "uselesskey-jsonwebtoken",
  "uselesskey-jwk",
+ "uselesskey-ring",
+ "uselesskey-rustls",
  "uselesskey-x509",
 ]
 
@@ -1451,7 +1543,18 @@ version = "0.3.0"
 dependencies = [
  "rand_core",
  "uselesskey-core",
+ "uselesskey-core-hmac-spec",
  "uselesskey-core-kid",
+]
+
+[[package]]
+name = "uselesskey-jsonwebtoken"
+version = "0.3.0"
+dependencies = [
+ "jsonwebtoken",
+ "uselesskey-ecdsa",
+ "uselesskey-ed25519",
+ "uselesskey-hmac",
 ]
 
 [[package]]
@@ -1460,6 +1563,15 @@ version = "0.3.0"
 dependencies = [
  "uselesskey-core-jwk",
  "uselesskey-core-jwk-builder",
+]
+
+[[package]]
+name = "uselesskey-ring"
+version = "0.3.0"
+dependencies = [
+ "ring",
+ "uselesskey-ecdsa",
+ "uselesskey-ed25519",
 ]
 
 [[package]]
@@ -1475,12 +1587,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "uselesskey-rustls"
+version = "0.3.0"
+dependencies = [
+ "uselesskey-core-rustls-pki",
+ "uselesskey-ecdsa",
+ "uselesskey-ed25519",
+ "uselesskey-x509",
+]
+
+[[package]]
 name = "uselesskey-token"
 version = "0.3.0"
 dependencies = [
  "uselesskey-core",
  "uselesskey-core-token",
+ "uselesskey-token-spec",
 ]
+
+[[package]]
+name = "uselesskey-token-spec"
+version = "0.3.0"
 
 [[package]]
 name = "uselesskey-x509"
@@ -1526,6 +1653,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,6 +31,11 @@ uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa" }
 uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519" }
 uselesskey-hmac = { path = "../crates/uselesskey-hmac" }
 uselesskey-x509 = { path = "../crates/uselesskey-x509" }
+uselesskey-jsonwebtoken = { path = "../crates/uselesskey-jsonwebtoken", features = ["ecdsa", "ed25519", "hmac"] }
+uselesskey-ring = { path = "../crates/uselesskey-ring", features = ["ecdsa", "ed25519"] }
+uselesskey-rustls = { path = "../crates/uselesskey-rustls", features = ["x509", "ecdsa", "ed25519"] }
+rustls-pki-types = "1"
+ring = "0.17"
 rsa = { version = "0.9", features = ["pem"] }
 p256 = { version = "0.13", features = ["ecdsa", "pkcs8", "pem"] }
 ed25519-dalek = { version = "2", features = ["pkcs8"] }
@@ -207,5 +212,41 @@ doc = false
 [[bin]]
 name = "fuzz_token_generation"
 path = "fuzz_targets/fuzz_token_generation.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "adapter_jsonwebtoken_roundtrip"
+path = "fuzz_targets/adapter_jsonwebtoken_roundtrip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "adapter_ring_roundtrip"
+path = "fuzz_targets/adapter_ring_roundtrip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "adapter_rustls_roundtrip"
+path = "fuzz_targets/adapter_rustls_roundtrip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "x509_chain_build"
+path = "fuzz_targets/x509_chain_build.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "factory_concurrent_access"
+path = "fuzz_targets/factory_concurrent_access.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "jwks_builder_ordering"
+path = "fuzz_targets/jwks_builder_ordering.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/adapter_jsonwebtoken_roundtrip.rs
+++ b/fuzz/fuzz_targets/adapter_jsonwebtoken_roundtrip.rs
@@ -1,0 +1,68 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{
+    EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, HmacFactoryExt,
+    HmacSpec, Seed,
+};
+use uselesskey_jsonwebtoken::JwtKeyExt;
+
+#[derive(Arbitrary, Debug)]
+enum KeyChoice {
+    EcdsaEs256,
+    EcdsaEs384,
+    Ed25519,
+    HmacHs256,
+    HmacHs384,
+    HmacHs512,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    seed: [u8; 32],
+    label: String,
+    key_choice: KeyChoice,
+}
+
+fuzz_target!(|input: Input| {
+    if input.label.len() > 256 {
+        return;
+    }
+
+    let fx = Factory::deterministic(Seed::new(input.seed));
+
+    match input.key_choice {
+        KeyChoice::EcdsaEs256 => {
+            let kp = fx.ecdsa(&input.label, EcdsaSpec::es256());
+            let _enc = kp.encoding_key();
+            let _dec = kp.decoding_key();
+        }
+        KeyChoice::EcdsaEs384 => {
+            let kp = fx.ecdsa(&input.label, EcdsaSpec::es384());
+            let _enc = kp.encoding_key();
+            let _dec = kp.decoding_key();
+        }
+        KeyChoice::Ed25519 => {
+            let kp = fx.ed25519(&input.label, Ed25519Spec::new());
+            let _enc = kp.encoding_key();
+            let _dec = kp.decoding_key();
+        }
+        KeyChoice::HmacHs256 => {
+            let secret = fx.hmac(&input.label, HmacSpec::hs256());
+            let _enc = secret.encoding_key();
+            let _dec = secret.decoding_key();
+        }
+        KeyChoice::HmacHs384 => {
+            let secret = fx.hmac(&input.label, HmacSpec::hs384());
+            let _enc = secret.encoding_key();
+            let _dec = secret.decoding_key();
+        }
+        KeyChoice::HmacHs512 => {
+            let secret = fx.hmac(&input.label, HmacSpec::hs512());
+            let _enc = secret.encoding_key();
+            let _dec = secret.decoding_key();
+        }
+    }
+});

--- a/fuzz/fuzz_targets/adapter_ring_roundtrip.rs
+++ b/fuzz/fuzz_targets/adapter_ring_roundtrip.rs
@@ -1,0 +1,50 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{
+    EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, Seed,
+};
+use ring::signature::KeyPair;
+use uselesskey_ring::{RingEcdsaKeyPairExt, RingEd25519KeyPairExt};
+
+#[derive(Arbitrary, Debug)]
+enum KeyChoice {
+    EcdsaEs256,
+    EcdsaEs384,
+    Ed25519,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    seed: [u8; 32],
+    label: String,
+    key_choice: KeyChoice,
+}
+
+fuzz_target!(|input: Input| {
+    if input.label.len() > 256 {
+        return;
+    }
+
+    let fx = Factory::deterministic(Seed::new(input.seed));
+
+    match input.key_choice {
+        KeyChoice::EcdsaEs256 => {
+            let kp = fx.ecdsa(&input.label, EcdsaSpec::es256());
+            let ring_kp = kp.ecdsa_key_pair_ring();
+            assert!(!ring_kp.public_key().as_ref().is_empty());
+        }
+        KeyChoice::EcdsaEs384 => {
+            let kp = fx.ecdsa(&input.label, EcdsaSpec::es384());
+            let ring_kp = kp.ecdsa_key_pair_ring();
+            assert!(!ring_kp.public_key().as_ref().is_empty());
+        }
+        KeyChoice::Ed25519 => {
+            let kp = fx.ed25519(&input.label, Ed25519Spec::new());
+            let ring_kp = kp.ed25519_key_pair_ring();
+            assert!(!ring_kp.public_key().as_ref().is_empty());
+        }
+    }
+});

--- a/fuzz/fuzz_targets/adapter_rustls_roundtrip.rs
+++ b/fuzz/fuzz_targets/adapter_rustls_roundtrip.rs
@@ -1,0 +1,62 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{
+    ChainSpec, EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, Seed,
+    X509FactoryExt, X509Spec,
+};
+use uselesskey_rustls::{RustlsCertExt, RustlsChainExt, RustlsPrivateKeyExt};
+
+#[derive(Arbitrary, Debug)]
+enum Scenario {
+    EcdsaKey,
+    Ed25519Key,
+    SelfSignedCert,
+    Chain,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    seed: [u8; 32],
+    label: String,
+    scenario: Scenario,
+}
+
+fuzz_target!(|input: Input| {
+    if input.label.len() > 256 {
+        return;
+    }
+
+    let fx = Factory::deterministic(Seed::new(input.seed));
+
+    match input.scenario {
+        Scenario::EcdsaKey => {
+            let kp = fx.ecdsa(&input.label, EcdsaSpec::es256());
+            let der = kp.private_key_der_rustls();
+            assert!(!der.secret_der().is_empty());
+        }
+        Scenario::Ed25519Key => {
+            let kp = fx.ed25519(&input.label, Ed25519Spec::new());
+            let der = kp.private_key_der_rustls();
+            assert!(!der.secret_der().is_empty());
+        }
+        Scenario::SelfSignedCert => {
+            let cert = fx.x509_self_signed(&input.label, X509Spec::self_signed("fuzz.test"));
+            let cert_der = cert.certificate_der_rustls();
+            assert!(!cert_der.as_ref().is_empty());
+            let key_der = cert.private_key_der_rustls();
+            assert!(!key_der.secret_der().is_empty());
+        }
+        Scenario::Chain => {
+            let chain = fx.x509_chain(&input.label, ChainSpec::new("fuzz.test"));
+            let chain_certs = chain.chain_der_rustls();
+            assert_eq!(chain_certs.len(), 2);
+            let root = chain.root_certificate_der_rustls();
+            assert!(!root.as_ref().is_empty());
+            let key_der = chain.private_key_der_rustls();
+            assert!(!key_der.secret_der().is_empty());
+        }
+    }
+});

--- a/fuzz/fuzz_targets/factory_concurrent_access.rs
+++ b/fuzz/fuzz_targets/factory_concurrent_access.rs
@@ -1,0 +1,69 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use rand_core::RngCore;
+use std::sync::Arc;
+use std::thread;
+use uselesskey::Seed;
+use uselesskey_core_factory::Factory;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 34 {
+        return;
+    }
+
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&data[..32]);
+    let thread_count = ((data[32] % 8) + 2) as usize;
+    let variant_count = ((data[33] % 4) + 1) as usize;
+
+    let factory = Factory::deterministic(Seed::new(seed));
+
+    // Spawn threads that concurrently call get_or_init with same and different keys
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_t| {
+            let fx = factory.clone();
+            thread::spawn(move || {
+                let mut results = Vec::new();
+                for v in 0..variant_count {
+                    let label = format!("label-{}", v);
+                    let val: Arc<u64> =
+                        fx.get_or_init("fuzz", &label, b"spec", "v", |rng| {
+                            let mut buf = [0u8; 8];
+                            rng.fill_bytes(&mut buf);
+                            u64::from_le_bytes(buf)
+                        });
+                    results.push((label, val));
+                }
+                // Each thread also re-fetches to confirm cache hit
+                for v in 0..variant_count {
+                    let label = format!("label-{}", v);
+                    let val2: Arc<u64> =
+                        fx.get_or_init("fuzz", &label, b"spec", "v", |rng| {
+                            let mut buf = [0u8; 8];
+                            rng.fill_bytes(&mut buf);
+                            u64::from_le_bytes(buf)
+                        });
+                    // Value must match (deterministic derivation)
+                    assert_eq!(*val2, *results[v].1);
+                }
+                results
+            })
+        })
+        .collect();
+
+    let all_results: Vec<Vec<(String, Arc<u64>)>> =
+        handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // All threads must agree on the same value for each label
+    for v in 0..variant_count {
+        let expected = &all_results[0][v].1;
+        for thread_results in &all_results[1..] {
+            assert_eq!(
+                *thread_results[v].1, **expected,
+                "threads disagree on value for label-{v}"
+            );
+        }
+    }
+});

--- a/fuzz/fuzz_targets/jwks_builder_ordering.rs
+++ b/fuzz/fuzz_targets/jwks_builder_ordering.rs
@@ -1,0 +1,71 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey_jwk::{EcPublicJwk, JwksBuilder, OkpPublicJwk, PublicJwk};
+
+#[derive(Arbitrary, Debug)]
+struct KeyEntry {
+    kid: String,
+    use_okp: bool,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    keys: Vec<KeyEntry>,
+}
+
+fuzz_target!(|input: Input| {
+    if input.keys.len() > 128 {
+        return;
+    }
+
+    // Build JWKS twice with the same keys in the same order → must be identical
+    let build = |entries: &[KeyEntry]| {
+        let mut builder = JwksBuilder::new();
+        for entry in entries {
+            if entry.use_okp {
+                builder.push_public(PublicJwk::Okp(OkpPublicJwk {
+                    kty: "OKP",
+                    use_: "sig",
+                    alg: "EdDSA",
+                    crv: "Ed25519",
+                    kid: entry.kid.clone(),
+                    x: "dGVzdA".to_string(),
+                }));
+            } else {
+                builder.push_public(PublicJwk::Ec(EcPublicJwk {
+                    kty: "EC",
+                    use_: "sig",
+                    alg: "ES256",
+                    crv: "P-256",
+                    kid: entry.kid.clone(),
+                    x: "dGVzdA".to_string(),
+                    y: "dGVzdA".to_string(),
+                }));
+            }
+        }
+        builder.build()
+    };
+
+    let jwks1 = build(&input.keys);
+    let jwks2 = build(&input.keys);
+
+    // Same input → same output
+    assert_eq!(jwks1.to_string(), jwks2.to_string());
+
+    // Output must be sorted by kid
+    let kids: Vec<&str> = jwks1.keys.iter().map(|k| k.kid()).collect();
+    for pair in kids.windows(2) {
+        assert!(pair[0] <= pair[1], "JWKS keys must be sorted by kid");
+    }
+
+    // JSON must be valid
+    let json = jwks1.to_string();
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    assert_eq!(
+        parsed["keys"].as_array().unwrap().len(),
+        input.keys.len()
+    );
+});

--- a/fuzz/fuzz_targets/x509_chain_build.rs
+++ b/fuzz/fuzz_targets/x509_chain_build.rs
@@ -1,0 +1,61 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+use uselesskey::{ChainSpec, Factory, Seed, X509FactoryExt};
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    seed: [u8; 32],
+    label: String,
+    domain: String,
+    san_count: u8,
+}
+
+fuzz_target!(|input: Input| {
+    if input.domain.is_empty() || input.domain.len() > 128 {
+        return;
+    }
+    if input.label.len() > 128 {
+        return;
+    }
+
+    let fx = Factory::deterministic(Seed::new(input.seed));
+
+    let mut spec = ChainSpec::new(&input.domain);
+
+    // Add a bounded number of SANs derived from the domain
+    let san_count = (input.san_count % 8) as usize;
+    if san_count > 0 {
+        let sans: Vec<String> = (0..san_count)
+            .map(|i| format!("san{i}.{}", input.domain))
+            .collect();
+        spec = spec.with_sans(sans);
+    }
+
+    let chain = fx.x509_chain(&input.label, spec);
+
+    // Leaf cert PEM envelope
+    let leaf_pem = chain.leaf_cert_pem();
+    assert!(leaf_pem.starts_with("-----BEGIN CERTIFICATE-----"));
+    assert!(leaf_pem.contains("-----END CERTIFICATE-----"));
+
+    // Intermediate cert present
+    assert!(!chain.intermediate_cert_der().is_empty());
+
+    // Root cert present
+    let root_pem = chain.root_cert_pem();
+    assert!(root_pem.starts_with("-----BEGIN CERTIFICATE-----"));
+
+    // Chain PEM has exactly 2 certs (leaf + intermediate)
+    let chain_pem = chain.chain_pem();
+    assert_eq!(chain_pem.matches("-----BEGIN CERTIFICATE-----").count(), 2);
+
+    // Private key present
+    assert!(!chain.leaf_private_key_pkcs8_der().is_empty());
+
+    // Determinism check
+    let chain2 = fx.x509_chain(&input.label, ChainSpec::new(&input.domain));
+    assert_eq!(chain.leaf_cert_pem(), chain2.leaf_cert_pem());
+});


### PR DESCRIPTION
## Wave 86: Fuzz Target Expansion

Add 6 new fuzz targets (29 → 35) covering previously under-fuzzed parsing and conversion paths:

### New targets

| Target | Area | What it fuzzes |
|--------|------|----------------|
| \dapter_jsonwebtoken_roundtrip\ | Adapter round-trips | ECDSA/Ed25519/HMAC → jsonwebtoken EncodingKey/DecodingKey |
| \dapter_ring_roundtrip\ | Adapter round-trips | ECDSA/Ed25519 PKCS#8 DER → ring KeyPair types |
| \dapter_rustls_roundtrip\ | Adapter round-trips | Key/cert/chain → rustls-pki-types PrivateKeyDer/CertificateDer |
| \x509_chain_build\ | X.509 chain building | Chain construction with arbitrary domains and SANs |
| \actory_concurrent_access\ | Concurrency | Factory get_or_init under multi-threaded contention |
| \jwks_builder_ordering\ | JWKS ordering | JwksBuilder deterministic kid-sorted output with arbitrary insertion orders |

### Invariants checked
- Adapter conversions don't panic on any deterministic seed
- X.509 chains always produce valid PEM envelopes and correct cert counts
- Factory cache returns consistent values across concurrent threads
- JWKS output is always sorted by kid and produces valid JSON
