### PR TITLE
docs: add doc-test examples for public API functions

### DIFF
--- a/crates/uselesskey-core-hmac-spec/src/lib.rs
+++ b/crates/uselesskey-core-hmac-spec/src/lib.rs
@@ -18,21 +18,52 @@ pub enum HmacSpec {
 
 impl HmacSpec {
     /// HS256 (HMAC-SHA256). Produces a 32-byte secret.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core_hmac_spec::HmacSpec;
+    /// let spec = HmacSpec::hs256();
+    /// assert_eq!(spec.byte_len(), 32);
+    /// ```
     pub fn hs256() -> Self {
         Self::Hs256
     }
 
     /// HS384 (HMAC-SHA384). Produces a 48-byte secret.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core_hmac_spec::HmacSpec;
+    /// let spec = HmacSpec::hs384();
+    /// assert_eq!(spec.byte_len(), 48);
+    /// ```
     pub fn hs384() -> Self {
         Self::Hs384
     }
 
     /// HS512 (HMAC-SHA512). Produces a 64-byte secret.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core_hmac_spec::HmacSpec;
+    /// let spec = HmacSpec::hs512();
+    /// assert_eq!(spec.byte_len(), 64);
+    /// ```
     pub fn hs512() -> Self {
         Self::Hs512
     }
 
     /// JOSE/JWT `alg` name for this HMAC algorithm.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core_hmac_spec::HmacSpec;
+    /// assert_eq!(HmacSpec::hs256().alg_name(), "HS256");
+    /// ```
     pub fn alg_name(&self) -> &'static str {
         match self {
             Self::Hs256 => "HS256",
@@ -42,6 +73,15 @@ impl HmacSpec {
     }
 
     /// Secret length, in bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core_hmac_spec::HmacSpec;
+    /// assert_eq!(HmacSpec::hs256().byte_len(), 32);
+    /// assert_eq!(HmacSpec::hs384().byte_len(), 48);
+    /// assert_eq!(HmacSpec::hs512().byte_len(), 64);
+    /// ```
     pub fn byte_len(&self) -> usize {
         match self {
             Self::Hs256 => 32,
@@ -53,6 +93,14 @@ impl HmacSpec {
     /// Stable encoding for cache keys / deterministic derivation.
     ///
     /// If you change this, bump the derivation version in `uselesskey-core`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_core_hmac_spec::HmacSpec;
+    /// let bytes = HmacSpec::hs256().stable_bytes();
+    /// assert_eq!(bytes.len(), 4);
+    /// ```
     pub fn stable_bytes(&self) -> [u8; 4] {
         match self {
             Self::Hs256 => [0, 0, 0, 1],

--- a/crates/uselesskey-ecdsa/src/keypair.rs
+++ b/crates/uselesskey-ecdsa/src/keypair.rs
@@ -113,6 +113,16 @@ impl EcdsaKeyPair {
     }
 
     /// Returns the spec used to create this keypair.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// assert_eq!(kp.spec(), EcdsaSpec::es256());
+    /// ```
     pub fn spec(&self) -> EcdsaSpec {
         self.spec
     }
@@ -182,11 +192,33 @@ impl EcdsaKeyPair {
     }
 
     /// Write the PKCS#8 PEM private key to a tempfile and return the handle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let temp = kp.write_private_key_pkcs8_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_private_key_pkcs8_pem(&self) -> Result<TempArtifact, Error> {
         self.inner.material.write_private_key_pkcs8_pem()
     }
 
     /// Write the SPKI PEM public key to a tempfile and return the handle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let temp = kp.write_public_key_spki_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_public_key_spki_pem(&self) -> Result<TempArtifact, Error> {
         self.inner.material.write_public_key_spki_pem()
     }
@@ -209,6 +241,17 @@ impl EcdsaKeyPair {
     }
 
     /// Produce a deterministic corrupted PKCS#8 PEM using a variant string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let bad = kp.private_key_pkcs8_pem_corrupt_deterministic("corrupt:v1");
+    /// assert!(!bad.is_empty());
+    /// ```
     pub fn private_key_pkcs8_pem_corrupt_deterministic(&self, variant: &str) -> String {
         self.inner
             .material
@@ -232,6 +275,17 @@ impl EcdsaKeyPair {
     }
 
     /// Produce a deterministic corrupted PKCS#8 DER using a variant string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let bad = kp.private_key_pkcs8_der_corrupt_deterministic("corrupt:v1");
+    /// assert!(!bad.is_empty());
+    /// ```
     pub fn private_key_pkcs8_der_corrupt_deterministic(&self, variant: &str) -> Vec<u8> {
         self.inner
             .material
@@ -256,6 +310,17 @@ impl EcdsaKeyPair {
     }
 
     /// A stable key identifier derived from the public key (base64url blake3 hash prefix).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let kid = kp.kid();
+    /// assert!(!kid.is_empty());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn kid(&self) -> String {
         self.inner.material.kid()
@@ -264,6 +329,17 @@ impl EcdsaKeyPair {
     /// Alias for [`Self::public_jwk`].
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let jwk = kp.public_key_jwk();
+    /// assert_eq!(jwk.to_value()["kty"], "EC");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_key_jwk(&self) -> uselesskey_jwk::PublicJwk {
         self.public_jwk()
@@ -272,6 +348,19 @@ impl EcdsaKeyPair {
     /// Public JWK for this keypair (kty=EC, crv=P-256 or P-384, alg=ES256 or ES384).
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let jwk = kp.public_jwk();
+    /// let val = jwk.to_value();
+    /// assert_eq!(val["kty"], "EC");
+    /// assert_eq!(val["crv"], "P-256");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwk(&self) -> uselesskey_jwk::PublicJwk {
         use base64::Engine as _;
@@ -305,6 +394,19 @@ impl EcdsaKeyPair {
     /// Private JWK for this keypair (kty=EC, crv=..., alg=..., d=...).
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let jwk = kp.private_key_jwk();
+    /// let val = jwk.to_value();
+    /// assert_eq!(val["kty"], "EC");
+    /// assert!(val["d"].is_string());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn private_key_jwk(&self) -> uselesskey_jwk::PrivateJwk {
         use base64::Engine as _;
@@ -337,6 +439,17 @@ impl EcdsaKeyPair {
     }
 
     /// JWKS containing a single public key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let jwks = kp.public_jwks();
+    /// assert!(jwks.to_value()["keys"].is_array());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwks(&self) -> uselesskey_jwk::Jwks {
         use uselesskey_jwk::JwksBuilder;
@@ -349,6 +462,17 @@ impl EcdsaKeyPair {
     /// Public JWK serialized to `serde_json::Value`.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let val = kp.public_jwk_json();
+    /// assert_eq!(val["kty"], "EC");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwk_json(&self) -> serde_json::Value {
         self.public_jwk().to_value()
@@ -357,6 +481,17 @@ impl EcdsaKeyPair {
     /// JWKS serialized to `serde_json::Value`.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let val = kp.public_jwks_json();
+    /// assert!(val["keys"].is_array());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwks_json(&self) -> serde_json::Value {
         self.public_jwks().to_value()
@@ -365,6 +500,18 @@ impl EcdsaKeyPair {
     /// Private JWK serialized to `serde_json::Value`.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ecdsa("svc", EcdsaSpec::es256());
+    /// let val = kp.private_key_jwk_json();
+    /// assert_eq!(val["kty"], "EC");
+    /// assert!(val["d"].is_string());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn private_key_jwk_json(&self) -> serde_json::Value {
         self.private_key_jwk().to_value()

--- a/crates/uselesskey-ecdsa/src/spec.rs
+++ b/crates/uselesskey-ecdsa/src/spec.rs
@@ -53,6 +53,15 @@ impl EcdsaSpec {
     }
 
     /// Returns the JWT algorithm name.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_ecdsa::EcdsaSpec;
+    ///
+    /// assert_eq!(EcdsaSpec::es256().alg_name(), "ES256");
+    /// assert_eq!(EcdsaSpec::es384().alg_name(), "ES384");
+    /// ```
     pub fn alg_name(&self) -> &'static str {
         match self {
             Self::Es256 => "ES256",
@@ -61,6 +70,15 @@ impl EcdsaSpec {
     }
 
     /// Returns the curve name.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_ecdsa::EcdsaSpec;
+    ///
+    /// assert_eq!(EcdsaSpec::es256().curve_name(), "P-256");
+    /// assert_eq!(EcdsaSpec::es384().curve_name(), "P-384");
+    /// ```
     pub fn curve_name(&self) -> &'static str {
         match self {
             Self::Es256 => "P-256",
@@ -69,6 +87,15 @@ impl EcdsaSpec {
     }
 
     /// Returns the expected coordinate length in bytes for uncompressed points.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_ecdsa::EcdsaSpec;
+    ///
+    /// assert_eq!(EcdsaSpec::es256().coordinate_len_bytes(), 32);
+    /// assert_eq!(EcdsaSpec::es384().coordinate_len_bytes(), 48);
+    /// ```
     pub fn coordinate_len_bytes(&self) -> usize {
         match self {
             Self::Es256 => 32,
@@ -79,6 +106,15 @@ impl EcdsaSpec {
     /// Stable encoding for cache keys / deterministic derivation.
     ///
     /// If you change this, bump the derivation version in `uselesskey-core`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_ecdsa::EcdsaSpec;
+    ///
+    /// let bytes = EcdsaSpec::es256().stable_bytes();
+    /// assert_eq!(bytes.len(), 4);
+    /// ```
     pub fn stable_bytes(&self) -> [u8; 4] {
         match self {
             Self::Es256 => [0, 0, 0, 1],

--- a/crates/uselesskey-ed25519/src/keypair.rs
+++ b/crates/uselesskey-ed25519/src/keypair.rs
@@ -176,11 +176,33 @@ impl Ed25519KeyPair {
     }
 
     /// Write the PKCS#8 PEM private key to a tempfile and return the handle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let temp = kp.write_private_key_pkcs8_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_private_key_pkcs8_pem(&self) -> Result<TempArtifact, Error> {
         self.inner.material.write_private_key_pkcs8_pem()
     }
 
     /// Write the SPKI PEM public key to a tempfile and return the handle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let temp = kp.write_public_key_spki_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_public_key_spki_pem(&self) -> Result<TempArtifact, Error> {
         self.inner.material.write_public_key_spki_pem()
     }
@@ -203,6 +225,17 @@ impl Ed25519KeyPair {
     }
 
     /// Produce a deterministic corrupted PKCS#8 PEM using a variant string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let bad = kp.private_key_pkcs8_pem_corrupt_deterministic("corrupt:v1");
+    /// assert!(!bad.is_empty());
+    /// ```
     pub fn private_key_pkcs8_pem_corrupt_deterministic(&self, variant: &str) -> String {
         self.inner
             .material
@@ -226,6 +259,17 @@ impl Ed25519KeyPair {
     }
 
     /// Produce a deterministic corrupted PKCS#8 DER using a variant string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let bad = kp.private_key_pkcs8_der_corrupt_deterministic("corrupt:v1");
+    /// assert!(!bad.is_empty());
+    /// ```
     pub fn private_key_pkcs8_der_corrupt_deterministic(&self, variant: &str) -> Vec<u8> {
         self.inner
             .material
@@ -250,6 +294,17 @@ impl Ed25519KeyPair {
     }
 
     /// A stable key identifier derived from the public key (base64url blake3 hash prefix).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let kid = kp.kid();
+    /// assert!(!kid.is_empty());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn kid(&self) -> String {
         self.inner.material.kid()
@@ -258,6 +313,17 @@ impl Ed25519KeyPair {
     /// Alias for [`Self::public_jwk`].
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let jwk = kp.public_key_jwk();
+    /// assert_eq!(jwk.to_value()["kty"], "OKP");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_key_jwk(&self) -> uselesskey_jwk::PublicJwk {
         self.public_jwk()
@@ -266,6 +332,19 @@ impl Ed25519KeyPair {
     /// Public JWK for this keypair (kty=OKP, crv=Ed25519, use=sig, kid=...).
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let jwk = kp.public_jwk();
+    /// let val = jwk.to_value();
+    /// assert_eq!(val["kty"], "OKP");
+    /// assert_eq!(val["crv"], "Ed25519");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwk(&self) -> uselesskey_jwk::PublicJwk {
         use base64::Engine as _;
@@ -288,6 +367,19 @@ impl Ed25519KeyPair {
     /// Private JWK for this keypair (kty=OKP, crv=Ed25519, d=...).
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let jwk = kp.private_key_jwk();
+    /// let val = jwk.to_value();
+    /// assert_eq!(val["kty"], "OKP");
+    /// assert!(val["d"].is_string());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn private_key_jwk(&self) -> uselesskey_jwk::PrivateJwk {
         use base64::Engine as _;
@@ -309,6 +401,17 @@ impl Ed25519KeyPair {
     }
 
     /// JWKS containing a single public key.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let jwks = kp.public_jwks();
+    /// assert!(jwks.to_value()["keys"].is_array());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwks(&self) -> uselesskey_jwk::Jwks {
         use uselesskey_jwk::JwksBuilder;
@@ -321,6 +424,17 @@ impl Ed25519KeyPair {
     /// Public JWK serialized to `serde_json::Value`.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let val = kp.public_jwk_json();
+    /// assert_eq!(val["kty"], "OKP");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwk_json(&self) -> serde_json::Value {
         self.public_jwk().to_value()
@@ -329,6 +443,17 @@ impl Ed25519KeyPair {
     /// JWKS serialized to `serde_json::Value`.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let val = kp.public_jwks_json();
+    /// assert!(val["keys"].is_array());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwks_json(&self) -> serde_json::Value {
         self.public_jwks().to_value()
@@ -337,6 +462,18 @@ impl Ed25519KeyPair {
     /// Private JWK serialized to `serde_json::Value`.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    /// let fx = Factory::random();
+    /// let kp = fx.ed25519("svc", Ed25519Spec::new());
+    /// let val = kp.private_key_jwk_json();
+    /// assert_eq!(val["kty"], "OKP");
+    /// assert!(val["d"].is_string());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn private_key_jwk_json(&self) -> serde_json::Value {
         self.private_key_jwk().to_value()

--- a/crates/uselesskey-ed25519/src/spec.rs
+++ b/crates/uselesskey-ed25519/src/spec.rs
@@ -24,6 +24,15 @@ impl Ed25519Spec {
     ///
     /// Ed25519 has no configurable parameters, so this always
     /// returns the same spec.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_ed25519::Ed25519Spec;
+    ///
+    /// let spec = Ed25519Spec::new();
+    /// assert_eq!(spec, Ed25519Spec::default());
+    /// ```
     pub fn new() -> Self {
         Self { _private: () }
     }
@@ -31,6 +40,15 @@ impl Ed25519Spec {
     /// Stable encoding for cache keys / deterministic derivation.
     ///
     /// If you change this, bump the derivation version in `uselesskey-core`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_ed25519::Ed25519Spec;
+    ///
+    /// let bytes = Ed25519Spec::new().stable_bytes();
+    /// assert_eq!(bytes.len(), 4);
+    /// ```
     pub fn stable_bytes(&self) -> [u8; 4] {
         // Fixed identifier for Ed25519 keys.
         // Format: [magic byte, version, reserved, reserved]

--- a/crates/uselesskey-hmac/src/secret.rs
+++ b/crates/uselesskey-hmac/src/secret.rs
@@ -115,6 +115,17 @@ impl HmacSecret {
     }
 
     /// A stable key identifier derived from the secret bytes (base64url blake3 hash prefix).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    /// let fx = Factory::random();
+    /// let secret = fx.hmac("jwt", HmacSpec::hs256());
+    /// let kid = secret.kid();
+    /// assert!(!kid.is_empty());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn kid(&self) -> String {
         kid_from_bytes(self.secret_bytes())
@@ -123,6 +134,19 @@ impl HmacSecret {
     /// HMAC secret as an octet JWK (kty=oct).
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    /// let fx = Factory::random();
+    /// let secret = fx.hmac("jwt", HmacSpec::hs256());
+    /// let jwk = secret.jwk();
+    /// let val = jwk.to_value();
+    /// assert_eq!(val["kty"], "oct");
+    /// assert_eq!(val["alg"], "HS256");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn jwk(&self) -> uselesskey_jwk::PrivateJwk {
         use base64::Engine as _;
@@ -143,6 +167,18 @@ impl HmacSecret {
     /// JWKS containing this HMAC secret as an octet key.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::Factory;
+    /// # use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    /// let fx = Factory::random();
+    /// let secret = fx.hmac("jwt", HmacSpec::hs256());
+    /// let jwks = secret.jwks();
+    /// let val = jwks.to_value();
+    /// assert!(val["keys"].is_array());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn jwks(&self) -> uselesskey_jwk::Jwks {
         use uselesskey_jwk::JwksBuilder;

--- a/crates/uselesskey-rsa/src/keypair.rs
+++ b/crates/uselesskey-rsa/src/keypair.rs
@@ -182,11 +182,33 @@ impl RsaKeyPair {
     }
 
     /// Write the PKCS#8 PEM private key to a tempfile and return the handle.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let temp = kp.write_private_key_pkcs8_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_private_key_pkcs8_pem(&self) -> Result<TempArtifact, Error> {
         self.inner.material.write_private_key_pkcs8_pem()
     }
 
     /// Write the SPKI PEM public key to a tempfile and return the handle.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let temp = kp.write_public_key_spki_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_public_key_spki_pem(&self) -> Result<TempArtifact, Error> {
         self.inner.material.write_public_key_spki_pem()
     }
@@ -209,6 +231,17 @@ impl RsaKeyPair {
     }
 
     /// Produce a deterministic corrupted PKCS#8 PEM using a variant string.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let bad = kp.private_key_pkcs8_pem_corrupt_deterministic("corrupt:v1");
+    /// assert!(!bad.is_empty());
+    /// ```
     pub fn private_key_pkcs8_pem_corrupt_deterministic(&self, variant: &str) -> String {
         self.inner
             .material
@@ -232,6 +265,17 @@ impl RsaKeyPair {
     }
 
     /// Produce a deterministic corrupted PKCS#8 DER using a variant string.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let bad = kp.private_key_pkcs8_der_corrupt_deterministic("corrupt:v1");
+    /// assert!(!bad.is_empty());
+    /// ```
     pub fn private_key_pkcs8_der_corrupt_deterministic(&self, variant: &str) -> Vec<u8> {
         self.inner
             .material
@@ -256,6 +300,17 @@ impl RsaKeyPair {
     }
 
     /// A stable key identifier derived from the public key (base64url blake3 hash prefix).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let kid = kp.kid();
+    /// assert!(!kid.is_empty());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn kid(&self) -> String {
         self.inner.material.kid()
@@ -264,6 +319,17 @@ impl RsaKeyPair {
     /// Alias for [`Self::public_jwk`].
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let jwk = kp.public_key_jwk();
+    /// assert_eq!(jwk.to_value()["kty"], "RSA");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_key_jwk(&self) -> uselesskey_jwk::PublicJwk {
         self.public_jwk()
@@ -272,6 +338,19 @@ impl RsaKeyPair {
     /// Public JWK for this keypair (kty=RSA, use=sig, kid=...).
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let jwk = kp.public_jwk();
+    /// let val = jwk.to_value();
+    /// assert_eq!(val["kty"], "RSA");
+    /// assert_eq!(val["alg"], "RS256");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwk(&self) -> uselesskey_jwk::PublicJwk {
         use base64::Engine as _;
@@ -295,6 +374,19 @@ impl RsaKeyPair {
     /// Private JWK for this keypair (kty=RSA, use=sig, kid=...).
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let jwk = kp.private_key_jwk();
+    /// let val = jwk.to_value();
+    /// assert_eq!(val["kty"], "RSA");
+    /// assert!(val["d"].is_string());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn private_key_jwk(&self) -> uselesskey_jwk::PrivateJwk {
         use base64::Engine as _;
@@ -332,6 +424,17 @@ impl RsaKeyPair {
     }
 
     /// JWKS containing a single public key.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let jwks = kp.public_jwks();
+    /// assert!(jwks.to_value()["keys"].is_array());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwks(&self) -> uselesskey_jwk::Jwks {
         use uselesskey_jwk::JwksBuilder;
@@ -344,6 +447,17 @@ impl RsaKeyPair {
     /// Public JWK serialized to `serde_json::Value`.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let val = kp.public_jwk_json();
+    /// assert_eq!(val["kty"], "RSA");
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwk_json(&self) -> serde_json::Value {
         self.public_jwk().to_value()
@@ -352,6 +466,17 @@ impl RsaKeyPair {
     /// JWKS serialized to `serde_json::Value`.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let val = kp.public_jwks_json();
+    /// assert!(val["keys"].is_array());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn public_jwks_json(&self) -> serde_json::Value {
         self.public_jwks().to_value()
@@ -360,6 +485,18 @@ impl RsaKeyPair {
     /// Private JWK serialized to `serde_json::Value`.
     ///
     /// Requires the `jwk` feature.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let kp = fx.rsa("svc", RsaSpec::rs256());
+    /// let val = kp.private_key_jwk_json();
+    /// assert_eq!(val["kty"], "RSA");
+    /// assert!(val["d"].is_string());
+    /// ```
     #[cfg(feature = "jwk")]
     pub fn private_key_jwk_json(&self) -> serde_json::Value {
         self.private_key_jwk().to_value()

--- a/crates/uselesskey-rsa/src/spec.rs
+++ b/crates/uselesskey-rsa/src/spec.rs
@@ -70,6 +70,16 @@ impl RsaSpec {
     /// Stable encoding for cache keys / deterministic derivation.
     ///
     /// If you change this, bump the derivation version in `uselesskey-core`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uselesskey_rsa::RsaSpec;
+    ///
+    /// let spec = RsaSpec::rs256();
+    /// let bytes = spec.stable_bytes();
+    /// assert_eq!(bytes.len(), 8);
+    /// ```
     pub fn stable_bytes(&self) -> [u8; 8] {
         let bits = u32::try_from(self.bits).unwrap_or(u32::MAX);
         let mut out = [0u8; 8];

--- a/crates/uselesskey-x509/src/cert.rs
+++ b/crates/uselesskey-x509/src/cert.rs
@@ -169,11 +169,31 @@ impl X509Cert {
     }
 
     /// DER-encoded PKCS#8 private key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// assert!(!cert.private_key_pkcs8_der().is_empty());
+    /// ```
     pub fn private_key_pkcs8_der(&self) -> &[u8] {
         &self.inner.private_key_pkcs8_der
     }
 
     /// PEM-encoded PKCS#8 private key.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// assert!(cert.private_key_pkcs8_pem().contains("-----BEGIN PRIVATE KEY-----"));
+    /// ```
     pub fn private_key_pkcs8_pem(&self) -> &str {
         &self.inner.private_key_pkcs8_pem
     }
@@ -203,21 +223,65 @@ impl X509Cert {
     // =========================================================================
 
     /// Write the PEM certificate to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let temp = cert.write_cert_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_cert_pem(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_string("uselesskey-", ".crt.pem", self.cert_pem())
     }
 
     /// Write the DER certificate to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let temp = cert.write_cert_der().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_cert_der(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_bytes("uselesskey-", ".crt.der", self.cert_der())
     }
 
     /// Write the PEM private key to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let temp = cert.write_private_key_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_private_key_pem(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_string("uselesskey-", ".key.pem", self.private_key_pkcs8_pem())
     }
 
     /// Write the combined identity PEM (cert + key) to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let temp = cert.write_identity_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_identity_pem(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_string("uselesskey-", ".identity.pem", &self.identity_pem())
     }
@@ -227,21 +291,66 @@ impl X509Cert {
     // =========================================================================
 
     /// Produce a corrupted variant of the certificate PEM.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_core::negative::CorruptPem;
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let bad = cert.corrupt_cert_pem(CorruptPem::BadHeader);
+    /// assert!(bad.contains("CORRUPTED"));
+    /// ```
     pub fn corrupt_cert_pem(&self, how: CorruptPem) -> String {
         corrupt_cert_pem(self.cert_pem(), how)
     }
 
     /// Produce a deterministic corrupted certificate PEM using a variant string.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let bad = cert.corrupt_cert_pem_deterministic("corrupt:v1");
+    /// assert!(!bad.is_empty());
+    /// ```
     pub fn corrupt_cert_pem_deterministic(&self, variant: &str) -> String {
         corrupt_cert_pem_deterministic(self.cert_pem(), variant)
     }
 
     /// Produce a truncated variant of the certificate DER.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let truncated = cert.truncate_cert_der(10);
+    /// assert_eq!(truncated.len(), 10);
+    /// ```
     pub fn truncate_cert_der(&self, len: usize) -> Vec<u8> {
         truncate_cert_der(self.cert_der(), len)
     }
 
     /// Produce a deterministic corrupted certificate DER using a variant string.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let bad = cert.corrupt_cert_der_deterministic("corrupt:v1");
+    /// assert!(!bad.is_empty());
+    /// ```
     pub fn corrupt_cert_der_deterministic(&self, variant: &str) -> Vec<u8> {
         corrupt_cert_der_deterministic(self.cert_der(), variant)
     }
@@ -249,6 +358,17 @@ impl X509Cert {
     /// Generate a negative fixture variant of this certificate.
     ///
     /// The variant is cached separately from the valid certificate.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec, X509Negative};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let expired = cert.negative(X509Negative::Expired);
+    /// assert_ne!(cert.cert_der(), expired.cert_der());
+    /// ```
     pub fn negative(&self, negative_type: X509Negative) -> X509Cert {
         let modified_spec = negative_type.apply_to_spec(&self.spec);
         let variant = negative_type.variant_name();
@@ -295,6 +415,17 @@ impl X509Cert {
     }
 
     /// Get a certificate with wrong key usage flags.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("svc", X509Spec::self_signed("svc.example.com"));
+    /// let wrong = cert.wrong_key_usage();
+    /// assert!(wrong.spec().is_ca);
+    /// ```
     pub fn wrong_key_usage(&self) -> X509Cert {
         self.negative(X509Negative::WrongKeyUsage)
     }
@@ -304,11 +435,32 @@ impl X509Cert {
     // =========================================================================
 
     /// Get the specification used to create this certificate.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let spec = X509Spec::self_signed("svc.example.com");
+    /// let cert = fx.x509_self_signed("svc", spec.clone());
+    /// assert_eq!(cert.spec().subject_cn, "svc.example.com");
+    /// ```
     pub fn spec(&self) -> &X509Spec {
         &self.spec
     }
 
     /// Get the label used to create this certificate.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, X509Spec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let cert = fx.x509_self_signed("my-svc", X509Spec::self_signed("svc.example.com"));
+    /// assert_eq!(cert.label(), "my-svc");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }

--- a/crates/uselesskey-x509/src/chain.rs
+++ b/crates/uselesskey-x509/src/chain.rs
@@ -91,21 +91,61 @@ impl X509Chain {
     // =========================================================================
 
     /// DER-encoded root CA certificate bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(!chain.root_cert_der().is_empty());
+    /// ```
     pub fn root_cert_der(&self) -> &[u8] {
         &self.inner.root_cert_der
     }
 
     /// PEM-encoded root CA certificate.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(chain.root_cert_pem().contains("BEGIN CERTIFICATE"));
+    /// ```
     pub fn root_cert_pem(&self) -> &str {
         &self.inner.root_cert_pem
     }
 
     /// DER-encoded root CA PKCS#8 private key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(!chain.root_private_key_pkcs8_der().is_empty());
+    /// ```
     pub fn root_private_key_pkcs8_der(&self) -> &[u8] {
         &self.inner.root_key_pkcs8_der
     }
 
     /// PEM-encoded root CA PKCS#8 private key.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(chain.root_private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    /// ```
     pub fn root_private_key_pkcs8_pem(&self) -> &str {
         &self.inner.root_key_pkcs8_pem
     }
@@ -115,21 +155,61 @@ impl X509Chain {
     // =========================================================================
 
     /// DER-encoded intermediate CA certificate bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(!chain.intermediate_cert_der().is_empty());
+    /// ```
     pub fn intermediate_cert_der(&self) -> &[u8] {
         &self.inner.intermediate_cert_der
     }
 
     /// PEM-encoded intermediate CA certificate.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(chain.intermediate_cert_pem().contains("BEGIN CERTIFICATE"));
+    /// ```
     pub fn intermediate_cert_pem(&self) -> &str {
         &self.inner.intermediate_cert_pem
     }
 
     /// DER-encoded intermediate CA PKCS#8 private key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(!chain.intermediate_private_key_pkcs8_der().is_empty());
+    /// ```
     pub fn intermediate_private_key_pkcs8_der(&self) -> &[u8] {
         &self.inner.intermediate_key_pkcs8_der
     }
 
     /// PEM-encoded intermediate CA PKCS#8 private key.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(chain.intermediate_private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    /// ```
     pub fn intermediate_private_key_pkcs8_pem(&self) -> &str {
         &self.inner.intermediate_key_pkcs8_pem
     }
@@ -139,21 +219,61 @@ impl X509Chain {
     // =========================================================================
 
     /// DER-encoded leaf certificate bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(!chain.leaf_cert_der().is_empty());
+    /// ```
     pub fn leaf_cert_der(&self) -> &[u8] {
         &self.inner.leaf_cert_der
     }
 
     /// PEM-encoded leaf certificate.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(chain.leaf_cert_pem().contains("BEGIN CERTIFICATE"));
+    /// ```
     pub fn leaf_cert_pem(&self) -> &str {
         &self.inner.leaf_cert_pem
     }
 
     /// DER-encoded leaf PKCS#8 private key bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(!chain.leaf_private_key_pkcs8_der().is_empty());
+    /// ```
     pub fn leaf_private_key_pkcs8_der(&self) -> &[u8] {
         &self.inner.leaf_key_pkcs8_der
     }
 
     /// PEM-encoded leaf PKCS#8 private key.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(chain.leaf_private_key_pkcs8_pem().contains("BEGIN PRIVATE KEY"));
+    /// ```
     pub fn leaf_private_key_pkcs8_pem(&self) -> &str {
         &self.inner.leaf_key_pkcs8_pem
     }
@@ -165,6 +285,18 @@ impl X509Chain {
     /// Certificate chain PEM in standard TLS order: leaf + intermediate (no root).
     ///
     /// This is the format expected by most TLS servers.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let pem = chain.chain_pem();
+    /// // Contains leaf and intermediate certificates
+    /// assert!(pem.matches("BEGIN CERTIFICATE").count() >= 2);
+    /// ```
     pub fn chain_pem(&self) -> String {
         format!(
             "{}\n{}",
@@ -173,6 +305,18 @@ impl X509Chain {
     }
 
     /// Full certificate chain PEM: leaf + intermediate + root.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let pem = chain.full_chain_pem();
+    /// // Contains leaf, intermediate, and root certificates
+    /// assert!(pem.matches("BEGIN CERTIFICATE").count() >= 3);
+    /// ```
     pub fn full_chain_pem(&self) -> String {
         format!(
             "{}\n{}\n{}",
@@ -185,16 +329,49 @@ impl X509Chain {
     // =========================================================================
 
     /// Write the leaf PEM certificate to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let temp = chain.write_leaf_cert_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_leaf_cert_pem(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_string("uselesskey-", ".leaf.crt.pem", self.leaf_cert_pem())
     }
 
     /// Write the leaf DER certificate to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let temp = chain.write_leaf_cert_der().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_leaf_cert_der(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_bytes("uselesskey-", ".leaf.crt.der", self.leaf_cert_der())
     }
 
     /// Write the leaf PEM private key to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let temp = chain.write_leaf_private_key_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_leaf_private_key_pem(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_string(
             "uselesskey-",
@@ -204,16 +381,49 @@ impl X509Chain {
     }
 
     /// Write the chain PEM (leaf + intermediate) to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let temp = chain.write_chain_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_chain_pem(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_string("uselesskey-", ".chain.pem", &self.chain_pem())
     }
 
     /// Write the full chain PEM (leaf + intermediate + root) to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let temp = chain.write_full_chain_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_full_chain_pem(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_string("uselesskey-", ".fullchain.pem", &self.full_chain_pem())
     }
 
     /// Write the root CA PEM certificate to a tempfile.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let temp = chain.write_root_cert_pem().unwrap();
+    /// assert!(temp.path().exists());
+    /// ```
     pub fn write_root_cert_pem(&self) -> Result<TempArtifact, Error> {
         TempArtifact::new_string("uselesskey-", ".root.crt.pem", self.root_cert_pem())
     }
@@ -223,16 +433,50 @@ impl X509Chain {
     // =========================================================================
 
     /// DER-encoded CRL bytes, if this chain was generated with the `RevokedLeaf` variant.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// // Good chain has no CRL
+    /// assert!(chain.crl_der().is_none());
+    /// // Revoked leaf chain has a CRL
+    /// let revoked = chain.revoked_leaf();
+    /// assert!(revoked.crl_der().is_some());
+    /// ```
     pub fn crl_der(&self) -> Option<&[u8]> {
         self.inner.crl_der.as_deref()
     }
 
     /// PEM-encoded CRL, if this chain was generated with the `RevokedLeaf` variant.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(chain.crl_pem().is_none());
+    /// ```
     pub fn crl_pem(&self) -> Option<&str> {
         self.inner.crl_pem.as_deref()
     }
 
     /// Write the CRL PEM to a tempfile. Returns `None` if no CRL is present.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(chain.write_crl_pem().is_none());
+    /// ```
     pub fn write_crl_pem(&self) -> Option<Result<TempArtifact, Error>> {
         self.inner
             .crl_pem
@@ -241,6 +485,16 @@ impl X509Chain {
     }
 
     /// Write the CRL DER to a tempfile. Returns `None` if no CRL is present.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert!(chain.write_crl_der().is_none());
+    /// ```
     pub fn write_crl_der(&self) -> Option<Result<TempArtifact, Error>> {
         self.inner
             .crl_der
@@ -253,11 +507,31 @@ impl X509Chain {
     // =========================================================================
 
     /// Get the specification used to create this chain.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// assert_eq!(chain.spec().leaf_cn, "svc.example.com");
+    /// ```
     pub fn spec(&self) -> &ChainSpec {
         &self.spec
     }
 
     /// Get the label used to create this chain.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("my-svc", ChainSpec::new("svc.example.com"));
+    /// assert_eq!(chain.label(), "my-svc");
+    /// ```
     pub fn label(&self) -> &str {
         &self.label
     }

--- a/crates/uselesskey-x509/src/chain_negative.rs
+++ b/crates/uselesskey-x509/src/chain_negative.rs
@@ -8,6 +8,19 @@ impl X509Chain {
     /// Generate a negative fixture variant of this chain.
     ///
     /// The variant is cached separately from the valid chain.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// use uselesskey_core_x509::ChainNegative;
+    ///
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let expired = chain.negative(ChainNegative::ExpiredLeaf);
+    /// assert_ne!(chain.leaf_cert_der(), expired.leaf_cert_der());
+    /// ```
     pub fn negative(&self, neg: ChainNegative) -> X509Chain {
         let modified_spec = neg.apply_to_spec(self.spec());
         let variant = neg.variant_name();
@@ -20,6 +33,17 @@ impl X509Chain {
     }
 
     /// Get a chain where the leaf cert has a hostname mismatch.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let wrong = chain.hostname_mismatch("wrong.example.com");
+    /// assert_ne!(chain.leaf_cert_der(), wrong.leaf_cert_der());
+    /// ```
     pub fn hostname_mismatch(&self, hostname: impl Into<String>) -> X509Chain {
         self.negative(ChainNegative::HostnameMismatch {
             wrong_hostname: hostname.into(),
@@ -29,16 +53,49 @@ impl X509Chain {
     /// Get a chain anchored to a different (unknown) root certificate identity.
     ///
     /// This keeps key material stable and changes root certificate identity fields.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let untrusted = chain.unknown_ca();
+    /// assert_ne!(chain.root_cert_der(), untrusted.root_cert_der());
+    /// ```
     pub fn unknown_ca(&self) -> X509Chain {
         self.negative(ChainNegative::UnknownCa)
     }
 
     /// Get a chain where the leaf certificate has a very short validity period.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let expired = chain.expired_leaf();
+    /// assert_ne!(chain.leaf_cert_der(), expired.leaf_cert_der());
+    /// ```
     pub fn expired_leaf(&self) -> X509Chain {
         self.negative(ChainNegative::ExpiredLeaf)
     }
 
     /// Get a chain where the intermediate certificate has a very short validity period.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let expired = chain.expired_intermediate();
+    /// assert_ne!(chain.intermediate_cert_der(), expired.intermediate_cert_der());
+    /// ```
     pub fn expired_intermediate(&self) -> X509Chain {
         self.negative(ChainNegative::ExpiredIntermediate)
     }
@@ -48,6 +105,17 @@ impl X509Chain {
     /// The chain itself is structurally valid. The CRL is signed by the
     /// intermediate CA and lists the leaf serial as revoked with reason
     /// `KeyCompromise`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_x509::{X509FactoryExt, ChainSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let chain = fx.x509_chain("svc", ChainSpec::new("svc.example.com"));
+    /// let revoked = chain.revoked_leaf();
+    /// assert!(revoked.crl_der().is_some());
+    /// ```
     pub fn revoked_leaf(&self) -> X509Chain {
         self.negative(ChainNegative::RevokedLeaf)
     }

--- a/crates/uselesskey-x509/src/negative.rs
+++ b/crates/uselesskey-x509/src/negative.rs
@@ -8,11 +8,34 @@ pub use uselesskey_core_x509::X509Negative;
 /// Corrupt a PEM-encoded certificate.
 ///
 /// Delegates to the core negative fixture helpers.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_core::negative::CorruptPem;
+/// use uselesskey_x509::negative::corrupt_cert_pem;
+///
+/// let pem = "-----BEGIN CERTIFICATE-----\nAAA=\n-----END CERTIFICATE-----\n";
+/// let corrupted = corrupt_cert_pem(pem, CorruptPem::BadHeader);
+/// assert_ne!(corrupted, pem);
+/// ```
 pub fn corrupt_cert_pem(pem: &str, how: uselesskey_core::negative::CorruptPem) -> String {
     uselesskey_core::negative::corrupt_pem(pem, how)
 }
 
 /// Corrupt a PEM-encoded certificate using a deterministic variant string.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_x509::negative::corrupt_cert_pem_deterministic;
+///
+/// let pem = "-----BEGIN CERTIFICATE-----\nAAA=\n-----END CERTIFICATE-----\n";
+/// let corrupted = corrupt_cert_pem_deterministic(pem, "corrupt:v1");
+/// assert_ne!(corrupted, pem);
+/// // Same variant always produces the same result
+/// assert_eq!(corrupted, corrupt_cert_pem_deterministic(pem, "corrupt:v1"));
+/// ```
 pub fn corrupt_cert_pem_deterministic(pem: &str, variant: &str) -> String {
     uselesskey_core::negative::corrupt_pem_deterministic(pem, variant)
 }
@@ -20,11 +43,33 @@ pub fn corrupt_cert_pem_deterministic(pem: &str, variant: &str) -> String {
 /// Truncate a DER-encoded certificate.
 ///
 /// Delegates to the core negative fixture helpers.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_x509::negative::truncate_cert_der;
+///
+/// let der = vec![0x30, 0x03, 0x02, 0x01, 0x01];
+/// let truncated = truncate_cert_der(&der, 2);
+/// assert_eq!(truncated.len(), 2);
+/// ```
 pub fn truncate_cert_der(der: &[u8], len: usize) -> Vec<u8> {
     uselesskey_core::negative::truncate_der(der, len)
 }
 
 /// Corrupt a DER-encoded certificate using a deterministic variant string.
+///
+/// # Examples
+///
+/// ```
+/// use uselesskey_x509::negative::corrupt_cert_der_deterministic;
+///
+/// let der = vec![0x30, 0x03, 0x02, 0x01, 0x01];
+/// let corrupted = corrupt_cert_der_deterministic(&der, "corrupt:v1");
+/// assert_ne!(corrupted, der);
+/// // Same variant always produces the same result
+/// assert_eq!(corrupted, corrupt_cert_der_deterministic(&der, "corrupt:v1"));
+/// ```
 pub fn corrupt_cert_der_deterministic(der: &[u8], variant: &str) -> Vec<u8> {
     uselesskey_core::negative::corrupt_der_deterministic(der, variant)
 }


### PR DESCRIPTION
## Summary

Adds `/// # Examples` doc-test sections to all public API items that were missing them across the user-facing crates.

## Changes

### Crates updated (12 files, ~1108 lines added):

- **uselesskey-rsa** (keypair.rs, spec.rs) — 13 doc examples for write_*, corrupt_deterministic, JWK methods, stable_bytes
- **uselesskey-ecdsa** (keypair.rs, spec.rs) — 17 doc examples for spec(), write_*, corrupt_deterministic, JWK methods, alg_name, curve_name, coordinate_len_bytes, stable_bytes
- **uselesskey-ed25519** (keypair.rs, spec.rs) — 15 doc examples for write_*, corrupt_deterministic, JWK methods, new(), stable_bytes
- **uselesskey-hmac** (secret.rs) — 3 doc examples for kid, jwk, jwks
- **uselesskey-core-hmac-spec** (lib.rs) — 6 doc examples for hs256/hs384/hs512, alg_name, byte_len, stable_bytes
- **uselesskey-x509** (cert.rs, chain.rs, chain_negative.rs, negative.rs) — 40+ doc examples for all cert/chain accessors, write_* methods, negative fixtures, CRL methods

### Conventions:
- RSA and X509 doc tests use `no_run` (slow RSA keygen)
- ECDSA, Ed25519, HMAC, Token use runnable examples
- Setup code is hidden with `# ` prefix
- JWK methods are feature-gated with `#[cfg(feature = "jwk")]`

## Verification

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --workspace --all-features --tests -- -D warnings` — 0 warnings
- [x] `cargo test --doc --workspace --all-features --exclude uselesskey-bdd` — all pass (0 failures)
