### PR TITLE
test: expand BDD scenarios for uncovered features

### DIFF
--- a/crates/uselesskey-bdd-steps/src/lib.rs
+++ b/crates/uselesskey-bdd-steps/src/lib.rs
@@ -1069,6 +1069,34 @@ fn corrupt_ed25519_bad_header(world: &mut UselessWorld) {
         Some(ed25519.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader));
 }
 
+#[when("I corrupt the Ed25519 PKCS8 PEM with BadFooter")]
+fn corrupt_ed25519_bad_footer(world: &mut UselessWorld) {
+    let ed25519 = world.ed25519.as_ref().expect("ed25519 not set");
+    world.ed25519_corrupted_pem =
+        Some(ed25519.private_key_pkcs8_pem_corrupt(CorruptPem::BadFooter));
+}
+
+#[when("I corrupt the Ed25519 PKCS8 PEM with BadBase64")]
+fn corrupt_ed25519_bad_base64(world: &mut UselessWorld) {
+    let ed25519 = world.ed25519.as_ref().expect("ed25519 not set");
+    world.ed25519_corrupted_pem =
+        Some(ed25519.private_key_pkcs8_pem_corrupt(CorruptPem::BadBase64));
+}
+
+#[when(regex = r"^I corrupt the Ed25519 PKCS8 PEM with Truncate to (\d+) bytes$")]
+fn corrupt_ed25519_truncate(world: &mut UselessWorld, bytes: usize) {
+    let ed25519 = world.ed25519.as_ref().expect("ed25519 not set");
+    world.ed25519_corrupted_pem =
+        Some(ed25519.private_key_pkcs8_pem_corrupt(CorruptPem::Truncate { bytes }));
+}
+
+#[when("I corrupt the Ed25519 PKCS8 PEM with ExtraBlankLine")]
+fn corrupt_ed25519_extra_blank(world: &mut UselessWorld) {
+    let ed25519 = world.ed25519.as_ref().expect("ed25519 not set");
+    world.ed25519_corrupted_pem =
+        Some(ed25519.private_key_pkcs8_pem_corrupt(CorruptPem::ExtraBlankLine));
+}
+
 #[when(regex = r"^I truncate the Ed25519 PKCS8 DER to (\d+) bytes$")]
 fn truncate_ed25519_der(world: &mut UselessWorld, len: usize) {
     let ed25519 = world.ed25519.as_ref().expect("ed25519 not set");
@@ -1220,6 +1248,31 @@ fn ed25519_truncated_der_length(world: &mut UselessWorld, expected: usize) {
         .as_ref()
         .expect("ed25519_truncated_der not set");
     assert_eq!(der.len(), expected);
+}
+
+#[then("the corrupted Ed25519 PEM should fail to parse")]
+fn ed25519_corrupted_pem_fails(world: &mut UselessWorld) {
+    use ed25519_dalek::SigningKey;
+    use ed25519_dalek::pkcs8::DecodePrivateKey;
+
+    let pem = world
+        .ed25519_corrupted_pem
+        .as_ref()
+        .expect("ed25519_corrupted_pem not set");
+    let result = SigningKey::from_pkcs8_pem(pem);
+    assert!(
+        result.is_err(),
+        "corrupted Ed25519 PEM should fail to parse"
+    );
+}
+
+#[then(regex = r"^the corrupted Ed25519 PEM should have length (\d+)$")]
+fn ed25519_corrupted_pem_length(world: &mut UselessWorld, expected: usize) {
+    let pem = world
+        .ed25519_corrupted_pem
+        .as_ref()
+        .expect("ed25519_corrupted_pem not set");
+    assert_eq!(pem.len(), expected);
 }
 
 #[then("the truncated Ed25519 DER should fail to parse")]
@@ -1437,6 +1490,32 @@ fn corrupt_ecdsa_bad_header(world: &mut UselessWorld) {
     world.ecdsa_corrupted_pem = Some(ecdsa.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader));
 }
 
