### PR TITLE
test: expand cross-adapter interop test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3922,13 +3922,16 @@ name = "uselesskey-interop-tests"
 version = "0.0.0"
 dependencies = [
  "aws-lc-rs",
+ "base64",
  "ed25519-dalek",
  "hmac",
  "jsonwebtoken",
  "p256",
+ "p384",
  "ring",
  "rsa",
  "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/uselesskey-interop-tests/Cargo.toml
+++ b/crates/uselesskey-interop-tests/Cargo.toml
@@ -26,6 +26,8 @@ uselesskey-ed25519 = { path = "../uselesskey-ed25519", features = ["jwk"] }
 # Crypto backends for verification
 ring = { workspace = true }
 p256 = { version = "0.13", features = ["ecdsa", "pkcs8", "pem"] }
+p384 = { version = "0.13", features = ["ecdsa", "pkcs8", "pem"] }
+rustls-pki-types = { workspace = true }
 ed25519-dalek = { workspace = true }
 rsa = { workspace = true }
 sha2 = { version = "0.10", features = ["oid"] }
@@ -33,6 +35,7 @@ signature = "2"
 hmac = "0.12"
 rustls = { workspace = true }
 jsonwebtoken = { workspace = true }
+base64 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/uselesskey-interop-tests/tests/all_adapters.rs
+++ b/crates/uselesskey-interop-tests/tests/all_adapters.rs
@@ -1,0 +1,428 @@
+//! Verify that every key type generated via uselesskey works correctly when
+//! converted through ALL adapter crates (ring, rustcrypto, jsonwebtoken,
+//! rustls, aws-lc-rs).
+//!
+//! These tests don't cross-sign; they confirm that each adapter can parse and
+//! use the generated key material.
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> &'static Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-all-adapters-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+}
+
+// =========================================================================
+// RSA through every adapter
+// =========================================================================
+
+mod rsa_all_adapters {
+    use super::*;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn rsa_ring_parse() {
+        let kp = fx().rsa("all-rsa-ring", RsaSpec::rs256());
+        let ring_kp = ring::rsa::KeyPair::from_pkcs8(kp.private_key_pkcs8_der())
+            .expect("ring should parse RSA PKCS#8 DER");
+        assert_eq!(ring_kp.public().modulus_len(), 256); // 2048-bit
+    }
+
+    #[test]
+    fn rsa_rustcrypto_parse() {
+        let kp = fx().rsa("all-rsa-rc", RsaSpec::rs256());
+        use rsa::pkcs8::DecodePrivateKey;
+        use rsa::traits::PublicKeyParts;
+        let priv_key = rsa::RsaPrivateKey::from_pkcs8_der(kp.private_key_pkcs8_der())
+            .expect("rustcrypto should parse RSA PKCS#8 DER");
+        assert_eq!(priv_key.size(), 256);
+    }
+
+    #[cfg(feature = "jwt-interop")]
+    #[test]
+    fn rsa_jsonwebtoken_round_trip() {
+        use uselesskey_jsonwebtoken::JwtKeyExt;
+
+        let kp = fx().rsa("all-rsa-jwt", RsaSpec::rs256());
+        let claims = serde_json::json!({
+            "sub": "all-adapter-rsa",
+            "iss": "uselesskey",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
+        validation.set_issuer(&["uselesskey"]);
+        let decoded =
+            jsonwebtoken::decode::<serde_json::Value>(&token, &kp.decoding_key(), &validation)
+                .expect("JWT decode");
+        assert_eq!(decoded.claims["sub"], "all-adapter-rsa");
+    }
+
+    #[cfg(feature = "cross-tls")]
+    #[test]
+    fn rsa_rustls_private_key_der() {
+        use uselesskey_rustls::RustlsPrivateKeyExt;
+
+        let kp = fx().rsa("all-rsa-rustls", RsaSpec::rs256());
+        let der = kp.private_key_der_rustls();
+        assert!(!der.secret_der().is_empty());
+    }
+
+    #[cfg(all(feature = "aws-lc-rs-interop", any(not(windows), has_nasm)))]
+    #[test]
+    fn rsa_aws_lc_rs_parse() {
+        let kp = fx().rsa("all-rsa-aws", RsaSpec::rs256());
+        let aws_kp = aws_lc_rs::rsa::KeyPair::from_pkcs8(kp.private_key_pkcs8_der())
+            .expect("aws-lc-rs should parse RSA PKCS#8 DER");
+        assert_eq!(aws_kp.public_modulus_len(), 256);
+    }
+
+    #[cfg(feature = "cross-signing")]
+    #[test]
+    fn rsa_ring_sign_verify() {
+        use ring::signature as ring_sig;
+        use uselesskey_ring::RingRsaKeyPairExt;
+
+        let kp = fx().rsa("all-rsa-ring-sv", RsaSpec::rs256());
+        let ring_kp = kp.rsa_key_pair_ring();
+        let rng = ring::rand::SystemRandom::new();
+        let msg = b"RSA ring sign-verify in all-adapters";
+        let mut sig = vec![0u8; ring_kp.public().modulus_len()];
+        ring_kp
+            .sign(&ring_sig::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("ring sign");
+
+        let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+        let public_key =
+            ring_sig::UnparsedPublicKey::new(&ring_sig::RSA_PKCS1_2048_8192_SHA256, raw_pubkey);
+        public_key.verify(msg, &sig).expect("ring self-verify");
+    }
+
+    #[cfg(feature = "cross-signing")]
+    #[test]
+    fn rsa_rustcrypto_sign_verify() {
+        use rsa::pkcs1v15;
+        use rsa::signature::{Signer, Verifier};
+        use sha2::Sha256;
+        use uselesskey_rustcrypto::RustCryptoRsaExt;
+
+        let kp = fx().rsa("all-rsa-rc-sv", RsaSpec::rs256());
+        let priv_key = kp.rsa_private_key();
+        let pub_key = kp.rsa_public_key();
+        let signing_key = pkcs1v15::SigningKey::<Sha256>::new(priv_key);
+        let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(pub_key);
+        let msg = b"RSA rustcrypto sign-verify in all-adapters";
+        let sig = signing_key.sign(msg);
+        verifying_key
+            .verify(msg, &sig)
+            .expect("rustcrypto self-verify");
+    }
+
+    #[cfg(all(
+        feature = "cross-signing",
+        feature = "aws-lc-rs-interop",
+        any(not(windows), has_nasm)
+    ))]
+    #[test]
+    fn rsa_aws_lc_rs_sign_verify() {
+        use uselesskey_aws_lc_rs::AwsLcRsRsaKeyPairExt;
+
+        let kp = fx().rsa("all-rsa-aws-sv", RsaSpec::rs256());
+        let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+        let rng = aws_lc_rs::rand::SystemRandom::new();
+        let msg = b"RSA aws-lc-rs sign-verify in all-adapters";
+        let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+        aws_kp
+            .sign(&aws_lc_rs::signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("aws sign");
+        // Verify via raw public key
+        let spki = kp.public_key_spki_der();
+        let public_key = aws_lc_rs::signature::UnparsedPublicKey::new(
+            &aws_lc_rs::signature::RSA_PKCS1_2048_8192_SHA256,
+            extract_public_key_from_spki(spki),
+        );
+        public_key.verify(msg, &sig).expect("aws-lc-rs self-verify");
+    }
+}
+
+// =========================================================================
+// ECDSA P-256 through every adapter
+// =========================================================================
+
+mod ecdsa_p256_all_adapters {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    #[test]
+    fn p256_ring_parse() {
+        let kp = fx().ecdsa("all-p256-ring", EcdsaSpec::es256());
+        let _ring_kp = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
+            kp.private_key_pkcs8_der(),
+            &ring::rand::SystemRandom::new(),
+        )
+        .expect("ring should parse P-256 PKCS#8");
+    }
+
+    #[test]
+    fn p256_rustcrypto_parse() {
+        use p256::pkcs8::DecodePrivateKey;
+
+        let kp = fx().ecdsa("all-p256-rc", EcdsaSpec::es256());
+        let _sk = p256::ecdsa::SigningKey::from_pkcs8_der(kp.private_key_pkcs8_der())
+            .expect("rustcrypto should parse P-256 PKCS#8");
+    }
+
+    #[cfg(feature = "jwt-interop")]
+    #[test]
+    fn p256_jsonwebtoken_round_trip() {
+        use uselesskey_jsonwebtoken::JwtKeyExt;
+
+        let kp = fx().ecdsa("all-p256-jwt", EcdsaSpec::es256());
+        let claims = serde_json::json!({
+            "sub": "all-adapter-p256",
+            "iss": "uselesskey",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::ES256);
+        validation.set_issuer(&["uselesskey"]);
+        let decoded =
+            jsonwebtoken::decode::<serde_json::Value>(&token, &kp.decoding_key(), &validation)
+                .expect("JWT decode");
+        assert_eq!(decoded.claims["sub"], "all-adapter-p256");
+    }
+
+    #[cfg(all(feature = "aws-lc-rs-interop", any(not(windows), has_nasm)))]
+    #[test]
+    fn p256_aws_lc_rs_parse() {
+        let kp = fx().ecdsa("all-p256-aws", EcdsaSpec::es256());
+        let _aws_kp = aws_lc_rs::signature::EcdsaKeyPair::from_pkcs8(
+            &aws_lc_rs::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
+            kp.private_key_pkcs8_der(),
+        )
+        .expect("aws-lc-rs should parse P-256 PKCS#8");
+    }
+}
+
+// =========================================================================
+// ECDSA P-384 through every adapter
+// =========================================================================
+
+mod ecdsa_p384_all_adapters {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    #[test]
+    fn p384_ring_parse() {
+        let kp = fx().ecdsa("all-p384-ring", EcdsaSpec::es384());
+        let _ring_kp = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P384_SHA384_ASN1_SIGNING,
+            kp.private_key_pkcs8_der(),
+            &ring::rand::SystemRandom::new(),
+        )
+        .expect("ring should parse P-384 PKCS#8");
+    }
+
+    #[test]
+    fn p384_rustcrypto_parse() {
+        use p384::pkcs8::DecodePrivateKey;
+
+        let kp = fx().ecdsa("all-p384-rc", EcdsaSpec::es384());
+        let _sk = p384::ecdsa::SigningKey::from_pkcs8_der(kp.private_key_pkcs8_der())
+            .expect("rustcrypto should parse P-384 PKCS#8");
+    }
+
+    #[cfg(feature = "jwt-interop")]
+    #[test]
+    fn p384_jsonwebtoken_round_trip() {
+        use uselesskey_jsonwebtoken::JwtKeyExt;
+
+        let kp = fx().ecdsa("all-p384-jwt", EcdsaSpec::es384());
+        let claims = serde_json::json!({
+            "sub": "all-adapter-p384",
+            "iss": "uselesskey",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES384);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::ES384);
+        validation.set_issuer(&["uselesskey"]);
+        let decoded =
+            jsonwebtoken::decode::<serde_json::Value>(&token, &kp.decoding_key(), &validation)
+                .expect("JWT decode");
+        assert_eq!(decoded.claims["sub"], "all-adapter-p384");
+    }
+
+    #[cfg(all(feature = "aws-lc-rs-interop", any(not(windows), has_nasm)))]
+    #[test]
+    fn p384_aws_lc_rs_parse() {
+        let kp = fx().ecdsa("all-p384-aws", EcdsaSpec::es384());
+        let _aws_kp = aws_lc_rs::signature::EcdsaKeyPair::from_pkcs8(
+            &aws_lc_rs::signature::ECDSA_P384_SHA384_ASN1_SIGNING,
+            kp.private_key_pkcs8_der(),
+        )
+        .expect("aws-lc-rs should parse P-384 PKCS#8");
+    }
+
+    #[cfg(feature = "cross-signing")]
+    #[test]
+    fn p384_ring_sign_rustcrypto_verify() {
+        use uselesskey_ring::RingEcdsaKeyPairExt;
+
+        let kp = fx().ecdsa("all-p384-r2rc", EcdsaSpec::es384());
+        let ring_kp = kp.ecdsa_key_pair_ring();
+        let rng = ring::rand::SystemRandom::new();
+        let msg = b"P-384 ring sign, rustcrypto verify";
+        let sig = ring_kp.sign(&rng, msg).expect("ring sign");
+
+        use p384::ecdsa::signature::Verifier;
+        use uselesskey_rustcrypto::RustCryptoEcdsaExt;
+        let verifying_key = kp.p384_verifying_key();
+        let der_sig = p384::ecdsa::DerSignature::try_from(sig.as_ref()).expect("valid ASN.1 sig");
+        verifying_key
+            .verify(msg, &der_sig)
+            .expect("rustcrypto should verify ring-signed P-384 signature");
+    }
+
+    #[cfg(feature = "cross-signing")]
+    #[test]
+    fn p384_rustcrypto_sign_ring_verify() {
+        use p384::ecdsa::signature::Signer;
+        use ring::signature as ring_sig;
+        use uselesskey_rustcrypto::RustCryptoEcdsaExt;
+
+        let kp = fx().ecdsa("all-p384-rc2r", EcdsaSpec::es384());
+        let signing_key = kp.p384_signing_key();
+        let msg = b"P-384 rustcrypto sign, ring verify";
+        let sig: p384::ecdsa::DerSignature = signing_key.sign(msg);
+
+        let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+        let public_key =
+            ring_sig::UnparsedPublicKey::new(&ring_sig::ECDSA_P384_SHA384_ASN1, raw_pubkey);
+        public_key
+            .verify(msg, sig.as_bytes())
+            .expect("ring should verify rustcrypto-signed P-384 signature");
+    }
+
+    #[cfg(all(
+        feature = "cross-signing",
+        feature = "aws-lc-rs-interop",
+        any(not(windows), has_nasm)
+    ))]
+    #[test]
+    fn p384_aws_sign_ring_verify() {
+        use ring::signature as ring_sig;
+        use uselesskey_aws_lc_rs::AwsLcRsEcdsaKeyPairExt;
+
+        let kp = fx().ecdsa("all-p384-a2r", EcdsaSpec::es384());
+        let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+        let rng = aws_lc_rs::rand::SystemRandom::new();
+        let msg = b"P-384 aws sign, ring verify";
+        let sig = aws_kp.sign(&rng, msg).expect("aws sign");
+
+        let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+        let public_key =
+            ring_sig::UnparsedPublicKey::new(&ring_sig::ECDSA_P384_SHA384_ASN1, raw_pubkey);
+        public_key
+            .verify(msg, sig.as_ref())
+            .expect("ring should verify aws-signed P-384 signature");
+    }
+}
+
+// =========================================================================
+// Ed25519 through every adapter
+// =========================================================================
+
+mod ed25519_all_adapters {
+    use super::*;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    #[test]
+    fn ed25519_ring_parse() {
+        let kp = fx().ed25519("all-ed-ring", Ed25519Spec::new());
+        let _ring_kp =
+            ring::signature::Ed25519KeyPair::from_pkcs8_maybe_unchecked(kp.private_key_pkcs8_der())
+                .expect("ring should parse Ed25519 PKCS#8");
+    }
+
+    #[test]
+    fn ed25519_rustcrypto_parse() {
+        use ed25519_dalek::pkcs8::DecodePrivateKey;
+
+        let kp = fx().ed25519("all-ed-rc", Ed25519Spec::new());
+        let _sk = ed25519_dalek::SigningKey::from_pkcs8_der(kp.private_key_pkcs8_der())
+            .expect("rustcrypto should parse Ed25519 PKCS#8");
+    }
+
+    #[cfg(feature = "jwt-interop")]
+    #[test]
+    fn ed25519_jsonwebtoken_round_trip() {
+        use uselesskey_jsonwebtoken::JwtKeyExt;
+
+        let kp = fx().ed25519("all-ed-jwt", Ed25519Spec::new());
+        let claims = serde_json::json!({
+            "sub": "all-adapter-ed25519",
+            "iss": "uselesskey",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::EdDSA);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::EdDSA);
+        validation.set_issuer(&["uselesskey"]);
+        let decoded =
+            jsonwebtoken::decode::<serde_json::Value>(&token, &kp.decoding_key(), &validation)
+                .expect("JWT decode");
+        assert_eq!(decoded.claims["sub"], "all-adapter-ed25519");
+    }
+
+    #[cfg(all(feature = "aws-lc-rs-interop", any(not(windows), has_nasm)))]
+    #[test]
+    fn ed25519_aws_lc_rs_parse() {
+        let kp = fx().ed25519("all-ed-aws", Ed25519Spec::new());
+        let _aws_kp = aws_lc_rs::signature::Ed25519KeyPair::from_pkcs8(kp.private_key_pkcs8_der())
+            .expect("aws-lc-rs should parse Ed25519 PKCS#8");
+    }
+}
+
+// =========================================================================
+// ASN.1 helpers
+// =========================================================================
+
+fn extract_public_key_from_spki(spki_der: &[u8]) -> &[u8] {
+    let (_, rest) = skip_tag_and_length(spki_der);
+    let (inner_len, rest) = skip_tag_and_length(rest);
+    let rest = &rest[inner_len..];
+    assert_eq!(rest[0], 0x03, "expected BIT STRING tag");
+    let (bit_string_len, rest) = skip_tag_and_length(rest);
+    assert_eq!(rest[0], 0x00, "expected 0 unused bits");
+    &rest[1..bit_string_len]
+}
+
+fn skip_tag_and_length(data: &[u8]) -> (usize, &[u8]) {
+    let data = &data[1..];
+    if data[0] & 0x80 == 0 {
+        let len = data[0] as usize;
+        (len, &data[1..])
+    } else {
+        let num_bytes = (data[0] & 0x7f) as usize;
+        let mut len: usize = 0;
+        for i in 0..num_bytes {
+            len = (len << 8) | (data[1 + i] as usize);
+        }
+        (len, &data[1 + num_bytes..])
+    }
+}

