### PR TITLE
test: add property-based tests for adapter crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,6 +3495,7 @@ dependencies = [
  "aws-lc-rs",
  "hex",
  "insta",
+ "proptest",
  "serde",
  "uselesskey-core",
  "uselesskey-ecdsa",
@@ -3952,6 +3953,7 @@ version = "0.3.0"
 dependencies = [
  "insta",
  "jsonwebtoken",
+ "proptest",
  "serde",
  "uselesskey-core",
  "uselesskey-ecdsa",
@@ -4039,6 +4041,7 @@ version = "0.3.0"
 dependencies = [
  "hex",
  "insta",
+ "proptest",
  "rustls",
  "rustls-pki-types",
  "serde",

--- a/crates/uselesskey-aws-lc-rs/Cargo.toml
+++ b/crates/uselesskey-aws-lc-rs/Cargo.toml
@@ -39,6 +39,11 @@ all = ["native", "rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
+aws-lc-rs = "1"
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true
+proptest.workspace = true

--- a/crates/uselesskey-aws-lc-rs/tests/prop_tests.rs
+++ b/crates/uselesskey-aws-lc-rs/tests/prop_tests.rs
@@ -1,0 +1,300 @@
+//! Property-based tests for uselesskey-aws-lc-rs adapter.
+//!
+//! Covers:
+//! - Roundtrip: generate key → convert to aws-lc-rs type → sign → verify
+//! - Determinism: same seed produces same adapter keys
+//! - Distinctness: different seeds produce different keys
+//! - All algorithm specs produce valid keys
+
+use proptest::prelude::*;
+use uselesskey_core::{Factory, Seed};
+
+// =========================================================================
+// RSA property-based tests
+// =========================================================================
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "rsa"))]
+mod rsa_props {
+    use super::*;
+    use aws_lc_rs::signature::{self, KeyPair};
+    use uselesskey_aws_lc_rs::AwsLcRsRsaKeyPairExt;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    proptest! {
+        // RSA keygen is very expensive; keep case count minimal.
+        #![proptest_config(ProptestConfig { cases: 5, ..ProptestConfig::default() })]
+
+        /// Arbitrary labels never panic during key generation + aws-lc-rs conversion.
+        #[test]
+        fn random_label_does_not_panic(label in "[a-z][a-z0-9-]{0,30}") {
+            let fx = Factory::random();
+            let kp = fx.rsa(&label, RsaSpec::rs256());
+            let _aws_kp = kp.rsa_key_pair_aws_lc_rs();
+        }
+
+        /// Deterministic factories with the same seed produce identical aws-lc-rs keys.
+        #[test]
+        fn deterministic_rsa_from_seed(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.rsa("prop-det-rsa", RsaSpec::rs256());
+            let kp2 = fx2.rsa("prop-det-rsa", RsaSpec::rs256());
+
+            prop_assert_eq!(
+                kp1.private_key_pkcs8_der(),
+                kp2.private_key_pkcs8_der(),
+                "Deterministic RSA keys should be identical"
+            );
+
+            let aws1 = kp1.rsa_key_pair_aws_lc_rs();
+            let aws2 = kp2.rsa_key_pair_aws_lc_rs();
+            prop_assert_eq!(
+                aws1.public_key().as_ref(),
+                aws2.public_key().as_ref(),
+                "aws-lc-rs RSA public keys should match"
+            );
+        }
+
+        /// Signing with a random message always produces a verifiable signature.
+        #[test]
+        fn signing_produces_valid_signature(msg in prop::collection::vec(any::<u8>(), 0..1024)) {
+            let fx = Factory::random();
+            let kp = fx.rsa("prop-rsa-sign", RsaSpec::rs256());
+            let aws_kp = kp.rsa_key_pair_aws_lc_rs();
+
+            let rng = aws_lc_rs::rand::SystemRandom::new();
+            let mut sig = vec![0u8; aws_kp.public_modulus_len()];
+            aws_kp
+                .sign(&signature::RSA_PKCS1_SHA256, &rng, &msg, &mut sig)
+                .expect("sign should succeed");
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::RSA_PKCS1_2048_8192_SHA256,
+                aws_kp.public_key().as_ref(),
+            );
+            prop_assert!(
+                pk.verify(&msg, &sig).is_ok(),
+                "Signature should verify for the same message"
+            );
+        }
+
+        /// Different seeds produce different RSA keys.
+        #[test]
+        fn different_seeds_different_rsa(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let kp_a = fx_a.rsa("prop-rsa", RsaSpec::rs256());
+            let kp_b = fx_b.rsa("prop-rsa", RsaSpec::rs256());
+
+            prop_assert_ne!(
+                kp_a.private_key_pkcs8_der(),
+                kp_b.private_key_pkcs8_der(),
+                "Different seeds should produce different RSA keys"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// ECDSA property-based tests
+// =========================================================================
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "ecdsa"))]
+mod ecdsa_props {
+    use super::*;
+    use aws_lc_rs::signature::{self, KeyPair};
+    use uselesskey_aws_lc_rs::AwsLcRsEcdsaKeyPairExt;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 16, ..ProptestConfig::default() })]
+
+        /// Arbitrary labels never panic during ECDSA key generation + aws-lc-rs conversion.
+        #[test]
+        fn random_label_does_not_panic(label in "[a-z][a-z0-9-]{0,30}") {
+            let fx = Factory::random();
+            let kp = fx.ecdsa(&label, EcdsaSpec::es256());
+            let _aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+        }
+
+        /// Deterministic factories produce identical ECDSA aws-lc-rs keys.
+        #[test]
+        fn deterministic_ecdsa_from_seed(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.ecdsa("prop-det-ec", EcdsaSpec::es256());
+            let kp2 = fx2.ecdsa("prop-det-ec", EcdsaSpec::es256());
+
+            prop_assert_eq!(
+                kp1.private_key_pkcs8_der(),
+                kp2.private_key_pkcs8_der(),
+                "Deterministic ECDSA keys should be identical"
+            );
+
+            let aws1 = kp1.ecdsa_key_pair_aws_lc_rs();
+            let aws2 = kp2.ecdsa_key_pair_aws_lc_rs();
+            prop_assert_eq!(
+                aws1.public_key().as_ref(),
+                aws2.public_key().as_ref(),
+                "aws-lc-rs ECDSA public keys should match"
+            );
+        }
+
+        /// ECDSA P-256 signing always produces a verifiable signature.
+        #[test]
+        fn p256_signing_produces_valid_signature(msg in prop::collection::vec(any::<u8>(), 0..1024)) {
+            let fx = Factory::random();
+            let kp = fx.ecdsa("prop-ec-sign", EcdsaSpec::es256());
+            let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+
+            let rng = aws_lc_rs::rand::SystemRandom::new();
+            let sig = aws_kp.sign(&rng, &msg).expect("sign should succeed");
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::ECDSA_P256_SHA256_ASN1,
+                aws_kp.public_key().as_ref(),
+            );
+            prop_assert!(
+                pk.verify(&msg, sig.as_ref()).is_ok(),
+                "ECDSA P-256 signature should verify"
+            );
+        }
+
+        /// ECDSA P-384 signing always produces a verifiable signature.
+        #[test]
+        fn p384_signing_produces_valid_signature(msg in prop::collection::vec(any::<u8>(), 0..512)) {
+            let fx = Factory::random();
+            let kp = fx.ecdsa("prop-ec384-sign", EcdsaSpec::es384());
+            let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+
+            let rng = aws_lc_rs::rand::SystemRandom::new();
+            let sig = aws_kp.sign(&rng, &msg).expect("sign should succeed");
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::ECDSA_P384_SHA384_ASN1,
+                aws_kp.public_key().as_ref(),
+            );
+            prop_assert!(
+                pk.verify(&msg, sig.as_ref()).is_ok(),
+                "ECDSA P-384 signature should verify"
+            );
+        }
+
+        /// Different seeds produce different ECDSA keys.
+        #[test]
+        fn different_seeds_different_ecdsa(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let kp_a = fx_a.ecdsa("prop-ec", EcdsaSpec::es256());
+            let kp_b = fx_b.ecdsa("prop-ec", EcdsaSpec::es256());
+
+            prop_assert_ne!(
+                kp_a.private_key_pkcs8_der(),
+                kp_b.private_key_pkcs8_der(),
+                "Different seeds should produce different ECDSA keys"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// Ed25519 property-based tests
+// =========================================================================
+
+#[cfg(all(feature = "native", any(not(windows), has_nasm), feature = "ed25519"))]
+mod ed25519_props {
+    use super::*;
+    use aws_lc_rs::signature::{self, KeyPair};
+    use uselesskey_aws_lc_rs::AwsLcRsEd25519KeyPairExt;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 32, ..ProptestConfig::default() })]
+
+        /// Arbitrary labels never panic during Ed25519 key generation + aws-lc-rs conversion.
+        #[test]
+        fn random_label_does_not_panic(label in "[a-z][a-z0-9-]{0,30}") {
+            let fx = Factory::random();
+            let kp = fx.ed25519(&label, Ed25519Spec::new());
+            let _aws_kp = kp.ed25519_key_pair_aws_lc_rs();
+        }
+
+        /// Deterministic factories produce identical Ed25519 aws-lc-rs keys.
+        #[test]
+        fn deterministic_ed25519_from_seed(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.ed25519("prop-det-ed", Ed25519Spec::new());
+            let kp2 = fx2.ed25519("prop-det-ed", Ed25519Spec::new());
+
+            prop_assert_eq!(
+                kp1.private_key_pkcs8_der(),
+                kp2.private_key_pkcs8_der(),
+                "Deterministic Ed25519 keys should be identical"
+            );
+
+            let aws1 = kp1.ed25519_key_pair_aws_lc_rs();
+            let aws2 = kp2.ed25519_key_pair_aws_lc_rs();
+            prop_assert_eq!(
+                aws1.public_key().as_ref(),
+                aws2.public_key().as_ref(),
+                "aws-lc-rs Ed25519 public keys should match"
+            );
+        }
+
+        /// Ed25519 signing always produces a verifiable signature.
+        #[test]
+        fn signing_produces_valid_signature(msg in prop::collection::vec(any::<u8>(), 0..2048)) {
+            let fx = Factory::random();
+            let kp = fx.ed25519("prop-ed-sign", Ed25519Spec::new());
+            let aws_kp = kp.ed25519_key_pair_aws_lc_rs();
+
+            let sig = aws_kp.sign(&msg);
+
+            let pk = signature::UnparsedPublicKey::new(
+                &signature::ED25519,
+                aws_kp.public_key().as_ref(),
+            );
+            prop_assert!(
+                pk.verify(&msg, sig.as_ref()).is_ok(),
+                "Ed25519 signature should verify"
+            );
+        }
+
+        /// Different seeds produce different Ed25519 keys.
+        #[test]
+        fn different_seeds_different_ed25519(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let kp_a = fx_a.ed25519("prop-ed", Ed25519Spec::new());
+            let kp_b = fx_b.ed25519("prop-ed", Ed25519Spec::new());
+
+            prop_assert_ne!(
+                kp_a.private_key_pkcs8_der(),
+                kp_b.private_key_pkcs8_der(),
+                "Different seeds should produce different Ed25519 keys"
+            );
+        }
+    }
+}