+#[when("I corrupt the ECDSA PKCS8 PEM with BadFooter")]
+fn corrupt_ecdsa_bad_footer(world: &mut UselessWorld) {
+    let ecdsa = world.ecdsa.as_ref().expect("ecdsa not set");
+    world.ecdsa_corrupted_pem = Some(ecdsa.private_key_pkcs8_pem_corrupt(CorruptPem::BadFooter));
+}
+
+#[when("I corrupt the ECDSA PKCS8 PEM with BadBase64")]
+fn corrupt_ecdsa_bad_base64(world: &mut UselessWorld) {
+    let ecdsa = world.ecdsa.as_ref().expect("ecdsa not set");
+    world.ecdsa_corrupted_pem = Some(ecdsa.private_key_pkcs8_pem_corrupt(CorruptPem::BadBase64));
+}
+
+#[when(regex = r"^I corrupt the ECDSA PKCS8 PEM with Truncate to (\d+) bytes$")]
+fn corrupt_ecdsa_truncate(world: &mut UselessWorld, bytes: usize) {
+    let ecdsa = world.ecdsa.as_ref().expect("ecdsa not set");
+    world.ecdsa_corrupted_pem =
+        Some(ecdsa.private_key_pkcs8_pem_corrupt(CorruptPem::Truncate { bytes }));
+}
+
+#[when("I corrupt the ECDSA PKCS8 PEM with ExtraBlankLine")]
+fn corrupt_ecdsa_extra_blank(world: &mut UselessWorld) {
+    let ecdsa = world.ecdsa.as_ref().expect("ecdsa not set");
+    world.ecdsa_corrupted_pem =
+        Some(ecdsa.private_key_pkcs8_pem_corrupt(CorruptPem::ExtraBlankLine));
+}
+
 #[when(regex = r"^I truncate the ECDSA PKCS8 DER to (\d+) bytes$")]
 fn truncate_ecdsa_der(world: &mut UselessWorld, len: usize) {
     let ecdsa = world.ecdsa.as_ref().expect("ecdsa not set");
@@ -1602,6 +1681,31 @@ fn ecdsa_corrupted_pem_contains(world: &mut UselessWorld, needle: String) {
         pem.contains(&needle),
         "expected ECDSA PEM to contain '{needle}'"
     );
+}
+
+#[then("the corrupted ECDSA PEM should fail to parse")]
+fn ecdsa_corrupted_pem_fails(world: &mut UselessWorld) {
+    use p256::pkcs8::DecodePrivateKey as _;
+
+    let pem = world
+        .ecdsa_corrupted_pem
+        .as_ref()
+        .expect("ecdsa_corrupted_pem not set");
+    let p256_result = p256::SecretKey::from_pkcs8_pem(pem);
+    let p384_result = p384::SecretKey::from_pkcs8_pem(pem);
+    assert!(
+        p256_result.is_err() && p384_result.is_err(),
+        "corrupted ECDSA PEM should fail to parse"
+    );
+}
+
+#[then(regex = r"^the corrupted ECDSA PEM should have length (\d+)$")]
+fn ecdsa_corrupted_pem_length(world: &mut UselessWorld, expected: usize) {
+    let pem = world
+        .ecdsa_corrupted_pem
+        .as_ref()
+        .expect("ecdsa_corrupted_pem not set");
+    assert_eq!(pem.len(), expected);
 }
 
 #[then(regex = r"^the truncated ECDSA DER should have length (\d+)$")]

--- a/crates/uselesskey-bdd/features/cache_behavior.feature
+++ b/crates/uselesskey-bdd/features/cache_behavior.feature
@@ -85,3 +85,57 @@ Feature: Cache behavior
     And I clear the factory cache
     And I generate an RSA key for label "random-clear" again
     Then the PKCS8 PEM should differ
