### PR TITLE
docs: improve rustdoc coverage across workspace

### DIFF
--- a/crates/uselesskey-core-cache/src/lib.rs
+++ b/crates/uselesskey-core-cache/src/lib.rs
@@ -7,12 +7,8 @@
 //! The primary type is [`ArtifactCache`].
 
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
-//! Identity-keyed typed cache primitives for uselesskey fixture factories.
-//!
-//! Provides a concurrent, identity-based cache that stores generated cryptographic
-//! artifacts keyed by [`ArtifactId`](uselesskey_core_id::ArtifactId). This avoids
-//! expensive re-generation (especially RSA) across test runs.
 
 extern crate alloc;
 

--- a/crates/uselesskey-core-rustls-pki/src/lib.rs
+++ b/crates/uselesskey-core-rustls-pki/src/lib.rs
@@ -1,9 +1,10 @@
-#![forbid(unsafe_code)]
-
 //! rustls-pki-types adapter traits for uselesskey fixtures.
 //!
 //! This crate is intentionally focused on PKI conversion only:
 //! converting fixture outputs into `rustls_pki_types` key and certificate types.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 

--- a/crates/uselesskey-core-sink/src/lib.rs
+++ b/crates/uselesskey-core-sink/src/lib.rs
@@ -6,6 +6,7 @@
 //! in-memory byte slices.
 
 #![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 use std::fmt;
 use std::fs;

--- a/crates/uselesskey-core-x509-chain-negative/src/lib.rs
+++ b/crates/uselesskey-core-x509-chain-negative/src/lib.rs
@@ -1,6 +1,3 @@
-#![forbid(unsafe_code)]
-#![cfg_attr(not(feature = "std"), no_std)]
-
 //! X.509 chain-level negative-fixture policy helpers.
 //!
 //! Defines [`ChainNegative`] variants (hostname mismatch, unknown CA,
@@ -8,6 +5,10 @@
 //! [`ChainNegative::apply_to_spec`] to derive a modified [`ChainSpec`]
 //! for each scenario. Used by `uselesskey-x509` to produce invalid
 //! certificate chains for TLS error-handling tests.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/crates/uselesskey-core-x509-derive/src/lib.rs
+++ b/crates/uselesskey-core-x509-derive/src/lib.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 //! Deterministic X.509 derivation helpers.
 //!
 //! This crate centralizes deterministic logic shared by X.509 fixture producers:
@@ -37,6 +35,9 @@
 //! assert_eq!(bytes.len(), SERIAL_NUMBER_BYTES);
 //! assert_eq!(bytes[0] & 0x80, 0, "high bit must be cleared");
 //! ```
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 use rand_core::RngCore;
 use rcgen::SerialNumber;

--- a/crates/uselesskey-feature-grid/src/lib.rs
+++ b/crates/uselesskey-feature-grid/src/lib.rs
@@ -2,13 +2,10 @@
 //!
 //! Exports [`FeatureSet`] entries and the [`CORE_FEATURE_MATRIX`] /
 //! [`BDD_FEATURE_MATRIX`] slices consumed by `xtask` and CI receipts.
+//! Each entry specifies a stable label and the corresponding Cargo CLI arguments.
 
 #![forbid(unsafe_code)]
-//! Canonical feature and matrix definitions for uselesskey automation.
-//!
-//! Defines `FeatureSet` entries consumed by `cargo xtask feature-matrix` to
-//! drive the CI feature-combination matrix. Each entry specifies a stable
-//! label and the corresponding Cargo CLI arguments.
+#![warn(missing_docs)]
 
 /// Canonical matrix entry used by automation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -26,29 +23,51 @@ impl FeatureSet {
     }
 }
 
-/// Canonical BDD feature names.
+/// BDD tag for the full feature set.
 pub const UK_FEATURE_ALL: &str = "uk-all";
+/// BDD tag for RSA fixtures.
 pub const UK_FEATURE_RSA: &str = "uk-rsa";
+/// BDD tag for ECDSA fixtures.
 pub const UK_FEATURE_ECDSA: &str = "uk-ecdsa";
+/// BDD tag for Ed25519 fixtures.
 pub const UK_FEATURE_ED25519: &str = "uk-ed25519";
+/// BDD tag for HMAC fixtures.
 pub const UK_FEATURE_HMAC: &str = "uk-hmac";
+/// BDD tag for PGP fixtures.
 pub const UK_FEATURE_PGP: &str = "uk-pgp";
+/// BDD tag for X.509 fixtures.
 pub const UK_FEATURE_X509: &str = "uk-x509";
+/// BDD tag for JWK fixtures.
 pub const UK_FEATURE_JWK: &str = "uk-jwk";
+/// BDD tag for token fixtures.
 pub const UK_FEATURE_TOKEN: &str = "uk-token";
+/// BDD tag for JWT adapter fixtures.
 pub const UK_FEATURE_JWT: &str = "uk-jwt";
+/// BDD tag for core identity module.
 pub const UK_FEATURE_CORE_ID: &str = "uk-core-id";
+/// BDD tag for core seed module.
 pub const UK_FEATURE_CORE_SEED: &str = "uk-core-seed";
+/// BDD tag for core factory module.
 pub const UK_FEATURE_CORE_FACTORY: &str = "uk-core-factory";
+/// BDD tag for core key-ID module.
 pub const UK_FEATURE_CORE_KID: &str = "uk-core-kid";
+/// BDD tag for core keypair module.
 pub const UK_FEATURE_CORE_KEYPAIR: &str = "uk-core-keypair";
+/// BDD tag for core negative-fixture module.
 pub const UK_FEATURE_CORE_NEGATIVE: &str = "uk-core-negative";
+/// BDD tag for core token-shape module.
 pub const UK_FEATURE_CORE_TOKEN_SHAPE: &str = "uk-core-token-shape";
+/// BDD tag for core sink module.
 pub const UK_FEATURE_CORE_SINK: &str = "uk-core-sink";
+/// BDD tag for aws-lc-rs adapter.
 pub const UK_FEATURE_AWS_LC_RS: &str = "uk-aws-lc-rs";
+/// BDD tag for ring adapter.
 pub const UK_FEATURE_RING: &str = "uk-ring";
+/// BDD tag for RustCrypto adapter.
 pub const UK_FEATURE_RUSTCRYPTO: &str = "uk-rustcrypto";
+/// BDD tag for rustls adapter.
 pub const UK_FEATURE_RUSTLS: &str = "uk-rustls";
+/// BDD tag for tonic adapter.
 pub const UK_FEATURE_TONIC: &str = "uk-tonic";
 
 /// All BDD feature names in one canonical slice.

--- a/crates/uselesskey-test-grid/src/lib.rs
+++ b/crates/uselesskey-test-grid/src/lib.rs
@@ -1,9 +1,10 @@
-#![forbid(unsafe_code)]
-
 //! Compatibility façade for the canonical feature grid definitions.
 //!
 //! The implementation moved to `uselesskey-feature-grid` so there is a single
 //! source of truth. This crate preserves the historical crate name used by
 //! automation and external consumers.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
 
 pub use uselesskey_feature_grid::*;


### PR DESCRIPTION
Improve rustdoc coverage across seven workspace crates. Add warn(missing_docs) lint, remove duplicate module-level doc blocks, add doc comments to undocumented constants, and reorder inner attributes to follow rustdoc conventions.