### PR TITLE
test: expand adapter integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,6 +3889,7 @@ dependencies = [
  "p256",
  "p384",
  "proptest",
+ "rand_core 0.6.4",
  "rsa",
  "serde",
  "sha2",

--- a/crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs
+++ b/crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs
@@ -1,0 +1,285 @@
+//! Multi-scheme and cross-factory integration tests for uselesskey-aws-lc-rs.
+//!
+//! Tests cover:
+//! - RSA with SHA-384 and SHA-512 signing/verification schemes
+//! - Cross-factory deterministic verification for all key types
+//! - Signature size validation
+//! - Multiple messages with the same key
+
+mod testutil;
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm)))]
+use testutil::fx;
+#[cfg(all(feature = "native", any(not(windows), has_nasm)))]
+use uselesskey_core::{Factory, Seed};
+
+// =========================================================================
+// RSA multiple signing/verification schemes
+// =========================================================================
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "rsa"))]
+mod rsa_multi_scheme {
+    use super::*;
+    use aws_lc_rs::{
+        rand::SystemRandom,
+        signature::{self, KeyPair},
+    };
+    use uselesskey_aws_lc_rs::AwsLcRsRsaKeyPairExt;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn rsa_pkcs1_sha384_sign_verify() {
+        let kp = fx()
+            .rsa("aws-sha384", RsaSpec::rs256())
+            .rsa_key_pair_aws_lc_rs();
+        let rng = SystemRandom::new();
+        let msg = b"pkcs1 sha384";
+        let mut sig = vec![0u8; kp.public_modulus_len()];
+        kp.sign(&signature::RSA_PKCS1_SHA384, &rng, msg, &mut sig)
+            .expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA384,
+            kp.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify");
+    }
+
+    #[test]
+    fn rsa_pkcs1_sha512_sign_verify() {
+        let kp = fx()
+            .rsa("aws-sha512", RsaSpec::rs256())
+            .rsa_key_pair_aws_lc_rs();
+        let rng = SystemRandom::new();
+        let msg = b"pkcs1 sha512";
+        let mut sig = vec![0u8; kp.public_modulus_len()];
+        kp.sign(&signature::RSA_PKCS1_SHA512, &rng, msg, &mut sig)
+            .expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA512,
+            kp.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify");
+    }
+
+    #[test]
+    fn rsa_pss_sha384_sign_verify() {
+        let kp = fx()
+            .rsa("aws-pss384", RsaSpec::rs256())
+            .rsa_key_pair_aws_lc_rs();
+        let rng = SystemRandom::new();
+        let msg = b"pss sha384";
+        let mut sig = vec![0u8; kp.public_modulus_len()];
+        kp.sign(&signature::RSA_PSS_SHA384, &rng, msg, &mut sig)
+            .expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PSS_2048_8192_SHA384,
+            kp.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify");
+    }
+
+    #[test]
+    fn rsa_pss_sha512_sign_verify() {
+        let kp = fx()
+            .rsa("aws-pss512", RsaSpec::rs256())
+            .rsa_key_pair_aws_lc_rs();
+        let rng = SystemRandom::new();
+        let msg = b"pss sha512";
+        let mut sig = vec![0u8; kp.public_modulus_len()];
+        kp.sign(&signature::RSA_PSS_SHA512, &rng, msg, &mut sig)
+            .expect("sign");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PSS_2048_8192_SHA512,
+            kp.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify");
+    }
+
+    /// Signature length must equal modulus length for RSA.
+    #[test]
+    fn rsa_signature_length_matches_modulus() {
+        for (bits, label) in [(2048, "aws-siglen-2k"), (4096, "aws-siglen-4k")] {
+            let kp = fx().rsa(label, RsaSpec::new(bits)).rsa_key_pair_aws_lc_rs();
+            let rng = SystemRandom::new();
+            let mut sig = vec![0u8; kp.public_modulus_len()];
+            kp.sign(&signature::RSA_PKCS1_SHA256, &rng, b"len-check", &mut sig)
+                .unwrap();
+            assert_eq!(
+                sig.len(),
+                bits / 8,
+                "signature length must match {bits}-bit key"
+            );
+        }
+    }
+
+    #[test]
+    fn rsa_multiple_messages_same_key() {
+        let kp = fx()
+            .rsa("aws-multi-msg", RsaSpec::rs256())
+            .rsa_key_pair_aws_lc_rs();
+        let rng = SystemRandom::new();
+
+        for i in 0..5 {
+            let msg = format!("message-{i}");
+            let mut sig = vec![0u8; kp.public_modulus_len()];
+            kp.sign(&signature::RSA_PKCS1_SHA256, &rng, msg.as_bytes(), &mut sig)
+                .unwrap();
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::RSA_PKCS1_2048_8192_SHA256,
+                kp.public_key().as_ref(),
+            );
+            pk.verify(msg.as_bytes(), &sig)
+                .unwrap_or_else(|_| panic!("verify message-{i}"));
+        }
+    }
+
+    #[test]
+    fn cross_factory_rsa_deterministic_verify() {
+        let seed = Seed::from_env_value("aws-cross-fac-rsa").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1
+            .rsa("cross-rsa", RsaSpec::rs256())
+            .rsa_key_pair_aws_lc_rs();
+        let kp2 = fx2
+            .rsa("cross-rsa", RsaSpec::rs256())
+            .rsa_key_pair_aws_lc_rs();
+
+        let rng = SystemRandom::new();
+        let msg = b"cross-factory-aws-rsa";
+        let mut sig = vec![0u8; kp1.public_modulus_len()];
+        kp1.sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .unwrap();
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            kp2.public_key().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("cross-factory rsa verify");
+    }
+}
+
+// =========================================================================
+// ECDSA cross-factory and multi-message
+// =========================================================================
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "ecdsa"))]
+mod ecdsa_multi_scheme {
+    use super::*;
+    use aws_lc_rs::{
+        rand::SystemRandom,
+        signature::{self, KeyPair},
+    };
+    use uselesskey_aws_lc_rs::AwsLcRsEcdsaKeyPairExt;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    #[test]
+    fn ecdsa_p256_multiple_messages() {
+        let kp = fx()
+            .ecdsa("aws-ec-multi", EcdsaSpec::es256())
+            .ecdsa_key_pair_aws_lc_rs();
+        let rng = SystemRandom::new();
+
+        for i in 0..5 {
+            let msg = format!("ec-msg-{i}");
+            let sig = kp.sign(&rng, msg.as_bytes()).unwrap();
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::ECDSA_P256_SHA256_ASN1,
+                kp.public_key().as_ref(),
+            );
+            pk.verify(msg.as_bytes(), sig.as_ref())
+                .unwrap_or_else(|_| panic!("verify ec-msg-{i}"));
+        }
+    }
+
+    #[test]
+    fn cross_factory_ecdsa_deterministic_verify() {
+        let seed = Seed::from_env_value("aws-cross-fac-ec").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1
+            .ecdsa("cross-ec", EcdsaSpec::es256())
+            .ecdsa_key_pair_aws_lc_rs();
+        let kp2 = fx2
+            .ecdsa("cross-ec", EcdsaSpec::es256())
+            .ecdsa_key_pair_aws_lc_rs();
+
+        let rng = SystemRandom::new();
+        let sig = kp1.sign(&rng, b"cross-factory-ec").unwrap();
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            kp2.public_key().as_ref(),
+        );
+        pk.verify(b"cross-factory-ec", sig.as_ref())
+            .expect("cross-factory ecdsa verify");
+    }
+}
+
+// =========================================================================
+// Ed25519 cross-factory
+// =========================================================================
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "ed25519"))]
+mod ed25519_multi_scheme {
+    use super::*;
+    use aws_lc_rs::signature::{self, KeyPair};
+    use uselesskey_aws_lc_rs::AwsLcRsEd25519KeyPairExt;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    #[test]
+    fn ed25519_multiple_messages() {
+        let kp = fx()
+            .ed25519("aws-ed-multi", Ed25519Spec::new())
+            .ed25519_key_pair_aws_lc_rs();
+
+        for i in 0..5 {
+            let msg = format!("ed-msg-{i}");
+            let sig = kp.sign(msg.as_bytes());
+
+            let pk =
+                signature::UnparsedPublicKey::new(&signature::ED25519, kp.public_key().as_ref());
+            pk.verify(msg.as_bytes(), sig.as_ref())
+                .unwrap_or_else(|_| panic!("verify ed-msg-{i}"));
+        }
+    }
+
+    #[test]
+    fn cross_factory_ed25519_deterministic_verify() {
+        let seed = Seed::from_env_value("aws-cross-fac-ed").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1
+            .ed25519("cross-ed", Ed25519Spec::new())
+            .ed25519_key_pair_aws_lc_rs();
+        let kp2 = fx2
+            .ed25519("cross-ed", Ed25519Spec::new())
+            .ed25519_key_pair_aws_lc_rs();
+
+        let sig = kp1.sign(b"cross-factory-ed");
+        let pk = signature::UnparsedPublicKey::new(&signature::ED25519, kp2.public_key().as_ref());
+        pk.verify(b"cross-factory-ed", sig.as_ref())
+            .expect("cross-factory ed25519 verify");
+    }
+
+    /// Ed25519 same key+message must produce identical signatures.
+    #[test]
+    fn ed25519_signature_determinism() {
+        let kp = fx()
+            .ed25519("aws-ed-det-sig", Ed25519Spec::new())
+            .ed25519_key_pair_aws_lc_rs();
+
+        let sig1 = kp.sign(b"deterministic");
+        let sig2 = kp.sign(b"deterministic");
+        assert_eq!(sig1.as_ref(), sig2.as_ref());
+    }
+}

