### PR TITLE
test: expand adapter crate snapshot tests

### DIFF
--- a/crates/uselesskey-aws-lc-rs/tests/snapshots/snapshots_aws_lc_rs__snapshot_tests__ecdsa_snapshots__aws_lc_ecdsa_key_sizes.snap
+++ b/crates/uselesskey-aws-lc-rs/tests/snapshots/snapshots_aws_lc_rs__snapshot_tests__ecdsa_snapshots__aws_lc_ecdsa_key_sizes.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-aws-lc-rs/tests/snapshots_aws_lc_rs.rs
+expression: cases
+---
+- curve: P-256
+  public_key_len: 65
+- curve: P-384
+  public_key_len: 97

--- a/crates/uselesskey-aws-lc-rs/tests/snapshots/snapshots_aws_lc_rs__snapshot_tests__ed25519_snapshots__aws_lc_ed25519_key_len_invariant.snap
+++ b/crates/uselesskey-aws-lc-rs/tests/snapshots/snapshots_aws_lc_rs__snapshot_tests__ed25519_snapshots__aws_lc_ed25519_key_len_invariant.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-aws-lc-rs/tests/snapshots_aws_lc_rs.rs
+expression: cases
+---
+- label: ed-len-a
+  public_key_len: 32
+- label: ed-len-b
+  public_key_len: 32
+- label: ed-len-c
+  public_key_len: 32

--- a/crates/uselesskey-aws-lc-rs/tests/snapshots/snapshots_aws_lc_rs__snapshot_tests__rsa_snapshots__aws_lc_rsa_4096_public_key.snap
+++ b/crates/uselesskey-aws-lc-rs/tests/snapshots/snapshots_aws_lc_rs__snapshot_tests__rsa_snapshots__aws_lc_rsa_4096_public_key.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-aws-lc-rs/tests/snapshots_aws_lc_rs.rs
+expression: result
+---
+algorithm: RSA-4096
+public_key_hex: "[REDACTED]"
+public_key_len: 526

--- a/crates/uselesskey-aws-lc-rs/tests/snapshots/snapshots_aws_lc_rs__snapshot_tests__rsa_snapshots__aws_lc_rsa_deterministic_same_label.snap
+++ b/crates/uselesskey-aws-lc-rs/tests/snapshots/snapshots_aws_lc_rs__snapshot_tests__rsa_snapshots__aws_lc_rsa_deterministic_same_label.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-aws-lc-rs/tests/snapshots_aws_lc_rs.rs
+expression: result
+---
+label: determinism-check
+first_modulus_len: 256
+second_modulus_len: 256
+lengths_match: true

--- a/crates/uselesskey-aws-lc-rs/tests/snapshots_aws_lc_rs.rs
+++ b/crates/uselesskey-aws-lc-rs/tests/snapshots_aws_lc_rs.rs
@@ -71,6 +71,52 @@ mod snapshot_tests {
 
             insta::assert_yaml_snapshot!("aws_lc_rsa_modulus_lengths", cases);
         }
+
+        #[test]
+        fn snapshot_aws_lc_rsa_4096_public_key() {
+            let fx = fx();
+            let keypair = fx.rsa("snapshot-rsa-4096", RsaSpec::new(4096));
+            let aws_kp = keypair.rsa_key_pair_aws_lc_rs();
+
+            let pub_bytes = aws_kp.public_key().as_ref();
+
+            let result = AwsLcKeySnapshot {
+                algorithm: "RSA-4096",
+                public_key_hex: hex::encode(pub_bytes),
+                public_key_len: pub_bytes.len(),
+            };
+
+            insta::assert_yaml_snapshot!("aws_lc_rsa_4096_public_key", result, {
+                ".public_key_hex" => "[REDACTED]",
+            });
+        }
+
+        #[test]
+        fn snapshot_aws_lc_rsa_deterministic_same_label() {
+            let fx = fx();
+
+            #[derive(Serialize)]
+            struct DeterminismCheck {
+                label: &'static str,
+                first_modulus_len: usize,
+                second_modulus_len: usize,
+                lengths_match: bool,
+            }
+
+            let kp1 = fx.rsa("determinism-check", RsaSpec::rs256());
+            let kp2 = fx.rsa("determinism-check", RsaSpec::rs256());
+            let r1 = kp1.rsa_key_pair_aws_lc_rs();
+            let r2 = kp2.rsa_key_pair_aws_lc_rs();
+
+            let result = DeterminismCheck {
+                label: "determinism-check",
+                first_modulus_len: r1.public_modulus_len(),
+                second_modulus_len: r2.public_modulus_len(),
+                lengths_match: r1.public_modulus_len() == r2.public_modulus_len(),
+            };
+
+            insta::assert_yaml_snapshot!("aws_lc_rsa_deterministic_same_label", result);
+        }
     }
 
     #[cfg(feature = "ecdsa")]
@@ -117,6 +163,38 @@ mod snapshot_tests {
                 ".public_key_hex" => "[REDACTED]",
             });
         }
+
+        #[test]
+        fn snapshot_aws_lc_ecdsa_key_sizes() {
+            let fx = fx();
+
+            #[derive(Serialize)]
+            struct EcdsaSizeInfo {
+                curve: &'static str,
+                public_key_len: usize,
+            }
+
+            let cases: Vec<EcdsaSizeInfo> = vec![
+                {
+                    let kp = fx.ecdsa("sizes-p256", EcdsaSpec::es256());
+                    let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+                    EcdsaSizeInfo {
+                        curve: "P-256",
+                        public_key_len: aws_kp.public_key().as_ref().len(),
+                    }
+                },
+                {
+                    let kp = fx.ecdsa("sizes-p384", EcdsaSpec::es384());
+                    let aws_kp = kp.ecdsa_key_pair_aws_lc_rs();
+                    EcdsaSizeInfo {
+                        curve: "P-384",
+                        public_key_len: aws_kp.public_key().as_ref().len(),
+                    }
+                },
+            ];
+
+            insta::assert_yaml_snapshot!("aws_lc_ecdsa_key_sizes", cases);
+        }
     }
 
     #[cfg(feature = "ed25519")]
