### PR TITLE
ci: harden CI configuration and xtask commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,27 @@ on:
       - main
   pull_request:
 
+# Cancel redundant runs: on PRs cancel previous runs for the same PR;
+# on main each push gets its own run.
+concurrency:
+  group: ci-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
 jobs:
   pr:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@1.92
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 
@@ -26,12 +37,14 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants
+        run: cargo install cargo-mutants --locked
 
       - name: Fetch base branch
         if: github.base_ref != ''
@@ -39,6 +52,7 @@ jobs:
 
       - name: xtask pr
         run: cargo xtask pr
+
       - name: Upload receipt
         uses: actions/upload-artifact@v4
         with:
@@ -49,12 +63,13 @@ jobs:
   main:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@1.92
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 
@@ -65,12 +80,14 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants
+        run: cargo install cargo-mutants --locked
 
       - name: xtask ci
         run: cargo xtask ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,24 @@ on:
     tags:
       - "v*"
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@1.92
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 
@@ -24,12 +33,14 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants
+        run: cargo install cargo-mutants --locked
 
       - name: xtask ci
         run: cargo xtask ci
@@ -37,12 +48,13 @@ jobs:
   publish:
     needs: ci
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@1.92
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Install NASM (for aws-lc-rs)
         run: sudo apt-get update && sudo apt-get install -y nasm
@@ -56,6 +68,7 @@ jobs:
   release:
     needs: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:

--- a/deny.toml
+++ b/deny.toml
@@ -1,19 +1,34 @@
-# cargo-deny configuration (optional)
+# cargo-deny configuration
 # https://github.com/EmbarkStudios/cargo-deny
 
 [advisories]
-# default = "warn"
 yanked = "warn"
-unmaintained = "warn"
-ignore = []
+# RUSTSEC-2023-0071: Marvin Attack timing side-channel in `rsa` crate.
+# Acceptable for this project — uselesskey is a *test-fixture* library,
+# not a production crypto implementation. The keys it generates are
+# intentionally throwaway.
+ignore = ["RUSTSEC-2023-0071"]
 
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+# Internal-only crates use path deps with wildcard versions; allow them.
+allow-wildcard-paths = true
 skip = []
 
 [licenses]
-allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "ISC", "CC0-1.0", "OpenSSL"]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BlueOak-1.0.0",
+    "ISC",
+    "CC0-1.0",
+    "OpenSSL",
+    "Unicode-3.0",
+    "Zlib",
+]
 confidence-threshold = 0.8
 
 [sources]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -243,14 +243,20 @@ fn feature_matrix_cmd() -> Result<()> {
 }
 
 const PUBLISH_CRATES: &[&str] = &[
+    // Leaf crates (no workspace deps)
+    "uselesskey-core-base62",
     "uselesskey-core-seed",
     "uselesskey-core-hash",
+    "uselesskey-core-hmac-spec",
     "uselesskey-core-id",
     "uselesskey-core-cache",
     "uselesskey-core-factory",
     "uselesskey-core-kid",
+    // Negative fixture crates
+    "uselesskey-core-negative-der",
     "uselesskey-core-negative-pem",
     "uselesskey-core-negative",
+    // Sinks and shapes
     "uselesskey-core-sink",
     "uselesskey-core-token",
     "uselesskey-core-token-shape",
@@ -258,22 +264,30 @@ const PUBLISH_CRATES: &[&str] = &[
     "uselesskey-core-jwks-order",
     "uselesskey-core-jwk-builder",
     "uselesskey-core-jwk",
+    // X.509 crates (in dep order)
     "uselesskey-core-x509-spec",
     "uselesskey-core-x509-derive",
+    "uselesskey-core-x509-chain-negative",
     "uselesskey-core-x509-negative",
     "uselesskey-core-x509",
+    // Core aggregate
     "uselesskey-core",
     "uselesskey-core-keypair-material",
     "uselesskey-core-keypair",
+    // Mid-level crates
     "uselesskey-jwk",
     "uselesskey-rsa",
     "uselesskey-ecdsa",
     "uselesskey-ed25519",
     "uselesskey-hmac",
     "uselesskey-token",
+    "uselesskey-token-spec",
     "uselesskey-pgp",
     "uselesskey-x509",
+    // Facade
     "uselesskey",
+    // Adapters (depend on facade / key crates)
+    "uselesskey-core-rustls-pki",
     "uselesskey-jsonwebtoken",
     "uselesskey-rustls",
     "uselesskey-tonic",


### PR DESCRIPTION
Hardens CI workflows, xtask PUBLISH_CRATES list, and deny.toml. Add concurrency, timeouts, stable toolchain, cache-on-failure, 6 missing publish crates, deny.toml fixes for 0.19+ compat.