### PR TITLE
docs: add module-level documentation to core microcrates

### DIFF
--- a/crates/uselesskey-core-base62/src/lib.rs
+++ b/crates/uselesskey-core-base62/src/lib.rs
@@ -3,7 +3,26 @@
 //! Base62 generation primitives for test fixtures.
 //!
 //! Provides deterministic, RNG-driven generation of base62 strings without
-//! modulo bias under normal RNG behavior.
+//! modulo bias under normal RNG behavior. Used internally by token fixture
+//! crates to produce realistic-looking API keys and bearer tokens.
+//!
+//! # Examples
+//!
+//! ```
+//! use rand_chacha::ChaCha20Rng;
+//! use rand_core::SeedableRng;
+//! use uselesskey_core_base62::random_base62;
+//!
+//! let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+//! let value = random_base62(&mut rng, 24);
+//! assert_eq!(value.len(), 24);
+//! assert!(value.chars().all(|c| c.is_ascii_alphanumeric()));
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 use rand_core::RngCore;
 

--- a/crates/uselesskey-core-cache/src/lib.rs
+++ b/crates/uselesskey-core-cache/src/lib.rs
@@ -5,6 +5,27 @@
 //! uses `DashMap` with `std`, `spin::Mutex` without.
 //!
 //! The primary type is [`ArtifactCache`].
+//!
+//! # Examples
+//!
+//! ```
+//! use std::sync::Arc;
+//! use uselesskey_core_cache::ArtifactCache;
+//! use uselesskey_core_id::{ArtifactId, DerivationVersion};
+//!
+//! let cache = ArtifactCache::new();
+//! let id = ArtifactId::new("domain:rsa", "issuer", b"RS256", "good", DerivationVersion::V1);
+//!
+//! // Insert once, retrieve many times
+//! cache.insert_if_absent_typed(id.clone(), Arc::new(42u32));
+//! let value = cache.get_typed::<u32>(&id).unwrap();
+//! assert_eq!(*value, 42);
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/crates/uselesskey-core-factory/src/lib.rs
+++ b/crates/uselesskey-core-factory/src/lib.rs
@@ -2,9 +2,29 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 //! Factory orchestration and cache lookup for uselesskey fixtures.
 //!
-//! Implements the core `Factory` type that manages deterministic derivation,
-//! caching, and artifact generation. Operates in either Random or Deterministic
-//! mode based on seed configuration.
+//! Implements the core [`Factory`] type that manages deterministic derivation,
+//! caching, and artifact generation. Operates in either [`Mode::Random`] or
+//! [`Mode::Deterministic`] based on seed configuration. Clones of a `Factory`
+//! share the same underlying cache.
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_factory::Factory;
+//! use uselesskey_core_id::Seed;
+//!
+//! // Random mode — each run produces different fixtures
+//! let fx = Factory::random();
+//!
+//! // Deterministic mode — reproducible across runs
+//! let seed = Seed::from_env_value("my-test-seed").unwrap();
+//! let fx = Factory::deterministic(seed);
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 extern crate alloc;
 

--- a/crates/uselesskey-core-hash/src/lib.rs
+++ b/crates/uselesskey-core-hash/src/lib.rs
@@ -4,6 +4,27 @@
 //!
 //! Wraps BLAKE3 to provide collision-resistant, deterministic digests used
 //! throughout the `uselesskey` workspace for seed derivation and artifact identity.
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_hash::{hash32, write_len_prefixed, Hasher};
+//!
+//! // Simple hash
+//! let digest = hash32(b"my-fixture-data");
+//! assert_eq!(digest, hash32(b"my-fixture-data")); // deterministic
+//!
+//! // Length-prefixed hashing preserves field boundaries
+//! let mut hasher = Hasher::new();
+//! write_len_prefixed(&mut hasher, b"field-a");
+//! write_len_prefixed(&mut hasher, b"field-b");
+//! let _ = hasher.finalize();
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 pub use blake3::{Hash, Hasher};
 

--- a/crates/uselesskey-core-hmac-spec/src/lib.rs
+++ b/crates/uselesskey-core-hmac-spec/src/lib.rs
@@ -2,8 +2,23 @@
 
 //! Core HMAC algorithm specification model.
 //!
