### PR TITLE
test: add coverage gap tests for core crates

### DIFF
--- a/crates/uselesskey-core-cache/src/lib.rs
+++ b/crates/uselesskey-core-cache/src/lib.rs
@@ -287,4 +287,75 @@ mod tests {
         let arc = downcast_or_panic::<u32>(arc_any, &id);
         assert_eq!(*arc, 123u32);
     }
+
+    #[test]
+    fn default_creates_empty_cache() {
+        let cache = ArtifactCache::default();
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn get_typed_missing_key_returns_none() {
+        let cache = ArtifactCache::new();
+        let id = sample_id();
+        assert!(cache.get_typed::<u32>(&id).is_none());
+    }
+
+    #[test]
+    fn distinct_ids_are_stored_independently() {
+        let cache = ArtifactCache::new();
+        let id_a = ArtifactId::new("domain:a", "label", b"spec", "good", DerivationVersion::V1);
+        let id_b = ArtifactId::new("domain:b", "label", b"spec", "good", DerivationVersion::V1);
+
+        cache.insert_if_absent_typed(id_a.clone(), Arc::new(1u32));
+        cache.insert_if_absent_typed(id_b.clone(), Arc::new(2u32));
+
+        assert_eq!(cache.len(), 2);
+        assert_eq!(*cache.get_typed::<u32>(&id_a).unwrap(), 1);
+        assert_eq!(*cache.get_typed::<u32>(&id_b).unwrap(), 2);
+    }
+
+    #[test]
+    fn concurrent_inserts_converge() {
+        use std::thread;
+
+        let cache = Arc::new(ArtifactCache::new());
+        let id = sample_id();
+
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let cache = Arc::clone(&cache);
+                let id = id.clone();
+                thread::spawn(move || cache.insert_if_absent_typed(id, Arc::new(i as u32)))
+            })
+            .collect();
+
+        let results: Vec<u32> = handles.into_iter().map(|h| *h.join().unwrap()).collect();
+
+        // All threads must see the same winning value.
+        let first = results[0];
+        assert!(results.iter().all(|v| *v == first));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn downcast_or_panic_message_contains_id_fields() {
+        let id = ArtifactId::new(
+            "domain:msg",
+            "my-label",
+            b"spec",
+            "my-variant",
+            DerivationVersion::V1,
+        );
+        let arc_any: Arc<dyn Any + Send + Sync> = Arc::new(42u32);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _ = downcast_or_panic::<String>(arc_any.clone(), &id);
+        }));
+        let err = result.unwrap_err();
+        let msg = err.downcast_ref::<String>().unwrap();
+        assert!(msg.contains("domain:msg"), "panic should mention domain");
+        assert!(msg.contains("my-label"), "panic should mention label");
+        assert!(msg.contains("my-variant"), "panic should mention variant");
+    }
 }

--- a/crates/uselesskey-core-factory/src/lib.rs
+++ b/crates/uselesskey-core-factory/src/lib.rs
@@ -224,4 +224,101 @@ mod tests {
             Mode::Random => panic!("wrong mode"),
         }
     }
