### PR TITLE
test: expand property-based tests across workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4169,6 +4169,7 @@ dependencies = [
 name = "uselesskey-jwk"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "serde_json",
  "uselesskey-core-jwk",
  "uselesskey-core-jwk-builder",
@@ -4280,6 +4281,9 @@ dependencies = [
 [[package]]
 name = "uselesskey-token-spec"
 version = "0.1.0"
+dependencies = [
+ "proptest",
+]
 
 [[package]]
 name = "uselesskey-tonic"
@@ -4835,9 +4839,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
 
 [[package]]
 name = "zmij"

--- a/crates/uselesskey-jwk/Cargo.toml
+++ b/crates/uselesskey-jwk/Cargo.toml
@@ -19,6 +19,7 @@ uselesskey-core-jwk = { path = "../uselesskey-core-jwk", version = "0.1.0" }
 uselesskey-core-jwk-builder = { path = "../uselesskey-core-jwk-builder", version = "0.1.0" }
 
 [dev-dependencies]
+proptest.workspace = true
 serde_json.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-jwk/tests/prop_jwk.rs
+++ b/crates/uselesskey-jwk/tests/prop_jwk.rs
@@ -1,0 +1,120 @@
+//! Property tests for the uselesskey-jwk re-export / builder layer.
+
+use proptest::prelude::*;
+use uselesskey_jwk::*;
+
+fn arb_rsa_public_jwk(kid: String) -> RsaPublicJwk {
+    RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid,
+        n: "modulus".to_string(),
+        e: "AQAB".to_string(),
+    }
+}
+
+fn arb_ec_public_jwk(kid: String) -> EcPublicJwk {
+    EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid,
+        x: "x-value".to_string(),
+        y: "y-value".to_string(),
+    }
+}
+
+fn arb_okp_public_jwk(kid: String) -> OkpPublicJwk {
+    OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid,
+        x: "x-value".to_string(),
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// kid() accessor always returns the kid passed at construction.
+    #[test]
+    fn kid_accessor_returns_correct_value(kid in "[a-zA-Z0-9_-]{1,30}") {
+        let rsa = PublicJwk::Rsa(arb_rsa_public_jwk(kid.clone()));
+        prop_assert_eq!(rsa.kid(), kid.as_str());
+
+        let ec = PublicJwk::Ec(arb_ec_public_jwk(kid.clone()));
+        prop_assert_eq!(ec.kid(), kid.as_str());
+
+        let okp = PublicJwk::Okp(arb_okp_public_jwk(kid.clone()));
+        prop_assert_eq!(okp.kid(), kid.as_str());
+    }
+
+    /// AnyJwk delegates kid() correctly for all public variants.
+    #[test]
+    fn any_jwk_kid_delegation(kid in "[a-zA-Z0-9_-]{1,30}") {
+        let rsa = AnyJwk::Public(PublicJwk::Rsa(arb_rsa_public_jwk(kid.clone())));
+        prop_assert_eq!(rsa.kid(), kid.as_str());
+
+        let ec = AnyJwk::Public(PublicJwk::Ec(arb_ec_public_jwk(kid.clone())));
+        prop_assert_eq!(ec.kid(), kid.as_str());
+
+        let okp = AnyJwk::Public(PublicJwk::Okp(arb_okp_public_jwk(kid.clone())));
+        prop_assert_eq!(okp.kid(), kid.as_str());
+    }
+
+    /// JwksBuilder produces keys sorted by kid.
+    #[test]
+    fn builder_sorts_by_kid(
+        kid_a in "[a-zA-Z][a-zA-Z0-9]{0,10}",
+        kid_b in "[a-zA-Z][a-zA-Z0-9]{0,10}",
+    ) {
+        let jwks = JwksBuilder::new()
+            .add_public(PublicJwk::Rsa(arb_rsa_public_jwk(kid_a.clone())))
+            .add_public(PublicJwk::Ec(arb_ec_public_jwk(kid_b.clone())))
+            .build();
+
+        prop_assert_eq!(jwks.keys.len(), 2);
+        // Keys should be sorted by kid.
+        prop_assert!(jwks.keys[0].kid() <= jwks.keys[1].kid());
+    }
+
+    /// JWKS Display is always valid JSON with a "keys" array.
+    #[test]
+    fn jwks_display_is_valid_json(kid in "[a-zA-Z0-9_]{1,15}") {
+        let jwks = JwksBuilder::new()
+            .add_public(PublicJwk::Rsa(arb_rsa_public_jwk(kid)))
+            .build();
+
+        let json: serde_json::Value = serde_json::from_str(&jwks.to_string())
+            .expect("JWKS Display should be valid JSON");
+        prop_assert!(json["keys"].is_array());
+        prop_assert_eq!(json["keys"].as_array().unwrap().len(), 1);
+    }
+
+    /// Serialized JWK always contains "use" field, not "use_".
+    #[test]
+    fn serde_uses_use_not_use_underscore(kid in "[a-zA-Z0-9]{1,10}") {
+        let jwk = arb_rsa_public_jwk(kid);
+        let json = serde_json::to_value(&jwk).unwrap();
+        prop_assert!(json.get("use").is_some(), "should have 'use' field");
+        prop_assert!(json.get("use_").is_none(), "should NOT have 'use_' field");
+    }
+
+    /// PublicJwk Display is always valid JSON with correct kty.
+    #[test]
+    fn public_jwk_display_valid_json(kid in "[a-zA-Z0-9_]{1,15}", variant in 0u8..3) {
+        let jwk = match variant {
+            0 => PublicJwk::Rsa(arb_rsa_public_jwk(kid)),
+            1 => PublicJwk::Ec(arb_ec_public_jwk(kid)),
+            _ => PublicJwk::Okp(arb_okp_public_jwk(kid)),
+        };
+        let json: serde_json::Value = serde_json::from_str(&jwk.to_string())
+            .expect("PublicJwk Display should be valid JSON");
+        prop_assert!(json["kty"].is_string());
+        prop_assert!(json["kid"].is_string());
+    }
+}