@@ -143,6 +221,31 @@ mod snapshot_tests {
             insta::assert_yaml_snapshot!("aws_lc_ed25519_public_key", result, {
                 ".public_key_hex" => "[REDACTED]",
             });
+        }
+
+        #[test]
+        fn snapshot_aws_lc_ed25519_key_len_invariant() {
+            let fx = fx();
+
+            #[derive(Serialize)]
+            struct Ed25519LenInfo {
+                label: &'static str,
+                public_key_len: usize,
+            }
+
+            let cases: Vec<Ed25519LenInfo> = ["ed-len-a", "ed-len-b", "ed-len-c"]
+                .into_iter()
+                .map(|label| {
+                    let kp = fx.ed25519(label, Ed25519Spec::new());
+                    let aws_kp = kp.ed25519_key_pair_aws_lc_rs();
+                    Ed25519LenInfo {
+                        label,
+                        public_key_len: aws_kp.public_key().as_ref().len(),
+                    }
+                })
+                .collect();
+
+            insta::assert_yaml_snapshot!("aws_lc_ed25519_key_len_invariant", cases);
         }
     }
 }

--- a/crates/uselesskey-jsonwebtoken/tests/snapshots/snapshots_jwt__hmac_snapshots__hmac_hs384_round_trip.snap
+++ b/crates/uselesskey-jsonwebtoken/tests/snapshots/snapshots_jwt__hmac_snapshots__hmac_hs384_round_trip.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs
+expression: result
+---
+algorithm: HS384
+token_parts: 3
+token_header_len: 36
+claims_sub: user-hmac384
+claims_iss: snapshot-hmac-384
+roundtrip_ok: true

--- a/crates/uselesskey-jsonwebtoken/tests/snapshots/snapshots_jwt__hmac_snapshots__hmac_hs512_round_trip.snap
+++ b/crates/uselesskey-jsonwebtoken/tests/snapshots/snapshots_jwt__hmac_snapshots__hmac_hs512_round_trip.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs
+expression: result
+---
+algorithm: HS512
+token_parts: 3
+token_header_len: 36
+claims_sub: user-hmac512
+claims_iss: snapshot-hmac-512
+roundtrip_ok: true

--- a/crates/uselesskey-jsonwebtoken/tests/snapshots/snapshots_jwt__rsa_snapshots__rsa_rs256_4096_round_trip.snap
+++ b/crates/uselesskey-jsonwebtoken/tests/snapshots/snapshots_jwt__rsa_snapshots__rsa_rs256_4096_round_trip.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs
+expression: result
+---
+algorithm: RS256-4096
+token_parts: 3
+token_header_len: 36
+claims_sub: user-4096
+claims_iss: snapshot-issuer-4096
+roundtrip_ok: true

--- a/crates/uselesskey-jsonwebtoken/tests/snapshots/snapshots_jwt__summary_snapshots__jwt_all_algorithms_summary.snap
+++ b/crates/uselesskey-jsonwebtoken/tests/snapshots/snapshots_jwt__summary_snapshots__jwt_all_algorithms_summary.snap
@@ -1,0 +1,25 @@
+---
+source: crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs
+expression: results
+---
+- algorithm: RS256
+  token_parts: 3
+  roundtrip_ok: true
+- algorithm: ES256
+  token_parts: 3
+  roundtrip_ok: true
+- algorithm: ES384
+  token_parts: 3
+  roundtrip_ok: true
+- algorithm: EdDSA
+  token_parts: 3
+  roundtrip_ok: true
+- algorithm: HS256
+  token_parts: 3
+  roundtrip_ok: true
+- algorithm: HS384
+  token_parts: 3
+  roundtrip_ok: true
+- algorithm: HS512
+  token_parts: 3
+  roundtrip_ok: true

--- a/crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs
+++ b/crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs
@@ -60,6 +60,34 @@ mod rsa_snapshots {
 
         insta::assert_yaml_snapshot!("rsa_rs256_round_trip", result);
     }
+
+    #[test]
+    fn snapshot_rsa_rs256_4096_jwt_round_trip() {
+        let fx = fx();
+        let keypair = fx.rsa("snapshot-issuer-4096", RsaSpec::new(4096));
+
+        let claims = Claims {
+            sub: "user-4096".into(),
+            exp: 2_000_000_000,
+            iss: "snapshot-issuer-4096".into(),
+        };
+        let header = Header::new(Algorithm::RS256);
+        let token = encode(&header, &claims, &keypair.encoding_key()).unwrap();
+
+        let validation = Validation::new(Algorithm::RS256);
+        let decoded = decode::<Claims>(&token, &keypair.decoding_key(), &validation).unwrap();
+
+        let result = JwtRoundTrip {
+            algorithm: "RS256-4096",
+            token_parts: token.split('.').count(),
+            token_header_len: token.split('.').next().unwrap().len(),
+            claims_sub: decoded.claims.sub,
+            claims_iss: decoded.claims.iss,
+            roundtrip_ok: true,
+        };
+
+        insta::assert_yaml_snapshot!("rsa_rs256_4096_round_trip", result);
+    }
 }
 
 #[cfg(feature = "ecdsa")]
@@ -216,5 +244,251 @@ mod hmac_snapshots {
         };
 
         insta::assert_yaml_snapshot!("hmac_hs256_round_trip", result);