+
+    #[test]
+    fn mode_pattern_matches_random() {
+        let fx = Factory::random();
+        assert!(matches!(fx.mode(), Mode::Random));
+    }
+
+    #[test]
+    fn deterministic_same_inputs_yield_same_output() {
+        let fx = Factory::deterministic(Seed::new([7u8; 32]));
+        let a: Arc<u64> = fx.get_or_init("domain:det", "lbl", b"sp", "good", |rng| {
+            use rand_core::RngCore;
+            rng.next_u64()
+        });
+        // Clear cache so init runs again from the same derived seed.
+        fx.clear_cache();
+        let b: Arc<u64> = fx.get_or_init("domain:det", "lbl", b"sp", "good", |rng| {
+            use rand_core::RngCore;
+            rng.next_u64()
+        });
+        assert_eq!(*a, *b, "deterministic mode must reproduce the same value");
+    }
+
+    #[test]
+    fn clone_shares_cache() {
+        let fx = Factory::random();
+        let _ = fx.get_or_init("domain:clone", "lbl", b"sp", "good", |_| 99u32);
+        let fx2 = fx.clone();
+        let val = fx2.get_or_init("domain:clone", "lbl", b"sp", "good", |_| 0u32);
+        assert_eq!(*val, 99, "clone must share the same cache");
+    }
+
+    #[test]
+    fn different_domains_produce_distinct_entries() {
+        let fx = Factory::deterministic(Seed::new([1u8; 32]));
+        let a: Arc<u64> = fx.get_or_init("domain:a", "lbl", b"sp", "good", |rng| {
+            use rand_core::RngCore;
+            rng.next_u64()
+        });
+        let b: Arc<u64> = fx.get_or_init("domain:b", "lbl", b"sp", "good", |rng| {
+            use rand_core::RngCore;
+            rng.next_u64()
+        });
+        assert_ne!(*a, *b);
+    }
+
+    #[test]
+    fn different_variants_produce_distinct_entries() {
+        let fx = Factory::deterministic(Seed::new([2u8; 32]));
+        let a: Arc<u64> = fx.get_or_init("domain:v", "lbl", b"sp", "good", |rng| {
+            use rand_core::RngCore;
+            rng.next_u64()
+        });
+        let b: Arc<u64> = fx.get_or_init("domain:v", "lbl", b"sp", "bad", |rng| {
+            use rand_core::RngCore;
+            rng.next_u64()
+        });
+        assert_ne!(*a, *b);
+    }
+
+    #[test]
+    fn different_specs_produce_distinct_entries() {
+        let fx = Factory::deterministic(Seed::new([3u8; 32]));
+        let a: Arc<u64> = fx.get_or_init("domain:s", "lbl", b"RS256", "good", |rng| {
+            use rand_core::RngCore;
+            rng.next_u64()
+        });
+        let b: Arc<u64> = fx.get_or_init("domain:s", "lbl", b"RS384", "good", |rng| {
+            use rand_core::RngCore;
+            rng.next_u64()
+        });
+        assert_ne!(*a, *b);
+    }
+
+    #[test]
+    fn debug_mode_random() {
+        let fx = Factory::random();
+        let dbg = format!("{:?}", fx);
+        assert!(
+            dbg.contains("Random"),
+            "debug should show Random mode: {dbg}"
+        );
+    }
+
+    #[test]
+    fn debug_mode_deterministic() {
+        let fx = Factory::deterministic(Seed::new([0u8; 32]));
+        let dbg = format!("{:?}", fx);
+        assert!(
+            dbg.contains("Deterministic"),
+            "debug should show Deterministic mode: {dbg}"
+        );
+        assert!(
+            dbg.contains("redacted"),
+            "seed must be redacted in debug output: {dbg}"
+        );
+    }
 }

--- a/crates/uselesskey-core-hash/src/lib.rs
+++ b/crates/uselesskey-core-hash/src/lib.rs
@@ -63,6 +63,28 @@ mod tests {
         assert_ne!(a_left.finalize(), b_left.finalize());
     }
 
+    #[test]
+    fn hash32_empty_input() {
+        let h = hash32(b"");
+        assert_eq!(h, blake3::hash(b""));
+    }
+
+    #[test]
+    fn write_len_prefixed_empty_data() {
+        let mut hasher = Hasher::new();
+        write_len_prefixed(&mut hasher, b"");
+        let actual = hasher.finalize();
+
+        let mut expected_hasher = Hasher::new();
+        expected_hasher.update(&0u32.to_be_bytes());
+        assert_eq!(actual, expected_hasher.finalize());
+    }
+
+    #[test]
+    fn hash32_different_inputs_differ() {
+        assert_ne!(hash32(b"alpha"), hash32(b"beta"));
+    }
+
     proptest! {
         #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
 

--- a/crates/uselesskey-core-id/src/lib.rs
+++ b/crates/uselesskey-core-id/src/lib.rs
@@ -171,4 +171,90 @@ mod tests {
             derive_seed(&master, &id_b).bytes()
         );
     }