--- a/crates/uselesskey-interop-tests/tests/cross_verify.rs
+++ b/crates/uselesskey-interop-tests/tests/cross_verify.rs
@@ -1,0 +1,372 @@
+//! Cross-verification tests: sign with one adapter, verify with a *different* one.
+//!
+//! Covers every feasible pair among ring, rustcrypto, aws-lc-rs, and
+//! jsonwebtoken for RSA, ECDSA P-256, ECDSA P-384, and Ed25519.
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> &'static Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-cross-verify-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+}
+
+fn extract_public_key_from_spki(spki_der: &[u8]) -> &[u8] {
+    let (_, rest) = skip_tag_and_length(spki_der);
+    let (inner_len, rest) = skip_tag_and_length(rest);
+    let rest = &rest[inner_len..];
+    assert_eq!(rest[0], 0x03, "expected BIT STRING tag");
+    let (bit_string_len, rest) = skip_tag_and_length(rest);
+    assert_eq!(rest[0], 0x00, "expected 0 unused bits");
+    &rest[1..bit_string_len]
+}
+
+fn skip_tag_and_length(data: &[u8]) -> (usize, &[u8]) {
+    let data = &data[1..];
+    if data[0] & 0x80 == 0 {
+        let len = data[0] as usize;
+        (len, &data[1..])
+    } else {
+        let num_bytes = (data[0] & 0x7f) as usize;
+        let mut len: usize = 0;
+        for i in 0..num_bytes {
+            len = (len << 8) | (data[1 + i] as usize);
+        }
+        (len, &data[1 + num_bytes..])
+    }
+}
+
+// =========================================================================
+// rustcrypto ↔ aws-lc-rs (RSA, ECDSA, Ed25519)
+// =========================================================================
+
+#[cfg(all(
+    feature = "cross-signing",
+    feature = "aws-lc-rs-interop",
+    any(not(windows), has_nasm)
+))]
+mod rustcrypto_aws {
+    use super::*;
+
+    mod rsa_cross {
+        use super::*;
+        use uselesskey_aws_lc_rs::AwsLcRsRsaKeyPairExt;
+        use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+        use uselesskey_rustcrypto::RustCryptoRsaExt;
+
+        #[test]
+        fn rustcrypto_sign_aws_verify() {
+            let kp = fx().rsa("xv-rsa-rc2a", RsaSpec::rs256());
+
+            use rsa::pkcs1v15;
+            use rsa::signature::{SignatureEncoding, Signer};
+            use sha2::Sha256;
+            let signing_key = pkcs1v15::SigningKey::<Sha256>::new(kp.rsa_private_key());
+            let msg = b"rustcrypto-to-aws RSA cross-verify";
+            let sig = signing_key.sign(msg);
+
+            let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+            let public_key = aws_lc_rs::signature::UnparsedPublicKey::new(
+                &aws_lc_rs::signature::RSA_PKCS1_2048_8192_SHA256,
+                raw_pubkey,
+            );
+            public_key
+                .verify(msg, &sig.to_bytes())
+                .expect("aws-lc-rs should verify rustcrypto-signed RSA");
+        }
+
+        #[test]
+        fn aws_sign_rustcrypto_verify() {
+            let kp = fx().rsa("xv-rsa-a2rc", RsaSpec::rs256());
+
+            let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+            let rng = aws_lc_rs::rand::SystemRandom::new();
+            let msg = b"aws-to-rustcrypto RSA cross-verify";
+            let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+            aws_kp
+                .sign(&aws_lc_rs::signature::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+                .expect("aws sign");
+
+            use rsa::pkcs1v15;
+            use rsa::signature::Verifier;
+            use sha2::Sha256;
+            let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(kp.rsa_public_key());
+            let signature = pkcs1v15::Signature::try_from(sig.as_slice()).expect("valid signature");
+            verifying_key
+                .verify(msg, &signature)
+                .expect("rustcrypto should verify aws-signed RSA");
+        }
+    }
+
+    mod ecdsa_p256_cross {
+        use super::*;
+        use uselesskey_aws_lc_rs::AwsLcRsEcdsaKeyPairExt;
+        use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+        use uselesskey_rustcrypto::RustCryptoEcdsaExt;
+
+        #[test]
+        fn rustcrypto_sign_aws_verify() {
+            let kp = fx().ecdsa("xv-p256-rc2a", EcdsaSpec::es256());
+
+            use p256::ecdsa::signature::Signer;
+            let signing_key = kp.p256_signing_key();
+            let msg = b"rustcrypto-to-aws P-256 cross-verify";
+            let sig: p256::ecdsa::DerSignature = signing_key.sign(msg);
+
+            let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+            let public_key = aws_lc_rs::signature::UnparsedPublicKey::new(
+                &aws_lc_rs::signature::ECDSA_P256_SHA256_ASN1,
+                raw_pubkey,
+            );
+            public_key
+                .verify(msg, sig.as_bytes())
+                .expect("aws-lc-rs should verify rustcrypto-signed P-256");
+        }
+
+        #[test]
+        fn aws_sign_rustcrypto_verify() {
+            let kp = fx().ecdsa("xv-p256-a2rc", EcdsaSpec::es256());
+
+            let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+            let rng = aws_lc_rs::rand::SystemRandom::new();
+            let msg = b"aws-to-rustcrypto P-256 cross-verify";
+            let sig = aws_kp.sign(&rng, msg).expect("aws sign");
+
+            use p256::ecdsa::signature::Verifier;
+            let verifying_key = kp.p256_verifying_key();
+            let der_sig =
+                p256::ecdsa::DerSignature::try_from(sig.as_ref()).expect("valid ASN.1 sig");
+            verifying_key
+                .verify(msg, &der_sig)
+                .expect("rustcrypto should verify aws-signed P-256");
+        }
+    }
+
+    mod ecdsa_p384_cross {
+        use super::*;
+        use uselesskey_aws_lc_rs::AwsLcRsEcdsaKeyPairExt;
+        use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+        use uselesskey_rustcrypto::RustCryptoEcdsaExt;
+
+        #[test]
+        fn rustcrypto_sign_aws_verify() {
+            let kp = fx().ecdsa("xv-p384-rc2a", EcdsaSpec::es384());
+
+            use p384::ecdsa::signature::Signer;
+            let signing_key = kp.p384_signing_key();
+            let msg = b"rustcrypto-to-aws P-384 cross-verify";
+            let sig: p384::ecdsa::DerSignature = signing_key.sign(msg);
+
+            let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+            let public_key = aws_lc_rs::signature::UnparsedPublicKey::new(
+                &aws_lc_rs::signature::ECDSA_P384_SHA384_ASN1,
+                raw_pubkey,
+            );
+            public_key
+                .verify(msg, sig.as_bytes())
+                .expect("aws-lc-rs should verify rustcrypto-signed P-384");
+        }
+
+        #[test]
+        fn aws_sign_rustcrypto_verify() {
+            let kp = fx().ecdsa("xv-p384-a2rc", EcdsaSpec::es384());
+
+            let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+            let rng = aws_lc_rs::rand::SystemRandom::new();
+            let msg = b"aws-to-rustcrypto P-384 cross-verify";
+            let sig = aws_kp.sign(&rng, msg).expect("aws sign");
+
+            use p384::ecdsa::signature::Verifier;
+            let verifying_key = kp.p384_verifying_key();
+            let der_sig =
+                p384::ecdsa::DerSignature::try_from(sig.as_ref()).expect("valid ASN.1 sig");
+            verifying_key
+                .verify(msg, &der_sig)
+                .expect("rustcrypto should verify aws-signed P-384");
+        }
+    }
+
+    mod ed25519_cross {
+        use super::*;
+        use uselesskey_aws_lc_rs::AwsLcRsEd25519KeyPairExt;
+        use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+        use uselesskey_rustcrypto::RustCryptoEd25519Ext;
+
+        #[test]
+        fn rustcrypto_sign_aws_verify() {
+            let kp = fx().ed25519("xv-ed-rc2a", Ed25519Spec::new());
+
+            use ed25519_dalek::Signer;
+            let signing_key = kp.ed25519_signing_key();
+            let msg = b"rustcrypto-to-aws Ed25519 cross-verify";
+            let sig = signing_key.sign(msg);
+
+            let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+            let public_key = aws_lc_rs::signature::UnparsedPublicKey::new(
+                &aws_lc_rs::signature::ED25519,
+                raw_pubkey,
+            );
+            public_key
+                .verify(msg, sig.to_bytes().as_ref())
+                .expect("aws-lc-rs should verify rustcrypto-signed Ed25519");
+        }
+
+        #[test]
+        fn aws_sign_rustcrypto_verify() {
+            let kp = fx().ed25519("xv-ed-a2rc", Ed25519Spec::new());
+
+            let aws_kp = kp.ed25519_key_pair_aws_lc_rs();
+            let msg = b"aws-to-rustcrypto Ed25519 cross-verify";
+            let sig = aws_kp.sign(msg);
+
+            use ed25519_dalek::Verifier;
+            let verifying_key = kp.ed25519_verifying_key();
+            let dalek_sig = ed25519_dalek::Signature::from_slice(sig.as_ref())
+                .expect("valid 64-byte signature");
+            verifying_key
+                .verify(msg, &dalek_sig)
+                .expect("rustcrypto should verify aws-signed Ed25519");
+        }
+    }
+}
+
+// =========================================================================
+// JWT cross-verify: sign JWT, then verify raw signature with ring/rustcrypto
+// =========================================================================
+
+#[cfg(all(feature = "jwt-interop", feature = "cross-signing"))]
+mod jwt_cross_verify {
+    use super::*;
+    use uselesskey_jsonwebtoken::JwtKeyExt;
+
+    #[test]
+    fn jwt_rsa_sign_ring_verify_raw() {
+        use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+        let kp = fx().rsa("xv-jwt-rsa-ring", RsaSpec::rs256());
+        let claims = serde_json::json!({
+            "sub": "jwt-cross-rsa",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        // Extract signing input and signature from the JWT
+        let parts: Vec<&str> = token.split('.').collect();
+        assert_eq!(parts.len(), 3);
+        let signing_input = format!("{}.{}", parts[0], parts[1]);
+        let sig_bytes = base64_url_decode(parts[2]);
+
+        // Verify with ring
+        let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+        let public_key = ring::signature::UnparsedPublicKey::new(
+            &ring::signature::RSA_PKCS1_2048_8192_SHA256,
+            raw_pubkey,
+        );
+        public_key
+            .verify(signing_input.as_bytes(), &sig_bytes)
+            .expect("ring should verify JWT RS256 signature");
+    }
+
+    #[test]
+    fn jwt_ecdsa_sign_ring_verify_raw() {
+        use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+        let kp = fx().ecdsa("xv-jwt-p256-ring", EcdsaSpec::es256());
+        let claims = serde_json::json!({
+            "sub": "jwt-cross-p256",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        let parts: Vec<&str> = token.split('.').collect();
+        let signing_input = format!("{}.{}", parts[0], parts[1]);
+        let sig_bytes = base64_url_decode(parts[2]);
+
+        // JWT ES256 uses fixed-size (r || s) encoding; convert to ASN.1 DER for ring
+        let der_sig = p256_fixed_to_der(&sig_bytes);
+
+        let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+        let public_key = ring::signature::UnparsedPublicKey::new(
+            &ring::signature::ECDSA_P256_SHA256_ASN1,
+            raw_pubkey,
+        );
+        public_key
+            .verify(signing_input.as_bytes(), &der_sig)
+            .expect("ring should verify JWT ES256 signature");
+    }
+
+    #[test]
+    fn jwt_ed25519_sign_ring_verify_raw() {
+        use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+        let kp = fx().ed25519("xv-jwt-ed-ring", Ed25519Spec::new());
+        let claims = serde_json::json!({
+            "sub": "jwt-cross-ed25519",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::EdDSA);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        let parts: Vec<&str> = token.split('.').collect();
+        let signing_input = format!("{}.{}", parts[0], parts[1]);
+        let sig_bytes = base64_url_decode(parts[2]);
+
+        let raw_pubkey = extract_public_key_from_spki(kp.public_key_spki_der());
+        let public_key =
+            ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, raw_pubkey);
+        public_key
+            .verify(signing_input.as_bytes(), &sig_bytes)
+            .expect("ring should verify JWT EdDSA signature");
+    }
+
+    // --- helpers ---
+
+    fn base64_url_decode(input: &str) -> Vec<u8> {
+        use base64::Engine;
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(input)
+            .expect("valid base64url")
+    }
+
+    /// Convert a fixed-size (r || s) P-256 signature to ASN.1 DER.
+    fn p256_fixed_to_der(fixed: &[u8]) -> Vec<u8> {
+        assert_eq!(fixed.len(), 64, "P-256 fixed signature must be 64 bytes");
+        let r = &fixed[..32];
+        let s = &fixed[32..];
+
+        fn encode_integer(val: &[u8]) -> Vec<u8> {
+            // Strip leading zeros, then add 0x00 pad if high bit set
+            let stripped = match val.iter().position(|&b| b != 0) {
+                Some(pos) => &val[pos..],
+                None => &[0u8],
+            };
+            let mut out = Vec::new();
+            out.push(0x02); // INTEGER tag
+            if stripped[0] & 0x80 != 0 {
+                out.push((stripped.len() + 1) as u8);
+                out.push(0x00);
+            } else {
+                out.push(stripped.len() as u8);
+            }
+            out.extend_from_slice(stripped);
+            out
+        }
+
+        let r_enc = encode_integer(r);
+        let s_enc = encode_integer(s);
+        let mut der = Vec::new();
+        der.push(0x30); // SEQUENCE tag
+        der.push((r_enc.len() + s_enc.len()) as u8);
+        der.extend_from_slice(&r_enc);
+        der.extend_from_slice(&s_enc);
+        der
+    }
+}

--- a/crates/uselesskey-interop-tests/tests/pem_der_compat.rs
+++ b/crates/uselesskey-interop-tests/tests/pem_der_compat.rs
@@ -1,0 +1,284 @@
+//! PEM / DER format compatibility tests.
+//!
+//! Verifies that PEM and DER outputs from uselesskey are consistent with each
+//! other and parseable by multiple crypto backends.
+
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> &'static Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-pem-der-compat-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+}
+
+// =========================================================================
+// RSA PEM/DER consistency
+// =========================================================================
+
+mod rsa_pem_der {
+    use super::*;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn private_pem_matches_der() {
+        let kp = fx().rsa("pem-rsa-priv", RsaSpec::rs256());
+        let pem = kp.private_key_pkcs8_pem();
+        let der = kp.private_key_pkcs8_der();
+
+        // Extract DER from PEM
+        let pem_der = pem_to_der(pem);
+        assert_eq!(pem_der, der, "PEM-decoded DER must match raw DER");
+    }
+
+    #[test]
+    fn public_pem_matches_der() {
+        let kp = fx().rsa("pem-rsa-pub", RsaSpec::rs256());
+        let pem = kp.public_key_spki_pem();
+        let der = kp.public_key_spki_der();
+
+        let pem_der = pem_to_der(pem);
+        assert_eq!(pem_der, der, "PEM-decoded SPKI DER must match raw DER");
+    }
+
+    #[test]
+    fn pem_parseable_by_rustcrypto() {
+        let kp = fx().rsa("pem-rsa-rc", RsaSpec::rs256());
+        let pem = kp.private_key_pkcs8_pem();
+
+        use rsa::pkcs8::DecodePrivateKey;
+        let _priv_key =
+            rsa::RsaPrivateKey::from_pkcs8_pem(pem).expect("rustcrypto should parse RSA PEM");
+    }
+
+    #[test]
+    fn der_parseable_by_ring() {
+        let kp = fx().rsa("pem-rsa-ring", RsaSpec::rs256());
+        let _ring_kp = ring::rsa::KeyPair::from_pkcs8(kp.private_key_pkcs8_der())
+            .expect("ring should parse RSA DER");
+    }
+
+    #[cfg(all(feature = "aws-lc-rs-interop", any(not(windows), has_nasm)))]
+    #[test]
+    fn der_parseable_by_aws_lc_rs() {
+        let kp = fx().rsa("pem-rsa-aws", RsaSpec::rs256());
+        let _aws_kp = aws_lc_rs::rsa::KeyPair::from_pkcs8(kp.private_key_pkcs8_der())
+            .expect("aws-lc-rs should parse RSA DER");
+    }
+}
+
+// =========================================================================
+// ECDSA PEM/DER consistency
+// =========================================================================
+
+mod ecdsa_pem_der {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    #[test]
+    fn p256_private_pem_matches_der() {
+        let kp = fx().ecdsa("pem-p256-priv", EcdsaSpec::es256());
+        let pem_der = pem_to_der(kp.private_key_pkcs8_pem());
+        assert_eq!(pem_der, kp.private_key_pkcs8_der());
+    }
+
+    #[test]
+    fn p256_public_pem_matches_der() {
+        let kp = fx().ecdsa("pem-p256-pub", EcdsaSpec::es256());
+        let pem_der = pem_to_der(kp.public_key_spki_pem());
+        assert_eq!(pem_der, kp.public_key_spki_der());
+    }
+
+    #[test]
+    fn p384_private_pem_matches_der() {
+        let kp = fx().ecdsa("pem-p384-priv", EcdsaSpec::es384());
+        let pem_der = pem_to_der(kp.private_key_pkcs8_pem());
+        assert_eq!(pem_der, kp.private_key_pkcs8_der());
+    }
+
+    #[test]
+    fn p384_public_pem_matches_der() {
+        let kp = fx().ecdsa("pem-p384-pub", EcdsaSpec::es384());
+        let pem_der = pem_to_der(kp.public_key_spki_pem());
+        assert_eq!(pem_der, kp.public_key_spki_der());
+    }
+
+    #[test]
+    fn p256_pem_parseable_by_rustcrypto() {
+        let kp = fx().ecdsa("pem-p256-rc", EcdsaSpec::es256());
+        use p256::pkcs8::DecodePrivateKey;
+        let _sk = p256::ecdsa::SigningKey::from_pkcs8_pem(kp.private_key_pkcs8_pem())
+            .expect("rustcrypto should parse P-256 PEM");
+    }
+
+    #[test]
+    fn p384_pem_parseable_by_rustcrypto() {
+        let kp = fx().ecdsa("pem-p384-rc", EcdsaSpec::es384());
+        use p384::pkcs8::DecodePrivateKey;
+        let _sk = p384::ecdsa::SigningKey::from_pkcs8_pem(kp.private_key_pkcs8_pem())
+            .expect("rustcrypto should parse P-384 PEM");
+    }
+
+    #[test]
+    fn p256_der_parseable_by_ring() {
+        let kp = fx().ecdsa("pem-p256-ring", EcdsaSpec::es256());
+        let _ring_kp = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
+            kp.private_key_pkcs8_der(),
+            &ring::rand::SystemRandom::new(),
+        )
+        .expect("ring should parse P-256 DER");
+    }
+
+    #[test]
+    fn p384_der_parseable_by_ring() {
+        let kp = fx().ecdsa("pem-p384-ring", EcdsaSpec::es384());
+        let _ring_kp = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P384_SHA384_ASN1_SIGNING,
+            kp.private_key_pkcs8_der(),
+            &ring::rand::SystemRandom::new(),
+        )
+        .expect("ring should parse P-384 DER");
+    }
+}
+
+// =========================================================================
+// Ed25519 PEM/DER consistency
+// =========================================================================
+
+mod ed25519_pem_der {
+    use super::*;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    #[test]
+    fn private_pem_matches_der() {
+        let kp = fx().ed25519("pem-ed-priv", Ed25519Spec::new());
+        let pem_der = pem_to_der(kp.private_key_pkcs8_pem());
+        assert_eq!(pem_der, kp.private_key_pkcs8_der());
+    }
+
+    #[test]
+    fn public_pem_matches_der() {
+        let kp = fx().ed25519("pem-ed-pub", Ed25519Spec::new());
+        let pem_der = pem_to_der(kp.public_key_spki_pem());
+        assert_eq!(pem_der, kp.public_key_spki_der());
+    }
+
+    #[test]
+    fn pem_parseable_by_rustcrypto() {
+        let kp = fx().ed25519("pem-ed-rc", Ed25519Spec::new());
+        use ed25519_dalek::pkcs8::DecodePrivateKey;
+        let _sk = ed25519_dalek::SigningKey::from_pkcs8_pem(kp.private_key_pkcs8_pem())
+            .expect("rustcrypto should parse Ed25519 PEM");
+    }
+
+    #[test]
+    fn der_parseable_by_ring() {
+        let kp = fx().ed25519("pem-ed-ring", Ed25519Spec::new());
+        let _ring_kp =
+            ring::signature::Ed25519KeyPair::from_pkcs8_maybe_unchecked(kp.private_key_pkcs8_der())
+                .expect("ring should parse Ed25519 DER");
+    }
+}
+
+// =========================================================================
+// X.509 PEM/DER consistency
+// =========================================================================
+
+#[cfg(feature = "cross-tls")]
+mod x509_pem_der {
+    use super::*;
+    use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+    #[test]
+    fn self_signed_cert_pem_matches_der() {
+        let cert = fx().x509_self_signed("pem-x509-ss", X509Spec::self_signed("pem.example.com"));
+        let pem_der = pem_to_der(cert.cert_pem());
+        assert_eq!(pem_der, cert.cert_der());
+    }
+
+    #[test]
+    fn self_signed_key_pem_matches_der() {
+        let cert =
+            fx().x509_self_signed("pem-x509-key", X509Spec::self_signed("pemkey.example.com"));
+        let pem_der = pem_to_der(cert.private_key_pkcs8_pem());
+        assert_eq!(pem_der, cert.private_key_pkcs8_der());
+    }
+
+    #[test]
+    fn chain_leaf_cert_pem_matches_der() {
+        let chain = fx().x509_chain("pem-x509-chain", ChainSpec::new("pemchain.example.com"));
+        let pem_der = pem_to_der(chain.leaf_cert_pem());
+        assert_eq!(pem_der, chain.leaf_cert_der());
+    }
+
+    #[test]
+    fn chain_root_cert_pem_matches_der() {
+        let chain = fx().x509_chain("pem-x509-root", ChainSpec::new("pemchainroot.example.com"));
+        let pem_der = pem_to_der(chain.root_cert_pem());
+        assert_eq!(pem_der, chain.root_cert_der());
+    }
+}
+
+// =========================================================================
+// Rustls pki-types conversions
+// =========================================================================
+
+#[cfg(feature = "cross-tls")]
+mod rustls_pki_conversions {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    use uselesskey_rustls::RustlsPrivateKeyExt;
+
+    #[test]
+    fn rsa_private_key_der_rustls_nonempty() {
+        let kp = fx().rsa("pem-rustls-rsa", RsaSpec::rs256());
+        let der = kp.private_key_der_rustls();
+        assert!(!der.secret_der().is_empty());
+    }
+
+    #[test]
+    fn ecdsa_p256_private_key_der_rustls_nonempty() {
+        let kp = fx().ecdsa("pem-rustls-p256", EcdsaSpec::es256());
+        let der = kp.private_key_der_rustls();
+        assert!(!der.secret_der().is_empty());
+    }
+
+    #[test]
+    fn ecdsa_p384_private_key_der_rustls_nonempty() {
+        let kp = fx().ecdsa("pem-rustls-p384", EcdsaSpec::es384());
+        let der = kp.private_key_der_rustls();
+        assert!(!der.secret_der().is_empty());
+    }
+
+    #[test]
+    fn ed25519_private_key_der_rustls_nonempty() {
+        let kp = fx().ed25519("pem-rustls-ed", Ed25519Spec::new());
+        let der = kp.private_key_der_rustls();
+        assert!(!der.secret_der().is_empty());
+    }
+}
+
+// =========================================================================
+// PEM helper
+// =========================================================================
+
+/// Decode PEM to raw DER bytes by stripping headers and base64 decoding.
+fn pem_to_der(pem: impl AsRef<str>) -> Vec<u8> {
+    use base64::Engine;
+    let b64: String = pem
+        .as_ref()
+        .lines()
+        .filter(|line| !line.starts_with("-----"))
+        .collect();
+    base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .expect("valid base64 in PEM")
+}

--- a/crates/uselesskey-interop-tests/tests/random_mode.rs
+++ b/crates/uselesskey-interop-tests/tests/random_mode.rs
@@ -1,0 +1,370 @@
+//! Random-mode interop tests.
+//!
+//! These tests use `Factory::random()` (non-deterministic) and verify that
+//! the generated keys still work across all adapters.
+
+use uselesskey_core::Factory;
+
+fn random_fx() -> Factory {
+    Factory::random()
+}
+
+// =========================================================================
+// RSA random mode
+// =========================================================================
+
+mod rsa_random {
+    use super::*;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[test]
+    fn random_rsa_ring_parse() {
+        let fx = random_fx();
+        let kp = fx.rsa("rand-rsa-ring", RsaSpec::rs256());
+        let _ring_kp = ring::rsa::KeyPair::from_pkcs8(kp.private_key_pkcs8_der())
+            .expect("ring should parse random RSA key");
+    }
+
+    #[test]
+    fn random_rsa_rustcrypto_parse() {
+        let fx = random_fx();
+        let kp = fx.rsa("rand-rsa-rc", RsaSpec::rs256());
+        use rsa::pkcs8::DecodePrivateKey;
+        let _pk = rsa::RsaPrivateKey::from_pkcs8_der(kp.private_key_pkcs8_der())
+            .expect("rustcrypto should parse random RSA key");
+    }
+
+    #[cfg(feature = "cross-signing")]
+    #[test]
+    fn random_rsa_ring_sign_rustcrypto_verify() {
+        use ring::signature as ring_sig;
+        use uselesskey_ring::RingRsaKeyPairExt;
+        use uselesskey_rustcrypto::RustCryptoRsaExt;
+
+        let fx = random_fx();
+        let kp = fx.rsa("rand-rsa-cross", RsaSpec::rs256());
+
+        let ring_kp = kp.rsa_key_pair_ring();
+        let rng = ring::rand::SystemRandom::new();
+        let msg = b"random RSA ring-to-rustcrypto";
+        let mut sig = vec![0u8; ring_kp.public().modulus_len()];
+        ring_kp
+            .sign(&ring_sig::RSA_PKCS1_SHA256, &rng, msg, &mut sig)
+            .expect("ring sign");
+
+        use rsa::pkcs1v15;
+        use rsa::signature::Verifier;
+        use sha2::Sha256;
+        let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(kp.rsa_public_key());
+        let signature =
+            pkcs1v15::Signature::try_from(sig.as_slice()).expect("valid signature bytes");
+        verifying_key
+            .verify(msg, &signature)
+            .expect("rustcrypto should verify random ring-signed RSA");
+    }
+
+    #[cfg(feature = "jwt-interop")]
+    #[test]
+    fn random_rsa_jwt_round_trip() {
+        use uselesskey_jsonwebtoken::JwtKeyExt;
+
+        let fx = random_fx();
+        let kp = fx.rsa("rand-rsa-jwt", RsaSpec::rs256());
+        let claims = serde_json::json!({
+            "sub": "random-rsa",
+            "iss": "uselesskey",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
+        validation.set_issuer(&["uselesskey"]);
+        let decoded =
+            jsonwebtoken::decode::<serde_json::Value>(&token, &kp.decoding_key(), &validation)
+                .expect("JWT decode");
+        assert_eq!(decoded.claims["sub"], "random-rsa");
+    }
+}
+
+// =========================================================================
+// ECDSA random mode
+// =========================================================================
+
+mod ecdsa_random {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    #[test]
+    fn random_p256_ring_parse() {
+        let fx = random_fx();
+        let kp = fx.ecdsa("rand-p256-ring", EcdsaSpec::es256());
+        let _ring_kp = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING,
+            kp.private_key_pkcs8_der(),
+            &ring::rand::SystemRandom::new(),
+        )
+        .expect("ring should parse random P-256 key");
+    }
+
+    #[test]
+    fn random_p384_ring_parse() {
+        let fx = random_fx();
+        let kp = fx.ecdsa("rand-p384-ring", EcdsaSpec::es384());
+        let _ring_kp = ring::signature::EcdsaKeyPair::from_pkcs8(
+            &ring::signature::ECDSA_P384_SHA384_ASN1_SIGNING,
+            kp.private_key_pkcs8_der(),
+            &ring::rand::SystemRandom::new(),
+        )
+        .expect("ring should parse random P-384 key");
+    }
+
+    #[test]
+    fn random_p256_rustcrypto_parse() {
+        let fx = random_fx();
+        let kp = fx.ecdsa("rand-p256-rc", EcdsaSpec::es256());
+        use p256::pkcs8::DecodePrivateKey;
+        let _sk = p256::ecdsa::SigningKey::from_pkcs8_der(kp.private_key_pkcs8_der())
+            .expect("rustcrypto should parse random P-256 key");
+    }
+
+    #[test]
+    fn random_p384_rustcrypto_parse() {
+        let fx = random_fx();
+        let kp = fx.ecdsa("rand-p384-rc", EcdsaSpec::es384());
+        use p384::pkcs8::DecodePrivateKey;
+        let _sk = p384::ecdsa::SigningKey::from_pkcs8_der(kp.private_key_pkcs8_der())
+            .expect("rustcrypto should parse random P-384 key");
+    }
+
+    #[cfg(feature = "cross-signing")]
+    #[test]
+    fn random_p256_ring_sign_rustcrypto_verify() {
+        use p256::ecdsa::signature::Verifier;
+        use uselesskey_ring::RingEcdsaKeyPairExt;
+        use uselesskey_rustcrypto::RustCryptoEcdsaExt;
+
+        let fx = random_fx();
+        let kp = fx.ecdsa("rand-p256-cross", EcdsaSpec::es256());
+
+        let ring_kp = kp.ecdsa_key_pair_ring();
+        let rng = ring::rand::SystemRandom::new();
+        let msg = b"random P-256 ring-to-rustcrypto";
+        let sig = ring_kp.sign(&rng, msg).expect("ring sign");
+
+        let verifying_key = kp.p256_verifying_key();
+        let der_sig = p256::ecdsa::DerSignature::try_from(sig.as_ref()).expect("valid ASN.1 sig");
+        verifying_key
+            .verify(msg, &der_sig)
+            .expect("rustcrypto should verify random ring-signed P-256");
+    }
+
+    #[cfg(feature = "cross-signing")]
+    #[test]
+    fn random_p384_ring_sign_rustcrypto_verify() {
+        use p384::ecdsa::signature::Verifier;
+        use uselesskey_ring::RingEcdsaKeyPairExt;
+        use uselesskey_rustcrypto::RustCryptoEcdsaExt;
+
+        let fx = random_fx();
+        let kp = fx.ecdsa("rand-p384-cross", EcdsaSpec::es384());
+
+        let ring_kp = kp.ecdsa_key_pair_ring();
+        let rng = ring::rand::SystemRandom::new();
+        let msg = b"random P-384 ring-to-rustcrypto";
+        let sig = ring_kp.sign(&rng, msg).expect("ring sign");
+
+        let verifying_key = kp.p384_verifying_key();
+        let der_sig = p384::ecdsa::DerSignature::try_from(sig.as_ref()).expect("valid ASN.1 sig");
+        verifying_key
+            .verify(msg, &der_sig)
+            .expect("rustcrypto should verify random ring-signed P-384");
+    }
+
+    #[cfg(feature = "jwt-interop")]
+    #[test]
+    fn random_p256_jwt_round_trip() {
+        use uselesskey_jsonwebtoken::JwtKeyExt;
+
+        let fx = random_fx();
+        let kp = fx.ecdsa("rand-p256-jwt", EcdsaSpec::es256());
+        let claims = serde_json::json!({
+            "sub": "random-p256",
+            "iss": "uselesskey",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::ES256);
+        validation.set_issuer(&["uselesskey"]);
+        let decoded =
+            jsonwebtoken::decode::<serde_json::Value>(&token, &kp.decoding_key(), &validation)
+                .expect("JWT decode");
+        assert_eq!(decoded.claims["sub"], "random-p256");
+    }
+}
+
+// =========================================================================
+// Ed25519 random mode
+// =========================================================================
+
+mod ed25519_random {
+    use super::*;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    #[test]
+    fn random_ed25519_ring_parse() {
+        let fx = random_fx();
+        let kp = fx.ed25519("rand-ed-ring", Ed25519Spec::new());
+        let _ring_kp =
+            ring::signature::Ed25519KeyPair::from_pkcs8_maybe_unchecked(kp.private_key_pkcs8_der())
+                .expect("ring should parse random Ed25519 key");
+    }
+
+    #[test]
+    fn random_ed25519_rustcrypto_parse() {
+        let fx = random_fx();
+        let kp = fx.ed25519("rand-ed-rc", Ed25519Spec::new());
+        use ed25519_dalek::pkcs8::DecodePrivateKey;
+        let _sk = ed25519_dalek::SigningKey::from_pkcs8_der(kp.private_key_pkcs8_der())
+            .expect("rustcrypto should parse random Ed25519 key");
+    }
+
+    #[cfg(feature = "cross-signing")]
+    #[test]
+    fn random_ed25519_ring_sign_rustcrypto_verify() {
+        use ed25519_dalek::Verifier;
+        use uselesskey_ring::RingEd25519KeyPairExt;
+        use uselesskey_rustcrypto::RustCryptoEd25519Ext;
+
+        let fx = random_fx();
+        let kp = fx.ed25519("rand-ed-cross", Ed25519Spec::new());
+
+        let ring_kp = kp.ed25519_key_pair_ring();
+        let msg = b"random Ed25519 ring-to-rustcrypto";
+        let sig = ring_kp.sign(msg);
+
+        let verifying_key = kp.ed25519_verifying_key();
+        let dalek_sig =
+            ed25519_dalek::Signature::from_slice(sig.as_ref()).expect("valid 64-byte sig");
+        verifying_key
+            .verify(msg, &dalek_sig)
+            .expect("rustcrypto should verify random ring-signed Ed25519");
+    }
+
+    #[cfg(feature = "jwt-interop")]
+    #[test]
+    fn random_ed25519_jwt_round_trip() {
+        use uselesskey_jsonwebtoken::JwtKeyExt;
+
+        let fx = random_fx();
+        let kp = fx.ed25519("rand-ed-jwt", Ed25519Spec::new());
+        let claims = serde_json::json!({
+            "sub": "random-ed25519",
+            "iss": "uselesskey",
+            "exp": 9_999_999_999u64,
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::EdDSA);
+        let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("JWT encode");
+
+        let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::EdDSA);
+        validation.set_issuer(&["uselesskey"]);
+        let decoded =
+            jsonwebtoken::decode::<serde_json::Value>(&token, &kp.decoding_key(), &validation)
+                .expect("JWT decode");
+        assert_eq!(decoded.claims["sub"], "random-ed25519");
+    }
+}
+
+// =========================================================================
+// X.509 random mode TLS
+// =========================================================================
+
+#[cfg(feature = "cross-tls")]
+mod x509_random_tls {
+    use super::*;
+    use std::sync::Arc;
+    use uselesskey_rustls::{RustlsClientConfigExt, RustlsServerConfigExt};
+    use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+    const MAX_HANDSHAKE_ITERATIONS: usize = 10;
+
+    fn complete_handshake(
+        client: &mut rustls::ClientConnection,
+        server: &mut rustls::ServerConnection,
+    ) {
+        let mut buf = Vec::new();
+        for iteration in 0..MAX_HANDSHAKE_ITERATIONS {
+            let mut progress = false;
+
+            buf.clear();
+            if client.wants_write() {
+                client.write_tls(&mut buf).unwrap();
+                if !buf.is_empty() {
+                    server.read_tls(&mut &buf[..]).unwrap();
+                    server.process_new_packets().unwrap();
+                    progress = true;
+                }
+            }
+
+            buf.clear();
+            if server.wants_write() {
+                server.write_tls(&mut buf).unwrap();
+                if !buf.is_empty() {
+                    client.read_tls(&mut &buf[..]).unwrap();
+                    client.process_new_packets().unwrap();
+                    progress = true;
+                }
+            }
+
+            if !progress {
+                break;
+            }
+
+            assert!(
+                iteration < MAX_HANDSHAKE_ITERATIONS - 1,
+                "TLS handshake did not complete within {MAX_HANDSHAKE_ITERATIONS} iterations",
+            );
+        }
+
+        assert!(!client.is_handshaking());
+        assert!(!server.is_handshaking());
+    }
+
+    #[test]
+    fn random_chain_tls_handshake() {
+        let fx = random_fx();
+        let chain = fx.x509_chain("rand-tls-chain", ChainSpec::new("random.example.com"));
+
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let server_config = Arc::new(chain.server_config_rustls_with_provider(provider.clone()));
+        let client_config = Arc::new(chain.client_config_rustls_with_provider(provider));
+
+        let server_name = "random.example.com".try_into().unwrap();
+        let mut server = rustls::ServerConnection::new(server_config).unwrap();
+        let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();
+
+        complete_handshake(&mut client, &mut server);
+    }
+
+    #[test]
+    fn random_self_signed_tls_handshake() {
+        let fx = random_fx();
+        let cert = fx.x509_self_signed(
+            "rand-tls-ss",
+            X509Spec::self_signed("random-ss.example.com")
+                .with_sans(vec!["random-ss.example.com".into()]),
+        );
+
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let server_config = Arc::new(cert.server_config_rustls_with_provider(provider.clone()));
+        let client_config = Arc::new(cert.client_config_rustls_with_provider(provider));
+
+        let server_name = "random-ss.example.com".try_into().unwrap();
+        let mut server = rustls::ServerConnection::new(server_config).unwrap();
+        let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();
+
+        complete_handshake(&mut client, &mut server);
+    }
+}

--- a/crates/uselesskey-interop-tests/tests/x509_tls_extended.rs
+++ b/crates/uselesskey-interop-tests/tests/x509_tls_extended.rs
@@ -1,0 +1,219 @@
+//! Extended X.509 + rustls TLS interop tests.
+//!
+//! Covers self-signed certificate TLS, data exchange after handshake,
+//! and provider-specific scenarios.
+
+#![cfg(feature = "cross-tls")]
+
+use std::io::{Read, Write};
+use std::sync::{Arc, OnceLock};
+
+use uselesskey_core::{Factory, Seed};
+use uselesskey_rustls::{RustlsClientConfigExt, RustlsServerConfigExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+fn fx() -> &'static Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-x509-tls-extended-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+}
+
+const MAX_HANDSHAKE_ITERATIONS: usize = 10;
+
+fn complete_handshake(
+    client: &mut rustls::ClientConnection,
+    server: &mut rustls::ServerConnection,
+) {
+    let mut buf = Vec::new();
+    for iteration in 0..MAX_HANDSHAKE_ITERATIONS {
+        let mut progress = false;
+
+        buf.clear();
+        if client.wants_write() {
+            client.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                server.read_tls(&mut &buf[..]).unwrap();
+                server.process_new_packets().unwrap();
+                progress = true;
+            }
+        }
+
+        buf.clear();
+        if server.wants_write() {
+            server.write_tls(&mut buf).unwrap();
+            if !buf.is_empty() {
+                client.read_tls(&mut &buf[..]).unwrap();
+                client.process_new_packets().unwrap();
+                progress = true;
+            }
+        }
+
+        if !progress {
+            break;
+        }
+
+        assert!(
+            iteration < MAX_HANDSHAKE_ITERATIONS - 1,
+            "TLS handshake did not complete within {MAX_HANDSHAKE_ITERATIONS} iterations",
+        );
+    }
+
+    assert!(!client.is_handshaking());
+    assert!(!server.is_handshaking());
+}
+
+// =========================================================================
+// Self-signed certificate TLS
+// =========================================================================
+
+#[test]
+fn self_signed_tls_handshake_ring_provider() {
+    let cert = fx().x509_self_signed(
+        "tls-ext-ss-ring",
+        X509Spec::self_signed("ss-ring.example.com").with_sans(vec!["ss-ring.example.com".into()]),
+    );
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let server_config = Arc::new(cert.server_config_rustls_with_provider(provider.clone()));
+    let client_config = Arc::new(cert.client_config_rustls_with_provider(provider));
+
+    let server_name = "ss-ring.example.com".try_into().unwrap();
+    let mut server = rustls::ServerConnection::new(server_config).unwrap();
+    let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();
+
+    complete_handshake(&mut client, &mut server);
+}
+
+#[cfg(all(feature = "aws-lc-rs-interop", any(not(windows), has_nasm)))]
+#[test]
+fn self_signed_tls_handshake_aws_provider() {
+    let cert = fx().x509_self_signed(
+        "tls-ext-ss-aws",
+        X509Spec::self_signed("ss-aws.example.com").with_sans(vec!["ss-aws.example.com".into()]),
+    );
+
+    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let server_config = Arc::new(cert.server_config_rustls_with_provider(provider.clone()));
+    let client_config = Arc::new(cert.client_config_rustls_with_provider(provider));
+
+    let server_name = "ss-aws.example.com".try_into().unwrap();
+    let mut server = rustls::ServerConnection::new(server_config).unwrap();
+    let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();
+
+    complete_handshake(&mut client, &mut server);
+}
+
+// =========================================================================
+// Data exchange over TLS (chain-based)
+// =========================================================================
+
+#[test]
+fn chain_tls_bidirectional_data_exchange() {
+    let chain = fx().x509_chain("tls-ext-bidir", ChainSpec::new("bidirectional.example.com"));
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let server_config = Arc::new(chain.server_config_rustls_with_provider(provider.clone()));
+    let client_config = Arc::new(chain.client_config_rustls_with_provider(provider));
+
+    let server_name = "bidirectional.example.com".try_into().unwrap();
+    let mut server = rustls::ServerConnection::new(server_config).unwrap();
+    let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();
+
+    complete_handshake(&mut client, &mut server);
+
+    // Client → Server
+    let client_msg = b"hello from client via uselesskey TLS";
+    client.writer().write_all(client_msg).unwrap();
+
+    let mut buf = Vec::new();
+    client.write_tls(&mut buf).unwrap();
+    server.read_tls(&mut &buf[..]).unwrap();
+    server.process_new_packets().unwrap();
+
+    let mut received = vec![0u8; client_msg.len()];
+    server.reader().read_exact(&mut received).unwrap();
+    assert_eq!(&received, client_msg);
+
+    // Server → Client
+    let server_msg = b"hello from server via uselesskey TLS";
+    server.writer().write_all(server_msg).unwrap();
+
+    buf.clear();
+    server.write_tls(&mut buf).unwrap();
+    client.read_tls(&mut &buf[..]).unwrap();
+    client.process_new_packets().unwrap();
+
+    let mut received = vec![0u8; server_msg.len()];
+    client.reader().read_exact(&mut received).unwrap();
+    assert_eq!(&received, server_msg);
+}
+
+// =========================================================================
+// Data exchange over TLS (self-signed)
+// =========================================================================
+
+#[test]
+fn self_signed_tls_data_exchange() {
+    let cert = fx().x509_self_signed(
+        "tls-ext-ss-data",
+        X509Spec::self_signed("ss-data.example.com").with_sans(vec!["ss-data.example.com".into()]),
+    );
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let server_config = Arc::new(cert.server_config_rustls_with_provider(provider.clone()));
+    let client_config = Arc::new(cert.client_config_rustls_with_provider(provider));
+
+    let server_name = "ss-data.example.com".try_into().unwrap();
+    let mut server = rustls::ServerConnection::new(server_config).unwrap();
+    let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();
+
+    complete_handshake(&mut client, &mut server);
+
+    let payload = b"self-signed TLS data round-trip";
+    client.writer().write_all(payload).unwrap();
+
+    let mut buf = Vec::new();
+    client.write_tls(&mut buf).unwrap();
+    server.read_tls(&mut &buf[..]).unwrap();
+    server.process_new_packets().unwrap();
+
+    let mut received = vec![0u8; payload.len()];
+    server.reader().read_exact(&mut received).unwrap();
+    assert_eq!(&received, payload);
+}
+
+// =========================================================================
+// aws-lc-rs provider data exchange
+// =========================================================================
+
+#[cfg(all(feature = "aws-lc-rs-interop", any(not(windows), has_nasm)))]
+#[test]
+fn chain_tls_data_exchange_aws_provider() {
+    let chain = fx().x509_chain("tls-ext-aws-data", ChainSpec::new("aws-data.example.com"));
+
+    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let server_config = Arc::new(chain.server_config_rustls_with_provider(provider.clone()));
+    let client_config = Arc::new(chain.client_config_rustls_with_provider(provider));
+
+    let server_name = "aws-data.example.com".try_into().unwrap();
+    let mut server = rustls::ServerConnection::new(server_config).unwrap();
+    let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();
+
+    complete_handshake(&mut client, &mut server);
+
+    let payload = b"aws-provider TLS data round-trip";
+    client.writer().write_all(payload).unwrap();
+
+    let mut buf = Vec::new();
+    client.write_tls(&mut buf).unwrap();
+    server.read_tls(&mut &buf[..]).unwrap();
+    server.process_new_packets().unwrap();
+
+    let mut received = vec![0u8; payload.len()];
+    server.reader().read_exact(&mut received).unwrap();
+    assert_eq!(&received, payload);
+}


### PR DESCRIPTION
## Summary

Expand the cross-adapter interop test suite with 5 new test files covering comprehensive cross-adapter testing.

### New test files

- **all_adapters.rs** (23 tests) — Every key type (RSA, ECDSA P-256/P-384, Ed25519) through every adapter (jsonwebtoken, ring, rustcrypto, aws-lc-rs)
- **cross_verify.rs** (11 tests) — Sign with one adapter, verify with another (rustcrypto↔aws-lc-rs for all key types, JWT cross-verify with raw ring signature verification)
- **pem_der_compat.rs** (25 tests) — PEM/DER format consistency and cross-backend parseability for all key types + X.509, plus rustls-pki-types conversion tests
- **random_mode.rs** (17 tests) — Random factory mode testing for all key types through all adapters, including TLS handshakes
- **x509_tls_extended.rs** (5 tests) — Self-signed cert TLS handshakes with ring and aws-lc-rs providers, bidirectional data exchange over TLS

### Test coverage highlights

- All key types × all adapters matrix
- Cross-adapter sign/verify interoperability
- JWT signature extraction and raw ring verification (including ECDSA fixed→ASN.1 DER conversion)
- PEM↔DER round-trip consistency
- Self-signed certs with SANs for proper TLS name verification
- Deterministic and random factory modes
- 171 total interop tests (up from 52)