--- a/crates/uselesskey-pgp/tests/prop_expanded.rs
+++ b/crates/uselesskey-pgp/tests/prop_expanded.rs
@@ -1,0 +1,103 @@
+//! Expanded property tests for PGP key generation.
+
+#[allow(dead_code)]
+mod testutil;
+
+use proptest::prelude::*;
+
+use uselesskey_core::{Factory, Seed};
+use uselesskey_pgp::{PgpFactoryExt, PgpSpec};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 16, ..ProptestConfig::default() })]
+
+    /// Debug output never leaks private key material.
+    #[test]
+    fn debug_does_not_leak_key_material(seed in any::<[u8; 32]>()) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let key = fx.pgp("prop-debug", PgpSpec::ed25519());
+        let dbg = format!("{key:?}");
+
+        prop_assert!(dbg.contains("PgpKeyPair"));
+        prop_assert!(!dbg.contains("BEGIN PGP PRIVATE KEY BLOCK"));
+        prop_assert!(!dbg.contains("BEGIN PGP PUBLIC KEY BLOCK"));
+    }
+
+    /// Different labels produce different fingerprints.
+    #[test]
+    fn label_independence(
+        seed in any::<[u8; 32]>(),
+        label_a in "[a-zA-Z][a-zA-Z0-9]{1,10}",
+        label_b in "[a-zA-Z][a-zA-Z0-9]{1,10}",
+    ) {
+        prop_assume!(label_a != label_b);
+        let fx = Factory::deterministic(Seed::new(seed));
+        let ka = fx.pgp(&label_a, PgpSpec::ed25519());
+        let kb = fx.pgp(&label_b, PgpSpec::ed25519());
+
+        prop_assert_ne!(
+            ka.fingerprint(),
+            kb.fingerprint(),
+            "Different labels should produce different fingerprints"
+        );
+    }
+
+    /// Determinism holds across cache clears.
+    #[test]
+    fn determinism_across_cache_clear(seed in any::<[u8; 32]>()) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let k1 = fx.pgp("prop-det-clear", PgpSpec::ed25519());
+        let fp1 = k1.fingerprint().to_string();
+        let armor1 = k1.private_key_armored().to_string();
+
+        fx.clear_cache();
+
+        let k2 = fx.pgp("prop-det-clear", PgpSpec::ed25519());
+        prop_assert_eq!(fp1, k2.fingerprint());
+        prop_assert_eq!(armor1, k2.private_key_armored());
+    }
+
+    /// Public key armored output has correct PGP header.
+    #[test]
+    fn public_key_has_correct_header(seed in any::<[u8; 32]>()) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let key = fx.pgp("prop-pub-hdr", PgpSpec::ed25519());
+
+        prop_assert!(
+            key.public_key_armored().contains("BEGIN PGP PUBLIC KEY BLOCK"),
+            "Public key should have correct PGP header"
+        );
+        prop_assert!(!key.public_key_binary().is_empty());
+    }
+
+    /// User ID contains the label.
+    #[test]
+    fn user_id_contains_label(
+        seed in any::<[u8; 32]>(),
+        label in "[a-zA-Z][a-zA-Z0-9]{1,12}",
+    ) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let key = fx.pgp(&label, PgpSpec::ed25519());
+
+        prop_assert!(
+            key.user_id().contains(&label),
+            "user_id '{}' should contain label '{}'",
+            key.user_id(),
+            label
+        );
+    }
+
+    /// Mismatched public key is always different from the real public key.
+    #[test]
+    fn mismatched_key_always_differs(seed in any::<[u8; 32]>()) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let key = fx.pgp("prop-mismatch", PgpSpec::ed25519());
+
+        let mismatch = key.mismatched_public_key_armored();
+        prop_assert_ne!(
+            mismatch.as_str(),
+            key.public_key_armored(),
+            "Mismatched key should differ from the real key"
+        );
+    }
+}