+    }
+
+    #[test]
+    fn snapshot_hmac_hs384_jwt_round_trip() {
+        let fx = fx();
+        let secret = fx.hmac("snapshot-hmac-384", HmacSpec::hs384());
+
+        let claims = Claims {
+            sub: "user-hmac384".into(),
+            exp: 2_000_000_000,
+            iss: "snapshot-hmac-384".into(),
+        };
+        let header = Header::new(Algorithm::HS384);
+        let token = encode(&header, &claims, &secret.encoding_key()).unwrap();
+
+        let validation = Validation::new(Algorithm::HS384);
+        let decoded = decode::<Claims>(&token, &secret.decoding_key(), &validation).unwrap();
+
+        let result = JwtRoundTrip {
+            algorithm: "HS384",
+            token_parts: token.split('.').count(),
+            token_header_len: token.split('.').next().unwrap().len(),
+            claims_sub: decoded.claims.sub,
+            claims_iss: decoded.claims.iss,
+            roundtrip_ok: true,
+        };
+
+        insta::assert_yaml_snapshot!("hmac_hs384_round_trip", result);
+    }
+
+    #[test]
+    fn snapshot_hmac_hs512_jwt_round_trip() {
+        let fx = fx();
+        let secret = fx.hmac("snapshot-hmac-512", HmacSpec::hs512());
+
+        let claims = Claims {
+            sub: "user-hmac512".into(),
+            exp: 2_000_000_000,
+            iss: "snapshot-hmac-512".into(),
+        };
+        let header = Header::new(Algorithm::HS512);
+        let token = encode(&header, &claims, &secret.encoding_key()).unwrap();
+
+        let validation = Validation::new(Algorithm::HS512);
+        let decoded = decode::<Claims>(&token, &secret.decoding_key(), &validation).unwrap();
+
+        let result = JwtRoundTrip {
+            algorithm: "HS512",
+            token_parts: token.split('.').count(),
+            token_header_len: token.split('.').next().unwrap().len(),
+            claims_sub: decoded.claims.sub,
+            claims_iss: decoded.claims.iss,
+            roundtrip_ok: true,
+        };
+
+        insta::assert_yaml_snapshot!("hmac_hs512_round_trip", result);
+    }
+}
+
+// =========================================================================
+// All-algorithm summary snapshot
+// =========================================================================
+
+#[cfg(all(
+    feature = "rsa",
+    feature = "ecdsa",
+    feature = "ed25519",
+    feature = "hmac"
+))]
+mod summary_snapshots {
+    use super::*;
+    use jsonwebtoken::{Algorithm, Header, Validation, decode, encode};
+    use serde::{Deserialize, Serialize};
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Claims {
+        sub: String,
+        exp: usize,
+    }
+
+    #[test]
+    fn snapshot_jwt_all_algorithms_summary() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct AlgoSummary {
+            algorithm: &'static str,
+            token_parts: usize,
+            roundtrip_ok: bool,
+        }
+
+        let mut results: Vec<AlgoSummary> = Vec::new();
+
+        // RS256
+        {
+            let kp = fx.rsa("summary-rsa", RsaSpec::rs256());
+            let claims = Claims {
+                sub: "user".into(),
+                exp: 2_000_000_000,
+            };
+            let token =
+                encode(&Header::new(Algorithm::RS256), &claims, &kp.encoding_key()).unwrap();
+            let ok = decode::<Claims>(
+                &token,
+                &kp.decoding_key(),
+                &Validation::new(Algorithm::RS256),
+            )
+            .is_ok();
+            results.push(AlgoSummary {
+                algorithm: "RS256",
+                token_parts: token.split('.').count(),
+                roundtrip_ok: ok,
+            });
+        }
+        // ES256
+        {
+            let kp = fx.ecdsa("summary-es256", EcdsaSpec::es256());
+            let claims = Claims {
+                sub: "user".into(),
+                exp: 2_000_000_000,
+            };
+            let token =
+                encode(&Header::new(Algorithm::ES256), &claims, &kp.encoding_key()).unwrap();
+            let ok = decode::<Claims>(
+                &token,
+                &kp.decoding_key(),
+                &Validation::new(Algorithm::ES256),
+            )
+            .is_ok();
+            results.push(AlgoSummary {
+                algorithm: "ES256",
+                token_parts: token.split('.').count(),
+                roundtrip_ok: ok,
+            });
+        }
+        // ES384
+        {
+            let kp = fx.ecdsa("summary-es384", EcdsaSpec::es384());
+            let claims = Claims {
+                sub: "user".into(),
+                exp: 2_000_000_000,
+            };
+            let token =
+                encode(&Header::new(Algorithm::ES384), &claims, &kp.encoding_key()).unwrap();
+            let ok = decode::<Claims>(
+                &token,
+                &kp.decoding_key(),
+                &Validation::new(Algorithm::ES384),
+            )
+            .is_ok();
+            results.push(AlgoSummary {
+                algorithm: "ES384",
+                token_parts: token.split('.').count(),
+                roundtrip_ok: ok,
+            });
+        }
+        // EdDSA
+        {
+            let kp = fx.ed25519("summary-ed", Ed25519Spec::new());
+            let claims = Claims {
+                sub: "user".into(),
+                exp: 2_000_000_000,
+            };
+            let token =
+                encode(&Header::new(Algorithm::EdDSA), &claims, &kp.encoding_key()).unwrap();
+            let ok = decode::<Claims>(
+                &token,
+                &kp.decoding_key(),
+                &Validation::new(Algorithm::EdDSA),
+            )
+            .is_ok();
+            results.push(AlgoSummary {
+                algorithm: "EdDSA",
+                token_parts: token.split('.').count(),
+                roundtrip_ok: ok,
+            });
+        }
+        // HS256
+        {
+            let kp = fx.hmac("summary-hs256", HmacSpec::hs256());
+            let claims = Claims {
+                sub: "user".into(),
+                exp: 2_000_000_000,
+            };
+            let token =
+                encode(&Header::new(Algorithm::HS256), &claims, &kp.encoding_key()).unwrap();
+            let ok = decode::<Claims>(
+                &token,
+                &kp.decoding_key(),
+                &Validation::new(Algorithm::HS256),
+            )
+            .is_ok();
+            results.push(AlgoSummary {
+                algorithm: "HS256",
+                token_parts: token.split('.').count(),
+                roundtrip_ok: ok,
+            });
+        }
+        // HS384
+        {
+            let kp = fx.hmac("summary-hs384", HmacSpec::hs384());
+            let claims = Claims {
+                sub: "user".into(),
+                exp: 2_000_000_000,
+            };
+            let token =
+                encode(&Header::new(Algorithm::HS384), &claims, &kp.encoding_key()).unwrap();
+            let ok = decode::<Claims>(
+                &token,
+                &kp.decoding_key(),
+                &Validation::new(Algorithm::HS384),
+            )
+            .is_ok();
+            results.push(AlgoSummary {
+                algorithm: "HS384",
+                token_parts: token.split('.').count(),
+                roundtrip_ok: ok,
+            });
+        }
+        // HS512
+        {
+            let kp = fx.hmac("summary-hs512", HmacSpec::hs512());
+            let claims = Claims {
+                sub: "user".into(),
+                exp: 2_000_000_000,
+            };
+            let token =
+                encode(&Header::new(Algorithm::HS512), &claims, &kp.encoding_key()).unwrap();
+            let ok = decode::<Claims>(
+                &token,
+                &kp.decoding_key(),
+                &Validation::new(Algorithm::HS512),
+            )
+            .is_ok();
+            results.push(AlgoSummary {
+                algorithm: "HS512",
+                token_parts: token.split('.').count(),
+                roundtrip_ok: ok,
+            });
+        }
+
+        insta::assert_yaml_snapshot!("jwt_all_algorithms_summary", results);
     }
 }