+
+    #[test]
+    fn derive_seed_domain_affects_output() {
+        let master = Seed::new([6u8; 32]);
+        let id_a = ArtifactId::new("domain:a", "lbl", b"spec", "v", DerivationVersion::V1);
+        let id_b = ArtifactId::new("domain:b", "lbl", b"spec", "v", DerivationVersion::V1);
+        assert_ne!(
+            derive_seed(&master, &id_a).bytes(),
+            derive_seed(&master, &id_b).bytes()
+        );
+    }
+
+    #[test]
+    fn derive_seed_variant_affects_output() {
+        let master = Seed::new([7u8; 32]);
+        let id_a = ArtifactId::new("d", "lbl", b"spec", "good", DerivationVersion::V1);
+        let id_b = ArtifactId::new("d", "lbl", b"spec", "bad", DerivationVersion::V1);
+        assert_ne!(
+            derive_seed(&master, &id_a).bytes(),
+            derive_seed(&master, &id_b).bytes()
+        );
+    }
+
+    #[test]
+    fn derive_seed_spec_affects_output() {
+        let master = Seed::new([8u8; 32]);
+        let id_a = ArtifactId::new("d", "lbl", b"RS256", "v", DerivationVersion::V1);
+        let id_b = ArtifactId::new("d", "lbl", b"RS384", "v", DerivationVersion::V1);
+        assert_ne!(
+            derive_seed(&master, &id_a).bytes(),
+            derive_seed(&master, &id_b).bytes()
+        );
+    }
+
+    #[test]
+    fn derive_seed_master_affects_output() {
+        let id = ArtifactId::new("d", "lbl", b"spec", "v", DerivationVersion::V1);
+        let a = derive_seed(&Seed::new([1u8; 32]), &id);
+        let b = derive_seed(&Seed::new([2u8; 32]), &id);
+        assert_ne!(a.bytes(), b.bytes());
+    }
+
+    #[test]
+    fn artifact_id_empty_fields() {
+        let id = ArtifactId::new("d", "", b"", "", DerivationVersion::V1);
+        assert_eq!(id.label, "");
+        assert_eq!(id.variant, "");
+        assert_eq!(id.spec_fingerprint, *hash32(b"").as_bytes());
+    }
+
+    #[test]
+    fn artifact_id_ordering() {
+        let a = ArtifactId::new("a", "lbl", b"spec", "v", DerivationVersion::V1);
+        let b = ArtifactId::new("b", "lbl", b"spec", "v", DerivationVersion::V1);
+        assert!(a < b, "ArtifactId ordering should be by domain first");
+    }
+
+    #[test]
+    fn artifact_id_clone_equals_original() {
+        let id = ArtifactId::new("d", "lbl", b"spec", "v", DerivationVersion::V1);
+        let cloned = id.clone();
+        assert_eq!(id, cloned);
+    }
+
+    #[test]
+    fn derivation_version_copy_and_hash() {
+        use core::hash::{Hash, Hasher};
+        let v = DerivationVersion::V1;
+        let copy = v;
+        assert_eq!(v, copy);
+
+        // Verify Hash is implemented.
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        v.hash(&mut h);
+        let hash1 = h.finish();
+
+        let mut h2 = std::collections::hash_map::DefaultHasher::new();
+        copy.hash(&mut h2);
+        assert_eq!(hash1, h2.finish());
+    }
+
+    #[test]
+    fn derivation_version_debug() {
+        let dbg = format!("{:?}", DerivationVersion::V1);
+        assert!(dbg.contains("1"), "Debug should contain the version number");
+    }
 }

--- a/crates/uselesskey-core-kid/src/lib.rs
+++ b/crates/uselesskey-core-kid/src/lib.rs
@@ -107,4 +107,50 @@ mod tests {
     fn prefix_length_must_be_non_zero() {
         let _ = kid_from_bytes_with_prefix(b"fixture-public-key", 0);
     }
+
+    #[test]
+    #[should_panic(expected = "prefix_bytes must be in 1..=32")]
+    fn prefix_length_above_32_panics() {
+        let _ = kid_from_bytes_with_prefix(b"fixture-public-key", 33);
+    }
+
+    #[test]
+    fn prefix_length_max_32_is_valid() {
+        let kid = kid_from_bytes_with_prefix(b"fixture-public-key", 32);
+        let decoded = URL_SAFE_NO_PAD
+            .decode(kid.as_bytes())
+            .expect("should be valid base64url");
+        assert_eq!(decoded.len(), 32);
+    }
+
+    #[test]
+    fn prefix_length_min_1_is_valid() {
+        let kid = kid_from_bytes_with_prefix(b"fixture-public-key", 1);
+        let decoded = URL_SAFE_NO_PAD
+            .decode(kid.as_bytes())
+            .expect("should be valid base64url");
+        assert_eq!(decoded.len(), 1);
+    }
+
+    #[test]
+    fn kid_from_empty_input() {
+        let kid = kid_from_bytes(b"");
+        assert!(!kid.is_empty(), "even empty input should produce a kid");
+    }
+
+    #[test]
+    fn default_kid_prefix_bytes_is_12() {
+        assert_eq!(DEFAULT_KID_PREFIX_BYTES, 12);
+    }
+
+    #[test]
+    fn kid_is_url_safe() {
+        let kid = kid_from_bytes(b"any-public-key-material");
+        // base64url uses only alphanumerics, '-', and '_'. No padding ('=') with NO_PAD.
+        assert!(
+            kid.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "kid should be URL-safe: {kid}"
+        );
+    }
 }