-//! Provides a stable enum used by fixture crates to select HS256/HS384/HS512 and
-//! derive deterministic cache keys.
+//! Provides [`HmacSpec`], a stable enum used by fixture crates to select
+//! HS256/HS384/HS512 and derive deterministic cache keys.
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_hmac_spec::HmacSpec;
+//!
+//! let spec = HmacSpec::hs256();
+//! assert_eq!(spec.alg_name(), "HS256");
+//! assert_eq!(spec.byte_len(), 32);
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 /// Specification for HMAC secret generation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]

--- a/crates/uselesskey-core-id/src/lib.rs
+++ b/crates/uselesskey-core-id/src/lib.rs
@@ -2,9 +2,29 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 //! Core identity and derivation primitives for uselesskey.
 //!
-//! Defines `ArtifactId` — the `(domain, label, spec_fingerprint, variant,
+//! Defines [`ArtifactId`] — the `(domain, label, spec_fingerprint, variant,
 //! derivation_version)` tuple that uniquely identifies each generated artifact.
-//! Provides deterministic seed derivation from a master seed and artifact id.
+//! Provides deterministic seed derivation from a master seed and artifact id
+//! via [`derive_seed`].
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_id::{ArtifactId, DerivationVersion, Seed, derive_seed};
+//!
+//! let master = Seed::from_env_value("my-test-seed").unwrap();
+//! let id = ArtifactId::new("domain:rsa", "issuer", b"RS256", "good", DerivationVersion::V1);
+//!
+//! // Same master + id always produces the same derived seed
+//! let seed_a = derive_seed(&master, &id);
+//! let seed_b = derive_seed(&master, &id);
+//! assert_eq!(seed_a.bytes(), seed_b.bytes());
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 extern crate alloc;
 

--- a/crates/uselesskey-core-jwk-builder/src/lib.rs
+++ b/crates/uselesskey-core-jwk-builder/src/lib.rs
@@ -3,8 +3,29 @@
 //! JWKS composition with deterministic ordering semantics.
 //!
 //! This crate centralizes JWKS assembly behavior that is shared across JWK-producing
-//! key fixtures. Entries are sorted by `kid` and preserve insertion order for duplicate
-//! `kid` values.
+//! key fixtures. [`JwksBuilder`] collects public, private, and any-typed JWK
+//! entries and emits a [`Jwks`] with entries sorted by `kid` (preserving insertion
+//! order for duplicate `kid` values).
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_jwk_builder::JwksBuilder;
+//! use uselesskey_core_jwk_shape::{RsaPublicJwk, PublicJwk};
+//!
+//! let jwk = PublicJwk::Rsa(RsaPublicJwk {
+//!     kty: "RSA", use_: "sig", alg: "RS256",
+//!     kid: "my-key".into(), n: "modulus".into(), e: "AQAB".into(),
+//! });
+//!
+//! let jwks = JwksBuilder::new().add_public(jwk).build();
+//! assert_eq!(jwks.keys.len(), 1);
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 use uselesskey_core_jwk_shape::{AnyJwk, Jwks, PrivateJwk, PublicJwk};
 use uselesskey_core_jwks_order::{HasKid, KidSorted};

--- a/crates/uselesskey-core-keypair-material/src/lib.rs
+++ b/crates/uselesskey-core-keypair-material/src/lib.rs
@@ -1,9 +1,31 @@
 #![forbid(unsafe_code)]
 //! PKCS#8 / SPKI key-material helpers shared by key fixture crates.
 //!
-//! Provides the `Pkcs8SpkiKeyMaterial` trait and related types for consistent
-//! access to private (PKCS#8) and public (SPKI) key encodings in PEM and DER
-//! formats, plus corrupt PEM/DER negative fixture support.
+//! Provides [`Pkcs8SpkiKeyMaterial`], a container for consistent access to
+//! private (PKCS#8) and public (SPKI) key encodings in PEM and DER formats,
+//! plus corrupt PEM/DER negative fixture support and deterministic key-ID
+//! generation.
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_keypair_material::Pkcs8SpkiKeyMaterial;
+//!
+//! let material = Pkcs8SpkiKeyMaterial::new(
+//!     vec![0x30, 0x82],                        // PKCS#8 DER (placeholder)
+//!     "-----BEGIN PRIVATE KEY-----\nAA==\n-----END PRIVATE KEY-----\n",
+//!     vec![0x30, 0x59],                        // SPKI DER (placeholder)
+//!     "-----BEGIN PUBLIC KEY-----\nAA==\n-----END PUBLIC KEY-----\n",
+//! );
+//!
+//! assert_eq!(material.private_key_pkcs8_der(), &[0x30, 0x82]);
+//! assert!(material.public_key_spki_pem().contains("PUBLIC KEY"));
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 use std::fmt;
 use std::sync::Arc;