--- a/crates/uselesskey-ring/tests/snapshots/snapshots_ring__ecdsa_snapshots__ring_ecdsa_different_labels.snap
+++ b/crates/uselesskey-ring/tests/snapshots/snapshots_ring__ecdsa_snapshots__ring_ecdsa_different_labels.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-ring/tests/snapshots_ring.rs
+expression: result
+---
+curve: P-256
+label_a_pub_len: 65
+label_b_pub_len: 65
+same_curve_same_size: true

--- a/crates/uselesskey-ring/tests/snapshots/snapshots_ring__ecdsa_snapshots__ring_ecdsa_key_sizes.snap
+++ b/crates/uselesskey-ring/tests/snapshots/snapshots_ring__ecdsa_snapshots__ring_ecdsa_key_sizes.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-ring/tests/snapshots_ring.rs
+expression: cases
+---
+- curve: P-256
+  public_key_len: 65
+- curve: P-384
+  public_key_len: 97

--- a/crates/uselesskey-ring/tests/snapshots/snapshots_ring__ed25519_snapshots__ring_ed25519_key_len_invariant.snap
+++ b/crates/uselesskey-ring/tests/snapshots/snapshots_ring__ed25519_snapshots__ring_ed25519_key_len_invariant.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-ring/tests/snapshots_ring.rs
+expression: cases
+---
+- label: ed-label-a
+  public_key_len: 32
+- label: ed-label-b
+  public_key_len: 32
+- label: ed-label-c
+  public_key_len: 32

--- a/crates/uselesskey-ring/tests/snapshots/snapshots_ring__rsa_snapshots__ring_rsa_4096_public_key.snap
+++ b/crates/uselesskey-ring/tests/snapshots/snapshots_ring__rsa_snapshots__ring_rsa_4096_public_key.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-ring/tests/snapshots_ring.rs
+expression: result
+---
+algorithm: RSA-4096
+public_key_hex: "[REDACTED]"
+public_key_len: 526

--- a/crates/uselesskey-ring/tests/snapshots/snapshots_ring__rsa_snapshots__ring_rsa_deterministic_same_label.snap
+++ b/crates/uselesskey-ring/tests/snapshots/snapshots_ring__rsa_snapshots__ring_rsa_deterministic_same_label.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-ring/tests/snapshots_ring.rs
+expression: result
+---
+label: determinism-check
+first_modulus_len: 256
+second_modulus_len: 256
+first_pub_len: 270
+second_pub_len: 270
+lengths_match: true

--- a/crates/uselesskey-ring/tests/snapshots_ring.rs
+++ b/crates/uselesskey-ring/tests/snapshots_ring.rs
@@ -66,6 +66,56 @@ mod rsa_snapshots {
 
         insta::assert_yaml_snapshot!("ring_rsa_modulus_lengths", cases);
     }
+
+    #[test]
+    fn snapshot_ring_rsa_4096_public_key() {
+        let fx = fx();
+        let keypair = fx.rsa("snapshot-rsa-4096", RsaSpec::new(4096));
+        let ring_kp = keypair.rsa_key_pair_ring();
+
+        let pub_bytes = ring_kp.public().as_ref();
+
+        let result = RingKeySnapshot {
+            algorithm: "RSA-4096",
+            public_key_hex: hex::encode(pub_bytes),
+            public_key_len: pub_bytes.len(),
+        };
+
+        insta::assert_yaml_snapshot!("ring_rsa_4096_public_key", result, {
+            ".public_key_hex" => "[REDACTED]",
+        });
+    }
+
+    #[test]
+    fn snapshot_ring_rsa_deterministic_same_label() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct DeterminismCheck {
+            label: &'static str,
+            first_modulus_len: usize,
+            second_modulus_len: usize,
+            first_pub_len: usize,
+            second_pub_len: usize,
+            lengths_match: bool,
+        }
+
+        let kp1 = fx.rsa("determinism-check", RsaSpec::rs256());
+        let kp2 = fx.rsa("determinism-check", RsaSpec::rs256());
+        let r1 = kp1.rsa_key_pair_ring();
+        let r2 = kp2.rsa_key_pair_ring();
+
+        let result = DeterminismCheck {
+            label: "determinism-check",
+            first_modulus_len: r1.public().modulus_len(),
+            second_modulus_len: r2.public().modulus_len(),
+            first_pub_len: r1.public().as_ref().len(),
+            second_pub_len: r2.public().as_ref().len(),
+            lengths_match: r1.public().as_ref().len() == r2.public().as_ref().len(),
+        };
+
+        insta::assert_yaml_snapshot!("ring_rsa_deterministic_same_label", result);
+    }
 }
 
 #[cfg(feature = "ecdsa")]
@@ -112,6 +162,66 @@ mod ecdsa_snapshots {
             ".public_key_hex" => "[REDACTED]",
         });
     }
+
+    #[test]
+    fn snapshot_ring_ecdsa_key_sizes() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct EcdsaSizeInfo {
+            curve: &'static str,
+            public_key_len: usize,
+        }
+
+        let cases: Vec<EcdsaSizeInfo> = vec![
+            {
+                let kp = fx.ecdsa("sizes-p256", EcdsaSpec::es256());
+                let ring_kp = kp.ecdsa_key_pair_ring();
+                EcdsaSizeInfo {
+                    curve: "P-256",
+                    public_key_len: ring_kp.public_key().as_ref().len(),
+                }
+            },
+            {
+                let kp = fx.ecdsa("sizes-p384", EcdsaSpec::es384());
+                let ring_kp = kp.ecdsa_key_pair_ring();
+                EcdsaSizeInfo {
+                    curve: "P-384",
+                    public_key_len: ring_kp.public_key().as_ref().len(),
+                }
+            },
+        ];
+
+        insta::assert_yaml_snapshot!("ring_ecdsa_key_sizes", cases);
+    }
+
+    #[test]
+    fn snapshot_ring_ecdsa_different_labels() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct EcdsaLabelCheck {
+            curve: &'static str,
+            label_a_pub_len: usize,
+            label_b_pub_len: usize,
+            same_curve_same_size: bool,
+        }
+
+        let kp_a = fx.ecdsa("label-a-p256", EcdsaSpec::es256());
+        let kp_b = fx.ecdsa("label-b-p256", EcdsaSpec::es256());
+        let ring_a = kp_a.ecdsa_key_pair_ring();
+        let ring_b = kp_b.ecdsa_key_pair_ring();
+
+        let result = EcdsaLabelCheck {
+            curve: "P-256",
+            label_a_pub_len: ring_a.public_key().as_ref().len(),
+            label_b_pub_len: ring_b.public_key().as_ref().len(),
+            same_curve_same_size: ring_a.public_key().as_ref().len()
+                == ring_b.public_key().as_ref().len(),
+        };
+
+        insta::assert_yaml_snapshot!("ring_ecdsa_different_labels", result);
+    }
 }
 
 #[cfg(feature = "ed25519")]
