### PR TITLE
docs: polish CHANGELOG and documentation for RC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,6 @@ Adapter crates (e.g. `uselesskey-jsonwebtoken`) are separate crates, not feature
 ## Configuration Files
 
 - `rustfmt.toml` - Formatting: Unix newlines, crate-level imports
-- `clippy.toml` - MSRV 1.88
+- `clippy.toml` - MSRV 1.92
 - `deny.toml` - Allowed licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, CC0-1.0
 - `mutants.toml` - Mutation testing exclusions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Release-candidate polish. The full feature set — RSA, ECDSA, Ed25519, HMAC,
+Token, OpenPGP, and X.509 fixtures plus six adapter crates (jsonwebtoken,
+rustls, ring, rustcrypto, aws-lc-rs, tonic) — is stable.  This cycle focused
+on crate-splitting for publish granularity, comprehensive test coverage, and
+documentation readiness.
+
 ### Added
 
 #### New microcrates
@@ -44,7 +50,7 @@ publish granularity and cross-crate reuse:
 #### Documentation
 
 - Improved sub-crate READMEs and `lib.rs` docs for crates.io readiness
-- Doc examples added to public API crates
+- Doc examples added to all public API crates, including `uselesskey-pgp` and `uselesskey-rustls`
 - Module-level documentation for previously undocumented crates
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,6 @@ Adapter crates (e.g. `uselesskey-jsonwebtoken`) are separate crates, not feature
 ## Configuration Files
 
 - `rustfmt.toml` - Formatting: Unix newlines, crate-level imports
-- `clippy.toml` - MSRV 1.88
+- `clippy.toml` - MSRV 1.92
 - `deny.toml` - Allowed licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, CC0-1.0
 - `mutants.toml` - Mutation testing exclusions

--- a/crates/uselesskey-pgp/src/lib.rs
+++ b/crates/uselesskey-pgp/src/lib.rs
@@ -4,6 +4,47 @@
 //!
 //! The main entry point is [`PgpFactoryExt`], which adds `.pgp()` to
 //! [`Factory`](uselesskey_core::Factory).
+//!
+//! # Quick start
+//!
+//! ```
+//! use uselesskey_core::Factory;
+//! use uselesskey_pgp::{PgpFactoryExt, PgpSpec};
+//!
+//! let fx = Factory::random();
+//! let key = fx.pgp("deploy", PgpSpec::ed25519());
+//!
+//! assert!(key.private_key_armored().contains("BEGIN PGP PRIVATE KEY BLOCK"));
+//! assert!(key.public_key_armored().contains("BEGIN PGP PUBLIC KEY BLOCK"));
+//! assert!(!key.fingerprint().is_empty());
+//! ```
+//!
+//! # Available specs
+//!
+//! | Constructor | Algorithm |
+//! |---|---|
+//! | [`PgpSpec::rsa_2048()`] | RSA 2048-bit |
+//! | [`PgpSpec::rsa_3072()`] | RSA 3072-bit |
+//! | [`PgpSpec::ed25519()`] | Ed25519 |
+//!
+//! # Negative fixtures
+//!
+//! ```
+//! use uselesskey_core::Factory;
+//! use uselesskey_core::negative::CorruptPem;
+//! use uselesskey_pgp::{PgpFactoryExt, PgpSpec};
+//!
+//! let fx = Factory::random();
+//! let key = fx.pgp("deploy", PgpSpec::ed25519());
+//!
+//! // Corrupt armored output
+//! let bad = key.private_key_armored_corrupt(CorruptPem::BadBase64);
+//! assert_ne!(bad, key.private_key_armored());
+//!
+//! // Mismatched public key (valid but wrong)
+//! let wrong_pub = key.mismatched_public_key_armored();
+//! assert_ne!(wrong_pub, key.public_key_armored());
+//! ```
 
 mod keypair;
 mod spec;

--- a/crates/uselesskey-rustls/src/lib.rs
+++ b/crates/uselesskey-rustls/src/lib.rs
@@ -9,6 +9,33 @@
 //! With the `server-config` and `client-config` features, it also provides
 //! convenience builders for `rustls::ServerConfig` and `rustls::ClientConfig`,
 //! including mutual TLS (mTLS) support.
+//!
+//! # Convert a private key to rustls format
+//!
+//! ```
+//! use uselesskey_core::Factory;
+//! use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+//! use uselesskey_rustls::RustlsPrivateKeyExt;
+//!
+//! let fx = Factory::random();
+//! let rsa = fx.rsa("server", RsaSpec::rs256());
+//! let key = rsa.private_key_der_rustls();
+//! assert_eq!(key.secret_der(), rsa.private_key_pkcs8_der());
+//! ```
+//!
+//! # Build TLS configs (requires `tls-config` + a crypto provider feature)
+//!
+//! ```no_run
+//! use uselesskey_core::Factory;
+//! use uselesskey_x509::{X509FactoryExt, ChainSpec};
+//! use uselesskey_rustls::{RustlsServerConfigExt, RustlsClientConfigExt};
+//!
+//! let fx = Factory::random();
+//! let chain = fx.x509_chain("svc", ChainSpec::new("test.example.com"));
+//!
+//! let server_cfg = chain.server_config_rustls();
+//! let client_cfg = chain.client_config_rustls();
+//! ```
 
 #[cfg(any(feature = "server-config", feature = "client-config"))]
 mod config;


### PR DESCRIPTION
## Summary

Polish documentation for release-candidate readiness.

### Changes

- **CHANGELOG.md**: Added RC overview paragraph to the [Unreleased] section summarizing the full feature set (RSA, ECDSA, Ed25519, HMAC, Token, PGP, X.509) and all six adapter crates (jsonwebtoken, rustls, ring, rustcrypto, aws-lc-rs, tonic). Updated doc entry to reflect new examples.
- **uselesskey-pgp lib.rs**: Added module-level doc examples (quick start, spec table, negative fixtures) with compilable doc-tests.
- **uselesskey-rustls lib.rs**: Added module-level doc examples (private key conversion, TLS config builders) with compilable doc-tests.
- **AGENTS.md / CLAUDE.md**: Fixed stale MSRV reference (1.88 → 1.92) to match clippy.toml and workspace Cargo.toml.

### Verification

- `cargo fmt` — clean
- `cargo test --doc --workspace --all-features --exclude uselesskey-bdd` — all doc tests pass
- No code logic changes — documentation and comments only