--- a/crates/uselesskey-core-kid/src/lib.rs
+++ b/crates/uselesskey-core-kid/src/lib.rs
@@ -2,14 +2,25 @@
 //!
 //! Produces URL-safe, base64url-encoded BLAKE3 hashes truncated to 96 bits
 //! by default. Use [`kid_from_bytes`] for the standard length or
-//! [`kid_from_bytes_with_prefix`] for a custom hash prefix.
+//! [`kid_from_bytes_with_prefix`] for a custom hash prefix length.
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_kid::kid_from_bytes;
+//!
+//! let kid = kid_from_bytes(b"my-public-key-bytes");
+//! assert!(!kid.is_empty());
+//! // Same input always produces the same kid
+//! assert_eq!(kid, kid_from_bytes(b"my-public-key-bytes"));
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 #![forbid(unsafe_code)]
-//! Deterministic key-id (kid) helpers for uselesskey fixture crates.
-//!
-//! Generates URL-safe base64 key identifiers by hashing public key material
-//! with BLAKE3. The default prefix length (12 bytes / 96 bits) provides
-//! sufficient collision resistance for test fixture scenarios.
 
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;

--- a/crates/uselesskey-core-negative-der/src/lib.rs
+++ b/crates/uselesskey-core-negative-der/src/lib.rs
@@ -7,6 +7,31 @@
 //! strategies for DER-encoded blobs. Used by higher-level negative fixture
 //! crates (`uselesskey-core-negative`) to generate invalid DER artifacts
 //! that exercise parser error paths in tests.
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_negative_der::{truncate_der, flip_byte, corrupt_der_deterministic};
+//!
+//! let der = vec![0x30, 0x82, 0x01, 0x22];
+//!
+//! // Truncate to 2 bytes
+//! let short = truncate_der(&der, 2);
+//! assert_eq!(short, vec![0x30, 0x82]);
+//!
+//! // Flip a single byte
+//! let flipped = flip_byte(&der, 0);
+//! assert_eq!(flipped[0], 0x31); // XOR with 0x01
+//!
+//! // Deterministic corruption from a variant string
+//! let bad = corrupt_der_deterministic(&der, "corrupt:test");
+//! assert_ne!(bad, der);
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 extern crate alloc;
 

--- a/crates/uselesskey-core-rustls-pki/src/lib.rs
+++ b/crates/uselesskey-core-rustls-pki/src/lib.rs
@@ -1,7 +1,19 @@
 //! rustls-pki-types adapter traits for uselesskey fixtures.
 //!
-//! This crate is intentionally focused on PKI conversion only:
-//! converting fixture outputs into `rustls_pki_types` key and certificate types.
+//! Converts fixture outputs into [`rustls_pki_types`] key and certificate
+//! types via extension traits:
+//!
+//! - [`RustlsPrivateKeyExt`] — PKCS#8 private key → `PrivateKeyDer`
+//! - [`RustlsCertExt`] — single certificate → `CertificateDer`
+//! - [`RustlsChainExt`] (with `x509` feature) — chain → `Vec<CertificateDer>`
+//!
+//! Enable cargo features (`rsa`, `ecdsa`, `ed25519`, `x509`) to get
+//! blanket impls for the corresponding fixture types.
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/crates/uselesskey-core-seed/src/lib.rs
+++ b/crates/uselesskey-core-seed/src/lib.rs
@@ -3,8 +3,28 @@
 //! Seed parsing and redaction primitives for uselesskey.
 //!
 //! Provides the [`Seed`] type that wraps 32 bytes of entropy used for
