### PR TITLE
perf: add criterion benchmarks for hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cast5"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +440,33 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "cipher"
@@ -568,6 +607,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +664,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -642,7 +721,7 @@ dependencies = [
  "globwalk",
  "humantime",
  "inventory",
- "itertools",
+ "itertools 0.14.0",
  "linked-hash-map",
  "pin-project",
  "ref-cast",
@@ -659,7 +738,7 @@ checksum = "5a1afaf9c422380861111c6be56f39b324e351fd9efc07a1486268798bf79cfd"
 dependencies = [
  "cucumber-expressions",
  "inflections",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1328,6 +1407,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,6 +1443,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1574,10 +1670,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1904,6 +2020,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -3052,6 +3174,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,6 +3472,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 name = "uselesskey"
 version = "0.3.0"
 dependencies = [
+ "criterion",
  "pem",
  "proptest",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ uselesskey-core-sink = { path = "crates/uselesskey-core-sink", version = "0.3.0"
 proptest = "1.10.0"
 rstest = "0.26.1"
 insta = { version = "1", features = ["yaml", "redactions"] }
+criterion = { version = "0.5", default-features = false, features = ["html_reports", "cargo_bench_support"] }
 
 # CLI helpers (xtask)
 anyhow = "1.0.102"

--- a/crates/uselesskey/Cargo.toml
+++ b/crates/uselesskey/Cargo.toml
@@ -64,5 +64,11 @@ full = ["all-keys", "token", "x509", "jwk"]
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true
+criterion.workspace = true
 pem = "3"
 x509-parser = "0.18"
+
+[[bench]]
+name = "keygen"
+harness = false
+required-features = ["full"]

--- a/crates/uselesskey/benches/keygen.rs
+++ b/crates/uselesskey/benches/keygen.rs
@@ -1,0 +1,200 @@
+#![forbid(unsafe_code)]
+
+//! Criterion benchmarks for the hot paths in the uselesskey workspace.
+//!
+//! Run with: `cargo bench -p uselesskey --features full`
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use uselesskey::{
+    EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, HmacFactoryExt, HmacSpec,
+    RsaFactoryExt, RsaSpec, Seed, X509FactoryExt, X509Spec,
+};
+
+// ── RSA key generation (the biggest hot path) ───────────────────────
+
+fn bench_rsa_keygen(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rsa_keygen");
+    group.sample_size(10);
+
+    group.bench_function("2048", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.rsa("bench", RsaSpec::rs256()),
+            criterion::BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("4096", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.rsa("bench", RsaSpec::new(4096)),
+            criterion::BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+// ── ECDSA P-256 / P-384 key generation ──────────────────────────────
+
+fn bench_ecdsa_keygen(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ecdsa_keygen");
+
+    group.bench_function("p256", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.ecdsa("bench", EcdsaSpec::es256()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("p384", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.ecdsa("bench", EcdsaSpec::es384()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ── Ed25519 key generation ──────────────────────────────────────────
+
+fn bench_ed25519_keygen(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ed25519_keygen");
+
+    group.bench_function("ed25519", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.ed25519("bench", Ed25519Spec::new()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ── HMAC key generation ─────────────────────────────────────────────
+
+fn bench_hmac_keygen(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hmac_keygen");
+
+    group.bench_function("hs256", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.hmac("bench", HmacSpec::hs256()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("hs384", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.hmac("bench", HmacSpec::hs384()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("hs512", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.hmac("bench", HmacSpec::hs512()),
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+// ── X.509 self-signed certificate generation ────────────────────────
+
+fn bench_x509_generation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("x509_generation");
+    group.sample_size(10);
+
+    group.bench_function("self_signed_2048", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.x509_self_signed("bench", X509Spec::self_signed("bench.example.com")),
+            criterion::BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+// ── Factory cache: hit vs miss ──────────────────────────────────────
+
+fn bench_cache_hit_vs_miss(c: &mut Criterion) {
+    // Cache miss: fresh factory ⇒ forces full RSA keygen each iteration
+    {
+        let mut group = c.benchmark_group("cache/miss");
+        group.sample_size(10);
+
+        group.bench_function("rsa_2048", |b| {
+            b.iter_batched(
+                Factory::random,
+                |fx| fx.rsa("bench", RsaSpec::rs256()),
+                criterion::BatchSize::PerIteration,
+            );
+        });
+
+        group.finish();
+    }
+
+    // Cache hit: reuse factory, key already materialised
+    {
+        let mut group = c.benchmark_group("cache/hit");
+
+        let fx = Factory::random();
+        let _ = fx.rsa("bench", RsaSpec::rs256()); // prime the cache
+
+        group.bench_function("rsa_2048", |b| {
+            b.iter(|| fx.rsa("bench", RsaSpec::rs256()));
+        });
+
+        group.finish();
+    }
+}
+
+// ── Deterministic vs random mode ────────────────────────────────────
+
+fn bench_deterministic_vs_random(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deterministic_vs_random");
+    group.sample_size(10);
+
+    group.bench_function("rsa_2048_random", |b| {
+        b.iter_batched(
+            Factory::random,
+            |fx| fx.rsa("bench", RsaSpec::rs256()),
+            criterion::BatchSize::PerIteration,
+        );
+    });
+
+    let seed = Seed::from_env_value("bench-seed").expect("valid seed");
+    group.bench_function("rsa_2048_deterministic", |b| {
+        b.iter_batched(
+            || Factory::deterministic(seed),
+            |fx| fx.rsa("bench", RsaSpec::rs256()),
+            criterion::BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+// ── Criterion wiring ────────────────────────────────────────────────
+
+criterion_group!(
+    keygen,
+    bench_rsa_keygen,
+    bench_ecdsa_keygen,
+    bench_ed25519_keygen,
+    bench_hmac_keygen,
+    bench_x509_generation,
+    bench_cache_hit_vs_miss,
+    bench_deterministic_vs_random,
+);
+
+criterion_main!(keygen);


### PR DESCRIPTION
Add criterion benchmarks for the hot paths in the workspace.

## Benchmarks added

| Group | Benchmarks |
|-------|-----------|
| **RSA keygen** | 2048-bit, 4096-bit |
| **ECDSA keygen** | P-256, P-384 |
| **Ed25519 keygen** | Ed25519 |
| **HMAC keygen** | HS256, HS384, HS512 |
| **X.509 generation** | Self-signed 2048-bit |
| **Cache hit vs miss** | RSA 2048 with/without primed cache |
| **Deterministic vs random** | RSA 2048 in both modes |

## Changes

- Added \criterion\ as a workspace dev-dependency in root \Cargo.toml\
- Created \crates/uselesskey/benches/keygen.rs\ with all benchmark functions
- Added \[[bench]]\ section to \crates/uselesskey/Cargo.toml\ (requires \ull\ feature)

## Running

\\\ash
cargo bench -p uselesskey --features full
\\\

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>