### PR TITLE
test: add cross-cutting integration tests for algorithm crates

### DIFF
--- a/crates/uselesskey-ecdsa/tests/cache_coherence.rs
+++ b/crates/uselesskey-ecdsa/tests/cache_coherence.rs
@@ -1,0 +1,55 @@
+//! Cache coherence integration tests for ECDSA.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+#[test]
+fn same_label_same_spec_returns_identical_bytes() {
+    let fx = fx();
+    let kp1 = fx.ecdsa("cache-eq", EcdsaSpec::es256());
+    let kp2 = fx.ecdsa("cache-eq", EcdsaSpec::es256());
+    assert_eq!(
+        kp1.private_key_pkcs8_der(),
+        kp2.private_key_pkcs8_der(),
+        "same label+spec must return identical private key bytes"
+    );
+}
+
+#[test]
+fn different_labels_produce_different_keys() {
+    let fx = fx();
+    let kp_a = fx.ecdsa("ecdsa-a", EcdsaSpec::es256());
+    let kp_b = fx.ecdsa("ecdsa-b", EcdsaSpec::es256());
+    assert_ne!(
+        kp_a.private_key_pkcs8_der(),
+        kp_b.private_key_pkcs8_der(),
+        "different labels must produce different keys"
+    );
+}
+
+#[test]
+fn different_curves_produce_different_keys() {
+    let fx = fx();
+    let kp_256 = fx.ecdsa("curve-diff", EcdsaSpec::es256());
+    let kp_384 = fx.ecdsa("curve-diff", EcdsaSpec::es384());
+    assert_ne!(
+        kp_256.private_key_pkcs8_der(),
+        kp_384.private_key_pkcs8_der(),
+        "different curves must produce different keys"
+    );
+}
+
+#[test]
+fn cache_survives_factory_clone() {
+    let fx = fx();
+    let _warm = fx.ecdsa("ecdsa-clone", EcdsaSpec::es256());
+    let fx2 = fx.clone();
+    let from_clone = fx2.ecdsa("ecdsa-clone", EcdsaSpec::es256());
+    assert_eq!(
+        _warm.private_key_pkcs8_der(),
+        from_clone.private_key_pkcs8_der(),
+        "cloned factory must share the cache"
+    );
+}