+
+  # --- Ed25519 cache behavior ---
+
+  Scenario: Ed25519 cache hit returns identical key material
+    Given a deterministic factory seeded with "cache-hit-ed25519"
+    When I generate an Ed25519 key for label "cached-ed25519"
+    And I generate an Ed25519 key for label "cached-ed25519" again
+    Then the Ed25519 PKCS8 PEM should be identical
+
+  Scenario: different labels are cache-isolated for Ed25519
+    Given a deterministic factory seeded with "cache-miss-label-ed25519"
+    When I generate an Ed25519 key for label "label-alpha"
+    And I generate another Ed25519 key for label "label-beta"
+    Then the Ed25519 keys should have different public keys
+
+  Scenario: cache clear followed by re-derive gives identical ECDSA key
+    Given a deterministic factory seeded with "cache-clear-ecdsa"
+    When I generate an ECDSA ES256 key for label "clear-ecdsa"
+    And I clear the factory cache
+    And I generate an ECDSA ES256 key for label "clear-ecdsa" again
+    Then the ECDSA PKCS8 PEM should be identical
+
+  Scenario: cache clear followed by re-derive gives identical Ed25519 key
+    Given a deterministic factory seeded with "cache-clear-ed25519"
+    When I generate an Ed25519 key for label "clear-ed25519"
+    And I clear the factory cache
+    And I generate an Ed25519 key for label "clear-ed25519" again
+    Then the Ed25519 PKCS8 PEM should be identical
+
+  # --- Cross-type cache isolation ---
+
+  Scenario: generating one key type does not invalidate another in cache
+    Given a deterministic factory seeded with "cache-cross-type-isolation"
+    When I generate an RSA key for label "rsa-stable"
+    And I generate an ECDSA ES256 key for label "ecdsa-stable"
+    And I generate an Ed25519 key for label "ed25519-stable"
+    And I generate an RSA key for label "rsa-stable" again
+    Then the PKCS8 PEM should be identical
+
+  # --- Bearer and OAuth token cache behavior ---
+
+  Scenario: cache clear followed by re-derive gives identical bearer token
+    Given a deterministic factory seeded with "cache-clear-bearer"
+    When I generate a bearer token for label "clear-bearer"
+    And I clear the factory cache
+    And I generate a bearer token for label "clear-bearer" again
+    Then the token values should be identical
+
+  Scenario: cache clear followed by re-derive gives identical OAuth token
+    Given a deterministic factory seeded with "cache-clear-oauth"
+    When I generate an OAuth access token for label "clear-oauth"
+    And I clear the factory cache
+    And I generate an OAuth access token for label "clear-oauth" again
+    Then the token values should be identical

--- a/crates/uselesskey-bdd/features/cross_key.feature
+++ b/crates/uselesskey-bdd/features/cross_key.feature
@@ -107,11 +107,36 @@ Feature: Cross-key validation failures
     Then a mismatched SPKI DER should parse and differ
     And an ECDSA mismatched SPKI DER should parse and differ
 
-  # --- Mismatch variants produce parseable but different keys across types ---
+  # --- JWKS with all four key types ---
 
-  Scenario: RSA and ECDSA mismatch variants both produce distinct public keys
-    Given a deterministic factory seeded with "cross-mismatch-test"
-    When I generate an RSA key for label "cross-mismatch" with spec RS256
-    And I generate an ECDSA ES256 key for label "cross-mismatch"
+  Scenario: JWKS can contain all four key types including HMAC
+    Given a deterministic factory seeded with "cross-jwks-all-four"
+    When I generate an RSA key for label "all-rsa" with spec RS256
+    And I generate an ECDSA ES256 key for label "all-ecdsa"
+    And I generate an Ed25519 key for label "all-ed25519"
+    And I generate an HMAC HS256 secret for label "all-hmac"
+    And I build a JWKS containing all keys
+    Then the JWKS should contain 4 keys
+    And the JWKS should contain a key with kty "RSA"
+    And the JWKS should contain a key with kty "EC"
+    And the JWKS should contain a key with kty "OKP"
+
+  # --- Ed25519 mismatch also works across types ---
+
+  Scenario: Ed25519 mismatch variant produces distinct public key
+    Given a deterministic factory seeded with "cross-ed25519-mismatch"
+    When I generate an RSA key for label "rsa-for-mismatch" with spec RS256
+    And I generate an Ed25519 key for label "ed25519-for-mismatch"
     Then a mismatched SPKI DER should parse and differ