--- a/crates/uselesskey-token-spec/Cargo.toml
+++ b/crates/uselesskey-token-spec/Cargo.toml
@@ -14,5 +14,8 @@ homepage.workspace = true
 documentation = "https://docs.rs/uselesskey-token-spec"
 authors.workspace = true
 
+[dev-dependencies]
+proptest.workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-token-spec/tests/prop_token_spec.rs
+++ b/crates/uselesskey-token-spec/tests/prop_token_spec.rs
@@ -1,0 +1,74 @@
+//! Property tests for `TokenSpec` enum invariants.
+
+use proptest::prelude::*;
+use uselesskey_token_spec::TokenSpec;
+
+fn arb_token_spec() -> impl Strategy<Value = TokenSpec> {
+    prop_oneof![
+        Just(TokenSpec::ApiKey),
+        Just(TokenSpec::Bearer),
+        Just(TokenSpec::OAuthAccessToken),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// Every spec variant has a non-empty kind_name.
+    #[test]
+    fn kind_name_is_non_empty(spec in arb_token_spec()) {
+        prop_assert!(!spec.kind_name().is_empty());
+    }
+
+    /// Every spec variant has a non-zero stable_bytes encoding.
+    #[test]
+    fn stable_bytes_is_non_zero(spec in arb_token_spec()) {
+        prop_assert_ne!(spec.stable_bytes(), [0, 0, 0, 0]);
+    }
+
+    /// kind_name is always pure ASCII snake_case.
+    #[test]
+    fn kind_name_is_ascii_snake_case(spec in arb_token_spec()) {
+        let name = spec.kind_name();
+        prop_assert!(
+            name.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+            "kind_name '{}' is not snake_case",
+            name
+        );
+    }
+
+    /// Two arbitrary specs either are equal or have different stable_bytes.
+    #[test]
+    fn equal_or_distinct_stable_bytes(
+        a in arb_token_spec(),
+        b in arb_token_spec(),
+    ) {
+        if a == b {
+            prop_assert_eq!(a.stable_bytes(), b.stable_bytes());
+        } else {
+            prop_assert_ne!(a.stable_bytes(), b.stable_bytes());
+        }
+    }
+
+    /// Clone preserves equality.
+    #[test]
+    fn clone_preserves_equality(spec in arb_token_spec()) {
+        #[allow(clippy::clone_on_copy)]
+        let cloned = spec.clone();
+        prop_assert_eq!(spec, cloned);
+        prop_assert_eq!(spec.stable_bytes(), cloned.stable_bytes());
+        prop_assert_eq!(spec.kind_name(), cloned.kind_name());
+    }
+
+    /// Debug output contains the variant name.
+    #[test]
+    fn debug_contains_variant(spec in arb_token_spec()) {
+        let dbg = format!("{spec:?}");
+        let expected = match spec {
+            TokenSpec::ApiKey => "ApiKey",
+            TokenSpec::Bearer => "Bearer",
+            TokenSpec::OAuthAccessToken => "OAuthAccessToken",
+        };
+        prop_assert!(dbg.contains(expected));
+    }
+}

--- a/crates/uselesskey-token/tests/prop_random_labels.rs
+++ b/crates/uselesskey-token/tests/prop_random_labels.rs
@@ -1,0 +1,81 @@
+//! Property tests: random labels produce valid output for all token specs.
+
+#[allow(dead_code)]
+mod testutil;
+
+use proptest::prelude::*;
+
+use uselesskey_core::{Factory, Seed};
+use uselesskey_token::{TokenFactoryExt, TokenSpec};
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    /// Random labels always produce a valid API key with correct prefix and length.
+    #[test]
+    fn random_label_api_key(
+        seed in any::<[u8; 32]>(),
+        label in "[a-zA-Z][a-zA-Z0-9_]{0,30}",
+    ) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let tok = fx.token(&label, TokenSpec::api_key());
+        prop_assert!(tok.value().starts_with("uk_test_"));
+        prop_assert_eq!(tok.value().len(), 40);
+    }
+
+    /// Random labels always produce a valid bearer token (43-char base64url).
+    #[test]
+    fn random_label_bearer(
+        seed in any::<[u8; 32]>(),
+        label in "[a-zA-Z][a-zA-Z0-9_]{0,30}",
+    ) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let tok = fx.token(&label, TokenSpec::bearer());
+        prop_assert_eq!(tok.value().len(), 43);
+        prop_assert!(!tok.value().contains('+'));
+        prop_assert!(!tok.value().contains('/'));
+    }
+
+    /// Random labels always produce a valid OAuth token with 3 dot-separated segments.
+    #[test]
+    fn random_label_oauth(
+        seed in any::<[u8; 32]>(),
+        label in "[a-zA-Z][a-zA-Z0-9_]{0,30}",
+    ) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let tok = fx.token(&label, TokenSpec::oauth_access_token());
+        let parts: Vec<&str> = tok.value().split('.').collect();
+        prop_assert_eq!(parts.len(), 3);
+    }
+
+    /// Different random labels with the same seed produce different tokens.
+    #[test]
+    fn label_independence(
+        seed in any::<[u8; 32]>(),
+        label_a in "[a-zA-Z][a-zA-Z0-9_]{1,15}",
+        label_b in "[a-zA-Z][a-zA-Z0-9_]{1,15}",
+    ) {
+        prop_assume!(label_a != label_b);
+        let fx = Factory::deterministic(Seed::new(seed));
+        let ta = fx.token(&label_a, TokenSpec::api_key());
+        let tb = fx.token(&label_b, TokenSpec::api_key());
+        prop_assert_ne!(ta.value(), tb.value());
+    }
+
+    /// Non-emptiness holds for all spec variants with random labels.
+    #[test]
+    fn all_specs_non_empty(
+        seed in any::<[u8; 32]>(),
+        label in "[a-zA-Z][a-zA-Z0-9_]{0,15}",
+        kind_idx in 0u8..3,
+    ) {
+        let spec = match kind_idx {
+            0 => TokenSpec::api_key(),
+            1 => TokenSpec::bearer(),
+            _ => TokenSpec::oauth_access_token(),
+        };
+        let fx = Factory::deterministic(Seed::new(seed));
+        let tok = fx.token(&label, spec);
+        prop_assert!(!tok.value().is_empty());
+    }
+}