@@ -138,5 +248,30 @@ mod ed25519_snapshots {
         insta::assert_yaml_snapshot!("ring_ed25519_public_key", result, {
             ".public_key_hex" => "[REDACTED]",
         });
+    }
+
+    #[test]
+    fn snapshot_ring_ed25519_key_len_invariant() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct Ed25519LenInfo {
+            label: &'static str,
+            public_key_len: usize,
+        }
+
+        let cases: Vec<Ed25519LenInfo> = ["ed-label-a", "ed-label-b", "ed-label-c"]
+            .into_iter()
+            .map(|label| {
+                let kp = fx.ed25519(label, Ed25519Spec::new());
+                let ring_kp = kp.ed25519_key_pair_ring();
+                Ed25519LenInfo {
+                    label,
+                    public_key_len: ring_kp.public_key().as_ref().len(),
+                }
+            })
+            .collect();
+
+        insta::assert_yaml_snapshot!("ring_ed25519_key_len_invariant", cases);
     }
 }

--- a/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__ecdsa_snapshots__rustcrypto_ecdsa_key_sizes.snap
+++ b/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__ecdsa_snapshots__rustcrypto_ecdsa_key_sizes.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-rustcrypto/tests/snapshots_rustcrypto.rs
+expression: cases
+---
+- curve: P-256
+  verifying_key_len: 65
+- curve: P-384
+  verifying_key_len: 97

--- a/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__ed25519_snapshots__rustcrypto_ed25519_key_len_invariant.snap
+++ b/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__ed25519_snapshots__rustcrypto_ed25519_key_len_invariant.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-rustcrypto/tests/snapshots_rustcrypto.rs
+expression: cases
+---
+- label: ed-len-a
+  verifying_key_len: 32
+- label: ed-len-b
+  verifying_key_len: 32
+- label: ed-len-c
+  verifying_key_len: 32

--- a/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__hmac_snapshots__rustcrypto_hmac_all_tag_sizes.snap
+++ b/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__hmac_snapshots__rustcrypto_hmac_all_tag_sizes.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-rustcrypto/tests/snapshots_rustcrypto.rs
+expression: cases
+---
+- algorithm: HMAC-SHA256
+  tag_len: 32
+- algorithm: HMAC-SHA384
+  tag_len: 48
+- algorithm: HMAC-SHA512
+  tag_len: 64

--- a/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__hmac_snapshots__rustcrypto_hmac_sha384_tag.snap
+++ b/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__hmac_snapshots__rustcrypto_hmac_sha384_tag.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-rustcrypto/tests/snapshots_rustcrypto.rs
+expression: result
+---
+algorithm: HMAC-SHA384
+tag_hex: "[REDACTED]"
+tag_len: 48

--- a/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__hmac_snapshots__rustcrypto_hmac_sha512_tag.snap
+++ b/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__hmac_snapshots__rustcrypto_hmac_sha512_tag.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-rustcrypto/tests/snapshots_rustcrypto.rs
+expression: result
+---
+algorithm: HMAC-SHA512
+tag_hex: "[REDACTED]"
+tag_len: 64

--- a/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__rsa_snapshots__rustcrypto_rsa_4096_public_key.snap
+++ b/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__rsa_snapshots__rustcrypto_rsa_4096_public_key.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-rustcrypto/tests/snapshots_rustcrypto.rs
+expression: result
+---
+algorithm: RSA-4096
+modulus_bits: 4096
+e_hex: "10001"

--- a/crates/uselesskey-rustcrypto/tests/snapshots_rustcrypto.rs
+++ b/crates/uselesskey-rustcrypto/tests/snapshots_rustcrypto.rs
@@ -72,6 +72,30 @@ mod rsa_snapshots {
 
         insta::assert_yaml_snapshot!("rustcrypto_rsa_key_sizes", cases);
     }
+
+    #[test]
+    fn snapshot_rustcrypto_rsa_4096_public_key() {
+        let fx = fx();
+        let keypair = fx.rsa("snapshot-rsa-4096", RsaSpec::new(4096));
+
+        let public_key = keypair.rsa_public_key();
+        let modulus_bits = public_key.n().bits();
+
+        #[derive(Serialize)]
+        struct RsaInfo {
+            algorithm: &'static str,
+            modulus_bits: u32,
+            e_hex: String,
+        }
+
+        let result = RsaInfo {
+            algorithm: "RSA-4096",
+            modulus_bits: modulus_bits as u32,
+            e_hex: format!("{:x}", public_key.e()),
+        };
+
+        insta::assert_yaml_snapshot!("rustcrypto_rsa_4096_public_key", result);
+    }
 }
 
 #[cfg(feature = "ecdsa")]
@@ -119,6 +143,40 @@ mod ecdsa_snapshots {
             ".public_key_hex" => "[REDACTED]",
         });
     }
+
+    #[test]
+    fn snapshot_rustcrypto_ecdsa_key_sizes() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct EcdsaSizeInfo {
+            curve: &'static str,
+            verifying_key_len: usize,
+        }
+
+        let cases: Vec<EcdsaSizeInfo> = vec![
+            {
+                let kp = fx.ecdsa("sizes-p256", EcdsaSpec::es256());
+                let vk = kp.p256_verifying_key();
+                let point = vk.to_encoded_point(false);
+                EcdsaSizeInfo {
+                    curve: "P-256",
+                    verifying_key_len: point.as_bytes().len(),
+                }
+            },
+            {
+                let kp = fx.ecdsa("sizes-p384", EcdsaSpec::es384());
+                let vk = kp.p384_verifying_key();
+                let point = vk.to_encoded_point(false);
+                EcdsaSizeInfo {
+                    curve: "P-384",
+                    verifying_key_len: point.as_bytes().len(),
+                }
+            },
+        ];
+
+        insta::assert_yaml_snapshot!("rustcrypto_ecdsa_key_sizes", cases);
+    }
 }
 
 #[cfg(feature = "ed25519")]