-    And an ECDSA mismatched SPKI DER should parse and differ
+    And an Ed25519 mismatched SPKI DER should parse and differ
+
+  # --- Key format validity across all types in same factory ---
+
+  Scenario: all key types produce valid DER formats from same factory
+    Given a deterministic factory seeded with "cross-format-validity"
+    When I generate an RSA key for label "format-rsa" with spec RS256
+    And I generate an ECDSA ES256 key for label "format-ecdsa"
+    And I generate an Ed25519 key for label "format-ed25519"
+    Then the PKCS8 DER should be parseable
+    And the ECDSA PKCS8 DER should be parseable
+    And the Ed25519 PKCS8 DER should be parseable

--- a/crates/uselesskey-bdd/features/determinism_edge_cases.feature
+++ b/crates/uselesskey-bdd/features/determinism_edge_cases.feature
@@ -87,3 +87,46 @@ Feature: Determinism edge cases
     And I switch to a deterministic factory seeded with "det-edge-x509-recreate"
     And I generate an X.509 certificate for domain "test.example.com" with label "stable-cert" again
     Then the X.509 certificate PEM should be identical
+
+  # --- HMAC determinism with interleaved generation ---
+
+  Scenario: HMAC determinism survives interleaved key generation
+    Given a deterministic factory seeded with "det-edge-hmac-interleave"
+    When I generate an HMAC HS256 secret for label "hmac-first"
+    And I generate an RSA key for label "interleave-rsa"
+    And I generate an Ed25519 key for label "interleave-ed25519"
+    And I clear the factory cache
+    And I generate an HMAC HS256 secret for label "hmac-first" again
+    Then the HMAC secrets should be identical
+
+  # --- ECDSA determinism with interleaved generation ---
+
+  Scenario: ECDSA determinism survives interleaved generation with other types
+    Given a deterministic factory seeded with "det-edge-ecdsa-interleave"
+    When I generate an ECDSA ES256 key for label "ecdsa-first"
+    And I generate an RSA key for label "interleave-rsa"
+    And I generate an HMAC HS256 secret for label "interleave-hmac"
+    And I generate an Ed25519 key for label "interleave-ed25519"
+    And I clear the factory cache
+    And I generate an ECDSA ES256 key for label "ecdsa-first" again
+    Then the ECDSA PKCS8 PEM should be identical
+
+  # --- Different seeds produce completely different material for all types ---
+
+  Scenario: different seeds produce different HMAC secrets
+    Given a deterministic factory seeded with "det-edge-hmac-seed-a"
+    When I generate an HMAC HS256 secret for label "service"
+    And I switch to a deterministic factory seeded with "det-edge-hmac-seed-b"
+    And I generate another HMAC HS256 secret for label "service"
+    Then the HMAC secrets should be different
+
+  # --- Token type does not perturb key generation ---
+
+  Scenario: generating tokens does not perturb RSA determinism
+    Given a deterministic factory seeded with "det-edge-token-no-perturb"
+    When I generate an RSA key for label "rsa-anchor"
+    And I generate an API key token for label "token-noise"
+    And I generate a bearer token for label "bearer-noise"
+    And I clear the factory cache
+    And I generate an RSA key for label "rsa-anchor" again
+    Then the PKCS8 PEM should be identical

--- a/crates/uselesskey-bdd/features/edge_cases.feature
+++ b/crates/uselesskey-bdd/features/edge_cases.feature
@@ -116,3 +116,53 @@ Feature: Edge cases and error handling
     And I switch to a deterministic factory seeded with "recreation-hmac-test"
     And I generate an HMAC HS256 secret for label "stable" again
     Then the HMAC secrets should be identical