--- a/crates/uselesskey-jsonwebtoken/Cargo.toml
+++ b/crates/uselesskey-jsonwebtoken/Cargo.toml
@@ -38,8 +38,13 @@ all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.3.0" }
 serde.workspace = true
 insta.workspace = true
+proptest.workspace = true
 
 # Enable rust_crypto for tests
 [dev-dependencies.jsonwebtoken]

--- a/crates/uselesskey-jsonwebtoken/tests/prop_tests.rs
+++ b/crates/uselesskey-jsonwebtoken/tests/prop_tests.rs
@@ -1,0 +1,333 @@
+//! Property-based tests for uselesskey-jsonwebtoken adapter.
+//!
+//! Covers:
+//! - JWT roundtrip: sign → verify for all algorithm types
+//! - Determinism: same seed produces same adapter keys
+//! - Distinctness: different seeds/labels produce different tokens
+
+use proptest::prelude::*;
+use uselesskey_core::{Factory, Seed};
+
+// =========================================================================
+// RSA property-based tests
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_props {
+    use super::*;
+    use jsonwebtoken::{Algorithm, Header, Validation, decode, encode};
+    use serde::{Deserialize, Serialize};
+    use uselesskey_jsonwebtoken::JwtKeyExt;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Claims {
+        sub: String,
+        exp: usize,
+    }
+
+    proptest! {
+        // RSA keygen is very expensive; keep case count minimal.
+        #![proptest_config(ProptestConfig { cases: 5, ..ProptestConfig::default() })]
+
+        /// JWT roundtrip: sign with encoding_key, verify with decoding_key.
+        #[test]
+        fn rsa_jwt_roundtrip(sub in "[a-z]{1,20}") {
+            let fx = Factory::random();
+            let kp = fx.rsa("prop-jwt-rsa", RsaSpec::rs256());
+
+            let claims = Claims { sub: sub.clone(), exp: 2_000_000_000 };
+            let token = encode(&Header::new(Algorithm::RS256), &claims, &kp.encoding_key()).unwrap();
+            let decoded = decode::<Claims>(&token, &kp.decoding_key(), &Validation::new(Algorithm::RS256)).unwrap();
+            prop_assert_eq!(decoded.claims.sub, sub);
+        }
+
+        /// Deterministic factories produce identical encoding/decoding behaviour.
+        #[test]
+        fn rsa_deterministic(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.rsa("prop-det-rsa", RsaSpec::rs256());
+            let kp2 = fx2.rsa("prop-det-rsa", RsaSpec::rs256());
+
+            let claims = Claims { sub: "det".into(), exp: 2_000_000_000 };
+            let token = encode(&Header::new(Algorithm::RS256), &claims, &kp1.encoding_key()).unwrap();
+            // Token signed by kp1 must verify with kp2's decoding key.
+            let decoded = decode::<Claims>(&token, &kp2.decoding_key(), &Validation::new(Algorithm::RS256)).unwrap();
+            prop_assert_eq!(decoded.claims.sub, "det");
+        }
+
+        /// Different seeds produce keys that cannot cross-verify.
+        #[test]
+        fn rsa_different_seeds_distinct(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let kp_a = fx_a.rsa("prop-rsa", RsaSpec::rs256());
+            let kp_b = fx_b.rsa("prop-rsa", RsaSpec::rs256());
+
+            let claims = Claims { sub: "x".into(), exp: 2_000_000_000 };
+            let token = encode(&Header::new(Algorithm::RS256), &claims, &kp_a.encoding_key()).unwrap();
+            let result = decode::<Claims>(&token, &kp_b.decoding_key(), &Validation::new(Algorithm::RS256));
+            prop_assert!(result.is_err(), "Different seeds should not cross-verify");
+        }
+    }
+}
+
+// =========================================================================
+// ECDSA property-based tests
+// =========================================================================
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_props {
+    use super::*;
+    use jsonwebtoken::{Algorithm, Header, Validation, decode, encode};
+    use serde::{Deserialize, Serialize};
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_jsonwebtoken::JwtKeyExt;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Claims {
+        sub: String,
+        exp: usize,
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 16, ..ProptestConfig::default() })]
+
+        /// ES256 JWT roundtrip.
+        #[test]
+        fn es256_jwt_roundtrip(sub in "[a-z]{1,20}") {
+            let fx = Factory::random();
+            let kp = fx.ecdsa("prop-jwt-ec256", EcdsaSpec::es256());
+
+            let claims = Claims { sub: sub.clone(), exp: 2_000_000_000 };
+            let token = encode(&Header::new(Algorithm::ES256), &claims, &kp.encoding_key()).unwrap();
+            let decoded = decode::<Claims>(&token, &kp.decoding_key(), &Validation::new(Algorithm::ES256)).unwrap();
+            prop_assert_eq!(decoded.claims.sub, sub);
+        }
+
+        /// ES384 JWT roundtrip.
+        #[test]
+        fn es384_jwt_roundtrip(sub in "[a-z]{1,20}") {
+            let fx = Factory::random();
+            let kp = fx.ecdsa("prop-jwt-ec384", EcdsaSpec::es384());
+
+            let claims = Claims { sub: sub.clone(), exp: 2_000_000_000 };
+            let token = encode(&Header::new(Algorithm::ES384), &claims, &kp.encoding_key()).unwrap();
+            let decoded = decode::<Claims>(&token, &kp.decoding_key(), &Validation::new(Algorithm::ES384)).unwrap();
+            prop_assert_eq!(decoded.claims.sub, sub);
+        }
+
+        /// Deterministic ECDSA keys produce identical JWT behaviour.
+        #[test]
+        fn ecdsa_deterministic(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.ecdsa("prop-det-ec", EcdsaSpec::es256());
+            let kp2 = fx2.ecdsa("prop-det-ec", EcdsaSpec::es256());
+
+            prop_assert_eq!(
+                kp1.private_key_pkcs8_der(),
+                kp2.private_key_pkcs8_der(),
+                "Deterministic ECDSA keys should be identical"
+            );
+        }
+
+        /// Different seeds yield different ECDSA keys.
+        #[test]
+        fn ecdsa_different_seeds_distinct(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let kp_a = fx_a.ecdsa("prop-ec", EcdsaSpec::es256());
+            let kp_b = fx_b.ecdsa("prop-ec", EcdsaSpec::es256());
+
+            prop_assert_ne!(
+                kp_a.private_key_pkcs8_der(),
+                kp_b.private_key_pkcs8_der(),
+                "Different seeds should produce different ECDSA keys"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// Ed25519 property-based tests
+// =========================================================================
+
+#[cfg(feature = "ed25519")]
+mod ed25519_props {
+    use super::*;
+    use jsonwebtoken::{Algorithm, Header, Validation, decode, encode};
+    use serde::{Deserialize, Serialize};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_jsonwebtoken::JwtKeyExt;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Claims {
+        sub: String,
+        exp: usize,
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 32, ..ProptestConfig::default() })]
+
+        /// Ed25519 JWT roundtrip.
+        #[test]
+        fn ed25519_jwt_roundtrip(sub in "[a-z]{1,20}") {
+            let fx = Factory::random();
+            let kp = fx.ed25519("prop-jwt-ed", Ed25519Spec::new());
+
+            let claims = Claims { sub: sub.clone(), exp: 2_000_000_000 };
+            let token = encode(&Header::new(Algorithm::EdDSA), &claims, &kp.encoding_key()).unwrap();
+            let decoded = decode::<Claims>(&token, &kp.decoding_key(), &Validation::new(Algorithm::EdDSA)).unwrap();
+            prop_assert_eq!(decoded.claims.sub, sub);
+        }
+
+        /// Deterministic Ed25519 keys are identical across factories.
+        #[test]
+        fn ed25519_deterministic(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.ed25519("prop-det-ed", Ed25519Spec::new());
+            let kp2 = fx2.ed25519("prop-det-ed", Ed25519Spec::new());
+
+            prop_assert_eq!(
+                kp1.private_key_pkcs8_der(),
+                kp2.private_key_pkcs8_der(),
+                "Deterministic Ed25519 keys should be identical"
+            );
+        }
+
+        /// Different seeds yield different Ed25519 keys.
+        #[test]
+        fn ed25519_different_seeds_distinct(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let kp_a = fx_a.ed25519("prop-ed", Ed25519Spec::new());
+            let kp_b = fx_b.ed25519("prop-ed", Ed25519Spec::new());
+
+            prop_assert_ne!(
+                kp_a.private_key_pkcs8_der(),
+                kp_b.private_key_pkcs8_der(),
+                "Different seeds should produce different Ed25519 keys"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// HMAC property-based tests
+// =========================================================================
+
+#[cfg(feature = "hmac")]
+mod hmac_props {
+    use super::*;
+    use jsonwebtoken::{Algorithm, Header, Validation, decode, encode};
+    use serde::{Deserialize, Serialize};
+    use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    use uselesskey_jsonwebtoken::JwtKeyExt;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Claims {
+        sub: String,
+        exp: usize,
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 32, ..ProptestConfig::default() })]
+
+        /// HS256 JWT roundtrip.
+        #[test]
+        fn hs256_jwt_roundtrip(sub in "[a-z]{1,20}") {
+            let fx = Factory::random();
+            let secret = fx.hmac("prop-jwt-hs256", HmacSpec::hs256());
+
+            let claims = Claims { sub: sub.clone(), exp: 2_000_000_000 };
+            let token = encode(&Header::new(Algorithm::HS256), &claims, &secret.encoding_key()).unwrap();
+            let decoded = decode::<Claims>(&token, &secret.decoding_key(), &Validation::new(Algorithm::HS256)).unwrap();
+            prop_assert_eq!(decoded.claims.sub, sub);
+        }
+
+        /// HS384 JWT roundtrip.
+        #[test]
+        fn hs384_jwt_roundtrip(sub in "[a-z]{1,20}") {
+            let fx = Factory::random();
+            let secret = fx.hmac("prop-jwt-hs384", HmacSpec::hs384());
+
+            let claims = Claims { sub: sub.clone(), exp: 2_000_000_000 };
+            let token = encode(&Header::new(Algorithm::HS384), &claims, &secret.encoding_key()).unwrap();
+            let decoded = decode::<Claims>(&token, &secret.decoding_key(), &Validation::new(Algorithm::HS384)).unwrap();
+            prop_assert_eq!(decoded.claims.sub, sub);
+        }
+
+        /// HS512 JWT roundtrip.
+        #[test]
+        fn hs512_jwt_roundtrip(sub in "[a-z]{1,20}") {
+            let fx = Factory::random();
+            let secret = fx.hmac("prop-jwt-hs512", HmacSpec::hs512());
+
+            let claims = Claims { sub: sub.clone(), exp: 2_000_000_000 };
+            let token = encode(&Header::new(Algorithm::HS512), &claims, &secret.encoding_key()).unwrap();
+            let decoded = decode::<Claims>(&token, &secret.decoding_key(), &Validation::new(Algorithm::HS512)).unwrap();
+            prop_assert_eq!(decoded.claims.sub, sub);
+        }
+
+        /// Deterministic HMAC secrets are identical across factories.
+        #[test]
+        fn hmac_deterministic(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let s1 = fx1.hmac("prop-det-hmac", HmacSpec::hs256());
+            let s2 = fx2.hmac("prop-det-hmac", HmacSpec::hs256());
+
+            prop_assert_eq!(
+                s1.secret_bytes(),
+                s2.secret_bytes(),
+                "Deterministic HMAC secrets should be identical"
+            );
+        }
+
+        /// Different seeds produce different HMAC secrets.
+        #[test]
+        fn hmac_different_seeds_distinct(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let s_a = fx_a.hmac("prop-hmac", HmacSpec::hs256());
+            let s_b = fx_b.hmac("prop-hmac", HmacSpec::hs256());
+
+            prop_assert_ne!(
+                s_a.secret_bytes(),
+                s_b.secret_bytes(),
+                "Different seeds should produce different HMAC secrets"
+            );
+        }
+    }
+}

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -51,3 +51,4 @@ rustls = { version = "0.23", features = ["ring"] }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true
+proptest.workspace = true