--- a/crates/uselesskey-core-seed/src/lib.rs
+++ b/crates/uselesskey-core-seed/src/lib.rs
@@ -122,4 +122,90 @@ mod tests {
         let expected = blake3::hash("deterministic-seed-value".as_bytes());
         assert_eq!(seed.bytes(), expected.as_bytes());
     }
+
+    #[test]
+    fn parse_hex_32_lowercase_valid() {
+        let hex = "aa".repeat(32);
+        let result = parse_hex_32(&hex).unwrap();
+        assert!(result.iter().all(|b| *b == 0xAA));
+    }
+
+    #[test]
+    fn parse_hex_32_mixed_case_valid() {
+        let hex = "aAbBcCdDeEfF".repeat(5);
+        // 60 chars — pad to 64
+        let hex = format!("{hex}0000");
+        assert_eq!(hex.len(), 64);
+        assert!(parse_hex_32(&hex).is_ok());
+    }
+
+    #[test]
+    fn parse_hex_32_invalid_lo_nibble() {
+        // Valid hi nibble, invalid lo nibble at position 1
+        let mut hex = "0".repeat(64);
+        hex.replace_range(1..2, "z");
+        let err = parse_hex_32(&hex).unwrap_err();
+        assert!(err.contains("invalid hex char: z"));
+    }
+
+    #[test]
+    fn seed_equality_and_clone() {
+        let a = Seed::new([42u8; 32]);
+        let b = a;
+        assert_eq!(a, b);
+        assert_eq!(a.bytes(), b.bytes());
+    }
+
+    #[test]
+    fn seed_inequality() {
+        let a = Seed::new([1u8; 32]);
+        let b = Seed::new([2u8; 32]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn seed_hash_consistent() {
+        use core::hash::{Hash, Hasher};
+        let seed = Seed::new([99u8; 32]);
+
+        let mut h1 = std::collections::hash_map::DefaultHasher::new();
+        seed.hash(&mut h1);
+        let hash1 = h1.finish();
+
+        let mut h2 = std::collections::hash_map::DefaultHasher::new();
+        seed.hash(&mut h2);
+        assert_eq!(hash1, h2.finish());
+    }
+
+    #[test]
+    fn from_env_value_short_string_uses_blake3() {
+        let seed = Seed::from_env_value("abc").unwrap();
+        let expected = blake3::hash(b"abc");
+        assert_eq!(seed.bytes(), expected.as_bytes());
+    }
+
+    #[test]
+    fn from_env_value_63_char_non_hex_uses_blake3() {
+        // 63 chars — not 64, so falls through to blake3 hashing.
+        let input = "a".repeat(63);
+        let seed = Seed::from_env_value(&input).unwrap();
+        let expected = blake3::hash(input.as_bytes());
+        assert_eq!(seed.bytes(), expected.as_bytes());
+    }
+
+    #[test]
+    fn from_env_value_65_char_non_hex_uses_blake3() {
+        // 65 chars — not 64, so falls through to blake3 hashing.
+        let input = "a".repeat(65);
+        let seed = Seed::from_env_value(&input).unwrap();
+        let expected = blake3::hash(input.as_bytes());
+        assert_eq!(seed.bytes(), expected.as_bytes());
+    }
+
+    #[test]
+    fn from_env_value_64_char_invalid_hex_returns_error() {
+        // 64 chars but not valid hex — parse_hex_32 error path.
+        let input = "g".repeat(64);
+        assert!(Seed::from_env_value(&input).is_err());
+    }
 }


### PR DESCRIPTION
Adds unit tests targeting coverage gaps across 6 core crates:

- **uselesskey-core-factory**: Random/deterministic mode switching, clone sharing cache, Debug output for both modes, distinct entries for different domains/variants/specs
- **uselesskey-core-cache**: Default trait, missing key returns None, distinct IDs stored independently, concurrent insert convergence, panic message field inspection
- **uselesskey-core-id**: Domain/variant/spec/master seed each affect derivation output, empty fields, ordering, clone equality, DerivationVersion copy/hash/debug
- **uselesskey-core-seed**: Lowercase/mixed-case hex parsing, lo-nibble error path, equality/inequality/hash, boundary lengths (63/64/65 chars), invalid 64-char hex error
- **uselesskey-core-kid**: Panic on prefix_bytes=33, boundary values (1 and 32), empty input, URL-safety assertion, constant value check
- **uselesskey-core-hash**: Empty input, empty data with length prefix, different inputs differ