### PR TITLE
chore: standardize Cargo.toml metadata across all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.92"
 repository = "https://github.com/EffortlessMetrics/uselesskey"
 homepage = "https://github.com/EffortlessMetrics/uselesskey"
-categories = ["development-tools::testing"]
+categories = ["development-tools::testing", "cryptography"]
 authors = ["Effortless Metrics <opensource@effortlessmetrics.com>"]
 
 [workspace.dependencies]


### PR DESCRIPTION
## Summary

Audit and fix Cargo.toml metadata for crates.io publishing across all workspace crates.

### Changes

- Add \cryptography\ category to workspace-level \[workspace.package].categories\, propagating to all publishable crates via workspace inheritance

### Audit Results

All publishable crates already had the following fields properly configured:
- \description\ - Unique per crate
- \license\ - Inherited from workspace (MIT OR Apache-2.0)
- \epository\ - Inherited from workspace
- \keywords\ - Unique per crate (max 5 each)
- \eadme\ - README.md
- \dition\ - Inherited from workspace (2024)
- \homepage\ - Inherited from workspace
- \documentation\ - docs.rs URLs
- \uthors\ - Inherited from workspace
- \xclude\ - Standard patterns

The only gap was the missing \cryptography\ category, which is now added at the workspace level.