-//! deterministic fixture derivation. Implements `Debug` with redaction
-//! to prevent accidental leakage of seed material in logs.
+//! deterministic fixture derivation. Supports creation from raw bytes,
+//! 64-char hex strings, or arbitrary strings (hashed with BLAKE3).
+//! Implements `Debug` with redaction to prevent accidental leakage of
+//! seed material in logs.
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_seed::Seed;
+//!
+//! // From an arbitrary string (hashed via BLAKE3)
+//! let seed = Seed::from_env_value("my-test-seed").unwrap();
+//! assert_eq!(seed.bytes().len(), 32);
+//!
+//! // Debug output never leaks the seed
+//! assert_eq!(format!("{seed:?}"), "Seed(**redacted**)");
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 extern crate alloc;
 

--- a/crates/uselesskey-core-sink/src/lib.rs
+++ b/crates/uselesskey-core-sink/src/lib.rs
@@ -4,6 +4,25 @@
 //! generated key material on disk and cleans up automatically on drop.  It is
 //! useful when downstream libraries require `Path`-based APIs rather than
 //! in-memory byte slices.
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_sink::TempArtifact;
+//!
+//! let temp = TempArtifact::new_string("prefix-", ".pem", "-----BEGIN KEY-----\n").unwrap();
+//! let path = temp.path();
+//! assert!(path.exists());
+//!
+//! let content = temp.read_to_string().unwrap();
+//! assert!(content.contains("BEGIN KEY"));
+//! // File is deleted when `temp` goes out of scope
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/crates/uselesskey-core-token/src/lib.rs
+++ b/crates/uselesskey-core-token/src/lib.rs
@@ -4,5 +4,22 @@
 //!
 //! This crate intentionally keeps the existing public path stable while delegating
 //! all token-generation behavior to [`uselesskey_core_token_shape`].
+//!
+//! # Examples
+//!
+//! ```
+//! use rand_chacha::ChaCha20Rng;
+//! use rand_chacha::rand_core::SeedableRng;
+//! use uselesskey_core_token::{generate_token, TokenKind};
+//!
+//! let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+//! let api_key = generate_token("my-service", TokenKind::ApiKey, &mut rng);
+//! assert!(api_key.starts_with("uk_test_"));
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 pub use uselesskey_core_token_shape::*;

--- a/crates/uselesskey-core-x509-chain-negative/src/lib.rs
+++ b/crates/uselesskey-core-x509-chain-negative/src/lib.rs
@@ -5,6 +5,24 @@
 //! [`ChainNegative::apply_to_spec`] to derive a modified [`ChainSpec`]
 //! for each scenario. Used by `uselesskey-x509` to produce invalid
 //! certificate chains for TLS error-handling tests.
+//!
+//! # Examples
+//!
+//! ```
+//! use uselesskey_core_x509_chain_negative::ChainNegative;
+//! use uselesskey_core_x509_spec::ChainSpec;
+//!
+//! let base = ChainSpec::new("test.example.com");
+//! let bad = ChainNegative::HostnameMismatch {
+//!     wrong_hostname: "wrong.example.com".into(),
+//! }.apply_to_spec(&base);
+//! assert_eq!(bad.leaf_cn, "wrong.example.com");
+//! ```
+//!
+//! # This is a test utility
+//!
+//! This crate is part of the [uselesskey](https://crates.io/crates/uselesskey)
+//! test-fixture ecosystem. It is **not** intended for production use.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]


### PR DESCRIPTION
## Wave 121: Module-level documentation for core microcrates

Added comprehensive `//!` module-level documentation to 15 core microcrates that had minimal docs. Each now includes:

1. **What the crate does** — clear description of purpose and primary types
2. **Usage examples** — compilable doc-test examples
3. **Test utility notice** — explicit note that these are part of the uselesskey test-fixture ecosystem and not for production use

### Crates updated:
- `uselesskey-core-cache`
- `uselesskey-core-keypair-material`
- `uselesskey-core-kid` (also fixed duplicate doc block)
- `uselesskey-core-negative-der`
- `uselesskey-core-sink`
- `uselesskey-core-token`
- `uselesskey-core-rustls-pki`
- `uselesskey-core-hmac-spec`
- `uselesskey-core-hash`
- `uselesskey-core-base62`
- `uselesskey-core-id`
- `uselesskey-core-seed`
- `uselesskey-core-factory`
- `uselesskey-core-jwk-builder`
- `uselesskey-core-x509-chain-negative`

### Verification:
- All doc tests pass (`cargo test --doc`)
- `cargo xtask clippy` passes with no warnings
- `cargo check` passes for all affected crates