--- a/crates/uselesskey-jsonwebtoken/tests/jwt_roundtrip_all_algos.rs
+++ b/crates/uselesskey-jsonwebtoken/tests/jwt_roundtrip_all_algos.rs
@@ -1,0 +1,280 @@
+//! Systematic JWT round-trip tests for every algorithm type.
+//!
+//! Tests cover:
+//! - Parameterized sign/verify round-trips across all 9 JWT algorithms
+//! - Token payload tampering detection
+//! - Mismatched key variant rejects signatures
+//! - Cross-factory deterministic verification (sign factory1, verify factory2)
+//! - Multiple tokens from the same key remain independently verifiable
+
+mod testutil;
+
+use jsonwebtoken::{Algorithm, DecodingKey, Header, Validation, decode, encode, errors::ErrorKind};
+use serde::{Deserialize, Serialize};
+use testutil::fx;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_jsonwebtoken::JwtKeyExt;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Claims {
+    sub: String,
+    exp: usize,
+}
+
+fn claims() -> Claims {
+    Claims {
+        sub: "roundtrip-user".into(),
+        exp: 2_000_000_000,
+    }
+}
+
+// =========================================================================
+// Parameterized round-trips: every RSA algorithm with one key
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_all_schemes {
+    use super::*;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    /// RSA keys can sign with any RS*/PS* algorithm.
+    #[test]
+    fn all_rsa_algorithms_round_trip() {
+        let kp = fx().rsa("all-rsa-algos", RsaSpec::rs256());
+
+        for alg in [
+            Algorithm::RS256,
+            Algorithm::RS384,
+            Algorithm::RS512,
+            Algorithm::PS256,
+            Algorithm::PS384,
+            Algorithm::PS512,
+        ] {
+            let token = encode(&Header::new(alg), &claims(), &kp.encoding_key())
+                .unwrap_or_else(|e| panic!("encode {alg:?} failed: {e:?}"));
+
+            let decoded = decode::<Claims>(&token, &kp.decoding_key(), &Validation::new(alg))
+                .unwrap_or_else(|e| panic!("decode {alg:?} failed: {e:?}"));
+
+            assert_eq!(decoded.claims, claims(), "claims mismatch for {alg:?}");
+        }
+    }
+
+    /// Tokens signed under different RSA algorithms are not interchangeable.
+    #[test]
+    fn rs256_token_rejected_as_ps256() {
+        let kp = fx().rsa("rsa-scheme-mismatch", RsaSpec::rs256());
+        let token = encode(
+            &Header::new(Algorithm::RS256),
+            &claims(),
+            &kp.encoding_key(),
+        )
+        .unwrap();
+
+        let result = decode::<Claims>(
+            &token,
+            &kp.decoding_key(),
+            &Validation::new(Algorithm::PS256),
+        );
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err().kind(),
+            ErrorKind::InvalidAlgorithm
+        ));
+    }
+}
+
+// =========================================================================
+// Token payload tampering detection
+// =========================================================================
+
+#[cfg(feature = "hmac")]
+mod payload_tampering {
+    use super::*;
+    use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+
+    /// Modify the base64-encoded payload section of a JWT; verification must fail.
+    #[test]
+    fn tampered_payload_rejected() {
+        let secret = fx().hmac("tamper-detect", HmacSpec::hs256());
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims(),
+            &secret.encoding_key(),
+        )
+        .unwrap();
+
+        // JWT = header.payload.signature — replace one char in the payload
+        let parts: Vec<&str> = token.split('.').collect();
+        assert_eq!(parts.len(), 3);
+
+        let mut payload_bytes: Vec<u8> = parts[1].bytes().collect();
+        // Flip one byte (safe because base64url uses ASCII)
+        if let Some(b) = payload_bytes.first_mut() {
+            *b = if *b == b'A' { b'B' } else { b'A' };
+        }
+        let tampered_payload = String::from_utf8(payload_bytes).unwrap();
+        let tampered_token = format!("{}.{}.{}", parts[0], tampered_payload, parts[2]);
+
+        let result = decode::<Claims>(
+            &tampered_token,
+            &secret.decoding_key(),
+            &Validation::new(Algorithm::HS256),
+        );
+        assert!(result.is_err(), "tampered payload must be rejected");
+    }
+
+    /// Modify the signature section of a JWT; verification must fail.
+    #[test]
+    fn tampered_signature_rejected() {
+        let secret = fx().hmac("sig-tamper", HmacSpec::hs256());
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims(),
+            &secret.encoding_key(),
+        )
+        .unwrap();
+
+        let parts: Vec<&str> = token.split('.').collect();
+        let mut sig_bytes: Vec<u8> = parts[2].bytes().collect();
+        if let Some(b) = sig_bytes.last_mut() {
+            *b = if *b == b'A' { b'B' } else { b'A' };
+        }
+        let tampered_sig = String::from_utf8(sig_bytes).unwrap();
+        let tampered_token = format!("{}.{}.{}", parts[0], parts[1], tampered_sig);
+
+        let result = decode::<Claims>(
+            &tampered_token,
+            &secret.decoding_key(),
+            &Validation::new(Algorithm::HS256),
+        );
+        assert!(result.is_err(), "tampered signature must be rejected");
+    }
+}
+
+// =========================================================================
+// Mismatched key variant rejects signatures
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod mismatch_variant {
+    use super::*;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    /// The fixture's `mismatched_public_key_spki_der()` should reject a valid token.
+    #[test]
+    fn mismatched_public_key_rejects_token() {
+        let kp = fx().rsa("mismatch-jwt", RsaSpec::rs256());
+        let token = encode(
+            &Header::new(Algorithm::RS256),
+            &claims(),
+            &kp.encoding_key(),
+        )
+        .unwrap();
+
+        let bad_pub = DecodingKey::from_rsa_der(&kp.mismatched_public_key_spki_der());
+        let result = decode::<Claims>(&token, &bad_pub, &Validation::new(Algorithm::RS256));
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err().kind(),
+            ErrorKind::InvalidSignature
+        ));
+    }
+}
+
+// =========================================================================
+// Cross-factory deterministic verification
+// =========================================================================
+
+#[cfg(feature = "ed25519")]
+mod cross_factory_deterministic {
+    use super::*;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    /// Sign with factory1, verify with factory2 using the same seed.
+    #[test]
+    fn sign_factory1_verify_factory2() {
+        let seed = Seed::from_env_value("jwt-cross-factory-ed").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ed25519("cross-fac", Ed25519Spec::new());
+        let kp2 = fx2.ed25519("cross-fac", Ed25519Spec::new());
+
+        let token = encode(
+            &Header::new(Algorithm::EdDSA),
+            &claims(),
+            &kp1.encoding_key(),
+        )
+        .unwrap();
+        let decoded = decode::<Claims>(
+            &token,
+            &kp2.decoding_key(),
+            &Validation::new(Algorithm::EdDSA),
+        )
+        .unwrap();
+        assert_eq!(decoded.claims, claims());
+    }
+}
+
+#[cfg(feature = "hmac")]
+mod cross_factory_hmac {
+    use super::*;
+    use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+
+    #[test]
+    fn hmac_sign_factory1_verify_factory2() {
+        let seed = Seed::from_env_value("jwt-cross-factory-hmac").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let s1 = fx1.hmac("cross-fac-hmac", HmacSpec::hs512());
+        let s2 = fx2.hmac("cross-fac-hmac", HmacSpec::hs512());
+
+        let token = encode(
+            &Header::new(Algorithm::HS512),
+            &claims(),
+            &s1.encoding_key(),
+        )
+        .unwrap();
+        let decoded = decode::<Claims>(
+            &token,
+            &s2.decoding_key(),
+            &Validation::new(Algorithm::HS512),
+        )
+        .unwrap();
+        assert_eq!(decoded.claims, claims());
+    }
+}
+
+// =========================================================================
+// Multiple tokens from same key are independently verifiable
+// =========================================================================
+
+#[cfg(feature = "ecdsa")]
+mod multi_token {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    #[test]
+    fn multiple_tokens_all_verify() {
+        let kp = fx().ecdsa("multi-tok", EcdsaSpec::es256());
+
+        let tokens: Vec<String> = (0..5)
+            .map(|i| {
+                let c = Claims {
+                    sub: format!("user-{i}"),
+                    exp: 2_000_000_000,
+                };
+                encode(&Header::new(Algorithm::ES256), &c, &kp.encoding_key()).unwrap()
+            })
+            .collect();
+
+        for (i, tok) in tokens.iter().enumerate() {
+            let decoded =
+                decode::<Claims>(tok, &kp.decoding_key(), &Validation::new(Algorithm::ES256))
+                    .unwrap();
+            assert_eq!(decoded.claims.sub, format!("user-{i}"));
+        }
+    }
+}

