### PR TITLE
test: add comprehensive tempfile and sink tests

### DIFF
--- a/crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs
+++ b/crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs
@@ -1,0 +1,333 @@
+//! Comprehensive tests for tempfile/sink functionality.
+//!
+//! Covers: concurrent writes, cleanup on drop, path uniqueness,
+//! file permissions, and various content shapes.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+
+use uselesskey_core_sink::TempArtifact;
+
+// ── Concurrent tempfile writes from multiple threads ─────────────────
+
+#[test]
+fn concurrent_tempfile_writes_produce_distinct_files() {
+    let barrier = Arc::new(std::sync::Barrier::new(8));
+    let handles: Vec<_> = (0..8)
+        .map(|i| {
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                let content = format!("thread-{i}-content");
+                let temp =
+                    TempArtifact::new_string("uk-conc-", ".pem", &content).expect("create temp");
+                let path = temp.path().to_path_buf();
+                let read_back = temp.read_to_string().expect("read back");
+                assert_eq!(read_back, content);
+                (path, temp)
+            })
+        })
+        .collect();
+
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let paths: HashSet<_> = results.iter().map(|(p, _)| p.clone()).collect();
+
+    // All paths must be unique
+    assert_eq!(
+        paths.len(),
+        8,
+        "all concurrent tempfiles must have unique paths"
+    );
+
+    // All files still exist while we hold the TempArtifacts
+    for (path, _artifact) in &results {
+        assert!(path.exists(), "file should exist while artifact is alive");
+    }
+}
+
+#[test]
+fn concurrent_bytes_writes_are_independent() {
+    let handles: Vec<_> = (0..4)
+        .map(|i| {
+            thread::spawn(move || {
+                let data: Vec<u8> = (0..100).map(|b| ((b + i) % 256) as u8).collect();
+                let temp = TempArtifact::new_bytes("uk-cbin-", ".der", &data).expect("create temp");
+                let read_back = temp.read_to_bytes().expect("read back");
+                assert_eq!(read_back, data);
+                temp
+            })
+        })
+        .collect();
+
+    let artifacts: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let paths: HashSet<_> = artifacts.iter().map(|a| a.path().to_path_buf()).collect();
+    assert_eq!(paths.len(), 4);
+}
+
+// ── Tempfiles cleaned up when TempArtifact dropped ──────────────────
+
+#[test]
+fn multiple_tempfiles_cleaned_up_on_drop() {
+    let paths: Vec<PathBuf> = {
+        let artifacts: Vec<_> = (0..5)
+            .map(|i| {
+                let content = format!("drop-test-{i}");
+                TempArtifact::new_string("uk-drop-", ".tmp", &content).unwrap()
+            })
+            .collect();
+
+        let paths: Vec<_> = artifacts.iter().map(|a| a.path().to_path_buf()).collect();
+        for p in &paths {
+            assert!(p.exists(), "file must exist before drop");
+        }
+        paths
+        // artifacts dropped here
+    };
+
+    // Allow filesystem latency
+    thread::sleep(std::time::Duration::from_millis(50));
+
+    for p in &paths {
+        assert!(!p.exists(), "file should be cleaned up after drop: {p:?}");
+    }
+}
+
+#[test]
+fn drop_in_thread_cleans_up() {
+    let path = thread::spawn(|| {
+        let temp = TempArtifact::new_string("uk-tdrop-", ".txt", "thread-drop").unwrap();
+        let p = temp.path().to_path_buf();
+        assert!(p.exists());
+        p
+        // temp dropped at end of closure
+    })
+    .join()
+    .unwrap();
+
+    thread::sleep(std::time::Duration::from_millis(50));
+    assert!(
+        !path.exists(),
+        "tempfile should be cleaned up after thread exits"
+    );
+}
+
+// ── Tempfile paths are unique across invocations ────────────────────
+
+#[test]
+fn paths_unique_same_prefix_suffix() {
+    let mut paths = HashSet::new();
+    for _ in 0..20 {
+        let temp = TempArtifact::new_string("uk-uniq-", ".pem", "data").unwrap();
+        let inserted = paths.insert(temp.path().to_path_buf());
+        assert!(inserted, "path should be unique across invocations");
+    }
+    assert_eq!(paths.len(), 20);
+}
+
+#[test]
+fn paths_unique_empty_prefix() {
+    let a = TempArtifact::new_string("", ".pem", "a").unwrap();
+    let b = TempArtifact::new_string("", ".pem", "b").unwrap();
+    assert_ne!(a.path(), b.path());
+}
+
+// ── Write multiple fixtures simultaneously ──────────────────────────
+
+#[test]
+fn multiple_fixtures_coexist_with_different_extensions() {
+    let pem = TempArtifact::new_string(
+        "uk-multi-",
+        ".pem",
+        "-----BEGIN PRIVATE KEY-----\nDATA\n-----END PRIVATE KEY-----\n",
+    )
+    .unwrap();
+    let der = TempArtifact::new_bytes("uk-multi-", ".der", &[0x30, 0x82, 0x01]).unwrap();
+    let crt = TempArtifact::new_string(
+        "uk-multi-",
+        ".crt.pem",
+        "-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----\n",
+    )
+    .unwrap();
+
+    assert!(pem.path().exists());
+    assert!(der.path().exists());
+    assert!(crt.path().exists());
+
+    assert_eq!(pem.path().extension().unwrap(), "pem");
+    assert_eq!(der.path().extension().unwrap(), "der");
+    assert_eq!(crt.path().extension().unwrap(), "pem");
+
+    // Verify contents are independent
+    assert!(pem.read_to_string().unwrap().contains("PRIVATE KEY"));
+    assert_eq!(der.read_to_bytes().unwrap(), vec![0x30, 0x82, 0x01]);
+    assert!(crt.read_to_string().unwrap().contains("CERTIFICATE"));
+}
+
+// ── File permissions (Unix only) ────────────────────────────────────
+
+#[cfg(unix)]
+mod unix_permissions {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn tempfile_is_owner_only_readable() {
+        let temp = TempArtifact::new_string("uk-perm-", ".pem", "secret-key-data").unwrap();
+        let metadata = std::fs::metadata(temp.path()).unwrap();
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "tempfile should be owner-read/write only (0600), got {mode:o}"
+        );
+    }
+
+    #[test]
+    fn tempfile_not_world_readable() {
+        let temp = TempArtifact::new_bytes("uk-perm-", ".der", &[0x30, 0x82]).unwrap();
+        let metadata = std::fs::metadata(temp.path()).unwrap();
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(mode & 0o004, 0, "tempfile must not be world-readable");
+        assert_eq!(mode & 0o040, 0, "tempfile must not be group-readable");
+    }
+
+    #[test]
+    fn permissions_apply_to_bytes_and_string_variants() {
+        let string_temp = TempArtifact::new_string("uk-ps-", ".pem", "pem-content").unwrap();
+        let bytes_temp = TempArtifact::new_bytes("uk-pb-", ".der", &[0x01, 0x02]).unwrap();
+
+        for temp in [&string_temp, &bytes_temp] {
+            let meta = std::fs::metadata(temp.path()).unwrap();
+            let mode = meta.permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+    }
+}
+
+// ── Windows: verify file is not read-only ────────────────────────────
+
+#[cfg(windows)]
+#[test]
+fn tempfile_is_not_readonly_on_windows() {
+    let temp = TempArtifact::new_string("uk-winperm-", ".pem", "data").unwrap();
+    let metadata = std::fs::metadata(temp.path()).unwrap();
+    assert!(
+        !metadata.permissions().readonly(),
+        "tempfile should be writable on Windows"
+    );
+}
+
+// ── PEM and DER content verification ────────────────────────────────
+
+#[test]
+fn write_pem_read_back_preserves_newlines() {
+    let pem =
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\nbase64data==\n-----END RSA PRIVATE KEY-----\n";
+    let temp = TempArtifact::new_string("uk-pem-nl-", ".pem", pem).unwrap();
+
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, pem);
+    assert_eq!(
+        content.matches('\n').count(),
+        pem.matches('\n').count(),
+        "newline count must be preserved"
+    );
+}
+
+#[test]
+fn write_der_read_back_preserves_exact_bytes() {
+    // Simulate a DER-encoded structure
+    let der = vec![
+        0x30, 0x82, 0x02, 0x22, // SEQUENCE header
+        0x02, 0x01, 0x00, // INTEGER version
+        0x30, 0x0D, // SEQUENCE AlgorithmIdentifier
+        0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01, // OID rsaEncryption
+        0x05, 0x00, // NULL
+    ];
+    let temp = TempArtifact::new_bytes("uk-der-", ".der", &der).unwrap();
+
+    let read_back = temp.read_to_bytes().unwrap();
+    assert_eq!(read_back, der, "DER bytes must be preserved exactly");
+}
+
+// ── Edge cases ──────────────────────────────────────────────────────
+
+#[test]
+fn single_byte_content() {
+    let temp = TempArtifact::new_bytes("uk-1b-", ".bin", &[0x42]).unwrap();
+    assert_eq!(temp.read_to_bytes().unwrap(), vec![0x42]);
+}
+
+#[test]
+fn unicode_string_content() {
+    let text = "🔑 key fixture — ñoño — 日本語";
+    let temp = TempArtifact::new_string("uk-utf8-", ".txt", text).unwrap();
+    assert_eq!(temp.read_to_string().unwrap(), text);
+}
+
+#[test]
+fn prefix_appears_in_path() {
+    let temp = TempArtifact::new_string("uselesskey-myprefix-", ".pem", "data").unwrap();
+    let filename = temp
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    assert!(
+        filename.contains("uselesskey-myprefix-"),
+        "filename should contain the prefix: {filename}"
+    );
+}
+
+#[test]
+fn suffix_appears_in_path() {
+    let temp = TempArtifact::new_string("uk-", ".pkcs8.pem", "data").unwrap();
+    let filename = temp
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    assert!(
+        filename.ends_with(".pkcs8.pem"),
+        "filename should end with the suffix: {filename}"
+    );
+}
+
+// ── proptest: arbitrary content round-trips ─────────────────────────
+
+mod property {
+    use proptest::prelude::*;
+
+    use uselesskey_core_sink::TempArtifact;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+        #[test]
+        fn arbitrary_bytes_round_trip(data in prop::collection::vec(any::<u8>(), 0..4096)) {
+            let temp = TempArtifact::new_bytes("uk-prop-", ".bin", &data).unwrap();
+            let read_back = temp.read_to_bytes().unwrap();
+            prop_assert_eq!(read_back, data);
+        }
+
+        #[test]
+        fn arbitrary_string_round_trip(text in "[\\w\\s\\p{L}]{0,2048}") {
+            let temp = TempArtifact::new_string("uk-prop-", ".txt", &text).unwrap();
+            let read_back = temp.read_to_string().unwrap();
+            prop_assert_eq!(read_back, text);
+        }
+
+        #[test]
+        fn paths_always_unique(n in 2usize..10) {
+            let artifacts: Vec<_> = (0..n)
+                .map(|_| TempArtifact::new_string("uk-puniq-", ".pem", "x").unwrap())
+                .collect();
+            let paths: std::collections::HashSet<_> =
+                artifacts.iter().map(|a| a.path().to_path_buf()).collect();
+            prop_assert_eq!(paths.len(), n);
+        }
+    }
+}