--- a/crates/uselesskey-tonic/tests/prop_random_labels.rs
+++ b/crates/uselesskey-tonic/tests/prop_random_labels.rs
@@ -1,0 +1,70 @@
+//! Property tests: random labels and mTLS adapters for tonic fixtures.
+
+use proptest::prelude::*;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_tonic::{TonicClientTlsExt, TonicIdentityExt, TonicMtlsExt, TonicServerTlsExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+proptest! {
+    // RSA keygen is expensive; keep case count low.
+    #![proptest_config(ProptestConfig { cases: 5, ..ProptestConfig::default() })]
+
+    /// Random labels produce valid tonic identity from self-signed certs.
+    #[test]
+    fn random_label_self_signed_identity(
+        seed in any::<[u8; 32]>(),
+        label in "[a-zA-Z][a-zA-Z0-9_]{0,15}",
+    ) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let spec = X509Spec::self_signed("prop.example.com");
+        let cert = fx.x509_self_signed(&label, spec);
+
+        // Adapter methods must not panic.
+        let _ = cert.identity_tonic();
+        let _ = cert.server_tls_config_tonic();
+        let _ = cert.client_tls_config_tonic("prop.example.com");
+    }
+
+    /// Random labels produce valid tonic identity from certificate chains.
+    #[test]
+    fn random_label_chain_identity(
+        seed in any::<[u8; 32]>(),
+        label in "[a-zA-Z][a-zA-Z0-9_]{0,15}",
+    ) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let spec = ChainSpec::new("prop-chain.example.com");
+        let chain = fx.x509_chain(&label, spec);
+
+        // Adapter methods must not panic.
+        let _ = chain.identity_tonic();
+        let _ = chain.server_tls_config_tonic();
+        let _ = chain.client_tls_config_tonic("prop-chain.example.com");
+    }
+
+    /// mTLS config generation from random seeds never panics.
+    #[test]
+    fn mtls_config_never_panics(seed in any::<[u8; 32]>()) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let chain = fx.x509_chain("prop-mtls", ChainSpec::new("mtls.example.com"));
+
+        let _ = chain.server_tls_config_mtls_tonic();
+        let _ = chain.client_tls_config_mtls_tonic("mtls.example.com");
+    }
+
+    /// Deterministic mTLS: same seed produces identical underlying PEM.
+    #[test]
+    fn deterministic_mtls_stability(seed in any::<[u8; 32]>()) {
+        let fx1 = Factory::deterministic(Seed::new(seed));
+        let fx2 = Factory::deterministic(Seed::new(seed));
+
+        let c1 = fx1.x509_chain("prop-mtls-det", ChainSpec::new("mtls.example.com"));
+        let c2 = fx2.x509_chain("prop-mtls-det", ChainSpec::new("mtls.example.com"));
+
+        prop_assert_eq!(c1.chain_pem(), c2.chain_pem());
+        prop_assert_eq!(c1.root_cert_pem(), c2.root_cert_pem());
+        prop_assert_eq!(
+            c1.leaf_private_key_pkcs8_pem(),
+            c2.leaf_private_key_pkcs8_pem(),
+        );
+    }
+}