--- a/crates/uselesskey-ring/tests/ring_multi_scheme.rs
+++ b/crates/uselesskey-ring/tests/ring_multi_scheme.rs
@@ -1,0 +1,318 @@
+//! Multi-scheme and cross-factory integration tests for uselesskey-ring.
+//!
+//! Tests cover:
+//! - RSA with multiple signing/verification schemes (PSS, SHA-384, SHA-512)
+//! - Empty and large message signing for all key types
+//! - Cross-factory deterministic verification (sign factory1, verify factory2)
+//! - Signature stability for deterministic Ed25519
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_core::{Factory, Seed};
+
+// =========================================================================
+// RSA multiple signing/verification schemes
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_multi_scheme {
+    use super::*;
+    use ring::{rand::SystemRandom, signature};
+    use uselesskey_ring::RingRsaKeyPairExt;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn rsa_pss_sha256_sign_verify() {
+        let kp = fx()
+            .rsa("ring-pss-256", RsaSpec::rs256())
+            .rsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let msg = b"pss sha256";
+        let mut sig = vec![0u8; kp.public().modulus_len()];
+        kp.sign(&signature::RSA_PSS_SHA256, &rng, msg, &mut sig)
+            .expect("sign PSS-SHA256");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PSS_2048_8192_SHA256,
+            kp.public().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify PSS-SHA256");
+    }
+
+    #[test]
+    fn rsa_pss_sha384_sign_verify() {
+        let kp = fx()
+            .rsa("ring-pss-384", RsaSpec::rs256())
+            .rsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let msg = b"pss sha384";
+        let mut sig = vec![0u8; kp.public().modulus_len()];
+        kp.sign(&signature::RSA_PSS_SHA384, &rng, msg, &mut sig)
+            .expect("sign PSS-SHA384");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PSS_2048_8192_SHA384,
+            kp.public().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify PSS-SHA384");
+    }
+
+    #[test]
+    fn rsa_pss_sha512_sign_verify() {
+        let kp = fx()
+            .rsa("ring-pss-512", RsaSpec::rs256())
+            .rsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let msg = b"pss sha512";
+        let mut sig = vec![0u8; kp.public().modulus_len()];
+        kp.sign(&signature::RSA_PSS_SHA512, &rng, msg, &mut sig)
+            .expect("sign PSS-SHA512");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PSS_2048_8192_SHA512,
+            kp.public().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify PSS-SHA512");
+    }
+
+    #[test]
+    fn rsa_pkcs1_sha384_sign_verify() {
+        let kp = fx()
+            .rsa("ring-sha384", RsaSpec::rs256())
+            .rsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let msg = b"pkcs1 sha384";
+        let mut sig = vec![0u8; kp.public().modulus_len()];
+        kp.sign(&signature::RSA_PKCS1_SHA384, &rng, msg, &mut sig)
+            .expect("sign PKCS1-SHA384");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA384,
+            kp.public().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify PKCS1-SHA384");
+    }
+
+    #[test]
+    fn rsa_pkcs1_sha512_sign_verify() {
+        let kp = fx()
+            .rsa("ring-sha512", RsaSpec::rs256())
+            .rsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let msg = b"pkcs1 sha512";
+        let mut sig = vec![0u8; kp.public().modulus_len()];
+        kp.sign(&signature::RSA_PKCS1_SHA512, &rng, msg, &mut sig)
+            .expect("sign PKCS1-SHA512");
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA512,
+            kp.public().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("verify PKCS1-SHA512");
+    }
+
+    #[test]
+    fn rsa_empty_message_sign_verify() {
+        let kp = fx()
+            .rsa("ring-rsa-empty", RsaSpec::rs256())
+            .rsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let mut sig = vec![0u8; kp.public().modulus_len()];
+        kp.sign(&signature::RSA_PKCS1_SHA256, &rng, b"", &mut sig)
+            .expect("sign empty");
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            kp.public().as_ref(),
+        );
+        pk.verify(b"", &sig).expect("verify empty");
+    }
+
+    #[test]
+    fn rsa_large_message_sign_verify() {
+        let kp = fx()
+            .rsa("ring-rsa-large", RsaSpec::rs256())
+            .rsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let msg = vec![0xABu8; 64 * 1024];
+        let mut sig = vec![0u8; kp.public().modulus_len()];
+        kp.sign(&signature::RSA_PKCS1_SHA256, &rng, &msg, &mut sig)
+            .expect("sign large");
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            kp.public().as_ref(),
+        );
+        pk.verify(&msg, &sig).expect("verify large");
+    }
+
+    /// Sign with factory1's key, verify with factory2's key (same seed).
+    #[test]
+    fn cross_factory_rsa_deterministic_verify() {
+        let seed = Seed::from_env_value("ring-cross-fac-rsa").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.rsa("cross-fac", RsaSpec::rs256()).rsa_key_pair_ring();
+        let kp2 = fx2.rsa("cross-fac", RsaSpec::rs256()).rsa_key_pair_ring();
+
+        let rng = SystemRandom::new();
+        let msg = b"cross factory rsa";
+        let mut sig = vec![0u8; kp1.public().modulus_len()];
+        kp1.sign(&signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .unwrap();
+
+        // Verify with factory2's public key
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::RSA_PKCS1_2048_8192_SHA256,
+            kp2.public().as_ref(),
+        );
+        pk.verify(msg, &sig).expect("cross-factory verify");
+    }
+}
+
+// =========================================================================
+// ECDSA empty/large message and cross-factory
+// =========================================================================
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_edge_cases {
+    use super::*;
+    use ring::{
+        rand::SystemRandom,
+        signature::{self, KeyPair},
+    };
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ring::RingEcdsaKeyPairExt;
+
+    #[test]
+    fn ecdsa_p256_empty_message() {
+        let kp = fx()
+            .ecdsa("ring-ec-empty", EcdsaSpec::es256())
+            .ecdsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let sig = kp.sign(&rng, b"").unwrap();
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            kp.public_key().as_ref(),
+        );
+        pk.verify(b"", sig.as_ref()).expect("verify empty");
+    }
+
+    #[test]
+    fn ecdsa_p384_empty_message() {
+        let kp = fx()
+            .ecdsa("ring-p384-empty", EcdsaSpec::es384())
+            .ecdsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let sig = kp.sign(&rng, b"").unwrap();
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P384_SHA384_ASN1,
+            kp.public_key().as_ref(),
+        );
+        pk.verify(b"", sig.as_ref()).expect("verify empty");
+    }
+
+    #[test]
+    fn ecdsa_large_message() {
+        let kp = fx()
+            .ecdsa("ring-ec-large", EcdsaSpec::es256())
+            .ecdsa_key_pair_ring();
+        let rng = SystemRandom::new();
+        let msg = vec![0xCDu8; 64 * 1024];
+        let sig = kp.sign(&rng, &msg).unwrap();
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            kp.public_key().as_ref(),
+        );
+        pk.verify(&msg, sig.as_ref()).expect("verify large");
+    }
+
+    #[test]
+    fn cross_factory_ecdsa_deterministic_verify() {
+        let seed = Seed::from_env_value("ring-cross-fac-ec").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1
+            .ecdsa("cross-fac-ec", EcdsaSpec::es256())
+            .ecdsa_key_pair_ring();
+        let kp2 = fx2
+            .ecdsa("cross-fac-ec", EcdsaSpec::es256())
+            .ecdsa_key_pair_ring();
+
+        let rng = SystemRandom::new();
+        let msg = b"cross factory ecdsa";
+        let sig = kp1.sign(&rng, msg).unwrap();
+
+        let pk = signature::UnparsedPublicKey::new(
+            &signature::ECDSA_P256_SHA256_ASN1,
+            kp2.public_key().as_ref(),
+        );
+        pk.verify(msg, sig.as_ref()).expect("cross-factory verify");
+    }
+}
+
+// =========================================================================
+// Ed25519 empty/large message and cross-factory
+// =========================================================================
+
+#[cfg(feature = "ed25519")]
+mod ed25519_edge_cases {
+    use super::*;
+    use ring::signature::{self, KeyPair};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_ring::RingEd25519KeyPairExt;
+
+    #[test]
+    fn ed25519_empty_message() {
+        let kp = fx()
+            .ed25519("ring-ed-empty", Ed25519Spec::new())
+            .ed25519_key_pair_ring();
+        let sig = kp.sign(b"");
+        let pk = signature::UnparsedPublicKey::new(&signature::ED25519, kp.public_key().as_ref());
+        pk.verify(b"", sig.as_ref()).expect("verify empty");
+    }
+
+    #[test]
+    fn ed25519_large_message() {
+        let kp = fx()
+            .ed25519("ring-ed-large", Ed25519Spec::new())
+            .ed25519_key_pair_ring();
+        let msg = vec![0xEFu8; 64 * 1024];
+        let sig = kp.sign(&msg);
+        let pk = signature::UnparsedPublicKey::new(&signature::ED25519, kp.public_key().as_ref());
+        pk.verify(&msg, sig.as_ref()).expect("verify large");
+    }
+
+    #[test]
+    fn cross_factory_ed25519_deterministic_verify() {
+        let seed = Seed::from_env_value("ring-cross-fac-ed").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1
+            .ed25519("cross-fac-ed", Ed25519Spec::new())
+            .ed25519_key_pair_ring();
+        let kp2 = fx2
+            .ed25519("cross-fac-ed", Ed25519Spec::new())
+            .ed25519_key_pair_ring();
+
+        let msg = b"cross factory ed25519";
+        let sig = kp1.sign(msg);
+
+        let pk = signature::UnparsedPublicKey::new(&signature::ED25519, kp2.public_key().as_ref());
+        pk.verify(msg, sig.as_ref()).expect("cross-factory verify");
+    }
+
+    /// Ed25519 is deterministic: same key + same message = same signature.
+    #[test]
+    fn ed25519_signature_is_deterministic() {
+        let kp = fx()
+            .ed25519("ring-ed-det-sig", Ed25519Spec::new())
+            .ed25519_key_pair_ring();
+        let msg = b"deterministic sig";
+        let sig1 = kp.sign(msg);
+        let sig2 = kp.sign(msg);
+        assert_eq!(sig1.as_ref(), sig2.as_ref());
+    }
+}