@@ -144,6 +202,31 @@ mod ed25519_snapshots {
         insta::assert_yaml_snapshot!("rustcrypto_ed25519_verifying_key", result, {
             ".public_key_hex" => "[REDACTED]",
         });
+    }
+
+    #[test]
+    fn snapshot_rustcrypto_ed25519_key_len_invariant() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct Ed25519LenInfo {
+            label: &'static str,
+            verifying_key_len: usize,
+        }
+
+        let cases: Vec<Ed25519LenInfo> = ["ed-len-a", "ed-len-b", "ed-len-c"]
+            .into_iter()
+            .map(|label| {
+                let kp = fx.ed25519(label, Ed25519Spec::new());
+                let vk = kp.ed25519_verifying_key();
+                Ed25519LenInfo {
+                    label,
+                    verifying_key_len: vk.as_bytes().len(),
+                }
+            })
+            .collect();
+
+        insta::assert_yaml_snapshot!("rustcrypto_ed25519_key_len_invariant", cases);
     }
 }
 
@@ -179,5 +262,102 @@ mod hmac_snapshots {
         insta::assert_yaml_snapshot!("rustcrypto_hmac_sha256_tag", result, {
             ".tag_hex" => "[REDACTED]",
         });
+    }
+
+    #[test]
+    fn snapshot_rustcrypto_hmac_sha384_tag() {
+        let fx = fx();
+        let secret = fx.hmac("snapshot-hmac-384", HmacSpec::hs384());
+
+        let mut mac = secret.hmac_sha384();
+        mac.update(b"snapshot-test-message");
+        let tag = mac.finalize().into_bytes();
+
+        #[derive(Serialize)]
+        struct HmacInfo {
+            algorithm: &'static str,
+            tag_hex: String,
+            tag_len: usize,
+        }
+
+        let result = HmacInfo {
+            algorithm: "HMAC-SHA384",
+            tag_hex: hex::encode(tag),
+            tag_len: tag.len(),
+        };
+
+        insta::assert_yaml_snapshot!("rustcrypto_hmac_sha384_tag", result, {
+            ".tag_hex" => "[REDACTED]",
+        });
+    }
+
+    #[test]
+    fn snapshot_rustcrypto_hmac_sha512_tag() {
+        let fx = fx();
+        let secret = fx.hmac("snapshot-hmac-512", HmacSpec::hs512());
+
+        let mut mac = secret.hmac_sha512();
+        mac.update(b"snapshot-test-message");
+        let tag = mac.finalize().into_bytes();
+
+        #[derive(Serialize)]
+        struct HmacInfo {
+            algorithm: &'static str,
+            tag_hex: String,
+            tag_len: usize,
+        }
+
+        let result = HmacInfo {
+            algorithm: "HMAC-SHA512",
+            tag_hex: hex::encode(tag),
+            tag_len: tag.len(),
+        };
+
+        insta::assert_yaml_snapshot!("rustcrypto_hmac_sha512_tag", result, {
+            ".tag_hex" => "[REDACTED]",
+        });
+    }
+
+    #[test]
+    fn snapshot_rustcrypto_hmac_all_tag_sizes() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct HmacTagSize {
+            algorithm: &'static str,
+            tag_len: usize,
+        }
+
+        let cases: Vec<HmacTagSize> = vec![
+            {
+                let secret = fx.hmac("tag-sizes-256", HmacSpec::hs256());
+                let mut mac = secret.hmac_sha256();
+                mac.update(b"test");
+                HmacTagSize {
+                    algorithm: "HMAC-SHA256",
+                    tag_len: mac.finalize().into_bytes().len(),
+                }
+            },
+            {
+                let secret = fx.hmac("tag-sizes-384", HmacSpec::hs384());
+                let mut mac = secret.hmac_sha384();
+                mac.update(b"test");
+                HmacTagSize {
+                    algorithm: "HMAC-SHA384",
+                    tag_len: mac.finalize().into_bytes().len(),
+                }
+            },
+            {
+                let secret = fx.hmac("tag-sizes-512", HmacSpec::hs512());
+                let mut mac = secret.hmac_sha512();
+                mac.update(b"test");
+                HmacTagSize {
+                    algorithm: "HMAC-SHA512",
+                    tag_len: mac.finalize().into_bytes().len(),
+                }
+            },
+        ];
+
+        insta::assert_yaml_snapshot!("rustcrypto_hmac_all_tag_sizes", cases);
     }
 }

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__all_key_types_snapshots__rustls_all_key_der_sizes.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__all_key_types_snapshots__rustls_all_key_der_sizes.snap
@@ -1,0 +1,14 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: cases
+---
+- key_type: RSA-2048
+  der_len: 1219
+- key_type: RSA-4096
+  der_len: 2374
+- key_type: ECDSA-P256
+  der_len: 138
+- key_type: ECDSA-P384
+  der_len: 185
+- key_type: Ed25519
+  der_len: 83

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rsa_snapshots__rustls_rsa_4096_private_key.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__rsa_snapshots__rustls_rsa_4096_private_key.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+key_type: RSA-4096
+der_variant: Pkcs8
+der_len: 2375
+der_hex: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_self_signed_custom_domain.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_self_signed_custom_domain.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: result
+---
+domain: custom.example.com
+cert_der_len: 762
+private_key_der_len: 1218
+der_variant: Pkcs8

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_x509_chain_key_sizes.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_x509_chain_key_sizes.snap
@@ -1,0 +1,14 @@
+---
+source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+expression: cases
+---
+- rsa_bits: 2048
+  chain_len: 2
+  leaf_cert_der_len: 815
+  root_cert_der_len: 802
+  private_key_der_len: 1216
+- rsa_bits: 4096
+  chain_len: 2
+  leaf_cert_der_len: 1327
+  root_cert_der_len: 1314
+  private_key_der_len: 2374

--- a/crates/uselesskey-rustls/tests/snapshots_rustls.rs
+++ b/crates/uselesskey-rustls/tests/snapshots_rustls.rs
@@ -71,6 +71,24 @@ mod rsa_snapshots {
 
         insta::assert_yaml_snapshot!("rustls_rsa_key_sizes", cases);
     }