--- a/crates/uselesskey-x509/tests/prop_random_labels.rs
+++ b/crates/uselesskey-x509/tests/prop_random_labels.rs
@@ -1,0 +1,88 @@
+//! Property tests: random labels and label independence for X.509 fixtures.
+
+use proptest::prelude::*;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+proptest! {
+    // RSA keygen is expensive; keep case count low.
+    #![proptest_config(ProptestConfig { cases: 5, ..ProptestConfig::default() })]
+
+    /// Random labels always produce valid self-signed cert PEM.
+    #[test]
+    fn random_label_self_signed_format(
+        seed in any::<[u8; 32]>(),
+        label in "[a-zA-Z][a-zA-Z0-9_]{0,15}",
+    ) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let spec = X509Spec::self_signed("prop.example.com");
+        let cert = fx.x509_self_signed(&label, spec);
+
+        prop_assert!(cert.cert_pem().starts_with("-----BEGIN CERTIFICATE-----"));
+        prop_assert!(cert.private_key_pkcs8_pem().starts_with("-----BEGIN PRIVATE KEY-----"));
+        prop_assert!(!cert.cert_der().is_empty());
+        prop_assert!(!cert.private_key_pkcs8_der().is_empty());
+    }
+
+    /// Different labels produce different self-signed certificates.
+    #[test]
+    fn self_signed_label_independence(
+        seed in any::<[u8; 32]>(),
+        label_a in "[a-zA-Z][a-zA-Z0-9]{1,8}",
+        label_b in "[a-zA-Z][a-zA-Z0-9]{1,8}",
+    ) {
+        prop_assume!(label_a != label_b);
+        let fx = Factory::deterministic(Seed::new(seed));
+        let spec = X509Spec::self_signed("prop.example.com");
+
+        let ca = fx.x509_self_signed(&label_a, spec.clone());
+        let cb = fx.x509_self_signed(&label_b, spec);
+
+        prop_assert_ne!(
+            ca.cert_der(),
+            cb.cert_der(),
+            "Different labels should produce different certs"
+        );
+    }
+
+    /// Random labels always produce valid chain PEM.
+    #[test]
+    fn random_label_chain_format(
+        seed in any::<[u8; 32]>(),
+        label in "[a-zA-Z][a-zA-Z0-9_]{0,15}",
+    ) {
+        let fx = Factory::deterministic(Seed::new(seed));
+        let spec = ChainSpec::new("prop-chain.example.com");
+        let chain = fx.x509_chain(&label, spec);
+
+        prop_assert!(chain.root_cert_pem().starts_with("-----BEGIN CERTIFICATE-----"));
+        prop_assert!(chain.leaf_cert_pem().starts_with("-----BEGIN CERTIFICATE-----"));
+        prop_assert!(chain.leaf_private_key_pkcs8_pem().starts_with("-----BEGIN PRIVATE KEY-----"));
+        prop_assert!(!chain.root_cert_der().is_empty());
+        prop_assert!(!chain.leaf_cert_der().is_empty());
+
+        let cert_count = chain.chain_pem().matches("-----BEGIN CERTIFICATE-----").count();
+        prop_assert_eq!(cert_count, 2);
+    }
+
+    /// Different labels produce different certificate chains.
+    #[test]
+    fn chain_label_independence(
+        seed in any::<[u8; 32]>(),
+        label_a in "[a-zA-Z][a-zA-Z0-9]{1,8}",
+        label_b in "[a-zA-Z][a-zA-Z0-9]{1,8}",
+    ) {
+        prop_assume!(label_a != label_b);
+        let fx = Factory::deterministic(Seed::new(seed));
+        let spec = ChainSpec::new("prop-chain.example.com");
+
+        let ca = fx.x509_chain(&label_a, spec.clone());
+        let cb = fx.x509_chain(&label_b, spec);
+
+        prop_assert_ne!(
+            ca.leaf_cert_der(),
+            cb.leaf_cert_der(),
+            "Different labels should produce different chains"
+        );
+    }
+}


### PR DESCRIPTION
Wave 123: Add property-based tests to crates that lack them. Adds proptest coverage across uselesskey-token, uselesskey-token-spec, uselesskey-x509, uselesskey-tonic, uselesskey-jwk, and uselesskey-pgp.