### PR TITLE
test: add edge-case and boundary tests

### DIFF
--- a/crates/uselesskey-core-base62/tests/edge_cases.rs
+++ b/crates/uselesskey-core-base62/tests/edge_cases.rs
@@ -1,0 +1,65 @@
+//! Edge-case and boundary tests for base62 generation.
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use uselesskey_core_base62::{BASE62_ALPHABET, random_base62};
+
+#[test]
+fn zero_length_produces_empty_string() {
+    let mut rng = ChaCha20Rng::from_seed([1u8; 32]);
+    let result = random_base62(&mut rng, 0);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn length_one_produces_single_base62_char() {
+    let mut rng = ChaCha20Rng::from_seed([2u8; 32]);
+    let result = random_base62(&mut rng, 1);
+    assert_eq!(result.len(), 1);
+    assert!(BASE62_ALPHABET.contains(&result.as_bytes()[0]));
+}
+
+#[test]
+fn large_length_produces_correct_length() {
+    let mut rng = ChaCha20Rng::from_seed([3u8; 32]);
+    let result = random_base62(&mut rng, 10_000);
+    assert_eq!(result.len(), 10_000);
+    assert!(result.bytes().all(|b| BASE62_ALPHABET.contains(&b)));
+}
+
+#[test]
+fn different_seeds_produce_different_strings() {
+    let a = random_base62(&mut ChaCha20Rng::from_seed([1u8; 32]), 64);
+    let b = random_base62(&mut ChaCha20Rng::from_seed([2u8; 32]), 64);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn same_seed_is_deterministic() {
+    let seed = [42u8; 32];
+    let a = random_base62(&mut ChaCha20Rng::from_seed(seed), 128);
+    let b = random_base62(&mut ChaCha20Rng::from_seed(seed), 128);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn output_contains_no_non_ascii() {
+    let mut rng = ChaCha20Rng::from_seed([5u8; 32]);
+    let result = random_base62(&mut rng, 1000);
+    assert!(result.is_ascii());
+}
+
+#[test]
+fn base62_alphabet_has_62_chars() {
+    assert_eq!(BASE62_ALPHABET.len(), 62);
+}
+
+#[test]
+fn base62_alphabet_is_all_alphanumeric() {
+    for &b in BASE62_ALPHABET.iter() {
+        assert!(
+            (b as char).is_ascii_alphanumeric(),
+            "non-alphanumeric byte in alphabet: {b}"
+        );
+    }
+}

--- a/crates/uselesskey-core-cache/tests/edge_cases.rs
+++ b/crates/uselesskey-core-cache/tests/edge_cases.rs
@@ -1,0 +1,182 @@
+//! Edge-case and boundary tests for ArtifactCache.
+
+#![cfg(feature = "std")]
+
+use std::sync::Arc;
+use std::thread;
+
+use uselesskey_core_cache::ArtifactCache;
+use uselesskey_core_id::{ArtifactId, DerivationVersion};
+
+fn make_id(label: &str) -> ArtifactId {
+    ArtifactId::new(
+        "domain:test",
+        label,
+        b"spec",
+        "default",
+        DerivationVersion::V1,
+    )
+}
+
+// ── Concurrent insert_if_absent_typed ───────────────────────────────
+
+#[test]
+fn concurrent_insert_if_absent_all_see_same_value() {
+    let cache = Arc::new(ArtifactCache::new());
+    let id = make_id("shared");
+
+    let handles: Vec<_> = (0..32)
+        .map(|i| {
+            let cache = Arc::clone(&cache);
+            let id = id.clone();
+            thread::spawn(move || {
+                let val = Arc::new(i as u64);
+                let result = cache.insert_if_absent_typed::<u64>(id, val);
+                *result
+            })
+        })
+        .collect();
+
+    let results: Vec<u64> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    // All threads must see the same "winner" value
+    assert!(results.windows(2).all(|w| w[0] == w[1]));
+}
+
+#[test]
+fn concurrent_reads_and_writes_no_panic() {
+    let cache = Arc::new(ArtifactCache::new());
+
+    // Pre-populate
+    for i in 0..100 {
+        let id = make_id(&format!("key-{i}"));
+        cache.insert_if_absent_typed::<u64>(id, Arc::new(i as u64));
+    }
+
+    let handles: Vec<_> = (0..16)
+        .map(|t| {
+            let cache = Arc::clone(&cache);
+            thread::spawn(move || {
+                for i in 0..100 {
+                    let id = make_id(&format!("key-{i}"));
+                    if t % 2 == 0 {
+                        // Reader
+                        let val = cache.get_typed::<u64>(&id);
+                        assert!(val.is_some());
+                    } else {
+                        // Writer (should return existing)
+                        let val = cache.insert_if_absent_typed::<u64>(id, Arc::new(999));
+                        assert_eq!(*val, i as u64); // first value wins
+                    }
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+}
+
+// ── Empty cache operations ──────────────────────────────────────────
+
+#[test]
+fn get_from_empty_cache_returns_none() {
+    let cache = ArtifactCache::new();
+    let id = make_id("nonexistent");
+    assert!(cache.get_typed::<u64>(&id).is_none());
+}
+
+#[test]
+fn empty_cache_len_is_zero() {
+    let cache = ArtifactCache::new();
+    assert_eq!(cache.len(), 0);
+    assert!(cache.is_empty());
+}
+
+// ── Many entries ────────────────────────────────────────────────────
+
+#[test]
+fn cache_handles_many_entries() {
+    let cache = ArtifactCache::new();
+    for i in 0..1000 {
+        let id = make_id(&format!("entry-{i}"));
+        cache.insert_if_absent_typed::<u64>(id, Arc::new(i));
+    }
+    assert_eq!(cache.len(), 1000);
+
+    // Verify retrieval
+    for i in 0..1000 {
+        let id = make_id(&format!("entry-{i}"));
+        let val = cache.get_typed::<u64>(&id).unwrap();
+        assert_eq!(*val, i);
+    }
+}
+
+// ── Clear with concurrent readers ───────────────────────────────────
+
+#[test]
+fn clear_while_reading_does_not_panic() {
+    let cache = Arc::new(ArtifactCache::new());
+    for i in 0..50 {
+        let id = make_id(&format!("item-{i}"));
+        cache.insert_if_absent_typed::<u64>(id, Arc::new(i as u64));
+    }
+
+    let handles: Vec<_> = (0..8)
+        .map(|t| {
+            let cache = Arc::clone(&cache);
+            thread::spawn(move || {
+                for _ in 0..100 {
+                    if t == 0 {
+                        cache.clear();
+                    } else {
+                        let id = make_id(&format!("item-{}", t % 50));
+                        let _ = cache.get_typed::<u64>(&id); // may be None after clear
+                    }
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+}
+
+// ── Unicode and special keys ────────────────────────────────────────
+
+#[test]
+fn cache_with_unicode_label() {
+    let cache = ArtifactCache::new();
+    let id = make_id("日本語🔑");
+    cache.insert_if_absent_typed::<String>(id.clone(), Arc::new("value".to_string()));
+    let val = cache.get_typed::<String>(&id).unwrap();
+    assert_eq!(&*val, "value");
+}
+
+#[test]
+fn cache_with_empty_label() {
+    let cache = ArtifactCache::new();
+    let id = make_id("");
+    cache.insert_if_absent_typed::<u64>(id.clone(), Arc::new(42));
+    assert_eq!(*cache.get_typed::<u64>(&id).unwrap(), 42);
+}
+
+// ── Debug format ────────────────────────────────────────────────────
+
+#[test]
+fn debug_shows_type_and_count() {
+    let cache = ArtifactCache::new();
+    let dbg = format!("{cache:?}");
+    assert!(dbg.contains("ArtifactCache"));
+    assert!(dbg.contains("0"), "should show count of zero");
+}
+
+#[test]
+fn debug_after_inserts_shows_count() {
+    let cache = ArtifactCache::new();
+    cache.insert_if_absent_typed::<u64>(make_id("a"), Arc::new(1));
+    cache.insert_if_absent_typed::<u64>(make_id("b"), Arc::new(2));
+    let dbg = format!("{cache:?}");
+    assert!(dbg.contains("2"), "should show count of 2");
+}

--- a/crates/uselesskey-core-factory/tests/edge_cases.rs
+++ b/crates/uselesskey-core-factory/tests/edge_cases.rs
@@ -1,0 +1,282 @@
+//! Edge-case and boundary tests for Factory.
+
+use std::sync::Arc;
+use std::thread;
+
+use uselesskey_core_factory::{Factory, Mode};
+use uselesskey_core_id::Seed;
+
+// ── Empty and unusual labels ────────────────────────────────────────
+
+#[test]
+fn empty_label_produces_valid_artifact() {
+    let fx = Factory::deterministic(Seed::new([1u8; 32]));
+    let result: Arc<String> = fx.get_or_init("domain:test", "", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        let mut buf = [0u8; 16];
+        rng.fill_bytes(&mut buf);
+        hex::encode(&buf)
+    });
+    assert!(!result.is_empty());
+}
+
+#[test]
+fn unicode_label_produces_valid_artifact() {
+    let fx = Factory::deterministic(Seed::new([2u8; 32]));
+    let result: Arc<String> =
+        fx.get_or_init("domain:test", "日本語🔑", b"spec", "default", |rng| {
+            use rand_core::RngCore;
+            let mut buf = [0u8; 16];
+            rng.fill_bytes(&mut buf);
+            hex::encode(&buf)
+        });
+    assert!(!result.is_empty());
+}
+
+#[test]
+fn very_long_label_produces_valid_artifact() {
+    let fx = Factory::deterministic(Seed::new([3u8; 32]));
+    let long_label = "x".repeat(10_000);
+    let result: Arc<String> =
+        fx.get_or_init("domain:test", &long_label, b"spec", "default", |rng| {
+            use rand_core::RngCore;
+            let mut buf = [0u8; 16];
+            rng.fill_bytes(&mut buf);
+            hex::encode(&buf)
+        });
+    assert!(!result.is_empty());
+}
+
+#[test]
+fn special_chars_in_label() {
+    let fx = Factory::deterministic(Seed::new([4u8; 32]));
+    let labels = [
+        "label/with/slashes",
+        "label\\with\\backslashes",
+        "label with spaces",
+        "label\twith\ttabs",
+        "label\nwith\nnewlines",
+        "label&with<special>chars\"'",
+        "",
+        "null\0byte",
+    ];
+    for label in labels {
+        let result: Arc<u64> = fx.get_or_init("domain:test", label, b"spec", "default", |rng| {
+            use rand_core::RngCore;
+            rng.next_u64()
+        });
+        let _ = *result; // just verify no panic
+    }
+}
+
+// ── Seed boundary values ────────────────────────────────────────────
+
+#[test]
+fn seed_zero_produces_deterministic_output() {
+    let fx1 = Factory::deterministic(Seed::new([0u8; 32]));
+    let fx2 = Factory::deterministic(Seed::new([0u8; 32]));
+    let a: Arc<u64> = fx1.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    let b: Arc<u64> = fx2.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    assert_eq!(*a, *b);
+}
+
+#[test]
+fn seed_max_produces_deterministic_output() {
+    let fx1 = Factory::deterministic(Seed::new([0xFF; 32]));
+    let fx2 = Factory::deterministic(Seed::new([0xFF; 32]));
+    let a: Arc<u64> = fx1.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    let b: Arc<u64> = fx2.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    assert_eq!(*a, *b);
+}
+
+#[test]
+fn seed_zero_differs_from_seed_max() {
+    let fx0 = Factory::deterministic(Seed::new([0u8; 32]));
+    let fxf = Factory::deterministic(Seed::new([0xFF; 32]));
+    let a: Arc<u64> = fx0.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    let b: Arc<u64> = fxf.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    assert_ne!(*a, *b);
+}
+
+#[test]
+fn seed_one_produces_deterministic_output() {
+    let mut seed_bytes = [0u8; 32];
+    seed_bytes[31] = 1;
+    let fx1 = Factory::deterministic(Seed::new(seed_bytes));
+    let fx2 = Factory::deterministic(Seed::new(seed_bytes));
+    let a: Arc<u64> = fx1.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    let b: Arc<u64> = fx2.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    assert_eq!(*a, *b);
+}
+
+// ── Empty spec and variant ──────────────────────────────────────────
+
+#[test]
+fn empty_spec_bytes_produces_valid_artifact() {
+    let fx = Factory::deterministic(Seed::new([5u8; 32]));
+    let result: Arc<u64> = fx.get_or_init("domain:test", "label", b"", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    let _ = *result;
+}
+
+#[test]
+fn empty_variant_produces_valid_artifact() {
+    let fx = Factory::deterministic(Seed::new([6u8; 32]));
+    let result: Arc<u64> = fx.get_or_init("domain:test", "label", b"spec", "", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    let _ = *result;
+}
+
+// ── Concurrent factory access (stress test) ─────────────────────────
+
+#[test]
+fn concurrent_factory_many_threads_same_key() {
+    let fx = Factory::deterministic(Seed::new([7u8; 32]));
+    let handles: Vec<_> = (0..32)
+        .map(|_| {
+            let fx = fx.clone();
+            thread::spawn(move || {
+                let val: Arc<u64> =
+                    fx.get_or_init("domain:test", "shared", b"spec", "default", |rng| {
+                        use rand_core::RngCore;
+                        rng.next_u64()
+                    });
+                *val
+            })
+        })
+        .collect();
+
+    let results: Vec<u64> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    // All threads must see the same value
+    assert!(results.windows(2).all(|w| w[0] == w[1]));
+}
+
+#[test]
+fn concurrent_factory_different_keys() {
+    let fx = Factory::deterministic(Seed::new([8u8; 32]));
+    let handles: Vec<_> = (0..16)
+        .map(|i| {
+            let fx = fx.clone();
+            thread::spawn(move || {
+                let label = format!("label-{i}");
+                let val: Arc<u64> =
+                    fx.get_or_init("domain:test", &label, b"spec", "default", |rng| {
+                        use rand_core::RngCore;
+                        rng.next_u64()
+                    });
+                (label, *val)
+            })
+        })
+        .collect();
+
+    let mut results: Vec<(String, u64)> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    results.sort_by_key(|(l, _)| l.clone());
+
+    // Each label should produce a unique value
+    let values: std::collections::HashSet<u64> = results.iter().map(|(_, v)| *v).collect();
+    assert_eq!(values.len(), 16);
+}
+
+// ── Mode::Debug format ──────────────────────────────────────────────
+
+#[test]
+fn debug_deterministic_factory_does_not_leak_seed() {
+    let fx = Factory::deterministic(Seed::new([0xAB; 32]));
+    let dbg = format!("{fx:?}");
+    assert!(!dbg.contains("ab"), "Debug must not leak seed bytes");
+    assert!(!dbg.contains("AB"), "Debug must not leak seed bytes");
+    assert!(dbg.contains("Factory"), "Debug should mention Factory");
+}
+
+#[test]
+fn debug_random_factory() {
+    let fx = Factory::random();
+    let dbg = format!("{fx:?}");
+    assert!(dbg.contains("Factory"), "Debug should mention Factory");
+    assert!(dbg.contains("Random"), "Debug should mention Random mode");
+}
+
+// ── Mode access ─────────────────────────────────────────────────────
+
+#[test]
+fn mode_returns_random_for_random_factory() {
+    let fx = Factory::random();
+    assert!(matches!(fx.mode(), Mode::Random));
+}
+
+#[test]
+fn mode_returns_deterministic_for_deterministic_factory() {
+    let fx = Factory::deterministic(Seed::new([1u8; 32]));
+    assert!(matches!(fx.mode(), Mode::Deterministic { .. }));
+}
+
+// ── Cache clear ─────────────────────────────────────────────────────
+
+#[test]
+fn clear_cache_then_regenerate_produces_same_value() {
+    let fx = Factory::deterministic(Seed::new([9u8; 32]));
+    let a: Arc<u64> = fx.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    fx.clear_cache();
+    let b: Arc<u64> = fx.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    assert_eq!(
+        *a, *b,
+        "deterministic regeneration after cache clear must match"
+    );
+}
+
+// ── Clone shares cache ──────────────────────────────────────────────
+
+#[test]
+fn cloned_factory_shares_cache() {
+    let fx1 = Factory::deterministic(Seed::new([10u8; 32]));
+    let _: Arc<u64> = fx1.get_or_init("domain:test", "label", b"spec", "default", |rng| {
+        use rand_core::RngCore;
+        rng.next_u64()
+    });
+    let fx2 = fx1.clone();
+    // fx2 should see the cached value without calling init
+    let val: Arc<u64> = fx2.get_or_init("domain:test", "label", b"spec", "default", |_rng| {
+        panic!("init should not be called for cached value");
+    });
+    let _ = *val;
+}
+
+mod hex {
+    pub fn encode(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+}

--- a/crates/uselesskey-core-hash/tests/edge_cases.rs
+++ b/crates/uselesskey-core-hash/tests/edge_cases.rs
@@ -111,3 +111,44 @@ fn field_order_matters() {
 
     assert_ne!(h1.finalize(), h2.finalize());
 }
+
+// ── Additional boundary tests ───────────────────────────────────────
+
+#[test]
+fn hash32_single_zero_byte_is_valid() {
+    let h = hash32(&[0x00]);
+    assert_eq!(h.as_bytes().len(), 32);
+    assert_ne!(h, hash32(b""), "\\0 differs from empty");
+}
+
+#[test]
+fn write_len_prefixed_single_byte_values_differ() {
+    let mut h1 = Hasher::new();
+    write_len_prefixed(&mut h1, &[0x00]);
+
+    let mut h2 = Hasher::new();
+    write_len_prefixed(&mut h2, &[0x01]);
+
+    assert_ne!(h1.finalize(), h2.finalize());
+}
+
+#[test]
+fn hash32_large_input() {
+    let data = vec![0xAB; 100_000];
+    let h = hash32(&data);
+    assert_eq!(h.as_bytes().len(), 32);
+}
+
+#[test]
+fn write_len_prefixed_three_empty_fields_differs_from_two() {
+    let mut h2 = Hasher::new();
+    write_len_prefixed(&mut h2, b"");
+    write_len_prefixed(&mut h2, b"");
+
+    let mut h3 = Hasher::new();
+    write_len_prefixed(&mut h3, b"");
+    write_len_prefixed(&mut h3, b"");
+    write_len_prefixed(&mut h3, b"");
+
+    assert_ne!(h2.finalize(), h3.finalize());
+}

--- a/crates/uselesskey-core-id/tests/edge_cases.rs
+++ b/crates/uselesskey-core-id/tests/edge_cases.rs
@@ -1,0 +1,193 @@
+//! Edge-case and boundary tests for ArtifactId and derivation.
+
+#![cfg(feature = "std")]
+
+use std::collections::HashSet;
+
+use uselesskey_core_id::{ArtifactId, DerivationVersion, Seed};
+
+// ── Empty and boundary inputs ───────────────────────────────────────
+
+#[test]
+fn empty_label_and_variant_produce_valid_derivation() {
+    let master = Seed::new([1u8; 32]);
+    let id = ArtifactId::new("domain:test", "", b"spec", "", DerivationVersion::V1);
+    let derived = uselesskey_core_id::derive_seed(&master, &id);
+    // Must produce a valid seed (not all zeros)
+    assert_ne!(derived.bytes(), &[0u8; 32]);
+}
+
+#[test]
+fn unicode_label_produces_unique_derivation() {
+    let master = Seed::new([2u8; 32]);
+    let id_ascii = ArtifactId::new("domain:test", "hello", b"spec", "v", DerivationVersion::V1);
+    let id_unicode = ArtifactId::new(
+        "domain:test",
+        "日本語🔑",
+        b"spec",
+        "v",
+        DerivationVersion::V1,
+    );
+
+    let d1 = uselesskey_core_id::derive_seed(&master, &id_ascii);
+    let d2 = uselesskey_core_id::derive_seed(&master, &id_unicode);
+    assert_ne!(d1, d2);
+}
+
+#[test]
+fn very_long_label_does_not_panic() {
+    let master = Seed::new([3u8; 32]);
+    let long_label = "a".repeat(100_000);
+    let id = ArtifactId::new(
+        "domain:test",
+        &long_label,
+        b"spec",
+        "default",
+        DerivationVersion::V1,
+    );
+    let derived = uselesskey_core_id::derive_seed(&master, &id);
+    assert_eq!(derived.bytes().len(), 32);
+}
+
+#[test]
+fn special_characters_in_variant() {
+    let master = Seed::new([4u8; 32]);
+    let variants = [
+        "",
+        "default",
+        "corrupt:bad_header",
+        "mismatch",
+        "null\0byte",
+        "日本語",
+    ];
+    let mut derived_set = HashSet::new();
+    for variant in variants {
+        let id = ArtifactId::new(
+            "domain:test",
+            "label",
+            b"spec",
+            variant,
+            DerivationVersion::V1,
+        );
+        let derived = uselesskey_core_id::derive_seed(&master, &id);
+        derived_set.insert(*derived.bytes());
+    }
+    // All unique variants produce unique seeds
+    assert_eq!(derived_set.len(), variants.len());
+}
+
+// ── Spec fingerprint sensitivity ────────────────────────────────────
+
+#[test]
+fn empty_spec_bytes_differs_from_nonempty() {
+    let master = Seed::new([5u8; 32]);
+    let id_empty = ArtifactId::new("domain:test", "label", b"", "v", DerivationVersion::V1);
+    let id_nonempty = ArtifactId::new("domain:test", "label", b"x", "v", DerivationVersion::V1);
+    let d1 = uselesskey_core_id::derive_seed(&master, &id_empty);
+    let d2 = uselesskey_core_id::derive_seed(&master, &id_nonempty);
+    assert_ne!(d1, d2);
+}
+
+#[test]
+fn single_bit_difference_in_spec_produces_different_seed() {
+    let master = Seed::new([6u8; 32]);
+    let id1 = ArtifactId::new("domain:test", "label", &[0x00], "v", DerivationVersion::V1);
+    let id2 = ArtifactId::new("domain:test", "label", &[0x01], "v", DerivationVersion::V1);
+    let d1 = uselesskey_core_id::derive_seed(&master, &id1);
+    let d2 = uselesskey_core_id::derive_seed(&master, &id2);
+    assert_ne!(d1, d2);
+}
+
+// ── Seed boundary values ────────────────────────────────────────────
+
+#[test]
+fn derive_seed_with_zero_master() {
+    let master = Seed::new([0u8; 32]);
+    let id = ArtifactId::new("domain:test", "label", b"spec", "v", DerivationVersion::V1);
+    let derived = uselesskey_core_id::derive_seed(&master, &id);
+    // Should still produce non-trivial output
+    assert_ne!(derived.bytes(), &[0u8; 32]);
+}
+
+#[test]
+fn derive_seed_with_max_master() {
+    let master = Seed::new([0xFF; 32]);
+    let id = ArtifactId::new("domain:test", "label", b"spec", "v", DerivationVersion::V1);
+    let derived = uselesskey_core_id::derive_seed(&master, &id);
+    assert_ne!(derived.bytes(), &[0xFF; 32]);
+}
+
+// ── DerivationVersion trait coverage ────────────────────────────────
+
+#[test]
+fn derivation_version_v1_debug_display() {
+    let v = DerivationVersion::V1;
+    let dbg = format!("{v:?}");
+    assert!(dbg.contains("1"));
+}
+
+#[test]
+fn derivation_version_clone_eq() {
+    let v1 = DerivationVersion::V1;
+    let v2 = v1;
+    assert_eq!(v1, v2);
+}
+
+#[test]
+fn derivation_version_hash_consistent() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let v1 = DerivationVersion::V1;
+    let v2 = DerivationVersion::V1;
+
+    let mut h1 = DefaultHasher::new();
+    v1.hash(&mut h1);
+    let mut h2 = DefaultHasher::new();
+    v2.hash(&mut h2);
+    assert_eq!(h1.finish(), h2.finish());
+}
+
+#[test]
+fn derivation_version_ord() {
+    let v1 = DerivationVersion(1);
+    let v2 = DerivationVersion(2);
+    assert!(v1 < v2);
+}
+
+// ── ArtifactId trait coverage ───────────────────────────────────────
+
+#[test]
+fn artifact_id_eq_requires_all_fields_match() {
+    let id1 = ArtifactId::new("domain:a", "label", b"spec", "v", DerivationVersion::V1);
+    let id2 = ArtifactId::new("domain:b", "label", b"spec", "v", DerivationVersion::V1);
+    assert_ne!(id1, id2, "different domain should differ");
+}
+
+#[test]
+fn artifact_id_hash_in_set() {
+    let mut set = HashSet::new();
+    let id1 = ArtifactId::new("d", "label1", b"spec", "v", DerivationVersion::V1);
+    let id2 = ArtifactId::new("d", "label2", b"spec", "v", DerivationVersion::V1);
+    let id3 = ArtifactId::new("d", "label1", b"spec", "v", DerivationVersion::V1);
+
+    set.insert(id1);
+    set.insert(id2);
+    set.insert(id3); // duplicate of id1
+
+    assert_eq!(set.len(), 2);
+}
+
+#[test]
+fn artifact_id_debug_shows_fields() {
+    let id = ArtifactId::new(
+        "domain:test",
+        "my-label",
+        b"spec",
+        "v1",
+        DerivationVersion::V1,
+    );
+    let dbg = format!("{id:?}");
+    assert!(dbg.contains("my-label"), "Debug should show label");
+    assert!(dbg.contains("domain:test"), "Debug should show domain");
+}

--- a/crates/uselesskey-core-kid/tests/edge_cases.rs
+++ b/crates/uselesskey-core-kid/tests/edge_cases.rs
@@ -1,0 +1,109 @@
+//! Edge-case and boundary tests for KID generation.
+
+use uselesskey_core_kid::{DEFAULT_KID_PREFIX_BYTES, kid_from_bytes, kid_from_bytes_with_prefix};
+
+// ── Empty input ─────────────────────────────────────────────────────
+
+#[test]
+fn kid_from_empty_bytes() {
+    let kid = kid_from_bytes(b"");
+    assert!(!kid.is_empty(), "KID from empty bytes should be non-empty");
+}
+
+#[test]
+fn kid_from_empty_bytes_is_deterministic() {
+    let k1 = kid_from_bytes(b"");
+    let k2 = kid_from_bytes(b"");
+    assert_eq!(k1, k2);
+}
+
+// ── Boundary prefix_bytes ───────────────────────────────────────────
+
+#[test]
+fn kid_with_prefix_bytes_1() {
+    let kid = kid_from_bytes_with_prefix(b"test", 1);
+    // 1 byte = 8 bits, base64url encodes to ~2 chars
+    assert!(!kid.is_empty());
+    assert!(kid.len() <= 4, "1-byte prefix should produce short kid");
+}
+
+#[test]
+fn kid_with_prefix_bytes_32() {
+    let kid = kid_from_bytes_with_prefix(b"test", 32);
+    // 32 bytes = full BLAKE3 output, base64url encodes to 43 chars
+    assert!(
+        kid.len() >= 40,
+        "32-byte prefix should produce ~43 char kid"
+    );
+}
+
+#[test]
+#[should_panic]
+fn kid_with_prefix_bytes_0_panics() {
+    kid_from_bytes_with_prefix(b"test", 0);
+}
+
+#[test]
+#[should_panic]
+fn kid_with_prefix_bytes_33_panics() {
+    kid_from_bytes_with_prefix(b"test", 33);
+}
+
+// ── Default prefix ──────────────────────────────────────────────────
+
+#[test]
+fn default_prefix_bytes_is_12() {
+    assert_eq!(DEFAULT_KID_PREFIX_BYTES, 12);
+}
+
+#[test]
+fn kid_from_bytes_uses_default_prefix() {
+    let k1 = kid_from_bytes(b"hello");
+    let k2 = kid_from_bytes_with_prefix(b"hello", DEFAULT_KID_PREFIX_BYTES);
+    assert_eq!(k1, k2);
+}
+
+// ── Determinism ─────────────────────────────────────────────────────
+
+#[test]
+fn different_inputs_produce_different_kids() {
+    let k1 = kid_from_bytes(b"key-a");
+    let k2 = kid_from_bytes(b"key-b");
+    assert_ne!(k1, k2);
+}
+
+#[test]
+fn single_bit_difference_produces_different_kid() {
+    let k1 = kid_from_bytes(&[0x00]);
+    let k2 = kid_from_bytes(&[0x01]);
+    assert_ne!(k1, k2);
+}
+
+// ── Large input ─────────────────────────────────────────────────────
+
+#[test]
+fn kid_from_large_input() {
+    let large = vec![0xAB; 100_000];
+    let kid = kid_from_bytes(&large);
+    assert!(!kid.is_empty());
+}
+
+// ── Base64url format ────────────────────────────────────────────────
+
+#[test]
+fn kid_contains_only_base64url_chars() {
+    let kid = kid_from_bytes(b"test key material");
+    for ch in kid.chars() {
+        assert!(
+            ch.is_ascii_alphanumeric() || ch == '-' || ch == '_',
+            "KID contains non-base64url char: {ch:?}"
+        );
+    }
+}
+
+#[test]
+fn kid_has_no_padding() {
+    // base64url without padding should never contain '='
+    let kid = kid_from_bytes(b"test");
+    assert!(!kid.contains('='), "KID should not contain padding");
+}

--- a/crates/uselesskey-core-negative-der/tests/edge_cases.rs
+++ b/crates/uselesskey-core-negative-der/tests/edge_cases.rs
@@ -1,0 +1,147 @@
+//! Edge-case and boundary tests for DER corruption.
+
+use uselesskey_core_negative_der::{corrupt_der_deterministic, flip_byte, truncate_der};
+
+// ── truncate_der edge cases ─────────────────────────────────────────
+
+#[test]
+fn truncate_empty_input() {
+    let result = truncate_der(b"", 5);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn truncate_to_zero() {
+    let result = truncate_der(b"hello", 0);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn truncate_single_byte_input() {
+    let result = truncate_der(&[0xAB], 1);
+    assert_eq!(result, [0xAB]);
+}
+
+#[test]
+fn truncate_exact_length() {
+    let data = b"hello";
+    let result = truncate_der(data, data.len());
+    assert_eq!(result, data);
+}
+
+#[test]
+fn truncate_beyond_length() {
+    let data = b"hello";
+    let result = truncate_der(data, data.len() + 100);
+    assert_eq!(result, data);
+}
+
+// ── flip_byte edge cases ────────────────────────────────────────────
+
+#[test]
+fn flip_byte_first_position() {
+    let data = [0x00, 0x01, 0x02];
+    let result = flip_byte(&data, 0);
+    assert_ne!(result[0], data[0]);
+    assert_eq!(result[1], data[1]);
+    assert_eq!(result[2], data[2]);
+}
+
+#[test]
+fn flip_byte_last_position() {
+    let data = [0x00, 0x01, 0x02];
+    let result = flip_byte(&data, 2);
+    assert_eq!(result[0], data[0]);
+    assert_eq!(result[1], data[1]);
+    assert_ne!(result[2], data[2]);
+}
+
+#[test]
+fn flip_byte_is_involutory() {
+    let data = [0xDE, 0xAD, 0xBE, 0xEF];
+    let flipped = flip_byte(&data, 1);
+    let flipped_again = flip_byte(&flipped, 1);
+    assert_eq!(flipped_again, data);
+}
+
+#[test]
+fn flip_byte_out_of_bounds_returns_copy() {
+    let data = [0x01, 0x02];
+    let result = flip_byte(&data, 5);
+    assert_eq!(result, data);
+}
+
+#[test]
+fn flip_byte_empty_input() {
+    let result = flip_byte(b"", 0);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn flip_byte_preserves_length() {
+    let data = [0x00; 100];
+    let result = flip_byte(&data, 50);
+    assert_eq!(result.len(), data.len());
+}
+
+// ── corrupt_der_deterministic edge cases ────────────────────────────
+
+#[test]
+fn corrupt_deterministic_empty_input() {
+    let result = corrupt_der_deterministic(b"", "variant");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn corrupt_deterministic_single_byte() {
+    let result = corrupt_der_deterministic(&[0xAB], "variant");
+    // Single byte: can truncate (empty) or flip
+    assert!(result.len() <= 1);
+}
+
+#[test]
+fn corrupt_deterministic_is_stable() {
+    let data = b"test DER data";
+    let c1 = corrupt_der_deterministic(data, "v1");
+    let c2 = corrupt_der_deterministic(data, "v1");
+    assert_eq!(c1, c2);
+}
+
+#[test]
+fn corrupt_deterministic_different_variants_differ() {
+    let data = b"test DER data for variants";
+    let c1 = corrupt_der_deterministic(data, "variant-a");
+    let _c2 = corrupt_der_deterministic(data, "variant-b");
+    // Different variants usually produce different corruptions
+    // At least one should differ from original
+    assert_ne!(&c1[..], data.as_slice());
+}
+
+#[test]
+fn corrupt_deterministic_empty_variant() {
+    let data = b"test DER";
+    let result = corrupt_der_deterministic(data, "");
+    assert_ne!(&result[..], data.as_slice());
+}
+
+#[test]
+fn corrupt_deterministic_unicode_variant() {
+    let data = b"test DER unicode";
+    let result = corrupt_der_deterministic(data, "日本語🔑");
+    assert_ne!(&result[..], data.as_slice());
+}
+
+#[test]
+fn corrupt_deterministic_never_returns_original() {
+    let data = b"some DER content to corrupt";
+    // Test many variants
+    for i in 0..20 {
+        let variant = format!("variant-{i}");
+        let result = corrupt_der_deterministic(data, &variant);
+        assert_ne!(
+            &result[..],
+            data.as_slice(),
+            "variant '{variant}' returned original data"
+        );
+    }
+}

--- a/crates/uselesskey-core-negative-pem/tests/edge_cases.rs
+++ b/crates/uselesskey-core-negative-pem/tests/edge_cases.rs
@@ -1,0 +1,118 @@
+//! Edge-case and boundary tests for PEM corruption.
+
+use uselesskey_core_negative_pem::{CorruptPem, corrupt_pem, corrupt_pem_deterministic};
+
+const SAMPLE_PEM: &str = "\
+-----BEGIN PRIVATE KEY-----
+MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEA0Z3VS5JJcds3xf0G
+-----END PRIVATE KEY-----";
+
+// ── Minimal PEM inputs ──────────────────────────────────────────────
+
+#[test]
+fn corrupt_empty_pem_bad_header() {
+    let result = corrupt_pem("", CorruptPem::BadHeader);
+    // Should not panic on empty input
+    let _ = result;
+}
+
+#[test]
+fn corrupt_single_line_pem_bad_footer() {
+    let result = corrupt_pem("-----BEGIN PRIVATE KEY-----", CorruptPem::BadFooter);
+    let _ = result;
+}
+
+#[test]
+fn corrupt_pem_with_no_base64_content() {
+    let pem = "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----";
+    let result = corrupt_pem(pem, CorruptPem::BadBase64);
+    let _ = result;
+}
+
+// ── Truncate boundary ───────────────────────────────────────────────
+
+#[test]
+fn truncate_zero_bytes_produces_empty() {
+    let result = corrupt_pem(SAMPLE_PEM, CorruptPem::Truncate { bytes: 0 });
+    assert!(
+        result.is_empty(),
+        "Truncate{{bytes: 0}} should produce empty string"
+    );
+}
+
+#[test]
+fn truncate_more_than_content_returns_full() {
+    let result = corrupt_pem(SAMPLE_PEM, CorruptPem::Truncate { bytes: 100_000 });
+    // Taking more chars than exist should return the full PEM
+    assert_eq!(result, SAMPLE_PEM);
+}
+
+// ── All CorruptPem variants produce different outputs ────────────────
+
+#[test]
+fn all_variants_produce_different_corruptions() {
+    use std::collections::HashSet;
+
+    let variants = [
+        CorruptPem::BadHeader,
+        CorruptPem::BadFooter,
+        CorruptPem::BadBase64,
+        CorruptPem::Truncate { bytes: 5 },
+        CorruptPem::ExtraBlankLine,
+    ];
+    let mut results = HashSet::new();
+    for variant in variants {
+        results.insert(corrupt_pem(SAMPLE_PEM, variant));
+    }
+    // All should differ from the original
+    for result in &results {
+        assert_ne!(result, SAMPLE_PEM, "corruption should change the PEM");
+    }
+}
+
+// ── Deterministic corruption ────────────────────────────────────────
+
+#[test]
+fn deterministic_corruption_is_stable() {
+    let c1 = corrupt_pem_deterministic(SAMPLE_PEM, "variant-a");
+    let c2 = corrupt_pem_deterministic(SAMPLE_PEM, "variant-a");
+    assert_eq!(c1, c2);
+}
+
+#[test]
+fn deterministic_different_variants_produce_different_corruptions() {
+    let c1 = corrupt_pem_deterministic(SAMPLE_PEM, "variant-a");
+    let c2 = corrupt_pem_deterministic(SAMPLE_PEM, "variant-b");
+    // High probability they differ (hash selects different strategy)
+    // but not guaranteed for all pairs; at least they should both be valid corruptions
+    assert_ne!(&c1, SAMPLE_PEM);
+    assert_ne!(&c2, SAMPLE_PEM);
+}
+
+#[test]
+fn deterministic_empty_variant() {
+    let result = corrupt_pem_deterministic(SAMPLE_PEM, "");
+    assert_ne!(&result, SAMPLE_PEM);
+}
+
+#[test]
+fn deterministic_unicode_variant() {
+    let result = corrupt_pem_deterministic(SAMPLE_PEM, "日本語🔑");
+    assert_ne!(&result, SAMPLE_PEM);
+}
+
+// ── CorruptPem trait coverage ───────────────────────────────────────
+
+#[test]
+fn corrupt_pem_clone() {
+    let c = CorruptPem::BadHeader;
+    let c2 = c;
+    assert!(matches!(c2, CorruptPem::BadHeader));
+}
+
+#[test]
+fn corrupt_pem_debug() {
+    let dbg = format!("{:?}", CorruptPem::Truncate { bytes: 42 });
+    assert!(dbg.contains("Truncate"));
+    assert!(dbg.contains("42"));
+}

--- a/crates/uselesskey-core-seed/tests/edge_cases.rs
+++ b/crates/uselesskey-core-seed/tests/edge_cases.rs
@@ -1,0 +1,144 @@
+//! Edge-case and boundary tests for Seed.
+
+#![cfg(feature = "std")]
+
+use std::collections::HashSet;
+
+use uselesskey_core_seed::Seed;
+
+// ── Seed boundary values ────────────────────────────────────────────
+
+#[test]
+fn seed_all_zeros_is_distinct_from_all_ones() {
+    let zero = Seed::new([0u8; 32]);
+    let ones = Seed::new([0xFF; 32]);
+    assert_ne!(zero, ones);
+}
+
+#[test]
+fn seed_single_bit_flip_at_each_position_produces_unique_seeds() {
+    let base = Seed::new([0u8; 32]);
+    let mut seen = HashSet::new();
+    seen.insert(*base.bytes());
+
+    for byte_idx in 0..32 {
+        for bit_idx in 0..8 {
+            let mut arr = [0u8; 32];
+            arr[byte_idx] |= 1 << bit_idx;
+            let seed = Seed::new(arr);
+            assert!(
+                seen.insert(*seed.bytes()),
+                "bit flip at byte {byte_idx} bit {bit_idx} collided"
+            );
+        }
+    }
+    // 1 base + 256 single-bit flips = 257 unique seeds
+    assert_eq!(seen.len(), 257);
+}
+
+// ── from_env_value edge cases ───────────────────────────────────────
+
+#[test]
+fn from_env_value_exactly_64_hex_zeros() {
+    let hex = "0".repeat(64);
+    let seed = Seed::from_env_value(&hex).unwrap();
+    assert_eq!(seed.bytes(), &[0u8; 32]);
+}
+
+#[test]
+fn from_env_value_exactly_64_hex_f() {
+    let hex = "f".repeat(64);
+    let seed = Seed::from_env_value(&hex).unwrap();
+    assert_eq!(seed.bytes(), &[0xFF; 32]);
+}
+
+#[test]
+fn from_env_value_0x_prefix_64_hex_chars() {
+    // "0x" + 64 hex chars = 66 chars, valid hex with prefix
+    let hex = "0x".to_owned() + &"ab".repeat(32);
+    let seed = Seed::from_env_value(&hex).unwrap();
+    assert!(seed.bytes().iter().all(|&b| b == 0xAB));
+}
+
+#[test]
+fn from_env_value_unicode_string_hashes_consistently() {
+    let seed1 = Seed::from_env_value("日本語テスト🔑").unwrap();
+    let seed2 = Seed::from_env_value("日本語テスト🔑").unwrap();
+    assert_eq!(seed1, seed2);
+}
+
+#[test]
+fn from_env_value_different_unicode_strings_differ() {
+    let seed1 = Seed::from_env_value("日本語").unwrap();
+    let seed2 = Seed::from_env_value("中文").unwrap();
+    assert_ne!(seed1, seed2);
+}
+
+#[test]
+fn from_env_value_very_long_string() {
+    let long = "x".repeat(100_000);
+    let seed = Seed::from_env_value(&long).unwrap();
+    // Must produce a valid 32-byte seed
+    assert_eq!(seed.bytes().len(), 32);
+}
+
+#[test]
+fn from_env_value_newlines_in_value() {
+    let seed1 = Seed::from_env_value("line1\nline2").unwrap();
+    let seed2 = Seed::from_env_value("line1\nline2").unwrap();
+    assert_eq!(seed1, seed2);
+}
+
+#[test]
+fn from_env_value_tab_characters() {
+    let seed = Seed::from_env_value("\t\thello\t").unwrap();
+    // Trims to "hello" then hashes
+    let expected = Seed::from_env_value("hello").unwrap();
+    assert_eq!(seed, expected);
+}
+
+#[test]
+fn from_env_value_invalid_hex_64_chars_returns_error() {
+    // 64 chars but not valid hex → parse_hex_32 returns Err
+    let not_hex = "g".repeat(64);
+    let result = Seed::from_env_value(&not_hex);
+    assert!(result.is_err(), "64 non-hex chars should fail");
+}
+
+// ── Hash trait in collections ───────────────────────────────────────
+
+#[test]
+fn seed_works_as_hashset_key() {
+    let mut set = HashSet::new();
+    set.insert(Seed::new([1u8; 32]));
+    set.insert(Seed::new([2u8; 32]));
+    set.insert(Seed::new([1u8; 32])); // duplicate
+
+    assert_eq!(set.len(), 2);
+}
+
+#[test]
+fn seed_works_as_hashmap_key() {
+    use std::collections::HashMap;
+    let mut map = HashMap::new();
+    let seed = Seed::new([42u8; 32]);
+    map.insert(seed, "value");
+    assert_eq!(map.get(&seed), Some(&"value"));
+}
+
+// ── Debug output safety ─────────────────────────────────────────────
+
+#[test]
+fn debug_never_contains_any_byte_representation() {
+    let arr = [
+        0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+        0x17, 0x18,
+    ];
+    let seed = Seed::new(arr);
+    let dbg = format!("{seed:?}");
+    assert!(!dbg.contains("dead"), "Debug must not contain hex bytes");
+    assert!(!dbg.contains("DEAD"), "Debug must not contain hex bytes");
+    assert!(!dbg.contains("cafe"), "Debug must not contain hex bytes");
+    assert!(!dbg.contains("babe"), "Debug must not contain hex bytes");
+}

--- a/crates/uselesskey-ecdsa/tests/edge_cases.rs
+++ b/crates/uselesskey-ecdsa/tests/edge_cases.rs
@@ -1,0 +1,209 @@
+//! Edge-case and boundary tests for ECDSA key fixtures.
+
+mod testutil;
+use testutil::fx;
+
+use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+// ── Empty and unusual labels ────────────────────────────────────────
+
+#[test]
+fn empty_label_produces_valid_keypair() {
+    let kp = fx().ecdsa("", EcdsaSpec::es256());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+    assert!(!kp.public_key_spki_pem().is_empty());
+}
+
+#[test]
+fn unicode_label_produces_valid_keypair() {
+    let kp = fx().ecdsa("日本語🔑", EcdsaSpec::es256());
+    assert!(!kp.private_key_pkcs8_der().is_empty());
+}
+
+#[test]
+fn very_long_label_works() {
+    let label = "x".repeat(10_000);
+    let kp = fx().ecdsa(&label, EcdsaSpec::es256());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+}
+
+#[test]
+fn null_byte_label() {
+    let kp = fx().ecdsa("label\0null", EcdsaSpec::es256());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+}
+
+// ── Debug does not leak key material ────────────────────────────────
+
+#[test]
+fn debug_does_not_leak_private_key() {
+    let kp = fx().ecdsa("debug-test", EcdsaSpec::es256());
+    let dbg = format!("{kp:?}");
+    let pem = kp.private_key_pkcs8_pem();
+
+    assert!(dbg.contains("EcdsaKeyPair"), "Debug should name the type");
+    assert!(dbg.contains("debug-test"), "Debug should show label");
+    for line in pem.lines().skip(1) {
+        if line.starts_with("-----") {
+            continue;
+        }
+        assert!(!dbg.contains(line), "Debug leaked PEM content: {line}");
+    }
+}
+
+#[test]
+fn debug_uses_non_exhaustive() {
+    let kp = fx().ecdsa("ne-test", EcdsaSpec::es256());
+    let dbg = format!("{kp:?}");
+    assert!(dbg.contains(".."), "Debug should use finish_non_exhaustive");
+}
+
+// ── Clone ───────────────────────────────────────────────────────────
+
+#[test]
+fn clone_shares_key_material() {
+    let kp = fx().ecdsa("clone-test", EcdsaSpec::es256());
+    let cloned = kp.clone();
+    assert_eq!(kp.private_key_pkcs8_der(), cloned.private_key_pkcs8_der());
+    assert_eq!(kp.public_key_spki_der(), cloned.public_key_spki_der());
+}
+
+// ── Spec trait coverage ─────────────────────────────────────────────
+
+#[test]
+fn spec_clone_copy_eq() {
+    let s1 = EcdsaSpec::es256();
+    let s2 = s1;
+    assert_eq!(s1, s2);
+
+    let s3 = EcdsaSpec::es384();
+    assert_ne!(s1, s3);
+}
+
+#[test]
+fn spec_debug_shows_variant() {
+    let dbg = format!("{:?}", EcdsaSpec::es256());
+    assert!(dbg.contains("Es256") || dbg.contains("ES256") || dbg.contains("es256"));
+}
+
+#[test]
+fn spec_alg_name() {
+    assert_eq!(EcdsaSpec::es256().alg_name(), "ES256");
+    assert_eq!(EcdsaSpec::es384().alg_name(), "ES384");
+}
+
+#[test]
+fn spec_curve_name() {
+    assert_eq!(EcdsaSpec::es256().curve_name(), "P-256");
+    assert_eq!(EcdsaSpec::es384().curve_name(), "P-384");
+}
+
+#[test]
+fn spec_coordinate_len() {
+    assert_eq!(EcdsaSpec::es256().coordinate_len_bytes(), 32);
+    assert_eq!(EcdsaSpec::es384().coordinate_len_bytes(), 48);
+}
+
+#[test]
+fn spec_stable_bytes_differ() {
+    assert_ne!(
+        EcdsaSpec::es256().stable_bytes(),
+        EcdsaSpec::es384().stable_bytes()
+    );
+}
+
+#[test]
+fn spec_hash_works() {
+    use std::collections::HashSet;
+    let mut set = HashSet::new();
+    set.insert(EcdsaSpec::es256());
+    set.insert(EcdsaSpec::es384());
+    set.insert(EcdsaSpec::es256()); // duplicate
+    assert_eq!(set.len(), 2);
+}
+
+// ── PEM format validation ───────────────────────────────────────────
+
+#[test]
+fn private_key_pem_headers() {
+    let kp = fx().ecdsa("pem-test", EcdsaSpec::es256());
+    let pem = kp.private_key_pkcs8_pem();
+    assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PRIVATE KEY-----"));
+}
+
+#[test]
+fn public_key_pem_headers() {
+    let kp = fx().ecdsa("pem-pub", EcdsaSpec::es256());
+    let pem = kp.public_key_spki_pem();
+    assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PUBLIC KEY-----"));
+}
+
+// ── Negative fixture edge cases ─────────────────────────────────────
+
+#[test]
+fn corrupt_deterministic_empty_variant() {
+    let kp = fx().ecdsa("corrupt-empty", EcdsaSpec::es256());
+    let corrupted = kp.private_key_pkcs8_pem_corrupt_deterministic("");
+    assert_ne!(corrupted, kp.private_key_pkcs8_pem());
+}
+
+#[test]
+fn der_truncated_zero() {
+    let kp = fx().ecdsa("truncate-zero", EcdsaSpec::es256());
+    let truncated = kp.private_key_pkcs8_der_truncated(0);
+    assert!(truncated.is_empty());
+}
+
+#[test]
+fn der_truncated_beyond_length() {
+    let kp = fx().ecdsa("truncate-beyond", EcdsaSpec::es256());
+    let der = kp.private_key_pkcs8_der();
+    let truncated = kp.private_key_pkcs8_der_truncated(der.len() + 100);
+    assert_eq!(truncated.len(), der.len());
+}
+
+#[test]
+fn mismatched_public_key_differs() {
+    let kp = fx().ecdsa("mismatch", EcdsaSpec::es256());
+    let mm = kp.mismatched_public_key_spki_der();
+    assert_ne!(mm, kp.public_key_spki_der());
+    assert!(!mm.is_empty());
+}
+
+// ── Both curves produce valid keys ──────────────────────────────────
+
+#[test]
+fn es256_and_es384_both_produce_valid_keys() {
+    let kp256 = fx().ecdsa("multi-curve", EcdsaSpec::es256());
+    let kp384 = fx().ecdsa("multi-curve", EcdsaSpec::es384());
+
+    // Different curves → different keys
+    assert_ne!(kp256.private_key_pkcs8_der(), kp384.private_key_pkcs8_der());
+    // P-384 key should be larger
+    assert!(kp384.private_key_pkcs8_der().len() > kp256.private_key_pkcs8_der().len());
+}
+
+// ── Concurrent access ───────────────────────────────────────────────
+
+#[test]
+fn concurrent_ecdsa_same_label() {
+    use std::thread;
+
+    let fx = fx();
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let fx = fx.clone();
+            thread::spawn(move || {
+                let kp = fx.ecdsa("concurrent-ec", EcdsaSpec::es256());
+                kp.private_key_pkcs8_der().to_vec()
+            })
+        })
+        .collect();
+
+    let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    for pair in results.windows(2) {
+        assert_eq!(pair[0], pair[1]);
+    }
+}

--- a/crates/uselesskey-ed25519/tests/edge_cases.rs
+++ b/crates/uselesskey-ed25519/tests/edge_cases.rs
@@ -1,0 +1,213 @@
+//! Edge-case and boundary tests for Ed25519 key fixtures.
+
+mod testutil;
+use testutil::fx;
+
+use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+// ── Empty and unusual labels ────────────────────────────────────────
+
+#[test]
+fn empty_label_produces_valid_keypair() {
+    let kp = fx().ed25519("", Ed25519Spec::new());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+    assert!(!kp.public_key_spki_pem().is_empty());
+}
+
+#[test]
+fn unicode_label_produces_valid_keypair() {
+    let kp = fx().ed25519("日本語🔑", Ed25519Spec::new());
+    assert!(!kp.private_key_pkcs8_der().is_empty());
+}
+
+#[test]
+fn very_long_label_works() {
+    let label = "x".repeat(10_000);
+    let kp = fx().ed25519(&label, Ed25519Spec::new());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+}
+
+#[test]
+fn null_byte_label() {
+    let kp = fx().ed25519("label\0null", Ed25519Spec::new());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+}
+
+// ── Debug does not leak key material ────────────────────────────────
+
+#[test]
+fn debug_does_not_leak_private_key() {
+    let kp = fx().ed25519("debug-test", Ed25519Spec::new());
+    let dbg = format!("{kp:?}");
+    let pem = kp.private_key_pkcs8_pem();
+
+    assert!(dbg.contains("Ed25519KeyPair"), "Debug should name the type");
+    assert!(dbg.contains("debug-test"), "Debug should show label");
+    for line in pem.lines().skip(1) {
+        if line.starts_with("-----") {
+            continue;
+        }
+        assert!(!dbg.contains(line), "Debug leaked PEM content: {line}");
+    }
+}
+
+#[test]
+fn debug_uses_non_exhaustive() {
+    let kp = fx().ed25519("ne-test", Ed25519Spec::new());
+    let dbg = format!("{kp:?}");
+    assert!(dbg.contains(".."), "Debug should use finish_non_exhaustive");
+}
+
+// ── Clone ───────────────────────────────────────────────────────────
+
+#[test]
+fn clone_shares_key_material() {
+    let kp = fx().ed25519("clone-test", Ed25519Spec::new());
+    let cloned = kp.clone();
+    assert_eq!(kp.private_key_pkcs8_der(), cloned.private_key_pkcs8_der());
+    assert_eq!(kp.public_key_spki_der(), cloned.public_key_spki_der());
+}
+
+// ── Spec trait coverage ─────────────────────────────────────────────
+
+#[test]
+fn spec_new_and_default_match() {
+    let s1 = Ed25519Spec::new();
+    let s2 = Ed25519Spec::default();
+    assert_eq!(s1, s2);
+}
+
+#[test]
+fn spec_clone_copy_eq() {
+    let s1 = Ed25519Spec::new();
+    let s2 = s1;
+    assert_eq!(s1, s2);
+}
+
+#[test]
+fn spec_hash_in_set() {
+    use std::collections::HashSet;
+    let mut set = HashSet::new();
+    set.insert(Ed25519Spec::new());
+    set.insert(Ed25519Spec::new()); // duplicate
+    assert_eq!(set.len(), 1);
+}
+
+#[test]
+fn spec_stable_bytes_are_fixed() {
+    let b1 = Ed25519Spec::new().stable_bytes();
+    let b2 = Ed25519Spec::new().stable_bytes();
+    assert_eq!(b1, b2);
+}
+
+// ── PEM format validation ───────────────────────────────────────────
+
+#[test]
+fn private_key_pem_headers() {
+    let kp = fx().ed25519("pem-test", Ed25519Spec::new());
+    let pem = kp.private_key_pkcs8_pem();
+    assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PRIVATE KEY-----"));
+}
+
+#[test]
+fn public_key_pem_headers() {
+    let kp = fx().ed25519("pem-pub", Ed25519Spec::new());
+    let pem = kp.public_key_spki_pem();
+    assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PUBLIC KEY-----"));
+}
+
+// ── Negative fixtures ───────────────────────────────────────────────
+
+#[test]
+fn corrupt_deterministic_empty_variant() {
+    let kp = fx().ed25519("corrupt-empty", Ed25519Spec::new());
+    let corrupted = kp.private_key_pkcs8_pem_corrupt_deterministic("");
+    assert_ne!(corrupted, kp.private_key_pkcs8_pem());
+}
+
+#[test]
+fn der_truncated_zero() {
+    let kp = fx().ed25519("truncate-zero", Ed25519Spec::new());
+    let truncated = kp.private_key_pkcs8_der_truncated(0);
+    assert!(truncated.is_empty());
+}
+
+#[test]
+fn der_truncated_to_one() {
+    let kp = fx().ed25519("truncate-one", Ed25519Spec::new());
+    let truncated = kp.private_key_pkcs8_der_truncated(1);
+    assert_eq!(truncated.len(), 1);
+}
+
+#[test]
+fn der_truncated_beyond_length() {
+    let kp = fx().ed25519("truncate-beyond", Ed25519Spec::new());
+    let der = kp.private_key_pkcs8_der();
+    let truncated = kp.private_key_pkcs8_der_truncated(der.len() + 100);
+    assert_eq!(truncated.len(), der.len());
+}
+
+#[test]
+fn der_corrupt_deterministic_differs() {
+    let kp = fx().ed25519("der-corrupt", Ed25519Spec::new());
+    let corrupted = kp.private_key_pkcs8_der_corrupt_deterministic("variant-a");
+    assert_ne!(corrupted, kp.private_key_pkcs8_der());
+}
+
+#[test]
+fn mismatched_public_key_differs() {
+    let kp = fx().ed25519("mismatch", Ed25519Spec::new());
+    let mm = kp.mismatched_public_key_spki_der();
+    assert_ne!(mm, kp.public_key_spki_der());
+    assert!(!mm.is_empty());
+}
+
+// ── Tempfile writes ─────────────────────────────────────────────────
+
+#[test]
+fn write_private_key_pem_roundtrip() {
+    let kp = fx().ed25519("tmpfile-priv", Ed25519Spec::new());
+    let tmp = kp.write_private_key_pkcs8_pem().unwrap();
+    assert_eq!(tmp.read_to_string().unwrap(), kp.private_key_pkcs8_pem());
+}
+
+#[test]
+fn write_public_key_pem_roundtrip() {
+    let kp = fx().ed25519("tmpfile-pub", Ed25519Spec::new());
+    let tmp = kp.write_public_key_spki_pem().unwrap();
+    assert_eq!(tmp.read_to_string().unwrap(), kp.public_key_spki_pem());
+}
+
+// ── Determinism with different labels ───────────────────────────────
+
+#[test]
+fn different_labels_produce_different_keys() {
+    let kp1 = fx().ed25519("label-a", Ed25519Spec::new());
+    let kp2 = fx().ed25519("label-b", Ed25519Spec::new());
+    assert_ne!(kp1.private_key_pkcs8_der(), kp2.private_key_pkcs8_der());
+}
+
+// ── Concurrent access ───────────────────────────────────────────────
+
+#[test]
+fn concurrent_ed25519_same_label() {
+    use std::thread;
+
+    let fx = fx();
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let fx = fx.clone();
+            thread::spawn(move || {
+                let kp = fx.ed25519("concurrent-ed", Ed25519Spec::new());
+                kp.private_key_pkcs8_der().to_vec()
+            })
+        })
+        .collect();
+
+    let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    for pair in results.windows(2) {
+        assert_eq!(pair[0], pair[1]);
+    }
+}

--- a/crates/uselesskey-hmac/tests/edge_cases.rs
+++ b/crates/uselesskey-hmac/tests/edge_cases.rs
@@ -1,0 +1,172 @@
+//! Edge-case and boundary tests for HMAC secret fixtures.
+
+mod testutil;
+use testutil::fx;
+
+use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+
+// ── Empty and unusual labels ────────────────────────────────────────
+
+#[test]
+fn empty_label_produces_valid_secret() {
+    let secret = fx().hmac("", HmacSpec::hs256());
+    assert_eq!(secret.secret_bytes().len(), 32);
+}
+
+#[test]
+fn unicode_label_produces_valid_secret() {
+    let secret = fx().hmac("日本語🔑", HmacSpec::hs256());
+    assert_eq!(secret.secret_bytes().len(), 32);
+}
+
+#[test]
+fn very_long_label_works() {
+    let label = "x".repeat(10_000);
+    let secret = fx().hmac(&label, HmacSpec::hs256());
+    assert_eq!(secret.secret_bytes().len(), 32);
+}
+
+#[test]
+fn null_byte_label() {
+    let secret = fx().hmac("label\0null", HmacSpec::hs256());
+    assert_eq!(secret.secret_bytes().len(), 32);
+}
+
+// ── All specs produce correct length ────────────────────────────────
+
+#[test]
+fn hs256_length() {
+    let s = fx().hmac("len-256", HmacSpec::hs256());
+    assert_eq!(s.secret_bytes().len(), 32);
+}
+
+#[test]
+fn hs384_length() {
+    let s = fx().hmac("len-384", HmacSpec::hs384());
+    assert_eq!(s.secret_bytes().len(), 48);
+}
+
+#[test]
+fn hs512_length() {
+    let s = fx().hmac("len-512", HmacSpec::hs512());
+    assert_eq!(s.secret_bytes().len(), 64);
+}
+
+// ── Debug does not leak secret material ─────────────────────────────
+
+#[test]
+fn debug_does_not_leak_secret() {
+    let s = fx().hmac("debug-test", HmacSpec::hs256());
+    let dbg = format!("{s:?}");
+    let hex: String = s
+        .secret_bytes()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+
+    assert!(dbg.contains("HmacSecret"), "Debug should name the type");
+    assert!(dbg.contains("debug-test"), "Debug should show label");
+    // Secret bytes should not appear in debug output
+    assert!(
+        !dbg.contains(&hex[..16]),
+        "Debug must not leak hex of secret"
+    );
+}
+
+#[test]
+fn debug_uses_non_exhaustive() {
+    let s = fx().hmac("ne-test", HmacSpec::hs256());
+    let dbg = format!("{s:?}");
+    assert!(dbg.contains(".."), "Debug should use finish_non_exhaustive");
+}
+
+// ── Clone ───────────────────────────────────────────────────────────
+
+#[test]
+fn clone_shares_secret() {
+    let s = fx().hmac("clone-test", HmacSpec::hs256());
+    let cloned = s.clone();
+    assert_eq!(s.secret_bytes(), cloned.secret_bytes());
+}
+
+// ── Spec trait coverage ─────────────────────────────────────────────
+
+#[test]
+fn spec_clone_copy_eq() {
+    let s1 = HmacSpec::hs256();
+    let s2 = s1;
+    assert_eq!(s1, s2);
+
+    let s3 = HmacSpec::hs384();
+    assert_ne!(s1, s3);
+}
+
+#[test]
+fn spec_hash_in_set() {
+    use std::collections::HashSet;
+    let mut set = HashSet::new();
+    set.insert(HmacSpec::hs256());
+    set.insert(HmacSpec::hs384());
+    set.insert(HmacSpec::hs512());
+    set.insert(HmacSpec::hs256()); // duplicate
+    assert_eq!(set.len(), 3);
+}
+
+#[test]
+fn spec_alg_names() {
+    assert_eq!(HmacSpec::hs256().alg_name(), "HS256");
+    assert_eq!(HmacSpec::hs384().alg_name(), "HS384");
+    assert_eq!(HmacSpec::hs512().alg_name(), "HS512");
+}
+
+#[test]
+fn spec_byte_lens() {
+    assert_eq!(HmacSpec::hs256().byte_len(), 32);
+    assert_eq!(HmacSpec::hs384().byte_len(), 48);
+    assert_eq!(HmacSpec::hs512().byte_len(), 64);
+}
+
+#[test]
+fn spec_stable_bytes_all_different() {
+    let b1 = HmacSpec::hs256().stable_bytes();
+    let b2 = HmacSpec::hs384().stable_bytes();
+    let b3 = HmacSpec::hs512().stable_bytes();
+    assert_ne!(b1, b2);
+    assert_ne!(b2, b3);
+    assert_ne!(b1, b3);
+}
+
+// ── Same label different spec → different secrets ───────────────────
+
+#[test]
+fn same_label_different_spec_produces_different_secrets() {
+    let s256 = fx().hmac("spec-diff", HmacSpec::hs256());
+    let s384 = fx().hmac("spec-diff", HmacSpec::hs384());
+    let s512 = fx().hmac("spec-diff", HmacSpec::hs512());
+
+    assert_ne!(s256.secret_bytes(), &s384.secret_bytes()[..32]);
+    assert_ne!(s384.secret_bytes(), &s512.secret_bytes()[..48]);
+}
+
+// ── Concurrent access ───────────────────────────────────────────────
+
+#[test]
+fn concurrent_hmac_same_label() {
+    use std::thread;
+
+    let fx = fx();
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let fx = fx.clone();
+            thread::spawn(move || {
+                let s = fx.hmac("concurrent-hmac", HmacSpec::hs256());
+                s.secret_bytes().to_vec()
+            })
+        })
+        .collect();
+
+    let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    for pair in results.windows(2) {
+        assert_eq!(pair[0], pair[1]);
+    }
+}

--- a/crates/uselesskey-rsa/tests/edge_cases.rs
+++ b/crates/uselesskey-rsa/tests/edge_cases.rs
@@ -1,0 +1,207 @@
+//! Edge-case and boundary tests for RSA key fixtures.
+
+mod testutil;
+use testutil::fx;
+
+use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+// ── Empty and unusual labels ────────────────────────────────────────
+
+#[test]
+fn empty_label_produces_valid_keypair() {
+    let kp = fx().rsa("", RsaSpec::rs256());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+    assert!(!kp.public_key_spki_pem().is_empty());
+}
+
+#[test]
+fn unicode_label_produces_valid_keypair() {
+    let kp = fx().rsa("日本語🔑キー", RsaSpec::rs256());
+    assert!(!kp.private_key_pkcs8_der().is_empty());
+}
+
+#[test]
+fn very_long_label_works() {
+    let label = "x".repeat(10_000);
+    let kp = fx().rsa(&label, RsaSpec::rs256());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+}
+
+#[test]
+fn special_chars_label() {
+    let kp = fx().rsa("label/with\\special<chars>&\"'", RsaSpec::rs256());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+}
+
+#[test]
+fn null_byte_in_label() {
+    let kp = fx().rsa("label\0null", RsaSpec::rs256());
+    assert!(!kp.private_key_pkcs8_pem().is_empty());
+}
+
+// ── Debug does not leak key material ────────────────────────────────
+
+#[test]
+fn debug_does_not_leak_private_key() {
+    let kp = fx().rsa("debug-test", RsaSpec::rs256());
+    let dbg = format!("{kp:?}");
+    let pem = kp.private_key_pkcs8_pem();
+
+    assert!(dbg.contains("RsaKeyPair"), "Debug should name the type");
+    assert!(dbg.contains("debug-test"), "Debug should show label");
+    // PEM second line contains base64 key material
+    for line in pem.lines().skip(1) {
+        if line.starts_with("-----") {
+            continue;
+        }
+        assert!(!dbg.contains(line), "Debug leaked PEM content: {line}");
+    }
+}
+
+#[test]
+fn debug_format_uses_non_exhaustive() {
+    let kp = fx().rsa("ne-test", RsaSpec::rs256());
+    let dbg = format!("{kp:?}");
+    assert!(dbg.contains(".."), "Debug should use finish_non_exhaustive");
+}
+
+// ── Clone ───────────────────────────────────────────────────────────
+
+#[test]
+fn clone_shares_key_material() {
+    let kp = fx().rsa("clone-test", RsaSpec::rs256());
+    let cloned = kp.clone();
+    assert_eq!(kp.private_key_pkcs8_der(), cloned.private_key_pkcs8_der());
+    assert_eq!(kp.public_key_spki_der(), cloned.public_key_spki_der());
+}
+
+// ── PEM format validation ───────────────────────────────────────────
+
+#[test]
+fn private_key_pem_has_correct_headers() {
+    let kp = fx().rsa("pem-header", RsaSpec::rs256());
+    let pem = kp.private_key_pkcs8_pem();
+    assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PRIVATE KEY-----"));
+}
+
+#[test]
+fn public_key_pem_has_correct_headers() {
+    let kp = fx().rsa("pem-header-pub", RsaSpec::rs256());
+    let pem = kp.public_key_spki_pem();
+    assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PUBLIC KEY-----"));
+}
+
+// ── Negative fixture edge cases ─────────────────────────────────────
+
+#[test]
+fn corrupt_deterministic_with_empty_variant() {
+    let kp = fx().rsa("corrupt-empty", RsaSpec::rs256());
+    let corrupted = kp.private_key_pkcs8_pem_corrupt_deterministic("");
+    assert_ne!(corrupted, kp.private_key_pkcs8_pem());
+}
+
+#[test]
+fn corrupt_deterministic_with_unicode_variant() {
+    let kp = fx().rsa("corrupt-unicode", RsaSpec::rs256());
+    let corrupted = kp.private_key_pkcs8_pem_corrupt_deterministic("日本語");
+    assert_ne!(corrupted, kp.private_key_pkcs8_pem());
+}
+
+#[test]
+fn der_truncated_to_zero() {
+    let kp = fx().rsa("truncate-zero", RsaSpec::rs256());
+    let truncated = kp.private_key_pkcs8_der_truncated(0);
+    assert!(truncated.is_empty());
+}
+
+#[test]
+fn der_truncated_to_one() {
+    let kp = fx().rsa("truncate-one", RsaSpec::rs256());
+    let truncated = kp.private_key_pkcs8_der_truncated(1);
+    assert_eq!(truncated.len(), 1);
+    assert_eq!(truncated[0], kp.private_key_pkcs8_der()[0]);
+}
+
+#[test]
+fn der_truncated_beyond_length_returns_full() {
+    let kp = fx().rsa("truncate-beyond", RsaSpec::rs256());
+    let der = kp.private_key_pkcs8_der();
+    let truncated = kp.private_key_pkcs8_der_truncated(der.len() + 100);
+    assert_eq!(truncated.len(), der.len());
+}
+
+#[test]
+fn der_corrupt_deterministic_differs_from_original() {
+    let kp = fx().rsa("der-corrupt", RsaSpec::rs256());
+    let corrupted = kp.private_key_pkcs8_der_corrupt_deterministic("variant-a");
+    assert_ne!(corrupted, kp.private_key_pkcs8_der());
+}
+
+#[test]
+fn mismatched_public_key_is_valid_but_different() {
+    let kp = fx().rsa("mismatch-test", RsaSpec::rs256());
+    let mismatched = kp.mismatched_public_key_spki_der();
+    assert_ne!(mismatched, kp.public_key_spki_der());
+    // Should still be a valid DER blob (non-empty)
+    assert!(!mismatched.is_empty());
+}
+
+// ── Tempfile writes ─────────────────────────────────────────────────
+
+#[test]
+fn write_private_key_pem_creates_readable_tempfile() {
+    let kp = fx().rsa("tempfile-priv", RsaSpec::rs256());
+    let tmp = kp.write_private_key_pkcs8_pem().unwrap();
+    let content = tmp.read_to_string().unwrap();
+    assert_eq!(content, kp.private_key_pkcs8_pem());
+}
+
+#[test]
+fn write_public_key_pem_creates_readable_tempfile() {
+    let kp = fx().rsa("tempfile-pub", RsaSpec::rs256());
+    let tmp = kp.write_public_key_spki_pem().unwrap();
+    let content = tmp.read_to_string().unwrap();
+    assert_eq!(content, kp.public_key_spki_pem());
+}
+
+// ── Spec edge cases ─────────────────────────────────────────────────
+
+#[test]
+fn same_label_different_spec_produces_different_keys() {
+    let kp1 = fx().rsa("spec-diff", RsaSpec::rs256());
+    let kp2 = fx().rsa("spec-diff", RsaSpec::new(4096));
+    assert_ne!(kp1.private_key_pkcs8_der(), kp2.private_key_pkcs8_der());
+}
+
+#[test]
+fn rsa_spec_stable_bytes_differ_for_different_sizes() {
+    let s1 = RsaSpec::rs256();
+    let s2 = RsaSpec::new(4096);
+    assert_ne!(s1.stable_bytes(), s2.stable_bytes());
+}
+
+// ── Concurrent access ───────────────────────────────────────────────
+
+#[test]
+fn concurrent_rsa_generation_same_label() {
+    use std::thread;
+
+    let fx = fx();
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let fx = fx.clone();
+            thread::spawn(move || {
+                let kp = fx.rsa("concurrent-rsa", RsaSpec::rs256());
+                kp.private_key_pkcs8_der().to_vec()
+            })
+        })
+        .collect();
+
+    let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    // All threads should get the same key
+    for pair in results.windows(2) {
+        assert_eq!(pair[0], pair[1]);
+    }
+}

--- a/crates/uselesskey-token/tests/edge_cases.rs
+++ b/crates/uselesskey-token/tests/edge_cases.rs
@@ -1,0 +1,227 @@
+//! Edge-case and boundary tests for Token fixtures.
+
+mod testutil;
+use testutil::fx;
+
+use uselesskey_token::{TokenFactoryExt, TokenSpec};
+
+// ── Empty and unusual labels ────────────────────────────────────────
+
+#[test]
+fn empty_label_produces_valid_token() {
+    let t = fx().token("", TokenSpec::api_key());
+    assert!(!t.value().is_empty());
+}
+
+#[test]
+fn unicode_label_produces_valid_token() {
+    let t = fx().token("日本語🔑", TokenSpec::bearer());
+    assert!(!t.value().is_empty());
+}
+
+#[test]
+fn very_long_label_works() {
+    let label = "x".repeat(10_000);
+    let t = fx().token(&label, TokenSpec::api_key());
+    assert!(!t.value().is_empty());
+}
+
+#[test]
+fn null_byte_label() {
+    let t = fx().token("label\0null", TokenSpec::api_key());
+    assert!(!t.value().is_empty());
+}
+
+// ── All spec shapes ─────────────────────────────────────────────────
+
+#[test]
+fn api_key_shape() {
+    let t = fx().token("shape-api", TokenSpec::api_key());
+    assert!(
+        t.value().starts_with("uk_test_"),
+        "API key should start with uk_test_"
+    );
+    // Total: prefix(8) + 32 base62 chars = 40
+    assert_eq!(t.value().len(), 40);
+}
+
+#[test]
+fn bearer_token_shape() {
+    let t = fx().token("shape-bearer", TokenSpec::bearer());
+    let v = t.value();
+    // base64url encoded 32 bytes = ~43 chars
+    assert!(!v.is_empty());
+    // Check base64url alphabet
+    for ch in v.chars() {
+        assert!(
+            ch.is_ascii_alphanumeric() || ch == '-' || ch == '_',
+            "Bearer token should be base64url: found {ch:?}"
+        );
+    }
+}
+
+#[test]
+fn oauth_token_has_three_segments() {
+    let t = fx().token("shape-oauth", TokenSpec::oauth_access_token());
+    let segments: Vec<&str> = t.value().split('.').collect();
+    assert_eq!(segments.len(), 3, "OAuth token should have 3 JWT segments");
+}
+
+// ── authorization_header ────────────────────────────────────────────
+
+#[test]
+fn api_key_authorization_header() {
+    let t = fx().token("auth-api", TokenSpec::api_key());
+    let header = t.authorization_header();
+    assert!(
+        header.starts_with("ApiKey "),
+        "API key auth header should start with 'ApiKey '"
+    );
+    assert!(header.ends_with(t.value()));
+}
+
+#[test]
+fn bearer_authorization_header() {
+    let t = fx().token("auth-bearer", TokenSpec::bearer());
+    let header = t.authorization_header();
+    assert!(header.starts_with("Bearer "));
+}
+
+#[test]
+fn oauth_authorization_header() {
+    let t = fx().token("auth-oauth", TokenSpec::oauth_access_token());
+    let header = t.authorization_header();
+    assert!(header.starts_with("Bearer "));
+}
+
+// ── Debug does not leak token value ─────────────────────────────────
+
+#[test]
+fn debug_does_not_leak_value() {
+    let t = fx().token("debug-test", TokenSpec::api_key());
+    let dbg = format!("{t:?}");
+    let value = t.value();
+
+    assert!(dbg.contains("TokenFixture"), "Debug should name the type");
+    assert!(!dbg.contains(value), "Debug must not contain token value");
+}
+
+#[test]
+fn debug_shows_label() {
+    let t = fx().token("my-label", TokenSpec::api_key());
+    let dbg = format!("{t:?}");
+    assert!(dbg.contains("my-label"), "Debug should show label");
+}
+
+// ── Clone ───────────────────────────────────────────────────────────
+
+#[test]
+fn clone_preserves_value() {
+    let t = fx().token("clone-test", TokenSpec::api_key());
+    let cloned = t.clone();
+    assert_eq!(t.value(), cloned.value());
+}
+
+// ── Spec trait coverage ─────────────────────────────────────────────
+
+#[test]
+fn spec_clone_copy_eq() {
+    let s1 = TokenSpec::api_key();
+    let s2 = s1;
+    assert_eq!(s1, s2);
+
+    let s3 = TokenSpec::bearer();
+    assert_ne!(s1, s3);
+}
+
+#[test]
+fn spec_hash_in_set() {
+    use std::collections::HashSet;
+    let mut set = HashSet::new();
+    set.insert(TokenSpec::api_key());
+    set.insert(TokenSpec::bearer());
+    set.insert(TokenSpec::oauth_access_token());
+    set.insert(TokenSpec::api_key()); // duplicate
+    assert_eq!(set.len(), 3);
+}
+
+#[test]
+fn spec_kind_names() {
+    assert_eq!(TokenSpec::api_key().kind_name(), "api_key");
+    assert_eq!(TokenSpec::bearer().kind_name(), "bearer");
+    assert_eq!(
+        TokenSpec::oauth_access_token().kind_name(),
+        "oauth_access_token"
+    );
+}
+
+#[test]
+fn spec_stable_bytes_all_different() {
+    let b1 = TokenSpec::api_key().stable_bytes();
+    let b2 = TokenSpec::bearer().stable_bytes();
+    let b3 = TokenSpec::oauth_access_token().stable_bytes();
+    assert_ne!(b1, b2);
+    assert_ne!(b2, b3);
+    assert_ne!(b1, b3);
+}
+
+// ── token_with_variant ──────────────────────────────────────────────
+
+#[test]
+fn variant_produces_different_token() {
+    let t1 = fx().token("variant-test", TokenSpec::api_key());
+    let t2 = fx().token_with_variant("variant-test", TokenSpec::api_key(), "alt");
+    assert_ne!(t1.value(), t2.value());
+}
+
+#[test]
+fn same_variant_is_deterministic() {
+    let t1 = fx().token_with_variant("variant-det", TokenSpec::api_key(), "v1");
+    let t2 = fx().token_with_variant("variant-det", TokenSpec::api_key(), "v1");
+    assert_eq!(t1.value(), t2.value());
+}
+
+#[test]
+fn empty_variant_differs_from_default() {
+    // Default variant is "default"; empty variant should differ
+    let t_default = fx().token("variant-empty", TokenSpec::bearer());
+    let t_empty = fx().token_with_variant("variant-empty", TokenSpec::bearer(), "");
+    // They might or might not differ depending on impl, but both should be valid
+    assert!(!t_default.value().is_empty());
+    assert!(!t_empty.value().is_empty());
+}
+
+// ── Same label different spec → different tokens ────────────────────
+
+#[test]
+fn same_label_different_spec_different_tokens() {
+    let t1 = fx().token("spec-diff", TokenSpec::api_key());
+    let t2 = fx().token("spec-diff", TokenSpec::bearer());
+    let t3 = fx().token("spec-diff", TokenSpec::oauth_access_token());
+    assert_ne!(t1.value(), t2.value());
+    assert_ne!(t2.value(), t3.value());
+    assert_ne!(t1.value(), t3.value());
+}
+
+// ── Concurrent access ───────────────────────────────────────────────
+
+#[test]
+fn concurrent_token_same_label() {
+    use std::thread;
+
+    let fx = fx();
+    let handles: Vec<_> = (0..8)
+        .map(|_| {
+            let fx = fx.clone();
+            thread::spawn(move || {
+                let t = fx.token("concurrent-token", TokenSpec::api_key());
+                t.value().to_string()
+            })
+        })
+        .collect();
+
+    let results: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    for pair in results.windows(2) {
+        assert_eq!(pair[0], pair[1]);
+    }
+}


### PR DESCRIPTION
Add comprehensive edge-case and boundary tests across the workspace, targeting paths that mutation testing or coverage might miss.

## Changes

Added 14 new \dge_cases.rs\ test files covering:

### Core crates
- **uselesskey-core-seed**: Seed boundary values (all zeros/ones), single-bit flips, from_env_value with unicode/whitespace/invalid hex, Hash trait in collections, Debug safety
- **uselesskey-core-factory**: Empty/unicode/long/special-char labels, seed boundaries (zero/max/one), empty spec/variant, concurrent factory access (32 threads), Debug format safety, cache clear/regenerate, clone shares cache
- **uselesskey-core-cache**: Concurrent insert_if_absent (32 threads), concurrent reads+writes, many entries (1000), clear while reading, unicode/empty keys, Debug format
- **uselesskey-core-id**: Empty label/variant derivation, unicode labels, long labels, special chars in variants, spec fingerprint sensitivity, seed boundary values, DerivationVersion traits, ArtifactId in HashSet
- **uselesskey-core-hash**: Single zero byte, large input, len-prefixed with single bytes, three empty fields vs two
- **uselesskey-core-kid**: Empty/large input, prefix_bytes boundaries (1, 32), panics at 0 and 33, base64url format validation, no padding
- **uselesskey-core-base62**: Zero/one/large length, seed determinism, alphabet validation

### Key type crates
- **uselesskey-rsa**: Empty/unicode/long/null-byte labels, Debug no-leak, Clone shares material, PEM headers, negative fixture edge cases (truncate 0/1/beyond, corrupt deterministic with empty/unicode variant, mismatched keys), tempfile writes, concurrent access
- **uselesskey-ecdsa**: Same pattern as RSA plus spec trait coverage (Clone, Copy, Eq, Hash, alg/curve/coordinate), both curves produce valid keys
- **uselesskey-ed25519**: Same pattern plus Ed25519Spec new/default match, spec Hash in set
- **uselesskey-hmac**: All specs correct length, Debug no-leak, spec trait coverage (Hash, alg_name, byte_len, stable_bytes), same label different spec
- **uselesskey-token**: All spec shapes (api_key prefix, bearer base64url, oauth 3 segments), authorization_header per scheme, Debug no-leak, spec traits, token_with_variant

### Negative fixture crates
- **uselesskey-core-negative-pem**: Minimal PEM inputs, truncate boundaries (0 chars, beyond content), all variants produce different corruptions, deterministic stability with empty/unicode variants
- **uselesskey-core-negative-der**: Truncate/flip_byte boundaries (empty, single byte, exact/beyond length), flip involutory, corrupt deterministic stability, never returns original