+
+  # --- Unicode labels for more key types ---
+
+  Scenario: label with unicode characters generates valid Ed25519 key
+    Given a deterministic factory seeded with "unicode-ed25519-test"
+    When I generate an Ed25519 key for label "名前テスト"
+    Then the Ed25519 PKCS8 DER should be parseable
+
+  Scenario: label with unicode characters generates valid HMAC secret
+    Given a deterministic factory seeded with "unicode-hmac-test"
+    When I generate an HMAC HS256 secret for label "clé-secrète-🔐"
+    Then the HMAC secret bytes should have length 32
+
+  # --- Very long labels for more key types ---
+
+  Scenario: very long label generates valid ECDSA key
+    Given a deterministic factory seeded with "long-label-ecdsa-test"
+    When I generate an ECDSA ES256 key for label "this-is-a-very-long-label-that-exceeds-normal-lengths-for-ecdsa"
+    Then the ECDSA PKCS8 DER should be parseable
+
+  Scenario: very long label generates valid Ed25519 key
+    Given a deterministic factory seeded with "long-label-ed25519-test"
+    When I generate an Ed25519 key for label "this-is-a-very-long-label-that-exceeds-normal-lengths-for-ed25519"
+    Then the Ed25519 PKCS8 DER should be parseable
+
+  Scenario: very long label generates valid HMAC secret
+    Given a deterministic factory seeded with "long-label-hmac-test"
+    When I generate an HMAC HS256 secret for label "this-is-a-very-long-label-that-exceeds-normal-lengths-for-hmac"
+    Then the HMAC secret bytes should have length 32
+
+  # --- DER truncation edge cases for ECDSA and Ed25519 ---
+
+  Scenario: truncating ECDSA DER to 0 bytes returns empty
+    Given a deterministic factory seeded with "truncate-zero-ecdsa"
+    When I generate an ECDSA ES256 key for label "truncate-zero"
+    And I truncate the ECDSA PKCS8 DER to 0 bytes
+    Then the truncated ECDSA DER should have length 0
+
+  Scenario: truncating Ed25519 DER to 0 bytes returns empty
+    Given a deterministic factory seeded with "truncate-zero-ed25519"
+    When I generate an Ed25519 key for label "truncate-zero"
+    And I truncate the Ed25519 PKCS8 DER to 0 bytes
+    Then the truncated Ed25519 DER should have length 0
+
+  # --- Special character labels for ECDSA ---
+
+  Scenario: label with special characters generates valid ECDSA key
+    Given a deterministic factory seeded with "special-chars-ecdsa"
+    When I generate an ECDSA ES256 key for label "test-label_123!@#$%"
+    Then the ECDSA PKCS8 DER should be parseable

--- a/crates/uselesskey-bdd/features/negative.feature
+++ b/crates/uselesskey-bdd/features/negative.feature
@@ -109,3 +109,93 @@ Feature: Negative fixtures
     And I deterministically corrupt the Ed25519 PKCS8 PEM with variant "corrupt-v1" again
     Then the deterministic text artifacts should be identical
     And the deterministic Ed25519 PEM artifact should fail to parse