--- a/crates/uselesskey-ecdsa/tests/format_roundtrip.rs
+++ b/crates/uselesskey-ecdsa/tests/format_roundtrip.rs
@@ -1,0 +1,118 @@
+//! Format roundtrip integration tests for ECDSA.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+// ---------------------------------------------------------------------------
+// PEM
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_pem_has_pkcs8_headers() {
+    let kp = fx().ecdsa("pem-hdr", EcdsaSpec::es256());
+    let pem = kp.private_key_pkcs8_pem();
+    assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PRIVATE KEY-----"));
+}
+
+#[test]
+fn public_pem_has_spki_headers() {
+    let kp = fx().ecdsa("pem-pub", EcdsaSpec::es256());
+    let pem = kp.public_key_spki_pem();
+    assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PUBLIC KEY-----"));
+}
+
+// ---------------------------------------------------------------------------
+// DER
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_der_starts_with_sequence_tag() {
+    let kp = fx().ecdsa("der-priv", EcdsaSpec::es256());
+    assert_eq!(kp.private_key_pkcs8_der()[0], 0x30);
+}
+
+#[test]
+fn public_der_starts_with_sequence_tag() {
+    let kp = fx().ecdsa("der-pub", EcdsaSpec::es384());
+    assert_eq!(kp.public_key_spki_der()[0], 0x30);
+}
+
+#[test]
+fn p384_keys_are_larger_than_p256() {
+    let fx = fx();
+    let p256 = fx.ecdsa("size-256", EcdsaSpec::es256());
+    let p384 = fx.ecdsa("size-384", EcdsaSpec::es384());
+    assert!(
+        p384.private_key_pkcs8_der().len() > p256.private_key_pkcs8_der().len(),
+        "P-384 DER should be larger than P-256 DER"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// JWK (requires `jwk` feature)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "jwk")]
+mod jwk_tests {
+    use super::*;
+
+    #[test]
+    fn jwk_has_ec_fields() {
+        let kp = fx().ecdsa("jwk-ec", EcdsaSpec::es256());
+        let v = kp.private_key_jwk().to_value();
+        assert_eq!(v["kty"], "EC");
+        assert_eq!(v["crv"], "P-256");
+        assert!(v["x"].is_string(), "EC JWK must have 'x'");
+        assert!(v["y"].is_string(), "EC JWK must have 'y'");
+        assert!(v["d"].is_string(), "private EC JWK must have 'd'");
+    }
+
+    #[test]
+    fn public_jwk_omits_private_component() {
+        let kp = fx().ecdsa("jwk-pub", EcdsaSpec::es384());
+        let v = kp.public_jwk().to_value();
+        assert_eq!(v["kty"], "EC");
+        assert_eq!(v["crv"], "P-384");
+        assert!(v["d"].is_null(), "public JWK must not contain 'd'");
+    }
+
+    #[test]
+    fn jwks_has_keys_array() {
+        let kp = fx().ecdsa("jwks-ec", EcdsaSpec::es256());
+        let v = kp.public_jwks().to_value();
+        let keys = v["keys"].as_array().expect("JWKS must have 'keys'");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0]["kty"], "EC");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Negative fixtures
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mismatch_public_key_differs_from_original() {
+    let kp = fx().ecdsa("mismatch-ec", EcdsaSpec::es256());
+    let original = kp.public_key_spki_der();
+    let mismatched = kp.mismatched_public_key_spki_der();
+    assert_ne!(original, mismatched.as_slice());
+}
+
+#[test]
+fn corrupt_pem_is_not_parseable_as_valid_key() {
+    let kp = fx().ecdsa("corrupt-ec", EcdsaSpec::es256());
+    let corrupt =
+        kp.private_key_pkcs8_pem_corrupt(uselesskey_core::negative::CorruptPem::BadHeader);
+    assert!(!corrupt.starts_with("-----BEGIN PRIVATE KEY-----"));
+}
+
+#[test]
+fn truncated_der_has_exact_length() {
+    let kp = fx().ecdsa("trunc-ec", EcdsaSpec::es256());
+    let truncated = kp.private_key_pkcs8_der_truncated(8);
+    assert_eq!(truncated.len(), 8);
+}

--- a/crates/uselesskey-ed25519/tests/cache_coherence.rs
+++ b/crates/uselesskey-ed25519/tests/cache_coherence.rs
@@ -1,0 +1,43 @@
+//! Cache coherence integration tests for Ed25519.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+#[test]
+fn same_label_returns_identical_bytes() {
+    let fx = fx();
+    let kp1 = fx.ed25519("cache-eq", Ed25519Spec::new());
+    let kp2 = fx.ed25519("cache-eq", Ed25519Spec::new());
+    assert_eq!(
+        kp1.private_key_pkcs8_der(),
+        kp2.private_key_pkcs8_der(),
+        "same label must return identical private key bytes"
+    );
+}
+
+#[test]
+fn different_labels_produce_different_keys() {
+    let fx = fx();
+    let kp_a = fx.ed25519("ed-a", Ed25519Spec::new());
+    let kp_b = fx.ed25519("ed-b", Ed25519Spec::new());
+    assert_ne!(
+        kp_a.private_key_pkcs8_der(),
+        kp_b.private_key_pkcs8_der(),
+        "different labels must produce different keys"
+    );
+}
+
+#[test]
+fn cache_survives_factory_clone() {
+    let fx = fx();
+    let _warm = fx.ed25519("ed-clone", Ed25519Spec::new());
+    let fx2 = fx.clone();
+    let from_clone = fx2.ed25519("ed-clone", Ed25519Spec::new());
+    assert_eq!(
+        _warm.private_key_pkcs8_der(),
+        from_clone.private_key_pkcs8_der(),
+        "cloned factory must share the cache"
+    );
+}

--- a/crates/uselesskey-ed25519/tests/format_roundtrip.rs
+++ b/crates/uselesskey-ed25519/tests/format_roundtrip.rs
@@ -1,0 +1,114 @@
+//! Format roundtrip integration tests for Ed25519.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+// ---------------------------------------------------------------------------
+// PEM
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_pem_has_pkcs8_headers() {
+    let kp = fx().ed25519("pem-hdr", Ed25519Spec::new());
+    let pem = kp.private_key_pkcs8_pem();
+    assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PRIVATE KEY-----"));
+}
+
+#[test]
+fn public_pem_has_spki_headers() {
+    let kp = fx().ed25519("pem-pub", Ed25519Spec::new());
+    let pem = kp.public_key_spki_pem();
+    assert!(pem.starts_with("-----BEGIN PUBLIC KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PUBLIC KEY-----"));
+}
+
+// ---------------------------------------------------------------------------
+// DER
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_der_starts_with_sequence_tag() {
+    let kp = fx().ed25519("der-priv", Ed25519Spec::new());
+    assert_eq!(kp.private_key_pkcs8_der()[0], 0x30);
+}
+
+#[test]
+fn ed25519_der_is_compact() {
+    let kp = fx().ed25519("der-size", Ed25519Spec::new());
+    let priv_der = kp.private_key_pkcs8_der();
+    let pub_der = kp.public_key_spki_der();
+    // Ed25519 keys are small: ~48 bytes private, ~44 bytes public
+    assert!(
+        priv_der.len() < 200,
+        "Ed25519 private DER should be compact"
+    );
+    assert!(pub_der.len() < 100, "Ed25519 public DER should be compact");
+}
+
+// ---------------------------------------------------------------------------
+// JWK (requires `jwk` feature)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "jwk")]
+mod jwk_tests {
+    use super::*;
+
+    #[test]
+    fn jwk_has_okp_fields() {
+        let kp = fx().ed25519("jwk-okp", Ed25519Spec::new());
+        let v = kp.private_key_jwk().to_value();
+        assert_eq!(v["kty"], "OKP");
+        assert_eq!(v["crv"], "Ed25519");
+        assert!(v["x"].is_string(), "OKP JWK must have 'x'");
+        assert!(v["d"].is_string(), "private OKP JWK must have 'd'");
+    }
+
+    #[test]
+    fn public_jwk_omits_d() {
+        let kp = fx().ed25519("jwk-pub", Ed25519Spec::new());
+        let v = kp.public_jwk().to_value();
+        assert_eq!(v["kty"], "OKP");
+        assert!(v["d"].is_null(), "public JWK must not contain 'd'");
+    }
+
+    #[test]
+    fn jwks_wraps_key_in_array() {
+        let kp = fx().ed25519("jwks-okp", Ed25519Spec::new());
+        let v = kp.public_jwks().to_value();
+        let keys = v["keys"].as_array().expect("JWKS must have 'keys'");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0]["kty"], "OKP");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Negative fixtures
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mismatch_public_key_differs_from_original() {
+    let kp = fx().ed25519("mismatch-ed", Ed25519Spec::new());
+    let original = kp.public_key_spki_der();
+    let mismatched = kp.mismatched_public_key_spki_der();
+    assert_ne!(original, mismatched.as_slice());
+}
+
+#[test]
+fn corrupt_pem_alters_header() {
+    let kp = fx().ed25519("corrupt-ed", Ed25519Spec::new());
+    let corrupt =
+        kp.private_key_pkcs8_pem_corrupt(uselesskey_core::negative::CorruptPem::BadHeader);
+    assert!(!corrupt.starts_with("-----BEGIN PRIVATE KEY-----"));
+}
+
+#[test]
+fn truncated_der_is_prefix_of_original() {
+    let kp = fx().ed25519("trunc-ed", Ed25519Spec::new());
+    let original = kp.private_key_pkcs8_der();
+    let truncated = kp.private_key_pkcs8_der_truncated(16);
+    assert_eq!(truncated.len(), 16);
+    assert_eq!(&original[..16], truncated.as_slice());
+}

--- a/crates/uselesskey-hmac/tests/cache_coherence.rs
+++ b/crates/uselesskey-hmac/tests/cache_coherence.rs
@@ -1,0 +1,97 @@
+//! Cache coherence integration tests for HMAC.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
+
+#[test]
+fn same_label_same_spec_returns_identical_bytes() {
+    let fx = fx();
+    let s1 = fx.hmac("cache-eq", HmacSpec::hs256());
+    let s2 = fx.hmac("cache-eq", HmacSpec::hs256());
+    assert_eq!(
+        s1.secret_bytes(),
+        s2.secret_bytes(),
+        "same label+spec must return identical secret bytes"
+    );
+}
+
+#[test]
+fn different_labels_produce_different_secrets() {
+    let fx = fx();
+    let s_a = fx.hmac("hmac-a", HmacSpec::hs256());
+    let s_b = fx.hmac("hmac-b", HmacSpec::hs256());
+    assert_ne!(
+        s_a.secret_bytes(),
+        s_b.secret_bytes(),
+        "different labels must produce different secrets"
+    );
+}
+
+#[test]
+fn different_specs_produce_different_secrets() {
+    let fx = fx();
+    let s_256 = fx.hmac("spec-diff", HmacSpec::hs256());
+    let s_512 = fx.hmac("spec-diff", HmacSpec::hs512());
+    assert_ne!(
+        s_256.secret_bytes(),
+        s_512.secret_bytes(),
+        "different specs must produce different secrets"
+    );
+}
+
+#[test]
+fn cache_survives_factory_clone() {
+    let fx = fx();
+    let _warm = fx.hmac("hmac-clone", HmacSpec::hs256());
+    let fx2 = fx.clone();
+    let from_clone = fx2.hmac("hmac-clone", HmacSpec::hs256());
+    assert_eq!(
+        _warm.secret_bytes(),
+        from_clone.secret_bytes(),
+        "cloned factory must share the cache"
+    );
+}
+
+#[test]
+fn secret_length_matches_spec() {
+    let fx = fx();
+    assert_eq!(
+        fx.hmac("len-256", HmacSpec::hs256()).secret_bytes().len(),
+        32
+    );
+    assert_eq!(
+        fx.hmac("len-384", HmacSpec::hs384()).secret_bytes().len(),
+        48
+    );
+    assert_eq!(
+        fx.hmac("len-512", HmacSpec::hs512()).secret_bytes().len(),
+        64
+    );
+}
+
+// ---------------------------------------------------------------------------
+// JWK (requires `jwk` feature)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "jwk")]
+mod jwk_tests {
+    use super::*;
+
+    #[test]
+    fn jwk_has_oct_kty() {
+        let s = fx().hmac("jwk-oct", HmacSpec::hs256());
+        let v = s.jwk().to_value();
+        assert_eq!(v["kty"], "oct");
+        assert!(v["k"].is_string(), "oct JWK must have 'k' (key value)");
+    }
+
+    #[test]
+    fn jwks_wraps_key_in_array() {
+        let s = fx().hmac("jwks-oct", HmacSpec::hs256());
+        let v = s.jwks().to_value();
+        let keys = v["keys"].as_array().expect("JWKS must have 'keys'");
+        assert_eq!(keys.len(), 1);
+    }
+}

--- a/crates/uselesskey-pgp/tests/cache_coherence.rs
+++ b/crates/uselesskey-pgp/tests/cache_coherence.rs
@@ -1,0 +1,55 @@
+//! Cache coherence integration tests for PGP.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_pgp::{PgpFactoryExt, PgpSpec};
+
+#[test]
+fn same_label_same_spec_returns_identical_bytes() {
+    let fx = fx();
+    let kp1 = fx.pgp("cache-eq", PgpSpec::ed25519());
+    let kp2 = fx.pgp("cache-eq", PgpSpec::ed25519());
+    assert_eq!(
+        kp1.private_key_binary(),
+        kp2.private_key_binary(),
+        "same label+spec must return identical key bytes"
+    );
+}
+
+#[test]
+fn different_labels_produce_different_keys() {
+    let fx = fx();
+    let kp_a = fx.pgp("pgp-a", PgpSpec::ed25519());
+    let kp_b = fx.pgp("pgp-b", PgpSpec::ed25519());
+    assert_ne!(
+        kp_a.private_key_binary(),
+        kp_b.private_key_binary(),
+        "different labels must produce different keys"
+    );
+}
+
+#[test]
+fn different_specs_produce_different_keys() {
+    let fx = fx();
+    let kp_ed = fx.pgp("spec-diff", PgpSpec::ed25519());
+    let kp_rsa = fx.pgp("spec-diff", PgpSpec::rsa_2048());
+    assert_ne!(
+        kp_ed.private_key_binary(),
+        kp_rsa.private_key_binary(),
+        "different specs must produce different keys"
+    );
+}
+
+#[test]
+fn cache_survives_factory_clone() {
+    let fx = fx();
+    let _warm = fx.pgp("pgp-clone", PgpSpec::ed25519());
+    let fx2 = fx.clone();
+    let from_clone = fx2.pgp("pgp-clone", PgpSpec::ed25519());
+    assert_eq!(
+        _warm.private_key_binary(),
+        from_clone.private_key_binary(),
+        "cloned factory must share the cache"
+    );
+}

--- a/crates/uselesskey-pgp/tests/format_roundtrip.rs
+++ b/crates/uselesskey-pgp/tests/format_roundtrip.rs
@@ -1,0 +1,108 @@
+//! Format roundtrip integration tests for PGP.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_pgp::{PgpFactoryExt, PgpSpec};
+
+// ---------------------------------------------------------------------------
+// Armored (PEM-like) format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_armored_has_pgp_headers() {
+    let kp = fx().pgp("arm-priv", PgpSpec::ed25519());
+    let armored = kp.private_key_armored();
+    assert!(
+        armored.contains("BEGIN PGP PRIVATE KEY BLOCK"),
+        "private armored must contain PGP private header"
+    );
+    assert!(
+        armored.contains("END PGP PRIVATE KEY BLOCK"),
+        "private armored must contain PGP private footer"
+    );
+}
+
+#[test]
+fn public_armored_has_pgp_headers() {
+    let kp = fx().pgp("arm-pub", PgpSpec::ed25519());
+    let armored = kp.public_key_armored();
+    assert!(
+        armored.contains("BEGIN PGP PUBLIC KEY BLOCK"),
+        "public armored must contain PGP public header"
+    );
+    assert!(
+        armored.contains("END PGP PUBLIC KEY BLOCK"),
+        "public armored must contain PGP public footer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Binary format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_binary_is_non_empty() {
+    let kp = fx().pgp("bin-priv", PgpSpec::ed25519());
+    assert!(!kp.private_key_binary().is_empty());
+}
+
+#[test]
+fn public_binary_is_non_empty() {
+    let kp = fx().pgp("bin-pub", PgpSpec::ed25519());
+    assert!(!kp.public_key_binary().is_empty());
+}
+
+#[test]
+fn rsa_keys_are_larger_than_ed25519() {
+    let fx = fx();
+    let ed = fx.pgp("size-ed", PgpSpec::ed25519());
+    let rsa = fx.pgp("size-rsa", PgpSpec::rsa_2048());
+    assert!(
+        rsa.private_key_binary().len() > ed.private_key_binary().len(),
+        "RSA PGP key should be larger than Ed25519 PGP key"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative fixtures
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mismatch_public_key_differs_from_original() {
+    let kp = fx().pgp("mismatch-pgp", PgpSpec::ed25519());
+    let original = kp.public_key_binary();
+    let mismatched = kp.mismatched_public_key_binary();
+    assert_ne!(
+        original,
+        &mismatched[..],
+        "mismatched public key must differ from original"
+    );
+}
+
+#[test]
+fn corrupt_armored_alters_header() {
+    let kp = fx().pgp("corrupt-pgp", PgpSpec::ed25519());
+    let corrupt = kp.private_key_armored_corrupt(uselesskey_core::negative::CorruptPem::BadHeader);
+    assert!(
+        !corrupt.contains("BEGIN PGP PRIVATE KEY BLOCK"),
+        "corrupt BadHeader must not have original PGP header"
+    );
+}
+
+#[test]
+fn truncated_binary_has_exact_length() {
+    let kp = fx().pgp("trunc-pgp", PgpSpec::ed25519());
+    let truncated = kp.private_key_binary_truncated(12);
+    assert_eq!(truncated.len(), 12);
+}
+
+#[test]
+fn mismatch_armored_is_valid_pgp_format() {
+    let kp = fx().pgp("mismatch-arm", PgpSpec::ed25519());
+    let mismatched = kp.mismatched_public_key_armored();
+    assert!(
+        mismatched.contains("BEGIN PGP PUBLIC KEY BLOCK"),
+        "mismatched armored key must be valid PGP format"
+    );
+}

--- a/crates/uselesskey-rsa/tests/cache_coherence.rs
+++ b/crates/uselesskey-rsa/tests/cache_coherence.rs
@@ -1,0 +1,63 @@
+//! Cache coherence integration tests for RSA.
+//!
+//! Verifies that the factory cache behaves correctly across repeated
+//! calls, different labels, and factory clones.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+#[test]
+fn same_label_same_spec_returns_identical_bytes() {
+    let fx = fx();
+    let kp1 = fx.rsa("cache-eq", RsaSpec::rs256());
+    let kp2 = fx.rsa("cache-eq", RsaSpec::rs256());
+    assert_eq!(
+        kp1.private_key_pkcs8_der(),
+        kp2.private_key_pkcs8_der(),
+        "same label+spec must return identical private key bytes"
+    );
+    assert_eq!(
+        kp1.public_key_spki_der(),
+        kp2.public_key_spki_der(),
+        "same label+spec must return identical public key bytes"
+    );
+}
+
+#[test]
+fn different_labels_produce_different_keys() {
+    let fx = fx();
+    let kp_a = fx.rsa("label-a", RsaSpec::rs256());
+    let kp_b = fx.rsa("label-b", RsaSpec::rs256());
+    assert_ne!(
+        kp_a.private_key_pkcs8_der(),
+        kp_b.private_key_pkcs8_der(),
+        "different labels must produce different private keys"
+    );
+}
+
+#[test]
+fn cache_survives_factory_clone() {
+    let fx = fx();
+    let _warm = fx.rsa("clone-test", RsaSpec::rs256());
+    let fx2 = fx.clone();
+    let from_clone = fx2.rsa("clone-test", RsaSpec::rs256());
+    assert_eq!(
+        _warm.private_key_pkcs8_der(),
+        from_clone.private_key_pkcs8_der(),
+        "cloned factory must share the cache"
+    );
+}
+
+#[test]
+fn different_specs_produce_different_keys() {
+    let fx = fx();
+    let kp_2048 = fx.rsa("spec-diff", RsaSpec::rs256());
+    let kp_4096 = fx.rsa("spec-diff", RsaSpec::new(4096));
+    assert_ne!(
+        kp_2048.private_key_pkcs8_der(),
+        kp_4096.private_key_pkcs8_der(),
+        "different specs must produce different keys"
+    );
+}

--- a/crates/uselesskey-rsa/tests/format_roundtrip.rs
+++ b/crates/uselesskey-rsa/tests/format_roundtrip.rs
@@ -1,0 +1,131 @@
+//! Format roundtrip integration tests for RSA.
+//!
+//! Validates PEM structure, DER ASN.1 framing, and JWK/JWKS field
+//! correctness for RSA key pairs.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+// ---------------------------------------------------------------------------
+// PEM roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_pem_has_correct_headers() {
+    let kp = fx().rsa("pem-hdr", RsaSpec::rs256());
+    let pem = kp.private_key_pkcs8_pem();
+    assert!(
+        pem.starts_with("-----BEGIN PRIVATE KEY-----"),
+        "private PEM must start with PKCS#8 header"
+    );
+    assert!(
+        pem.trim_end().ends_with("-----END PRIVATE KEY-----"),
+        "private PEM must end with PKCS#8 footer"
+    );
+}
+
+#[test]
+fn public_pem_has_correct_headers() {
+    let kp = fx().rsa("pem-pub", RsaSpec::rs256());
+    let pem = kp.public_key_spki_pem();
+    assert!(
+        pem.starts_with("-----BEGIN PUBLIC KEY-----"),
+        "public PEM must start with SPKI header"
+    );
+    assert!(
+        pem.trim_end().ends_with("-----END PUBLIC KEY-----"),
+        "public PEM must end with SPKI footer"
+    );
+}
+
+#[test]
+fn private_pem_body_is_valid_base64_lines() {
+    let kp = fx().rsa("pem-b64", RsaSpec::rs256());
+    let pem = kp.private_key_pkcs8_pem();
+    for line in pem.lines() {
+        if line.starts_with("-----") {
+            continue;
+        }
+        assert!(
+            line.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '='),
+            "PEM body line must be valid base64: {line}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DER structure
+// ---------------------------------------------------------------------------
+
+#[test]
+fn private_der_starts_with_sequence_tag() {
+    let kp = fx().rsa("der-priv", RsaSpec::rs256());
+    let der = kp.private_key_pkcs8_der();
+    assert!(!der.is_empty(), "DER must not be empty");
+    assert_eq!(
+        der[0], 0x30,
+        "PKCS#8 DER must start with SEQUENCE tag (0x30)"
+    );
+}
+
+#[test]
+fn public_der_starts_with_sequence_tag() {
+    let kp = fx().rsa("der-pub", RsaSpec::rs256());
+    let der = kp.public_key_spki_der();
+    assert_eq!(der[0], 0x30, "SPKI DER must start with SEQUENCE tag (0x30)");
+}
+
+#[test]
+fn der_length_is_reasonable() {
+    let kp = fx().rsa("der-len", RsaSpec::rs256());
+    let priv_der = kp.private_key_pkcs8_der();
+    let pub_der = kp.public_key_spki_der();
+    // RSA-2048 private key DER is typically ~1200 bytes
+    assert!(priv_der.len() > 500, "RSA-2048 private DER too short");
+    assert!(priv_der.len() < 3000, "RSA-2048 private DER too long");
+    // RSA-2048 public key DER is typically ~300 bytes
+    assert!(pub_der.len() > 200, "RSA-2048 public DER too short");
+    assert!(pub_der.len() < 600, "RSA-2048 public DER too long");
+}
+
+// ---------------------------------------------------------------------------
+// JWK roundtrip (requires `jwk` feature)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "jwk")]
+mod jwk_tests {
+    use super::*;
+
+    #[test]
+    fn jwk_has_required_rsa_fields() {
+        let kp = fx().rsa("jwk-fields", RsaSpec::rs256());
+        let v = kp.private_key_jwk().to_value();
+        assert_eq!(v["kty"], "RSA", "JWK kty must be RSA");
+        assert!(v["n"].is_string(), "JWK must have modulus 'n'");
+        assert!(v["e"].is_string(), "JWK must have exponent 'e'");
+        assert!(v["d"].is_string(), "private JWK must have 'd'");
+        assert!(v["kid"].is_string(), "JWK must have 'kid'");
+    }
+
+    #[test]
+    fn public_jwk_omits_private_fields() {
+        let kp = fx().rsa("jwk-pub", RsaSpec::rs256());
+        let v = kp.public_jwk().to_value();
+        assert_eq!(v["kty"], "RSA");
+        assert!(v["d"].is_null(), "public JWK must not contain 'd'");
+        assert!(v["p"].is_null(), "public JWK must not contain 'p'");
+        assert!(v["q"].is_null(), "public JWK must not contain 'q'");
+    }
+
+    #[test]
+    fn jwks_wraps_single_key_in_keys_array() {
+        let kp = fx().rsa("jwks-arr", RsaSpec::rs256());
+        let v = kp.public_jwks().to_value();
+        let keys = v["keys"].as_array().expect("JWKS must have 'keys' array");
+        assert_eq!(keys.len(), 1, "single-key JWKS must have exactly 1 entry");
+        assert_eq!(keys[0]["kty"], "RSA");
+    }
+}

--- a/crates/uselesskey-rsa/tests/negative_integration.rs
+++ b/crates/uselesskey-rsa/tests/negative_integration.rs
@@ -1,0 +1,127 @@
+//! Negative fixture integration tests for RSA.
+//!
+//! Validates mismatch keys, corrupt PEM variants, and truncated DER
+//! produce the expected invalid-but-structurally-correct outputs.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_core::negative::CorruptPem;
+use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+// ---------------------------------------------------------------------------
+// Mismatch variant
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mismatch_public_key_differs_from_original() {
+    let kp = fx().rsa("mismatch-rsa", RsaSpec::rs256());
+    let original_pub = kp.public_key_spki_der();
+    let mismatched_pub = kp.mismatched_public_key_spki_der();
+    assert_ne!(
+        original_pub,
+        mismatched_pub.as_slice(),
+        "mismatched public key must differ from the original"
+    );
+}
+
+#[test]
+fn mismatch_key_is_valid_spki_der() {
+    let kp = fx().rsa("mismatch-valid", RsaSpec::rs256());
+    let mismatched = kp.mismatched_public_key_spki_der();
+    assert!(!mismatched.is_empty(), "mismatched DER must not be empty");
+    assert_eq!(
+        mismatched[0], 0x30,
+        "mismatched DER must start with SEQUENCE tag"
+    );
+}
+
+#[test]
+fn mismatch_is_deterministic() {
+    let fx = fx();
+    let kp1 = fx.rsa("mismatch-det", RsaSpec::rs256());
+    let kp2 = fx.rsa("mismatch-det", RsaSpec::rs256());
+    assert_eq!(
+        kp1.mismatched_public_key_spki_der(),
+        kp2.mismatched_public_key_spki_der(),
+        "mismatched key must be deterministic"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Corrupt PEM variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn corrupt_pem_bad_header() {
+    let kp = fx().rsa("corrupt-hdr", RsaSpec::rs256());
+    let corrupt = kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+    assert!(
+        !corrupt.starts_with("-----BEGIN PRIVATE KEY-----"),
+        "corrupt BadHeader must not have the original header"
+    );
+    // Should still look PEM-ish (has dashes)
+    assert!(
+        corrupt.contains("-----"),
+        "corrupt PEM should still contain dashes"
+    );
+}
+
+#[test]
+fn corrupt_pem_bad_footer() {
+    let kp = fx().rsa("corrupt-ftr", RsaSpec::rs256());
+    let corrupt = kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadFooter);
+    assert!(
+        !corrupt.trim_end().ends_with("-----END PRIVATE KEY-----"),
+        "corrupt BadFooter must not have the original footer"
+    );
+}
+
+#[test]
+fn corrupt_pem_bad_base64() {
+    let kp = fx().rsa("corrupt-b64", RsaSpec::rs256());
+    let corrupt = kp.private_key_pkcs8_pem_corrupt(CorruptPem::BadBase64);
+    // The corrupt PEM should still have PEM headers
+    assert!(
+        corrupt.contains("BEGIN"),
+        "BadBase64 variant should retain PEM framing"
+    );
+}
+
+#[test]
+fn corrupt_pem_truncate() {
+    let kp = fx().rsa("corrupt-trunc", RsaSpec::rs256());
+    let original = kp.private_key_pkcs8_pem();
+    let corrupt = kp.private_key_pkcs8_pem_corrupt(CorruptPem::Truncate { bytes: 50 });
+    assert!(
+        corrupt.len() < original.len(),
+        "truncated PEM must be shorter than original"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Truncated DER
+// ---------------------------------------------------------------------------
+
+#[test]
+fn truncated_der_has_requested_length() {
+    let kp = fx().rsa("trunc-der", RsaSpec::rs256());
+    let truncated = kp.private_key_pkcs8_der_truncated(10);
+    assert_eq!(
+        truncated.len(),
+        10,
+        "truncated DER must be exactly 10 bytes"
+    );
+}
+
+#[test]
+fn truncated_der_is_prefix_of_original() {
+    let kp = fx().rsa("trunc-prefix", RsaSpec::rs256());
+    let original = kp.private_key_pkcs8_der();
+    let truncated = kp.private_key_pkcs8_der_truncated(20);
+    assert_eq!(
+        &original[..20],
+        truncated.as_slice(),
+        "truncated DER must be a prefix of the original"
+    );
+}

--- a/crates/uselesskey-token/tests/cache_coherence.rs
+++ b/crates/uselesskey-token/tests/cache_coherence.rs
@@ -1,0 +1,84 @@
+//! Cache coherence integration tests for Token.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_token::{TokenFactoryExt, TokenSpec};
+
+#[test]
+fn same_label_same_spec_returns_identical_token() {
+    let fx = fx();
+    let t1 = fx.token("cache-eq", TokenSpec::api_key());
+    let t2 = fx.token("cache-eq", TokenSpec::api_key());
+    assert_eq!(
+        t1.value(),
+        t2.value(),
+        "same label+spec must return identical token value"
+    );
+}
+
+#[test]
+fn different_labels_produce_different_tokens() {
+    let fx = fx();
+    let t_a = fx.token("tok-a", TokenSpec::api_key());
+    let t_b = fx.token("tok-b", TokenSpec::api_key());
+    assert_ne!(
+        t_a.value(),
+        t_b.value(),
+        "different labels must produce different tokens"
+    );
+}
+
+#[test]
+fn different_specs_produce_different_tokens() {
+    let fx = fx();
+    let t_api = fx.token("spec-diff", TokenSpec::api_key());
+    let t_bearer = fx.token("spec-diff", TokenSpec::bearer());
+    assert_ne!(
+        t_api.value(),
+        t_bearer.value(),
+        "different specs must produce different tokens"
+    );
+}
+
+#[test]
+fn cache_survives_factory_clone() {
+    let fx = fx();
+    let _warm = fx.token("tok-clone", TokenSpec::bearer());
+    let fx2 = fx.clone();
+    let from_clone = fx2.token("tok-clone", TokenSpec::bearer());
+    assert_eq!(
+        _warm.value(),
+        from_clone.value(),
+        "cloned factory must share the cache"
+    );
+}
+
+#[test]
+fn api_key_has_expected_prefix() {
+    let fx = fx();
+    let t = fx.token("prefix-test", TokenSpec::api_key());
+    assert!(
+        t.value().starts_with("uk_test_"),
+        "api key must start with 'uk_test_' prefix, got: {}",
+        t.value()
+    );
+}
+
+#[test]
+fn bearer_token_is_non_empty() {
+    let fx = fx();
+    let t = fx.token("bearer-ne", TokenSpec::bearer());
+    assert!(!t.value().is_empty(), "bearer token must not be empty");
+}
+
+#[test]
+fn authorization_header_contains_token() {
+    let fx = fx();
+    let t = fx.token("auth-hdr", TokenSpec::bearer());
+    let hdr = t.authorization_header();
+    assert!(
+        hdr.contains(t.value()),
+        "authorization header must contain the token value"
+    );
+}

--- a/crates/uselesskey-x509/tests/cache_coherence.rs
+++ b/crates/uselesskey-x509/tests/cache_coherence.rs
@@ -1,0 +1,47 @@
+//! Cache coherence integration tests for X.509.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_x509::{X509FactoryExt, X509Spec};
+
+#[test]
+fn same_label_same_spec_returns_identical_cert() {
+    let fx = fx();
+    let spec = X509Spec::self_signed("cache.example.com");
+    let c1 = fx.x509_self_signed("cache-eq", spec);
+    let spec = X509Spec::self_signed("cache.example.com");
+    let c2 = fx.x509_self_signed("cache-eq", spec);
+    assert_eq!(
+        c1.cert_der(),
+        c2.cert_der(),
+        "same label+spec must return identical cert DER"
+    );
+}
+
+#[test]
+fn different_labels_produce_different_certs() {
+    let fx = fx();
+    let c_a = fx.x509_self_signed("x509-a", X509Spec::self_signed("a.example.com"));
+    let c_b = fx.x509_self_signed("x509-b", X509Spec::self_signed("a.example.com"));
+    assert_ne!(
+        c_a.cert_der(),
+        c_b.cert_der(),
+        "different labels must produce different certs"
+    );
+}
+
+#[test]
+fn cache_survives_factory_clone() {
+    let fx = fx();
+    let spec = X509Spec::self_signed("clone.example.com");
+    let _warm = fx.x509_self_signed("x509-clone", spec);
+    let fx2 = fx.clone();
+    let spec2 = X509Spec::self_signed("clone.example.com");
+    let from_clone = fx2.x509_self_signed("x509-clone", spec2);
+    assert_eq!(
+        _warm.cert_der(),
+        from_clone.cert_der(),
+        "cloned factory must share the cache"
+    );
+}

--- a/crates/uselesskey-x509/tests/format_roundtrip.rs
+++ b/crates/uselesskey-x509/tests/format_roundtrip.rs
@@ -1,0 +1,92 @@
+//! Format roundtrip integration tests for X.509.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_x509::{X509FactoryExt, X509Negative, X509Spec};
+
+// ---------------------------------------------------------------------------
+// PEM
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cert_pem_has_certificate_headers() {
+    let cert = fx().x509_self_signed("pem-hdr", X509Spec::self_signed("test.example.com"));
+    let pem = cert.cert_pem();
+    assert!(pem.starts_with("-----BEGIN CERTIFICATE-----"));
+    assert!(pem.trim_end().ends_with("-----END CERTIFICATE-----"));
+}
+
+#[test]
+fn private_key_pem_has_pkcs8_headers() {
+    let cert = fx().x509_self_signed("pem-key", X509Spec::self_signed("test.example.com"));
+    let pem = cert.private_key_pkcs8_pem();
+    assert!(pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    assert!(pem.trim_end().ends_with("-----END PRIVATE KEY-----"));
+}
+
+// ---------------------------------------------------------------------------
+// DER
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cert_der_starts_with_sequence_tag() {
+    let cert = fx().x509_self_signed("der-cert", X509Spec::self_signed("test.example.com"));
+    let der = cert.cert_der();
+    assert!(!der.is_empty());
+    assert_eq!(der[0], 0x30, "X.509 cert DER must start with SEQUENCE tag");
+}
+
+#[test]
+fn private_key_der_starts_with_sequence_tag() {
+    let cert = fx().x509_self_signed("der-key", X509Spec::self_signed("test.example.com"));
+    let der = cert.private_key_pkcs8_der();
+    assert_eq!(der[0], 0x30, "PKCS#8 DER must start with SEQUENCE tag");
+}
+
+// ---------------------------------------------------------------------------
+// Negative: expired / not-yet-valid
+// ---------------------------------------------------------------------------
+
+#[test]
+fn expired_cert_has_different_der_than_valid() {
+    let cert = fx().x509_self_signed("neg-exp", X509Spec::self_signed("test.example.com"));
+    let expired = cert.negative(X509Negative::Expired);
+    assert_ne!(
+        cert.cert_der(),
+        expired.cert_der(),
+        "expired cert must differ from valid cert"
+    );
+}
+
+#[test]
+fn not_yet_valid_cert_has_different_der_than_valid() {
+    let cert = fx().x509_self_signed("neg-nyv", X509Spec::self_signed("test.example.com"));
+    let nyv = cert.negative(X509Negative::NotYetValid);
+    assert_ne!(
+        cert.cert_der(),
+        nyv.cert_der(),
+        "not-yet-valid cert must differ from valid cert"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Corrupt PEM
+// ---------------------------------------------------------------------------
+
+#[test]
+fn corrupt_cert_pem_bad_header() {
+    let cert = fx().x509_self_signed("corrupt-cert", X509Spec::self_signed("test.example.com"));
+    let corrupt = cert.corrupt_cert_pem(uselesskey_core::negative::CorruptPem::BadHeader);
+    assert!(
+        !corrupt.starts_with("-----BEGIN CERTIFICATE-----"),
+        "corrupt BadHeader must not have original header"
+    );
+}
+
+#[test]
+fn truncated_cert_der_has_requested_length() {
+    let cert = fx().x509_self_signed("trunc-cert", X509Spec::self_signed("test.example.com"));
+    let truncated = cert.truncate_cert_der(20);
+    assert_eq!(truncated.len(), 20);
+}

--- a/crates/uselesskey/tests/multi_algorithm_isolation.rs
+++ b/crates/uselesskey/tests/multi_algorithm_isolation.rs
@@ -1,0 +1,87 @@
+//! Multi-algorithm isolation tests.
+//!
+//! Verifies that generating keys of different algorithm types from the
+//! same factory does not interfere with each other, and that generation
+//! order does not affect outputs.
+
+#![cfg(feature = "full")]
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey::prelude::*;
+
+/// Generating RSA, ECDSA, and Ed25519 from the same factory produces
+/// distinct, algorithm-appropriate keys.
+#[test]
+fn different_algorithms_produce_independent_keys() {
+    let fx = fx();
+    let rsa = fx.rsa("multi-alg", RsaSpec::rs256());
+    let ecdsa = fx.ecdsa("multi-alg", EcdsaSpec::es256());
+    let ed = fx.ed25519("multi-alg", Ed25519Spec::new());
+
+    // Each algorithm domain is independent (keys differ by nature)
+    let rsa_der = rsa.private_key_pkcs8_der();
+    let ecdsa_der = ecdsa.private_key_pkcs8_der();
+    let ed_der = ed.private_key_pkcs8_der();
+
+    assert_ne!(rsa_der, ecdsa_der, "RSA and ECDSA keys must differ");
+    assert_ne!(rsa_der, ed_der, "RSA and Ed25519 keys must differ");
+    assert_ne!(ecdsa_der, ed_der, "ECDSA and Ed25519 keys must differ");
+}
+
+/// Order of generation must not affect the output of any algorithm.
+#[test]
+fn generation_order_does_not_affect_outputs() {
+    let seed = Seed::from_env_value("order-test-seed-v1").unwrap();
+
+    // Generate in order: RSA → ECDSA → Ed25519
+    let fx1 = Factory::deterministic(seed);
+    let rsa1 = fx1.rsa("order-test", RsaSpec::rs256());
+    let ecdsa1 = fx1.ecdsa("order-test", EcdsaSpec::es256());
+    let ed1 = fx1.ed25519("order-test", Ed25519Spec::new());
+
+    // Generate in reverse order: Ed25519 → ECDSA → RSA
+    let fx2 = Factory::deterministic(seed);
+    let ed2 = fx2.ed25519("order-test", Ed25519Spec::new());
+    let ecdsa2 = fx2.ecdsa("order-test", EcdsaSpec::es256());
+    let rsa2 = fx2.rsa("order-test", RsaSpec::rs256());
+
+    assert_eq!(
+        rsa1.private_key_pkcs8_der(),
+        rsa2.private_key_pkcs8_der(),
+        "RSA key must be identical regardless of generation order"
+    );
+    assert_eq!(
+        ecdsa1.private_key_pkcs8_der(),
+        ecdsa2.private_key_pkcs8_der(),
+        "ECDSA key must be identical regardless of generation order"
+    );
+    assert_eq!(
+        ed1.private_key_pkcs8_der(),
+        ed2.private_key_pkcs8_der(),
+        "Ed25519 key must be identical regardless of generation order"
+    );
+}
+
+/// HMAC and token generation does not interfere with asymmetric keys.
+#[test]
+fn symmetric_and_asymmetric_do_not_interfere() {
+    let seed = Seed::from_env_value("sym-asym-test-v1").unwrap();
+
+    // Generate HMAC first, then RSA
+    let fx1 = Factory::deterministic(seed);
+    let _hmac1 = fx1.hmac("interference", HmacSpec::hs256());
+    let rsa1 = fx1.rsa("interference", RsaSpec::rs256());
+
+    // Generate RSA first, then HMAC
+    let fx2 = Factory::deterministic(seed);
+    let rsa2 = fx2.rsa("interference", RsaSpec::rs256());
+    let _hmac2 = fx2.hmac("interference", HmacSpec::hs256());
+
+    assert_eq!(
+        rsa1.private_key_pkcs8_der(),
+        rsa2.private_key_pkcs8_der(),
+        "HMAC generation must not affect RSA output"
+    );
+}


### PR DESCRIPTION
## Wave 126: Expand integration tests for algorithm crates

Adds comprehensive integration tests to all algorithm crates (RSA, ECDSA, Ed25519, HMAC, token, X.509, PGP) covering cross-cutting concerns that unit tests miss.

### Tests added (14 files, ~80 new tests):

**Cache coherence** (7 crates):
- Same factory + same label + same spec → identical bytes
- Different labels → different keys
- Different specs → different keys
- Cache survives across factory clone

**Format roundtrip** (RSA, ECDSA, Ed25519, X509, PGP):
- PEM headers/footers validation (PKCS#8, SPKI, CERTIFICATE, PGP armor)
- PEM body is valid base64 lines
- DER starts with ASN.1 SEQUENCE tag (0x30)
- DER size is reasonable for key type
- JWK has required fields (kty, kid, algorithm-specific fields)
- Public JWK omits private components (d, p, q)
- JWKS wraps key in keys array

**Negative fixture integration** (RSA, ECDSA, Ed25519, X509, PGP):
- Mismatch public key differs from original
- Mismatch key is valid SPKI DER / PGP format
- Mismatch is deterministic
- All CorruptPem variants (BadHeader, BadFooter, BadBase64, Truncate)
- Truncated DER has exact requested length and is prefix of original

**Multi-algorithm isolation** (facade crate):
- RSA, ECDSA, Ed25519 from same factory don't interfere
- Generation order doesn't affect deterministic outputs
- Symmetric (HMAC) and asymmetric key generation don't interfere

### Verification:
- All tests pass with \--all-features\
- \cargo xtask clippy\ passes
- \cargo fmt --check\ passes