--- a/crates/uselesskey/tests/tempfile_sink.rs
+++ b/crates/uselesskey/tests/tempfile_sink.rs
@@ -1,0 +1,497 @@
+//! Integration tests for tempfile/sink functionality across all key types.
+//!
+//! Tests every `write_*` method on RSA, ECDSA, Ed25519, HMAC, Token, X.509
+//! key fixtures, verifying content round-trips and cleanup-on-drop.
+
+mod testutil;
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use uselesskey::prelude::*;
+
+fn fx() -> Factory {
+    testutil::fx()
+}
+
+// ===========================================================================
+// RSA tempfile writes
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "rsa")]
+fn rsa_write_private_key_pkcs8_pem_round_trip() {
+    let kp = fx().rsa("sink-rsa-priv", RsaSpec::rs256());
+    let temp = kp.write_private_key_pkcs8_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, kp.private_key_pkcs8_pem());
+    assert!(content.contains("-----BEGIN PRIVATE KEY-----"));
+    assert!(content.contains("-----END PRIVATE KEY-----"));
+
+    let filename = temp.path().file_name().unwrap().to_string_lossy();
+    assert!(filename.ends_with(".pkcs8.pem"), "filename: {filename}");
+}
+
+#[test]
+#[cfg(feature = "rsa")]
+fn rsa_write_public_key_spki_pem_round_trip() {
+    let kp = fx().rsa("sink-rsa-pub", RsaSpec::rs256());
+    let temp = kp.write_public_key_spki_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, kp.public_key_spki_pem());
+    assert!(content.contains("-----BEGIN PUBLIC KEY-----"));
+
+    let filename = temp.path().file_name().unwrap().to_string_lossy();
+    assert!(filename.ends_with(".spki.pem"), "filename: {filename}");
+}
+
+#[test]
+#[cfg(feature = "rsa")]
+fn rsa_tempfile_paths_unique_across_invocations() {
+    let kp = fx().rsa("sink-rsa-uniq", RsaSpec::rs256());
+    let a = kp.write_private_key_pkcs8_pem().unwrap();
+    let b = kp.write_private_key_pkcs8_pem().unwrap();
+    assert_ne!(a.path(), b.path(), "each call produces a new tempfile");
+}
+
+#[test]
+#[cfg(feature = "rsa")]
+fn rsa_private_and_public_tempfiles_coexist() {
+    let kp = fx().rsa("sink-rsa-both", RsaSpec::rs256());
+    let priv_temp = kp.write_private_key_pkcs8_pem().unwrap();
+    let pub_temp = kp.write_public_key_spki_pem().unwrap();
+
+    assert_ne!(priv_temp.path(), pub_temp.path());
+    assert!(priv_temp.path().exists());
+    assert!(pub_temp.path().exists());
+    assert!(priv_temp.read_to_string().unwrap().contains("PRIVATE KEY"));
+    assert!(pub_temp.read_to_string().unwrap().contains("PUBLIC KEY"));
+}
+
+// ===========================================================================
+// ECDSA tempfile writes
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_write_private_key_pkcs8_pem_round_trip() {
+    let kp = fx().ecdsa("sink-ec-priv", EcdsaSpec::es256());
+    let temp = kp.write_private_key_pkcs8_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, kp.private_key_pkcs8_pem());
+    assert!(content.contains("-----BEGIN PRIVATE KEY-----"));
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_write_public_key_spki_pem_round_trip() {
+    let kp = fx().ecdsa("sink-ec-pub", EcdsaSpec::es256());
+    let temp = kp.write_public_key_spki_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, kp.public_key_spki_pem());
+    assert!(content.contains("-----BEGIN PUBLIC KEY-----"));
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_es384_tempfile_round_trip() {
+    let kp = fx().ecdsa("sink-ec384", EcdsaSpec::es384());
+    let temp = kp.write_private_key_pkcs8_pem().unwrap();
+    assert_eq!(temp.read_to_string().unwrap(), kp.private_key_pkcs8_pem());
+}
+
+// ===========================================================================
+// Ed25519 tempfile writes
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_write_private_key_pkcs8_pem_round_trip() {
+    let kp = fx().ed25519("sink-ed-priv", Ed25519Spec::new());
+    let temp = kp.write_private_key_pkcs8_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, kp.private_key_pkcs8_pem());
+    assert!(content.contains("-----BEGIN PRIVATE KEY-----"));
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_write_public_key_spki_pem_round_trip() {
+    let kp = fx().ed25519("sink-ed-pub", Ed25519Spec::new());
+    let temp = kp.write_public_key_spki_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, kp.public_key_spki_pem());
+    assert!(content.contains("-----BEGIN PUBLIC KEY-----"));
+}
+
+// ===========================================================================
+// X.509 tempfile writes (certificates for TLS)
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_write_cert_pem_round_trip() {
+    let cert = fx().x509_self_signed("sink-x509-cert", X509Spec::self_signed("sink.example.com"));
+    let temp = cert.write_cert_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, cert.cert_pem());
+    assert!(content.contains("-----BEGIN CERTIFICATE-----"));
+
+    let filename = temp.path().file_name().unwrap().to_string_lossy();
+    assert!(filename.ends_with(".crt.pem"), "filename: {filename}");
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_write_cert_der_round_trip() {
+    let cert = fx().x509_self_signed("sink-x509-der", X509Spec::self_signed("sink.example.com"));
+    let temp = cert.write_cert_der().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_bytes().unwrap();
+    assert_eq!(content, cert.cert_der());
+    assert_eq!(content[0], 0x30, "DER starts with SEQUENCE tag");
+
+    let filename = temp.path().file_name().unwrap().to_string_lossy();
+    assert!(filename.ends_with(".crt.der"), "filename: {filename}");
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_write_private_key_pem_round_trip() {
+    let cert = fx().x509_self_signed("sink-x509-key", X509Spec::self_signed("sink.example.com"));
+    let temp = cert.write_private_key_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, cert.private_key_pkcs8_pem());
+    assert!(content.contains("-----BEGIN PRIVATE KEY-----"));
+
+    let filename = temp.path().file_name().unwrap().to_string_lossy();
+    assert!(filename.ends_with(".key.pem"), "filename: {filename}");
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_write_identity_pem_contains_cert_and_key() {
+    let cert = fx().x509_self_signed("sink-x509-id", X509Spec::self_signed("sink.example.com"));
+    let temp = cert.write_identity_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert!(content.contains("-----BEGIN CERTIFICATE-----"));
+    assert!(content.contains("-----BEGIN PRIVATE KEY-----"));
+
+    let filename = temp.path().file_name().unwrap().to_string_lossy();
+    assert!(filename.ends_with(".identity.pem"), "filename: {filename}");
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_all_tempfile_paths_are_unique() {
+    let cert = fx().x509_self_signed(
+        "sink-x509-unique",
+        X509Spec::self_signed("sink.example.com"),
+    );
+    let paths: HashSet<PathBuf> = [
+        cert.write_cert_pem().unwrap().path().to_path_buf(),
+        cert.write_cert_der().unwrap().path().to_path_buf(),
+        cert.write_private_key_pem().unwrap().path().to_path_buf(),
+        cert.write_identity_pem().unwrap().path().to_path_buf(),
+    ]
+    .into_iter()
+    .collect();
+
+    assert_eq!(paths.len(), 4, "each tempfile must have a unique path");
+}
+
+// ===========================================================================
+// X.509 chain tempfile writes
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_chain_write_leaf_cert_pem() {
+    let chain = fx().x509_chain("sink-chain", ChainSpec::new("leaf.example.com"));
+    let temp = chain.write_leaf_cert_pem().unwrap();
+
+    assert!(temp.path().exists());
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, chain.leaf_cert_pem());
+    assert!(content.contains("-----BEGIN CERTIFICATE-----"));
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_chain_write_leaf_cert_der() {
+    let chain = fx().x509_chain("sink-chain-der", ChainSpec::new("leaf.example.com"));
+    let temp = chain.write_leaf_cert_der().unwrap();
+
+    assert!(temp.path().exists());
+    assert_eq!(temp.read_to_bytes().unwrap(), chain.leaf_cert_der());
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_chain_write_chain_pem() {
+    let chain = fx().x509_chain("sink-chain-chain", ChainSpec::new("leaf.example.com"));
+    let temp = chain.write_chain_pem().unwrap();
+
+    let content = temp.read_to_string().unwrap();
+    // Chain PEM should contain multiple certificates
+    let cert_count = content.matches("-----BEGIN CERTIFICATE-----").count();
+    assert!(
+        cert_count >= 2,
+        "chain PEM should have at least 2 certs, got {cert_count}"
+    );
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_chain_write_full_chain_pem() {
+    let chain = fx().x509_chain("sink-chain-full", ChainSpec::new("leaf.example.com"));
+    let temp = chain.write_full_chain_pem().unwrap();
+
+    let content = temp.read_to_string().unwrap();
+    let cert_count = content.matches("-----BEGIN CERTIFICATE-----").count();
+    assert!(
+        cert_count >= 3,
+        "full chain PEM should have at least 3 certs (leaf+intermediate+root), got {cert_count}"
+    );
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_chain_write_root_cert_pem() {
+    let chain = fx().x509_chain("sink-chain-root", ChainSpec::new("leaf.example.com"));
+    let temp = chain.write_root_cert_pem().unwrap();
+
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, chain.root_cert_pem());
+    assert!(content.contains("-----BEGIN CERTIFICATE-----"));
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_chain_write_leaf_private_key_pem() {
+    let chain = fx().x509_chain("sink-chain-key", ChainSpec::new("leaf.example.com"));
+    let temp = chain.write_leaf_private_key_pem().unwrap();
+
+    let content = temp.read_to_string().unwrap();
+    assert_eq!(content, chain.leaf_private_key_pkcs8_pem());
+    assert!(content.contains("-----BEGIN PRIVATE KEY-----"));
+}
+
+// ===========================================================================
+// Tempfiles for TLS configuration scenario
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_tempfiles_for_tls_config() {
+    let cert = fx().x509_self_signed("tls-server", X509Spec::self_signed("localhost"));
+
+    // A typical TLS setup needs cert + key as files
+    let cert_file = cert.write_cert_pem().unwrap();
+    let key_file = cert.write_private_key_pem().unwrap();
+
+    // Both files exist and have content
+    assert!(cert_file.path().exists());
+    assert!(key_file.path().exists());
+
+    let cert_content = cert_file.read_to_string().unwrap();
+    let key_content = key_file.read_to_string().unwrap();
+
+    assert!(cert_content.contains("CERTIFICATE"));
+    assert!(key_content.contains("PRIVATE KEY"));
+
+    // Paths are different
+    assert_ne!(cert_file.path(), key_file.path());
+}
+
+// ===========================================================================
+// Cleanup verification across key types
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "rsa")]
+fn rsa_tempfile_cleaned_up_on_drop() {
+    let path = {
+        let kp = fx().rsa("sink-rsa-drop", RsaSpec::rs256());
+        let temp = kp.write_private_key_pkcs8_pem().unwrap();
+        let p = temp.path().to_path_buf();
+        assert!(p.exists());
+        p
+    };
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert!(!path.exists(), "RSA tempfile should be cleaned up on drop");
+}
+
+#[test]
+#[cfg(feature = "ecdsa")]
+fn ecdsa_tempfile_cleaned_up_on_drop() {
+    let path = {
+        let kp = fx().ecdsa("sink-ec-drop", EcdsaSpec::es256());
+        let temp = kp.write_private_key_pkcs8_pem().unwrap();
+        let p = temp.path().to_path_buf();
+        assert!(p.exists());
+        p
+    };
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert!(
+        !path.exists(),
+        "ECDSA tempfile should be cleaned up on drop"
+    );
+}
+
+#[test]
+#[cfg(feature = "ed25519")]
+fn ed25519_tempfile_cleaned_up_on_drop() {
+    let path = {
+        let kp = fx().ed25519("sink-ed-drop", Ed25519Spec::new());
+        let temp = kp.write_private_key_pkcs8_pem().unwrap();
+        let p = temp.path().to_path_buf();
+        assert!(p.exists());
+        p
+    };
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert!(
+        !path.exists(),
+        "Ed25519 tempfile should be cleaned up on drop"
+    );
+}
+
+#[test]
+#[cfg(feature = "x509")]
+fn x509_tempfile_cleaned_up_on_drop() {
+    let paths: Vec<PathBuf> = {
+        let cert =
+            fx().x509_self_signed("sink-x509-drop", X509Spec::self_signed("drop.example.com"));
+        let cert_pem = cert.write_cert_pem().unwrap();
+        let cert_der = cert.write_cert_der().unwrap();
+        let key_pem = cert.write_private_key_pem().unwrap();
+        let identity = cert.write_identity_pem().unwrap();
+        vec![
+            cert_pem.path().to_path_buf(),
+            cert_der.path().to_path_buf(),
+            key_pem.path().to_path_buf(),
+            identity.path().to_path_buf(),
+        ]
+    };
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    for p in &paths {
+        assert!(
+            !p.exists(),
+            "X.509 tempfile should be cleaned up on drop: {p:?}"
+        );
+    }
+}
+
+// ===========================================================================
+// Concurrent tempfile writes from multiple threads (all key types)
+// ===========================================================================
+
+#[test]
+#[cfg(feature = "rsa")]
+fn rsa_concurrent_tempfile_writes() {
+    let factory = fx();
+    let handles: Vec<_> = (0..4)
+        .map(|i| {
+            let fx = factory.clone();
+            std::thread::spawn(move || {
+                let label = format!("sink-rsa-conc-{i}");
+                let kp = fx.rsa(&label, RsaSpec::rs256());
+                let priv_temp = kp.write_private_key_pkcs8_pem().unwrap();
+                let pub_temp = kp.write_public_key_spki_pem().unwrap();
+                assert!(priv_temp.path().exists());
+                assert!(pub_temp.path().exists());
+                (
+                    priv_temp.path().to_path_buf(),
+                    pub_temp.path().to_path_buf(),
+                    priv_temp,
+                    pub_temp,
+                )
+            })
+        })
+        .collect();
+
+    let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let all_paths: HashSet<_> = results
+        .iter()
+        .flat_map(|(a, b, _, _)| [a.clone(), b.clone()])
+        .collect();
+
+    assert_eq!(
+        all_paths.len(),
+        8,
+        "all concurrent tempfile paths must be unique"
+    );
+}
+
+#[test]
+#[cfg(all(feature = "ecdsa", feature = "ed25519"))]
+fn mixed_key_types_concurrent_tempfile_writes() {
+    let factory = fx();
+
+    let ec_handle = {
+        let fx = factory.clone();
+        std::thread::spawn(move || {
+            let kp = fx.ecdsa("sink-mixed-ec", EcdsaSpec::es256());
+            let temp = kp.write_private_key_pkcs8_pem().unwrap();
+            (temp.path().to_path_buf(), temp)
+        })
+    };
+
+    let ed_handle = {
+        let fx = factory.clone();
+        std::thread::spawn(move || {
+            let kp = fx.ed25519("sink-mixed-ed", Ed25519Spec::new());
+            let temp = kp.write_private_key_pkcs8_pem().unwrap();
+            (temp.path().to_path_buf(), temp)
+        })
+    };
+
+    let (ec_path, _ec_temp) = ec_handle.join().unwrap();
+    let (ed_path, _ed_temp) = ed_handle.join().unwrap();
+
+    assert_ne!(
+        ec_path, ed_path,
+        "different key type tempfiles must be distinct"
+    );
+}
+
+// ===========================================================================
+// Direct TempArtifact usage (re-exported from facade)
+// ===========================================================================
+
+#[test]
+fn temp_artifact_reexported_from_facade() {
+    let temp = TempArtifact::new_string("uk-facade-", ".pem", "facade-test-data").unwrap();
+    assert!(temp.path().exists());
+    assert_eq!(temp.read_to_string().unwrap(), "facade-test-data");
+}
+
+#[test]
+fn temp_artifact_debug_does_not_leak() {
+    let temp = TempArtifact::new_string("uk-facade-", ".pem", "SUPER_SECRET_KEY_MATERIAL").unwrap();
+    let dbg = format!("{temp:?}");
+    assert!(dbg.contains("TempArtifact"));
+    assert!(
+        !dbg.contains("SUPER_SECRET_KEY_MATERIAL"),
+        "debug must not leak key content"
+    );
+}


### PR DESCRIPTION
Adds 46 comprehensive tests for TempArtifact/sink across uselesskey-core-sink and the facade crate. Covers round-trips, drop cleanup, concurrency, path uniqueness, permissions, and all key types (RSA, ECDSA, Ed25519, X.509).