+
+  # --- ECDSA corruption type coverage ---
+
+  Scenario: ECDSA BadFooter corruption replaces the END line
+    Given a deterministic factory seeded with "ecdsa-badfooter-neg"
+    When I generate an ECDSA ES256 key for label "footer-test"
+    And I corrupt the ECDSA PKCS8 PEM with BadFooter
+    Then the corrupted ECDSA PEM should contain "END CORRUPTED KEY"
+    And the corrupted ECDSA PEM should fail to parse
+
+  Scenario: ECDSA BadBase64 corruption injects invalid characters
+    Given a deterministic factory seeded with "ecdsa-badbase64-neg"
+    When I generate an ECDSA ES256 key for label "base64-test"
+    And I corrupt the ECDSA PKCS8 PEM with BadBase64
+    Then the corrupted ECDSA PEM should contain "THIS_IS_NOT_BASE64"
+    And the corrupted ECDSA PEM should fail to parse
+
+  Scenario: ECDSA Truncate corruption cuts the PEM short
+    Given a deterministic factory seeded with "ecdsa-truncate-pem-neg"
+    When I generate an ECDSA ES256 key for label "truncate-pem"
+    And I corrupt the ECDSA PKCS8 PEM with Truncate to 30 bytes
+    Then the corrupted ECDSA PEM should have length 30
+    And the corrupted ECDSA PEM should fail to parse
+
+  Scenario: ECDSA ExtraBlankLine corruption fails parsing
+    Given a deterministic factory seeded with "ecdsa-blankline-neg"
+    When I generate an ECDSA ES256 key for label "blankline-test"
+    And I corrupt the ECDSA PKCS8 PEM with ExtraBlankLine
+    Then the corrupted ECDSA PEM should fail to parse
+
+  # --- Ed25519 corruption type coverage ---
+
+  Scenario: Ed25519 BadFooter corruption replaces the END line
+    Given a deterministic factory seeded with "ed25519-badfooter-neg"
+    When I generate an Ed25519 key for label "footer-test"
+    And I corrupt the Ed25519 PKCS8 PEM with BadFooter
+    Then the corrupted Ed25519 PEM should contain "END CORRUPTED KEY"
+    And the corrupted Ed25519 PEM should fail to parse
+
+  Scenario: Ed25519 BadBase64 corruption injects invalid characters
+    Given a deterministic factory seeded with "ed25519-badbase64-neg"
+    When I generate an Ed25519 key for label "base64-test"
+    And I corrupt the Ed25519 PKCS8 PEM with BadBase64
+    Then the corrupted Ed25519 PEM should contain "THIS_IS_NOT_BASE64"
+    And the corrupted Ed25519 PEM should fail to parse
+
+  Scenario: Ed25519 Truncate corruption cuts the PEM short
+    Given a deterministic factory seeded with "ed25519-truncate-pem-neg"
+    When I generate an Ed25519 key for label "truncate-pem"
+    And I corrupt the Ed25519 PKCS8 PEM with Truncate to 20 bytes
+    Then the corrupted Ed25519 PEM should have length 20
+    And the corrupted Ed25519 PEM should fail to parse
+
+  Scenario: Ed25519 ExtraBlankLine corruption fails parsing
+    Given a deterministic factory seeded with "ed25519-blankline-neg"
+    When I generate an Ed25519 key for label "blankline-test"
+    And I corrupt the Ed25519 PKCS8 PEM with ExtraBlankLine
+    Then the corrupted Ed25519 PEM should fail to parse
+
+  # --- DER corruption variants across key types ---
+
+  Scenario: ECDSA different DER corruption variants produce different outputs
+    Given a deterministic factory seeded with "ecdsa-der-variants-neg"
+    When I generate an ECDSA ES256 key for label "der-variant-test"
+    And I deterministically corrupt the ECDSA PKCS8 DER with variant "alpha"
+    And I deterministically corrupt the ECDSA PKCS8 DER with variant "beta" again
+    Then the deterministic binary artifacts should differ
+
+  Scenario: Ed25519 different DER corruption variants produce different outputs
+    Given a deterministic factory seeded with "ed25519-der-variants-neg"
+    When I generate an Ed25519 key for label "der-variant-test"
+    And I deterministically corrupt the Ed25519 PKCS8 DER with variant "alpha"
+    And I deterministically corrupt the Ed25519 PKCS8 DER with variant "beta" again
+    Then the deterministic binary artifacts should differ
+
+  # --- Mismatched key determinism across types ---
+
+  Scenario: ECDSA mismatched key variant is deterministic
+    Given a deterministic factory seeded with "ecdsa-mismatch-det-neg"
+    When I generate an ECDSA ES256 key for label "mismatch-victim"
+    And I get the mismatched ECDSA public key
+    And I get the mismatched ECDSA public key again
+    Then the mismatched ECDSA keys should be identical
+
+  Scenario: Ed25519 mismatched key variant is deterministic
+    Given a deterministic factory seeded with "ed25519-mismatch-det-neg"
+    When I generate an Ed25519 key for label "mismatch-victim"
+    And I get the mismatched Ed25519 public key
+    And I get the mismatched Ed25519 public key again
+    Then the mismatched Ed25519 keys should be identical