--- a/crates/uselesskey-rustcrypto/Cargo.toml
+++ b/crates/uselesskey-rustcrypto/Cargo.toml
@@ -48,6 +48,7 @@ uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.3.0" }
 proptest.workspace = true
 sha2 = "0.10"
 rsa = { workspace = true }
+rand_core.workspace = true
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs
+++ b/crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs
@@ -1,0 +1,237 @@
+//! Cross-factory and multi-message integration tests for uselesskey-rustcrypto.
+//!
+//! Tests cover:
+//! - RSA PSS signatures via RustCrypto
+//! - Cross-factory deterministic verification for all key types
+//! - Multiple sequential signatures with the same key
+//! - Large message handling
+//! - HMAC cross-factory tag verification
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_core::{Factory, Seed};
+
+// =========================================================================
+// RSA PSS signatures
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_pss {
+    use super::*;
+    use rsa::pss::{SigningKey as PssSigningKey, VerifyingKey as PssVerifyingKey};
+    use rsa::signature::{RandomizedSigner, Verifier};
+    use sha2::Sha256;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    use uselesskey_rustcrypto::RustCryptoRsaExt;
+
+    fn rng() -> rand_core::OsRng {
+        rand_core::OsRng
+    }
+
+    #[test]
+    fn rsa_pss_sign_verify_roundtrip() {
+        let kp = fx().rsa("rc-pss-rt", RsaSpec::rs256());
+        let signing = PssSigningKey::<Sha256>::new(kp.rsa_private_key());
+        let sig = signing.sign_with_rng(&mut rng(), b"pss message");
+
+        let verifying = PssVerifyingKey::<Sha256>::new(kp.rsa_public_key());
+        verifying.verify(b"pss message", &sig).expect("PSS verify");
+    }
+
+    #[test]
+    fn rsa_pss_wrong_message_rejects() {
+        let kp = fx().rsa("rc-pss-reject", RsaSpec::rs256());
+        let signing = PssSigningKey::<Sha256>::new(kp.rsa_private_key());
+        let sig = signing.sign_with_rng(&mut rng(), b"correct");
+
+        let verifying = PssVerifyingKey::<Sha256>::new(kp.rsa_public_key());
+        assert!(verifying.verify(b"wrong", &sig).is_err());
+    }
+
+    #[test]
+    fn rsa_pss_cross_key_rejects() {
+        let fx = fx();
+        let kp_a = fx.rsa("rc-pss-a", RsaSpec::rs256());
+        let kp_b = fx.rsa("rc-pss-b", RsaSpec::rs256());
+
+        let sig = PssSigningKey::<Sha256>::new(kp_a.rsa_private_key())
+            .sign_with_rng(&mut rng(), b"cross-key");
+        let verifying = PssVerifyingKey::<Sha256>::new(kp_b.rsa_public_key());
+        assert!(verifying.verify(b"cross-key", &sig).is_err());
+    }
+}
+
+// =========================================================================
+// Cross-factory deterministic verification
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_cross_factory {
+    use super::*;
+    use rsa::pkcs1v15::{SigningKey, VerifyingKey};
+    use rsa::signature::{Signer, Verifier};
+    use sha2::Sha256;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    use uselesskey_rustcrypto::RustCryptoRsaExt;
+
+    #[test]
+    fn sign_factory1_verify_factory2() {
+        let seed = Seed::from_env_value("rc-cross-fac-rsa").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.rsa("cross-rsa", RsaSpec::rs256());
+        let kp2 = fx2.rsa("cross-rsa", RsaSpec::rs256());
+
+        let sig =
+            SigningKey::<Sha256>::new_unprefixed(kp1.rsa_private_key()).sign(b"cross-factory");
+        VerifyingKey::<Sha256>::new_unprefixed(kp2.rsa_public_key())
+            .verify(b"cross-factory", &sig)
+            .expect("cross-factory verify");
+    }
+}
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_cross_factory {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_rustcrypto::RustCryptoEcdsaExt;
+
+    #[test]
+    fn p256_sign_factory1_verify_factory2() {
+        use p256::ecdsa::signature::{Signer, Verifier};
+
+        let seed = Seed::from_env_value("rc-cross-fac-ec").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ecdsa("cross-ec", EcdsaSpec::es256());
+        let kp2 = fx2.ecdsa("cross-ec", EcdsaSpec::es256());
+
+        let sig: p256::ecdsa::Signature = kp1.p256_signing_key().sign(b"cross-factory-ec");
+        kp2.p256_verifying_key()
+            .verify(b"cross-factory-ec", &sig)
+            .expect("cross-factory p256 verify");
+    }
+
+    #[test]
+    fn p384_sign_factory1_verify_factory2() {
+        use p384::ecdsa::signature::{Signer, Verifier};
+
+        let seed = Seed::from_env_value("rc-cross-fac-p384").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ecdsa("cross-p384", EcdsaSpec::es384());
+        let kp2 = fx2.ecdsa("cross-p384", EcdsaSpec::es384());
+
+        let sig: p384::ecdsa::Signature = kp1.p384_signing_key().sign(b"cross-factory-p384");
+        kp2.p384_verifying_key()
+            .verify(b"cross-factory-p384", &sig)
+            .expect("cross-factory p384 verify");
+    }
+}
+
+#[cfg(feature = "ed25519")]
+mod ed25519_cross_factory {
+    use super::*;
+    use ed25519_dalek::{Signer, Verifier};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rustcrypto::RustCryptoEd25519Ext;
+
+    #[test]
+    fn sign_factory1_verify_factory2() {
+        let seed = Seed::from_env_value("rc-cross-fac-ed").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let kp1 = fx1.ed25519("cross-ed", Ed25519Spec::new());
+        let kp2 = fx2.ed25519("cross-ed", Ed25519Spec::new());
+
+        let sig = kp1.ed25519_signing_key().sign(b"cross-factory-ed");
+        kp2.ed25519_verifying_key()
+            .verify(b"cross-factory-ed", &sig)
+            .expect("cross-factory ed25519 verify");
+    }
+
+    /// Ed25519 signatures from the same key are deterministic.
+    #[test]
+    fn ed25519_deterministic_signatures() {
+        let kp = fx().ed25519("rc-ed-det-sig", Ed25519Spec::new());
+        let sk = kp.ed25519_signing_key();
+        let sig1 = sk.sign(b"deterministic");
+        let sig2 = sk.sign(b"deterministic");
+        assert_eq!(sig1.to_bytes(), sig2.to_bytes());
+    }
+}
+
+// =========================================================================
+// HMAC cross-factory verification
+// =========================================================================
+
+#[cfg(feature = "hmac")]
+mod hmac_cross_factory {
+    use super::*;
+    use hmac::Mac;
+    use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    use uselesskey_rustcrypto::RustCryptoHmacExt;
+
+    #[test]
+    fn hmac_sha256_cross_factory_tag_matches() {
+        let seed = Seed::from_env_value("rc-cross-fac-hmac").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 = Factory::deterministic(seed);
+
+        let s1 = fx1.hmac("cross-hmac", HmacSpec::hs256());
+        let s2 = fx2.hmac("cross-hmac", HmacSpec::hs256());
+
+        let mut m1 = s1.hmac_sha256();
+        m1.update(b"cross-factory-hmac");
+        let tag = m1.finalize().into_bytes();
+
+        let mut m2 = s2.hmac_sha256();
+        m2.update(b"cross-factory-hmac");
+        m2.verify(&tag).expect("cross-factory HMAC verify");
+    }
+}
+
+// =========================================================================
+// Multiple sequential signatures
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_multi_sig {
+    use super::*;
+    use rsa::pkcs1v15::{SigningKey, VerifyingKey};
+    use rsa::signature::{Signer, Verifier};
+    use sha2::Sha256;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    use uselesskey_rustcrypto::RustCryptoRsaExt;
+
+    #[test]
+    fn multiple_signatures_all_verify() {
+        let kp = fx().rsa("rc-multi-sig", RsaSpec::rs256());
+        let signing = SigningKey::<Sha256>::new_unprefixed(kp.rsa_private_key());
+        let verifying = VerifyingKey::<Sha256>::new_unprefixed(kp.rsa_public_key());
+
+        for i in 0..5 {
+            let msg = format!("message-{i}");
+            let sig = signing.sign(msg.as_bytes());
+            verifying
+                .verify(msg.as_bytes(), &sig)
+                .unwrap_or_else(|e| panic!("verify message-{i} failed: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn large_message_sign_verify() {
+        let kp = fx().rsa("rc-rsa-large", RsaSpec::rs256());
+        let signing = SigningKey::<Sha256>::new_unprefixed(kp.rsa_private_key());
+        let verifying = VerifyingKey::<Sha256>::new_unprefixed(kp.rsa_public_key());
+
+        let msg = vec![0xABu8; 64 * 1024];
+        let sig = signing.sign(&msg);
+        verifying.verify(&msg, &sig).expect("verify large");
+    }
+}

--- a/crates/uselesskey-rustls/tests/tls_data_transfer.rs
+++ b/crates/uselesskey-rustls/tests/tls_data_transfer.rs
@@ -1,0 +1,258 @@
+//! TLS data-transfer integration tests.
+//!
+//! Tests cover:
+//! - Bidirectional data transfer after TLS handshake
+//! - Multiple sequential handshakes from the same chain
+//! - Cross-factory deterministic chain handshake
+//! - mTLS data transfer
+//! - Large payload transfer
+
+#![cfg(all(feature = "tls-config", feature = "x509"))]
+
+use std::io::{Read, Write};
+use std::sync::{Arc, Once};
+
+use rustls::crypto::CryptoProvider;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_rustls::{RustlsClientConfigExt, RustlsServerConfigExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt};
+
+use std::sync::OnceLock;
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> &'static Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-rustls-data-xfer-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+}
+
+static INIT: Once = Once::new();
+
+fn install_provider() {
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+fn ring_provider() -> Arc<CryptoProvider> {
+    Arc::new(rustls::crypto::ring::default_provider())
+}
+
+const MAX_HANDSHAKE_ITERATIONS: usize = 10;
+
+fn complete_handshake(
+    server: &mut rustls::ServerConnection,
+    client: &mut rustls::ClientConnection,
+) {
+    let mut buf = Vec::new();
+    for _ in 0..MAX_HANDSHAKE_ITERATIONS {
+        let mut progress = false;
+
+        buf.clear();
+        if client.wants_write() {
+            client.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                server.read_tls(&mut &buf[..]).unwrap();
+                server.process_new_packets().expect("server process");
+                progress = true;
+            }
+        }
+
+        buf.clear();
+        if server.wants_write() {
+            server.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                client.read_tls(&mut &buf[..]).unwrap();
+                client.process_new_packets().expect("client process");
+                progress = true;
+            }
+        }
+
+        if !progress {
+            break;
+        }
+    }
+    assert!(!client.is_handshaking());
+    assert!(!server.is_handshaking());
+}
+
+/// Transfer a round-trip message: client -> server -> client.
+fn transfer_roundtrip(
+    server: &mut rustls::ServerConnection,
+    client: &mut rustls::ClientConnection,
+    request: &[u8],
+    response: &[u8],
+) {
+    // client writes request
+    client.writer().write_all(request).unwrap();
+    let mut buf = Vec::new();
+    while client.wants_write() {
+        client.write_tls(&mut buf).unwrap();
+    }
+    server.read_tls(&mut &buf[..]).unwrap();
+    server.process_new_packets().unwrap();
+
+    let mut received = Vec::new();
+    loop {
+        let mut tmp = [0u8; 4096];
+        match server.reader().read(&mut tmp) {
+            Ok(0) => break,
+            Ok(n) => received.extend_from_slice(&tmp[..n]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) => panic!("server read error: {e:?}"),
+        }
+    }
+    assert_eq!(received, request);
+
+    // server writes response
+    server.writer().write_all(response).unwrap();
+    buf.clear();
+    while server.wants_write() {
+        server.write_tls(&mut buf).unwrap();
+    }
+    client.read_tls(&mut &buf[..]).unwrap();
+    client.process_new_packets().unwrap();
+
+    let mut received = Vec::new();
+    loop {
+        let mut tmp = [0u8; 4096];
+        match client.reader().read(&mut tmp) {
+            Ok(0) => break,
+            Ok(n) => received.extend_from_slice(&tmp[..n]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(e) => panic!("client read error: {e:?}"),
+        }
+    }
+    assert_eq!(received, response);
+}
+
+fn make_connections(
+    chain: &uselesskey_x509::X509Chain,
+    domain: &str,
+) -> (rustls::ServerConnection, rustls::ClientConnection) {
+    let provider = ring_provider();
+    let server_config = Arc::new(chain.server_config_rustls_with_provider(provider.clone()));
+    let client_config = Arc::new(chain.client_config_rustls_with_provider(provider));
+
+    let server_name: rustls::pki_types::ServerName<'_> = domain.try_into().unwrap();
+    let server = rustls::ServerConnection::new(server_config).unwrap();
+    let client = rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();
+    (server, client)
+}
+
+// =========================================================================
+// Bidirectional data transfer after handshake
+// =========================================================================
+
+#[test]
+fn data_transfer_after_chain_handshake() {
+    install_provider();
+    let chain = fx().x509_chain("data-xfer", ChainSpec::new("test.example.com"));
+    let (mut server, mut client) = make_connections(&chain, "test.example.com");
+
+    complete_handshake(&mut server, &mut client);
+    transfer_roundtrip(
+        &mut server,
+        &mut client,
+        b"GET / HTTP/1.1\r\n",
+        b"HTTP/1.1 200 OK\r\n",
+    );
+}
+
+// =========================================================================
+// Multiple sequential handshakes from the same chain
+// =========================================================================
+
+#[test]
+fn multiple_handshakes_same_chain() {
+    install_provider();
+    let chain = fx().x509_chain("multi-hs", ChainSpec::new("test.example.com"));
+
+    for i in 0..3 {
+        let (mut server, mut client) = make_connections(&chain, "test.example.com");
+        complete_handshake(&mut server, &mut client);
+        let req = format!("request-{i}");
+        let resp = format!("response-{i}");
+        transfer_roundtrip(&mut server, &mut client, req.as_bytes(), resp.as_bytes());
+    }
+}
+
+// =========================================================================
+// Cross-factory deterministic chain handshake
+// =========================================================================
+
+#[test]
+fn cross_factory_deterministic_handshake() {
+    install_provider();
+    let seed = Seed::from_env_value("rustls-cross-fac-v1").unwrap();
+
+    // Factory1 produces the server chain, Factory2 produces the client trust store
+    let fx1 = Factory::deterministic(seed);
+    let fx2 = Factory::deterministic(seed);
+
+    let chain1 = fx1.x509_chain("cross-fac", ChainSpec::new("test.example.com"));
+    let chain2 = fx2.x509_chain("cross-fac", ChainSpec::new("test.example.com"));
+
+    // Verify they are the same chain
+    assert_eq!(chain1.leaf_cert_der(), chain2.leaf_cert_der());
+
+    let provider = ring_provider();
+    // Server uses chain1, client trusts chain2's root (same root, different factory instance)
+    let server_config = Arc::new(chain1.server_config_rustls_with_provider(provider.clone()));
+    let client_config = Arc::new(chain2.client_config_rustls_with_provider(provider));
+
+    let server_name: rustls::pki_types::ServerName<'_> = "test.example.com".try_into().unwrap();
+    let mut server = rustls::ServerConnection::new(server_config).unwrap();
+    let mut client = rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();
+
+    complete_handshake(&mut server, &mut client);
+    transfer_roundtrip(&mut server, &mut client, b"cross-factory", b"ok");
+}
+
+// =========================================================================
+// mTLS with data transfer
+// =========================================================================
+
+#[test]
+fn mtls_data_transfer() {
+    install_provider();
+    let fx = fx();
+    let chain = fx.x509_chain("mtls-data", ChainSpec::new("test.example.com"));
+
+    let provider = ring_provider();
+    use uselesskey_rustls::RustlsMtlsExt;
+    let server_config = Arc::new(chain.server_config_mtls_rustls_with_provider(provider.clone()));
+    let client_config = Arc::new(chain.client_config_mtls_rustls_with_provider(provider));
+
+    let server_name: rustls::pki_types::ServerName<'_> = "test.example.com".try_into().unwrap();
+    let mut server = rustls::ServerConnection::new(server_config).unwrap();
+    let mut client = rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();
+
+    complete_handshake(&mut server, &mut client);
+    transfer_roundtrip(
+        &mut server,
+        &mut client,
+        b"mutual-auth-request",
+        b"mutual-auth-response",
+    );
+}
+
+// =========================================================================
+// Non-trivial payload transfer
+// =========================================================================
+
+#[test]
+fn nontrivial_payload_transfer() {
+    install_provider();
+    let chain = fx().x509_chain("large-data", ChainSpec::new("test.example.com"));
+    let (mut server, mut client) = make_connections(&chain, "test.example.com");
+
+    complete_handshake(&mut server, &mut client);
+
+    let request = vec![0xABu8; 512];
+    let response = vec![0xCDu8; 512];
+    transfer_roundtrip(&mut server, &mut client, &request, &response);
+}


### PR DESCRIPTION
## Wave 88: Expand Adapter Integration Tests

Adds new integration test files for all 5 adapter crates, covering gaps identified in existing test coverage.

### New test files

| Crate | File | Tests | Key scenarios |
|-------|------|-------|---------------|
| **uselesskey-jsonwebtoken** | \jwt_roundtrip_all_algos.rs\ | 8 | All RSA algorithms round-trip, payload/signature tampering, mismatched key variant, cross-factory deterministic (Ed25519+HMAC), multi-token ECDSA |
| **uselesskey-rustls** | \	ls_data_transfer.rs\ | 5 | Bidirectional data transfer after TLS handshake, multiple handshakes same chain, cross-factory deterministic chain, mTLS data transfer, non-trivial payload |
| **uselesskey-ring** | \ing_multi_scheme.rs\ | 16 | RSA PSS SHA-256/384/512, PKCS1 SHA-384/512, empty/large messages for all key types, cross-factory deterministic, Ed25519 signature determinism |
| **uselesskey-rustcrypto** | \ustcrypto_cross_verify.rs\ | 11 | RSA PSS via RandomizedSigner, cross-factory deterministic for RSA/ECDSA/Ed25519/HMAC, Ed25519 determinism, multi-signature, large message |
| **uselesskey-aws-lc-rs** | \ws_lc_rs_multi_scheme.rs\ | 12 | RSA PKCS1+PSS with SHA-384/512, signature length validation (2048/4096), multi-message all key types, cross-factory deterministic, Ed25519 determinism |

### Test coverage themes
- **Cross-factory deterministic verification**: Sign with factory1, verify with factory2 using same seed
- **Multiple signing schemes**: RSA PSS, PKCS1 with SHA-384/SHA-512 (previously only SHA-256)
- **Token integrity**: JWT payload and signature tampering detection
- **TLS data transfer**: Actual application data exchange after handshake (not just handshake completion)
- **Edge cases**: Empty messages, large messages, mismatched key variants
- **Determinism**: Ed25519 same key+message produces identical signatures

### Validation
- \cargo fmt --all\ ✅
- \cargo test --workspace --all-features --exclude uselesskey-bdd\ — **2,934 tests pass** ✅
