### PR TITLE
test: add trybuild compile-fail tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,6 +2840,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3098,6 +3107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,6 +3123,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3259,9 +3283,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.0.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3283,6 +3322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3290,7 +3338,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
@@ -3322,6 +3370,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -3418,6 +3472,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.0.3+spec-1.1.0",
+]
 
 [[package]]
 name = "twofish"
@@ -3969,7 +4038,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "toml",
+ "toml 0.8.23",
+ "trybuild",
  "uselesskey",
  "uselesskey-core",
  "uselesskey-ecdsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ proptest = "1.10.0"
 rstest = "0.26.1"
 insta = { version = "1", features = ["yaml", "redactions"] }
 criterion = { version = "0.5", default-features = false, features = ["html_reports", "cargo_bench_support"] }
+trybuild = "1"
 
 # CLI helpers (xtask)
 anyhow = "1.0.102"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -41,6 +41,9 @@ serde.workspace = true
 serde_json.workspace = true
 toml = "0.8"
 
+[dev-dependencies]
+trybuild.workspace = true
+
 [features]
 # JWT integration tests
 jwt = [
@@ -125,8 +128,11 @@ concurrency = [
     "dep:uselesskey-hmac",
 ]
 
-# All integration tests
-all = ["jwt", "tls", "crypto-backend", "e2e", "key-rotation", "cross-adapter", "determinism", "concurrency", "kid-stability"]
+# Compile-fail (trybuild) tests
+compile-fail = [
+    "dep:uselesskey-rsa",
+    "dep:uselesskey-ecdsa",
+]
 
 # KID stability and uniqueness tests
 kid-stability = [
@@ -136,6 +142,9 @@ kid-stability = [
     "dep:uselesskey-hmac",
     "dep:uselesskey-jwk",
 ]
+
+# All integration tests
+all = ["jwt", "tls", "crypto-backend", "e2e", "key-rotation", "cross-adapter", "determinism", "concurrency", "kid-stability", "compile-fail"]
 
 [[test]]
 name = "jwt_integration"
@@ -189,3 +198,8 @@ required-features = ["concurrency"]
 name = "kid_stability"
 path = "kid_stability.rs"
 required-features = ["kid-stability"]
+
+[[test]]
+name = "compile_tests"
+path = "compile_tests.rs"
+required-features = ["compile-fail"]

--- a/tests/compile_fail/dangling_pem_ref.rs
+++ b/tests/compile_fail/dangling_pem_ref.rs
@@ -1,0 +1,14 @@
+/// Verify that holding a reference to PEM data beyond the keypair's
+/// lifetime produces a clear borrow-checker error.
+use uselesskey_core::Factory;
+use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+fn main() {
+    let pem: &str;
+    {
+        let fx = Factory::random();
+        let kp = fx.ecdsa("test", EcdsaSpec::es256());
+        pem = kp.private_key_pkcs8_pem();
+    }
+    println!("{}", pem);
+}

--- a/tests/compile_fail/dangling_pem_ref.stderr
+++ b/tests/compile_fail/dangling_pem_ref.stderr
@@ -1,0 +1,11 @@
+error[E0597]: `kp` does not live long enough
+  --> compile_fail/dangling_pem_ref.rs:11:15
+   |
+10 |         let kp = fx.ecdsa("test", EcdsaSpec::es256());
+   |             -- binding `kp` declared here
+11 |         pem = kp.private_key_pkcs8_pem();
+   |               ^^ borrowed value does not live long enough
+12 |     }
+   |     - `kp` dropped here while still borrowed
+13 |     println!("{}", pem);
+   |                    --- borrow later used here

--- a/tests/compile_fail/missing_trait_import.rs
+++ b/tests/compile_fail/missing_trait_import.rs
@@ -1,0 +1,11 @@
+/// Verify that calling an extension method without importing the trait
+/// produces a clear "method not found" error, guiding the user to import
+/// the correct trait.
+use uselesskey_core::Factory;
+use uselesskey_rsa::RsaSpec;
+
+fn main() {
+    let fx = Factory::random();
+    // RsaFactoryExt is not imported — should fail with a helpful error.
+    let _kp = fx.rsa("test", RsaSpec::rs256());
+}

--- a/tests/compile_fail/missing_trait_import.stderr
+++ b/tests/compile_fail/missing_trait_import.stderr
@@ -1,0 +1,16 @@
+error[E0599]: no method named `rsa` found for struct `Factory` in the current scope
+  --> compile_fail/missing_trait_import.rs:10:18
+   |
+10 |     let _kp = fx.rsa("test", RsaSpec::rs256());
+   |                  ^^^ method not found in `Factory`
+   |
+  ::: $WORKSPACE/crates/uselesskey-rsa/src/keypair.rs
+   |
+   |     fn rsa(&self, label: impl AsRef<str>, spec: RsaSpec) -> RsaKeyPair;
+   |        --- the method is available for `Factory` here
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: trait `RsaFactoryExt` which provides `rsa` is implemented but not in scope; perhaps you want to import it
+   |
+ 1 + use uselesskey_rsa::RsaFactoryExt;
+   |

--- a/tests/compile_fail/wrong_spec_type.rs
+++ b/tests/compile_fail/wrong_spec_type.rs
@@ -1,0 +1,10 @@
+/// Verify that passing the wrong spec type (EcdsaSpec to rsa()) produces
+/// a clear compile-time type error.
+use uselesskey_core::Factory;
+use uselesskey_ecdsa::EcdsaSpec;
+use uselesskey_rsa::RsaFactoryExt;
+
+fn main() {
+    let fx = Factory::random();
+    let _kp = fx.rsa("test", EcdsaSpec::es256());
+}

--- a/tests/compile_fail/wrong_spec_type.stderr
+++ b/tests/compile_fail/wrong_spec_type.stderr
@@ -1,0 +1,13 @@
+error[E0308]: mismatched types
+ --> compile_fail/wrong_spec_type.rs:9:30
+  |
+9 |     let _kp = fx.rsa("test", EcdsaSpec::es256());
+  |                  ---         ^^^^^^^^^^^^^^^^^^ expected `RsaSpec`, found `EcdsaSpec`
+  |                  |
+  |                  arguments to this method are incorrect
+  |
+note: method defined here
+ --> $WORKSPACE/crates/uselesskey-rsa/src/keypair.rs
+  |
+  |     fn rsa(&self, label: impl AsRef<str>, spec: RsaSpec) -> RsaKeyPair;
+  |        ^^^

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -1,0 +1,5 @@
+#[test]
+fn compile_fail_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("compile_fail/*.rs");
+}


### PR DESCRIPTION
Adds trybuild compile-fail tests verifying type safety, lifetime safety, and feature gate error messages.