--- a/crates/uselesskey-rustls/tests/prop_tests.rs
+++ b/crates/uselesskey-rustls/tests/prop_tests.rs
@@ -1,0 +1,393 @@
+//! Property-based tests for uselesskey-rustls adapter.
+//!
+//! Covers:
+//! - Roundtrip: fixture → rustls type → DER bytes match
+//! - Determinism: same seed produces same rustls keys
+//! - Distinctness: different seeds produce different keys
+//! - All key types produce valid rustls conversions
+
+use proptest::prelude::*;
+use uselesskey_core::{Factory, Seed};
+
+// =========================================================================
+// X.509 self-signed property-based tests
+// =========================================================================
+
+#[cfg(feature = "x509")]
+mod x509_self_signed_props {
+    use super::*;
+    use uselesskey_rustls::{RustlsCertExt, RustlsPrivateKeyExt};
+    use uselesskey_x509::{X509FactoryExt, X509Spec};
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 8, ..ProptestConfig::default() })]
+
+        /// Self-signed cert → rustls private key DER matches original.
+        #[test]
+        fn self_signed_private_key_matches(seed in any::<[u8; 32]>()) {
+            let fx = Factory::deterministic(Seed::new(seed));
+            let cert = fx.x509_self_signed("prop-ss", X509Spec::self_signed("prop.example.com"));
+
+            let key = cert.private_key_der_rustls();
+            prop_assert_eq!(
+                key.secret_der(),
+                cert.private_key_pkcs8_der(),
+                "rustls private key DER should match original"
+            );
+        }
+
+        /// Self-signed cert → rustls certificate DER matches original.
+        #[test]
+        fn self_signed_cert_matches(seed in any::<[u8; 32]>()) {
+            let fx = Factory::deterministic(Seed::new(seed));
+            let cert = fx.x509_self_signed("prop-ss", X509Spec::self_signed("prop.example.com"));
+
+            let cert_der = cert.certificate_der_rustls();
+            prop_assert_eq!(
+                cert_der.as_ref(),
+                cert.cert_der(),
+                "rustls certificate DER should match original"
+            );
+        }
+
+        /// Deterministic self-signed certs produce identical rustls conversions.
+        #[test]
+        fn self_signed_deterministic(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let c1 = fx1.x509_self_signed("prop-det", X509Spec::self_signed("prop.example.com"));
+            let c2 = fx2.x509_self_signed("prop-det", X509Spec::self_signed("prop.example.com"));
+
+            let k1 = c1.private_key_der_rustls();
+            let k2 = c2.private_key_der_rustls();
+            prop_assert_eq!(
+                k1.secret_der(),
+                k2.secret_der(),
+                "Deterministic certs should produce identical private keys"
+            );
+
+            let cd1 = c1.certificate_der_rustls();
+            let cd2 = c2.certificate_der_rustls();
+            prop_assert_eq!(
+                cd1.as_ref(),
+                cd2.as_ref(),
+                "Deterministic certs should produce identical certificates"
+            );
+        }
+
+        /// Different seeds produce different self-signed certs.
+        #[test]
+        fn self_signed_different_seeds(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let c_a = fx_a.x509_self_signed("prop-ss", X509Spec::self_signed("prop.example.com"));
+            let c_b = fx_b.x509_self_signed("prop-ss", X509Spec::self_signed("prop.example.com"));
+
+            let cd_a = c_a.certificate_der_rustls();
+            let cd_b = c_b.certificate_der_rustls();
+            prop_assert_ne!(
+                cd_a.as_ref(),
+                cd_b.as_ref(),
+                "Different seeds should produce different certificates"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// X.509 chain property-based tests
+// =========================================================================
+
+#[cfg(feature = "x509")]
+mod x509_chain_props {
+    use super::*;
+    use uselesskey_rustls::{RustlsCertExt, RustlsChainExt, RustlsPrivateKeyExt};
+    use uselesskey_x509::{ChainSpec, X509FactoryExt};
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 8, ..ProptestConfig::default() })]
+
+        /// Chain → rustls conversions preserve the original DER bytes.
+        #[test]
+        fn chain_der_roundtrip(seed in any::<[u8; 32]>()) {
+            let fx = Factory::deterministic(Seed::new(seed));
+            let chain = fx.x509_chain("prop-chain", ChainSpec::new("prop.example.com"));
+
+            let key = chain.private_key_der_rustls();
+            prop_assert_eq!(
+                key.secret_der(),
+                chain.leaf_private_key_pkcs8_der(),
+                "Chain private key should match"
+            );
+
+            let leaf_cert = chain.certificate_der_rustls();
+            prop_assert_eq!(
+                leaf_cert.as_ref(),
+                chain.leaf_cert_der(),
+                "Chain leaf cert should match"
+            );
+
+            let chain_certs = chain.chain_der_rustls();
+            prop_assert_eq!(chain_certs.len(), 2, "Chain should have leaf + intermediate");
+            prop_assert_eq!(chain_certs[0].as_ref(), chain.leaf_cert_der());
+            prop_assert_eq!(chain_certs[1].as_ref(), chain.intermediate_cert_der());
+
+            let root = chain.root_certificate_der_rustls();
+            prop_assert_eq!(
+                root.as_ref(),
+                chain.root_cert_der(),
+                "Root cert should match"
+            );
+        }
+
+        /// Deterministic chains produce identical rustls output.
+        #[test]
+        fn chain_deterministic(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let ch1 = fx1.x509_chain("prop-det-ch", ChainSpec::new("prop.example.com"));
+            let ch2 = fx2.x509_chain("prop-det-ch", ChainSpec::new("prop.example.com"));
+
+            prop_assert_eq!(
+                ch1.leaf_cert_der(),
+                ch2.leaf_cert_der(),
+                "Deterministic chains should produce identical leaf certs"
+            );
+            prop_assert_eq!(
+                ch1.root_cert_der(),
+                ch2.root_cert_der(),
+                "Deterministic chains should produce identical root certs"
+            );
+        }
+
+        /// Different seeds produce different chain certificates.
+        #[test]
+        fn chain_different_seeds(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let ch_a = fx_a.x509_chain("prop-ch", ChainSpec::new("prop.example.com"));
+            let ch_b = fx_b.x509_chain("prop-ch", ChainSpec::new("prop.example.com"));
+
+            prop_assert_ne!(
+                ch_a.leaf_cert_der(),
+                ch_b.leaf_cert_der(),
+                "Different seeds should produce different leaf certs"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// RSA key → rustls private key
+// =========================================================================
+
+#[cfg(feature = "rsa")]
+mod rsa_props {
+    use super::*;
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    use uselesskey_rustls::RustlsPrivateKeyExt;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 5, ..ProptestConfig::default() })]
+
+        /// RSA private key → rustls DER matches original.
+        #[test]
+        fn rsa_private_key_roundtrip(seed in any::<[u8; 32]>()) {
+            let fx = Factory::deterministic(Seed::new(seed));
+            let kp = fx.rsa("prop-rsa", RsaSpec::rs256());
+
+            let key = kp.private_key_der_rustls();
+            prop_assert_eq!(
+                key.secret_der(),
+                kp.private_key_pkcs8_der(),
+                "RSA private key DER should match"
+            );
+        }
+
+        /// Deterministic RSA keys produce identical rustls conversions.
+        #[test]
+        fn rsa_deterministic(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.rsa("prop-det-rsa", RsaSpec::rs256());
+            let kp2 = fx2.rsa("prop-det-rsa", RsaSpec::rs256());
+
+            let k1 = kp1.private_key_der_rustls();
+            let k2 = kp2.private_key_der_rustls();
+            prop_assert_eq!(
+                k1.secret_der(),
+                k2.secret_der(),
+                "Deterministic RSA keys should produce identical rustls keys"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// ECDSA key → rustls private key
+// =========================================================================
+
+#[cfg(feature = "ecdsa")]
+mod ecdsa_props {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_rustls::RustlsPrivateKeyExt;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 16, ..ProptestConfig::default() })]
+
+        /// ECDSA P-256 private key → rustls DER matches original.
+        #[test]
+        fn ecdsa_p256_private_key_roundtrip(seed in any::<[u8; 32]>()) {
+            let fx = Factory::deterministic(Seed::new(seed));
+            let kp = fx.ecdsa("prop-ec256", EcdsaSpec::es256());
+
+            let key = kp.private_key_der_rustls();
+            prop_assert_eq!(
+                key.secret_der(),
+                kp.private_key_pkcs8_der(),
+                "P-256 private key DER should match"
+            );
+        }
+
+        /// ECDSA P-384 private key → rustls DER matches original.
+        #[test]
+        fn ecdsa_p384_private_key_roundtrip(seed in any::<[u8; 32]>()) {
+            let fx = Factory::deterministic(Seed::new(seed));
+            let kp = fx.ecdsa("prop-ec384", EcdsaSpec::es384());
+
+            let key = kp.private_key_der_rustls();
+            prop_assert_eq!(
+                key.secret_der(),
+                kp.private_key_pkcs8_der(),
+                "P-384 private key DER should match"
+            );
+        }
+
+        /// Deterministic ECDSA keys produce identical rustls conversions.
+        #[test]
+        fn ecdsa_deterministic(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.ecdsa("prop-det-ec", EcdsaSpec::es256());
+            let kp2 = fx2.ecdsa("prop-det-ec", EcdsaSpec::es256());
+
+            let k1 = kp1.private_key_der_rustls();
+            let k2 = kp2.private_key_der_rustls();
+            prop_assert_eq!(
+                k1.secret_der(),
+                k2.secret_der(),
+                "Deterministic ECDSA keys should produce identical rustls keys"
+            );
+        }
+
+        /// Different seeds yield different ECDSA keys.
+        #[test]
+        fn ecdsa_different_seeds(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let kp_a = fx_a.ecdsa("prop-ec", EcdsaSpec::es256());
+            let kp_b = fx_b.ecdsa("prop-ec", EcdsaSpec::es256());
+
+            let k_a = kp_a.private_key_der_rustls();
+            let k_b = kp_b.private_key_der_rustls();
+            prop_assert_ne!(
+                k_a.secret_der(),
+                k_b.secret_der(),
+                "Different seeds should produce different ECDSA keys"
+            );
+        }
+    }
+}
+
+// =========================================================================
+// Ed25519 key → rustls private key
+// =========================================================================
+
+#[cfg(feature = "ed25519")]
+mod ed25519_props {
+    use super::*;
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rustls::RustlsPrivateKeyExt;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 32, ..ProptestConfig::default() })]
+
+        /// Ed25519 private key → rustls DER matches original.
+        #[test]
+        fn ed25519_private_key_roundtrip(seed in any::<[u8; 32]>()) {
+            let fx = Factory::deterministic(Seed::new(seed));
+            let kp = fx.ed25519("prop-ed", Ed25519Spec::new());
+
+            let key = kp.private_key_der_rustls();
+            prop_assert_eq!(
+                key.secret_der(),
+                kp.private_key_pkcs8_der(),
+                "Ed25519 private key DER should match"
+            );
+        }
+
+        /// Deterministic Ed25519 keys produce identical rustls conversions.
+        #[test]
+        fn ed25519_deterministic(seed in any::<[u8; 32]>()) {
+            let fx1 = Factory::deterministic(Seed::new(seed));
+            let fx2 = Factory::deterministic(Seed::new(seed));
+
+            let kp1 = fx1.ed25519("prop-det-ed", Ed25519Spec::new());
+            let kp2 = fx2.ed25519("prop-det-ed", Ed25519Spec::new());
+
+            let k1 = kp1.private_key_der_rustls();
+            let k2 = kp2.private_key_der_rustls();
+            prop_assert_eq!(
+                k1.secret_der(),
+                k2.secret_der(),
+                "Deterministic Ed25519 keys should produce identical rustls keys"
+            );
+        }
+
+        /// Different seeds yield different Ed25519 keys.
+        #[test]
+        fn ed25519_different_seeds(
+            seed_a in any::<[u8; 32]>(),
+            seed_b in any::<[u8; 32]>(),
+        ) {
+            prop_assume!(seed_a != seed_b);
+
+            let fx_a = Factory::deterministic(Seed::new(seed_a));
+            let fx_b = Factory::deterministic(Seed::new(seed_b));
+
+            let kp_a = fx_a.ed25519("prop-ed", Ed25519Spec::new());
+            let kp_b = fx_b.ed25519("prop-ed", Ed25519Spec::new());
+
+            let k_a = kp_a.private_key_der_rustls();
+            let k_b = kp_b.private_key_der_rustls();
+            prop_assert_ne!(
+                k_a.secret_der(),
+                k_b.secret_der(),
+                "Different seeds should produce different Ed25519 keys"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Add property-based tests (proptest) to the three adapter crates that were missing them.

- uselesskey-jsonwebtoken: JWT roundtrip (sign → verify), determinism, distinctness, all algorithm specs (RS256, ES256, ES384, EdDSA, HS256/384/512)
- uselesskey-rustls: DER roundtrip (fixture → rustls type → bytes match), determinism, distinctness for X.509 self-signed, X.509 chains, RSA, ECDSA (P-256/P-384), and Ed25519
- uselesskey-aws-lc-rs: Sign → verify roundtrip, determinism, distinctness for RSA, ECDSA (P-256/P-384), and Ed25519

The four other adapter crates (ring, rustcrypto, tonic, pgp) already had proptests and were not modified.

All tests pass: cargo test --workspace --all-features --exclude uselesskey-bdd
Clippy clean: cargo clippy --workspace --all-features --tests -- -D warnings