--- a/crates/uselesskey-bdd/features/token.feature
+++ b/crates/uselesskey-bdd/features/token.feature
@@ -144,3 +144,45 @@ Feature: Token fixtures
     When I generate an API key token for label "service" with variant "v1"
     And I generate an API key token for label "service" with variant "v1" again
     Then the token values should be identical
+
+  # --- Different labels produce different tokens for all types ---
+
+  Scenario: different labels produce different bearer tokens
+    Given a deterministic factory seeded with "bearer-label-diff"
+    When I generate a bearer token for label "alice"
+    And I generate another bearer token for label "bob"
+    Then the token values should be different
+
+  Scenario: different labels produce different OAuth tokens
+    Given a deterministic factory seeded with "oauth-label-diff"
+    When I generate an OAuth access token for label "alice"
+    And I generate another OAuth access token for label "bob"
+    Then the token values should be different
+
+  # --- Random mode for bearer and OAuth ---
+
+  Scenario: random factory produces different bearer tokens after cache clear
+    Given a random factory
+    When I generate a bearer token for label "ephemeral-bearer"
+    And I clear the factory cache
+    And I generate a bearer token for label "ephemeral-bearer" again
+    Then the token values should be different
+
+  Scenario: random factory caches bearer tokens within same session
+    Given a random factory
+    When I generate a bearer token for label "cached-bearer"
+    And I generate a bearer token for label "cached-bearer" again
+    Then the token values should be identical
+
+  Scenario: random factory produces different OAuth tokens after cache clear
+    Given a random factory
+    When I generate an OAuth access token for label "ephemeral-oauth"
+    And I clear the factory cache
+    And I generate an OAuth access token for label "ephemeral-oauth" again
+    Then the token values should be different
+
+  Scenario: random factory caches OAuth tokens within same session
+    Given a random factory
+    When I generate an OAuth access token for label "cached-oauth"
+    And I generate an OAuth access token for label "cached-oauth" again
+    Then the token values should be identical


### PR DESCRIPTION
## Summary

Expands BDD test coverage by adding ~45 new scenarios across 6 feature files and new step definitions for previously uncovered features.

## Changes

### New step definitions (lib.rs)
- ECDSA corruption: BadFooter, BadBase64, Truncate, ExtraBlankLine
- Ed25519 corruption: BadFooter, BadBase64, Truncate, ExtraBlankLine
- Parse-failure assertions for corrupted ECDSA/Ed25519 PEM
- Length assertions for corrupted ECDSA/Ed25519 PEM

### New scenarios by feature file

| File | New scenarios | Coverage area |
|------|--------------|--------------|
| cache_behavior.feature | 8 | Ed25519 cache hit/miss, ECDSA/Ed25519 re-derive, cross-type isolation, bearer/OAuth cache |
| negative.feature | 13 | Full ECDSA/Ed25519 corruption suite, DER variants, mismatch determinism |
| token.feature | 8 | Bearer/OAuth label differentiation, random mode |
| cross_key.feature | 3 | JWKS all 4 types, Ed25519 mismatch, format validity |
| determinism_edge_cases.feature | 5 | HMAC/ECDSA interleave, different seeds, token no-perturb |
| edge_cases.feature | 8 | Unicode/long labels, DER truncation, special chars |

### Bug fix
- Removed duplicate scenario in cross_key.feature

## Verification
- `cargo fmt` - passed
- `cargo check -p uselesskey-bdd-steps --all-features` - passed
- `cargo clippy -p uselesskey-bdd-steps --all-features -- -D warnings` - passed