+
+    #[test]
+    fn snapshot_rustls_rsa_4096_private_key() {
+        let fx = fx();
+        let keypair = fx.rsa("snapshot-rsa-4096", RsaSpec::new(4096));
+        let key = keypair.private_key_der_rustls();
+
+        let result = RustlsKeySnapshot {
+            key_type: "RSA-4096",
+            der_variant: "Pkcs8",
+            der_len: key.secret_der().len(),
+            der_hex: hex::encode(key.secret_der()),
+        };
+
+        insta::assert_yaml_snapshot!("rustls_rsa_4096_private_key", result, {
+            ".der_hex" => "[REDACTED]",
+        });
+    }
 }
 
 // =========================================================================
@@ -146,6 +164,70 @@ mod ed25519_snapshots {
         insta::assert_yaml_snapshot!("rustls_ed25519_private_key", result, {
             ".der_hex" => "[REDACTED]",
         });
+    }
+}
+
+// =========================================================================
+// All key types DER size comparison
+// =========================================================================
+
+#[cfg(all(feature = "rsa", feature = "ecdsa", feature = "ed25519"))]
+mod all_key_types_snapshots {
+    use super::*;
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+    use uselesskey_rustls::RustlsPrivateKeyExt;
+
+    #[test]
+    fn snapshot_rustls_all_key_der_sizes() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct KeyDerSize {
+            key_type: &'static str,
+            der_len: usize,
+        }
+
+        let cases: Vec<KeyDerSize> = vec![
+            {
+                let kp = fx.rsa("der-sizes-rsa-2048", RsaSpec::rs256());
+                KeyDerSize {
+                    key_type: "RSA-2048",
+                    der_len: kp.private_key_der_rustls().secret_der().len(),
+                }
+            },
+            {
+                let kp = fx.rsa("der-sizes-rsa-4096", RsaSpec::new(4096));
+                KeyDerSize {
+                    key_type: "RSA-4096",
+                    der_len: kp.private_key_der_rustls().secret_der().len(),
+                }
+            },
+            {
+                let kp = fx.ecdsa("der-sizes-p256", EcdsaSpec::es256());
+                KeyDerSize {
+                    key_type: "ECDSA-P256",
+                    der_len: kp.private_key_der_rustls().secret_der().len(),
+                }
+            },
+            {
+                let kp = fx.ecdsa("der-sizes-p384", EcdsaSpec::es384());
+                KeyDerSize {
+                    key_type: "ECDSA-P384",
+                    der_len: kp.private_key_der_rustls().secret_der().len(),
+                }
+            },
+            {
+                let kp = fx.ed25519("der-sizes-ed25519", Ed25519Spec::new());
+                KeyDerSize {
+                    key_type: "Ed25519",
+                    der_len: kp.private_key_der_rustls().secret_der().len(),
+                }
+            },
+        ];
+
+        insta::assert_yaml_snapshot!("rustls_all_key_der_sizes", cases);
     }
 }
 
@@ -230,5 +312,70 @@ mod x509_snapshots {
             ".root_cert_der_hex" => "[REDACTED]",
             ".private_key_der_hex" => "[REDACTED]",
         });
+    }
+
+    #[test]
+    fn snapshot_rustls_x509_chain_key_sizes() {
+        let fx = fx();
+
+        #[derive(Serialize)]
+        struct ChainKeySizeInfo {
+            rsa_bits: usize,
+            chain_len: usize,
+            leaf_cert_der_len: usize,
+            root_cert_der_len: usize,
+            private_key_der_len: usize,
+        }
+
+        let cases: Vec<ChainKeySizeInfo> = [2048, 4096]
+            .into_iter()
+            .map(|bits| {
+                let chain = fx.x509_chain(
+                    format!("rustls-chain-bits-{bits}"),
+                    ChainSpec::new(format!("bits{bits}.example.com")).with_rsa_bits(bits),
+                );
+                let chain_certs = chain.chain_der_rustls();
+                let root = chain.root_certificate_der_rustls();
+                let key = chain.private_key_der_rustls();
+                ChainKeySizeInfo {
+                    rsa_bits: bits,
+                    chain_len: chain_certs.len(),
+                    leaf_cert_der_len: chain_certs[0].as_ref().len(),
+                    root_cert_der_len: root.as_ref().len(),
+                    private_key_der_len: key.secret_der().len(),
+                }
+            })
+            .collect();
+
+        insta::assert_yaml_snapshot!("rustls_x509_chain_key_sizes", cases);
+    }
+
+    #[test]
+    fn snapshot_rustls_self_signed_custom_domain() {
+        let fx = fx();
+        let cert = fx.x509_self_signed(
+            "snapshot-custom",
+            X509Spec::self_signed("custom.example.com"),
+        );
+
+        #[derive(Serialize)]
+        struct CustomDomainInfo {
+            domain: &'static str,
+            cert_der_len: usize,
+            private_key_der_len: usize,
+            der_variant: &'static str,
+        }
+
+        let cert_der = cert.certificate_der_rustls();
+        let key = cert.private_key_der_rustls();
+
+        let result = CustomDomainInfo {
+            domain: "custom.example.com",
+            cert_der_len: cert_der.as_ref().len(),
+            private_key_der_len: key.secret_der().len(),
+            der_variant: "Pkcs8",
+        };
+
+        insta::assert_yaml_snapshot!("rustls_self_signed_custom_domain", result);
     }
 }

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_custom_domain_metadata.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_custom_domain_metadata.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+expression: result
+---
+domain: rpc.custom.io
+chain_pem_cert_count: 2
+root_cert_der_len: 788
+intermediate_cert_der_len: 796
+leaf_cert_der_len: 794
+leaf_private_key_der_len: 1217

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__mtls_snapshots__tonic_mtls_chain_cert_details.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__mtls_snapshots__tonic_mtls_chain_cert_details.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+expression: result
+---
+domain: secure.example.com
+root_cert_der_len: 798
+intermediate_cert_der_len: 806
+leaf_cert_der_len: 809
+leaf_private_key_der_len: 1218
+full_chain_pem_cert_count: 3
+server_mtls_built: true
+client_mtls_built: true

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_custom_domain.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_custom_domain.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+expression: result
+---
+domain: api.example.com
+cert_pem_has_begin: true
+cert_pem_has_end: true
+cert_der_len: 756
+private_key_der_len: 1219
+identity_built: true

--- a/crates/uselesskey-tonic/tests/snapshots_tonic.rs
+++ b/crates/uselesskey-tonic/tests/snapshots_tonic.rs
@@ -87,6 +87,39 @@ mod self_signed_snapshots {
 
         insta::assert_yaml_snapshot!("tonic_self_signed_identity_builds", result);
     }
+
+    #[test]
+    fn snapshot_self_signed_custom_domain() {
+        let fx = fx();
+        let cert = fx.x509_self_signed(
+            "snapshot-ss-custom",
+            X509Spec::self_signed("api.example.com"),
+        );
+
+        #[derive(Serialize)]
+        struct CustomDomainSnapshot {
+            domain: &'static str,
+            cert_pem_has_begin: bool,
+            cert_pem_has_end: bool,
+            cert_der_len: usize,
+            private_key_der_len: usize,
+            identity_built: bool,
+        }
+
+        let cert_pem = cert.cert_pem().to_string();
+        let _identity = cert.identity_tonic();
+
+        let result = CustomDomainSnapshot {
+            domain: "api.example.com",
+            cert_pem_has_begin: cert_pem.contains("-----BEGIN CERTIFICATE-----"),
+            cert_pem_has_end: cert_pem.contains("-----END CERTIFICATE-----"),
+            cert_der_len: cert.cert_der().len(),
+            private_key_der_len: cert.private_key_pkcs8_der().len(),
+            identity_built: true,
+        };
+
+        insta::assert_yaml_snapshot!("tonic_self_signed_custom_domain", result);
+    }
 }
 
 // =========================================================================
@@ -173,6 +206,35 @@ mod chain_snapshots {
 
         insta::assert_yaml_snapshot!("tonic_chain_all_configs_build", result);
     }
+
+    #[test]
+    fn snapshot_chain_custom_domain_metadata() {
+        let fx = fx();
+        let chain = fx.x509_chain("snapshot-chain-custom", ChainSpec::new("rpc.custom.io"));
+
+        let chain_pem = chain.chain_pem().to_string();
+
+        #[derive(Serialize)]
+        struct CustomChainInfo {
+            domain: &'static str,
+            chain_pem_cert_count: usize,
+            root_cert_der_len: usize,
+            intermediate_cert_der_len: usize,
+            leaf_cert_der_len: usize,
+            leaf_private_key_der_len: usize,
+        }
+
+        let result = CustomChainInfo {
+            domain: "rpc.custom.io",
+            chain_pem_cert_count: chain_pem.matches("-----BEGIN CERTIFICATE-----").count(),
+            root_cert_der_len: chain.root_cert_der().len(),
+            intermediate_cert_der_len: chain.intermediate_cert_der().len(),
+            leaf_cert_der_len: chain.leaf_cert_der().len(),
+            leaf_private_key_der_len: chain.leaf_private_key_pkcs8_der().len(),
+        };
+
+        insta::assert_yaml_snapshot!("tonic_chain_custom_domain_metadata", result);
+    }
 }
 
 // =========================================================================
@@ -211,6 +273,47 @@ mod mtls_snapshots {
         };
 
         insta::assert_yaml_snapshot!("tonic_mtls_configs_build", result);
+    }
+
+    #[test]
+    fn snapshot_mtls_chain_cert_details() {
+        let fx = fx();
+        let chain = fx.x509_chain(
+            "snapshot-mtls-details",
+            ChainSpec::new("secure.example.com"),
+        );
+
+        let _server = chain.server_tls_config_mtls_tonic();
+        let _client = chain.client_tls_config_mtls_tonic("secure.example.com");
+
+        #[derive(Serialize)]
+        struct MtlsCertDetails {
+            domain: &'static str,
+            root_cert_der_len: usize,
+            intermediate_cert_der_len: usize,
+            leaf_cert_der_len: usize,
+            leaf_private_key_der_len: usize,
+            full_chain_pem_cert_count: usize,
+            server_mtls_built: bool,
+            client_mtls_built: bool,
+        }
+
+        let full_chain_pem = chain.full_chain_pem();
+
+        let result = MtlsCertDetails {
+            domain: "secure.example.com",
+            root_cert_der_len: chain.root_cert_der().len(),
+            intermediate_cert_der_len: chain.intermediate_cert_der().len(),
+            leaf_cert_der_len: chain.leaf_cert_der().len(),
+            leaf_private_key_der_len: chain.leaf_private_key_pkcs8_der().len(),
+            full_chain_pem_cert_count: full_chain_pem
+                .matches("-----BEGIN CERTIFICATE-----")
+                .count(),
+            server_mtls_built: true,
+            client_mtls_built: true,
+        };
+
+        insta::assert_yaml_snapshot!("tonic_mtls_chain_cert_details", result);
     }
 }
 


### PR DESCRIPTION
## Wave 120: Expand snapshot tests for adapter crates

Adds new insta snapshot tests to 6 adapter crates, covering additional algorithm variants, edge cases, and determinism checks.

### New tests per crate:

| Crate | Before | After | New Tests |
|-------|--------|-------|-----------|
| uselesskey-ring | 5 | 10 | RSA-4096, ECDSA key sizes, ECDSA different labels, Ed25519 key len invariant, RSA deterministic same label |
| uselesskey-rustcrypto | 6 | 12 | RSA-4096, ECDSA key sizes, Ed25519 key len invariant, HMAC-SHA384, HMAC-SHA512, HMAC all tag sizes |
| uselesskey-aws-lc-rs | 5 | 9 | RSA-4096, RSA deterministic same label, ECDSA key sizes, Ed25519 key len invariant |
| uselesskey-jsonwebtoken | 5 | 9 | RS256-4096 round trip, HS384 round trip, HS512 round trip, all-algorithms summary |
| uselesskey-rustls | 7 | 11 | RSA-4096 private key, all key DER sizes, X509 chain key sizes, self-signed custom domain |
| uselesskey-tonic | 6 | 9 | Self-signed custom domain, chain custom domain metadata, mTLS chain cert details |

### Pattern followed:
- `insta::assert_yaml_snapshot!` with YAML redactions
- No actual key material in snapshots (only metadata: lengths, algorithm names, PEM headers)
- Deterministic factory with seed-based reproducibility
- Feature-gated modules matching existing structure

### Verification:
- All snapshot tests pass across all 6 crates
- `cargo clippy` clean with `-D warnings`