### PR TITLE
docs: add comprehensive API examples

### DIFF
--- a/crates/uselesskey/examples/basic_hmac.rs
+++ b/crates/uselesskey/examples/basic_hmac.rs
@@ -1,0 +1,71 @@
+//! Basic HMAC secret generation for HS256, HS384, and HS512.
+//!
+//! Demonstrates generating HMAC secrets of different sizes and
+//! accessing them as raw bytes and (with `jwk` feature) as JWK/JWKS.
+//!
+//! Run with: cargo run -p uselesskey --example basic_hmac --features full
+
+#[cfg(all(feature = "hmac", feature = "jwk"))]
+fn main() {
+    use uselesskey::{Factory, HmacFactoryExt, HmacSpec};
+
+    let fx = Factory::random();
+
+    // =========================================================================
+    // 1. HS256 — 32-byte secret
+    // =========================================================================
+    println!("=== HMAC HS256 (32 bytes) ===");
+    let hs256 = fx.hmac("jwt-signer", HmacSpec::hs256());
+    println!("  Secret length : {} bytes", hs256.secret_bytes().len());
+    assert_eq!(hs256.secret_bytes().len(), 32);
+
+    let jwk256 = hs256.jwk().to_value();
+    println!("  JWK kty : {}", jwk256["kty"]);
+    println!("  JWK alg : {}", jwk256["alg"]);
+    println!("  kid     : {}", hs256.kid());
+
+    // =========================================================================
+    // 2. HS384 — 48-byte secret
+    // =========================================================================
+    println!("\n=== HMAC HS384 (48 bytes) ===");
+    let hs384 = fx.hmac("jwt-signer", HmacSpec::hs384());
+    println!("  Secret length : {} bytes", hs384.secret_bytes().len());
+    assert_eq!(hs384.secret_bytes().len(), 48);
+
+    let jwk384 = hs384.jwk().to_value();
+    println!("  JWK alg : {}", jwk384["alg"]);
+    println!("  kid     : {}", hs384.kid());
+
+    // =========================================================================
+    // 3. HS512 — 64-byte secret
+    // =========================================================================
+    println!("\n=== HMAC HS512 (64 bytes) ===");
+    let hs512 = fx.hmac("jwt-signer", HmacSpec::hs512());
+    println!("  Secret length : {} bytes", hs512.secret_bytes().len());
+    assert_eq!(hs512.secret_bytes().len(), 64);
+
+    let jwk512 = hs512.jwk().to_value();
+    println!("  JWK alg : {}", jwk512["alg"]);
+    println!("  kid     : {}", hs512.kid());
+
+    // =========================================================================
+    // 4. JWKS (single-key set)
+    // =========================================================================
+    println!("\n=== HMAC JWKS ===");
+    let jwks = hs256.jwks().to_value();
+    let key_count = jwks["keys"].as_array().map_or(0, |a| a.len());
+    println!("  Key count : {key_count}");
+
+    // =========================================================================
+    // 5. Caching: same label + spec → same secret
+    // =========================================================================
+    let again = fx.hmac("jwt-signer", HmacSpec::hs256());
+    assert_eq!(hs256.secret_bytes(), again.secret_bytes());
+    println!("\n✓ Cache hit verified: same label + spec → same secret");
+}
+
+#[cfg(not(all(feature = "hmac", feature = "jwk")))]
+fn main() {
+    eprintln!("Enable 'hmac' and 'jwk' features:");
+    eprintln!("  cargo run -p uselesskey --example basic_hmac --features full");
+}

--- a/crates/uselesskey/examples/basic_token.rs
+++ b/crates/uselesskey/examples/basic_token.rs
@@ -1,0 +1,66 @@
+//! Token fixtures: API key, bearer, and OAuth access-token shapes.
+//!
+//! Demonstrates generating test tokens in common formats without
+//! committing real secrets to version control.
+//!
+//! Run with: cargo run -p uselesskey --example basic_token --features token
+
+#[cfg(feature = "token")]
+fn main() {
+    use uselesskey::{Factory, Seed, TokenFactoryExt, TokenSpec};
+
+    // Use a deterministic factory so output is reproducible.
+    let fx = Factory::deterministic(Seed::from_env_value("token-demo").unwrap());
+
+    // =========================================================================
+    // 1. API key — `uk_test_<base62>` format
+    // =========================================================================
+    println!("=== API Key ===\n");
+    let api_key = fx.token("my-api", TokenSpec::api_key());
+    println!("  Value  : {}", api_key.value());
+    println!("  Header : {}", api_key.authorization_header());
+    assert!(api_key.value().starts_with("uk_test_"));
+
+    // =========================================================================
+    // 2. Bearer token — base64url-encoded opaque blob
+    // =========================================================================
+    println!("\n=== Bearer Token ===\n");
+    let bearer = fx.token("session", TokenSpec::bearer());
+    println!("  Value  : {}", bearer.value());
+    println!("  Header : {}", bearer.authorization_header());
+    println!("  Length : {} chars", bearer.value().len());
+
+    // =========================================================================
+    // 3. OAuth / JWT-shaped access token
+    // =========================================================================
+    println!("\n=== OAuth Access Token ===\n");
+    let oauth = fx.token("oauth-provider", TokenSpec::oauth_access_token());
+    println!("  Value  : {}", oauth.value());
+    println!("  Header : {}", oauth.authorization_header());
+    // JWT-shaped tokens have three dot-separated segments.
+    let dot_count = oauth.value().matches('.').count();
+    println!("  Segments: {} (JWT-shaped)", dot_count + 1);
+
+    // =========================================================================
+    // 4. Variant support — multiple tokens from the same label
+    // =========================================================================
+    println!("\n=== Token Variants ===\n");
+    let admin_key = fx.token_with_variant("my-api", TokenSpec::api_key(), "admin");
+    let readonly_key = fx.token_with_variant("my-api", TokenSpec::api_key(), "readonly");
+    assert_ne!(admin_key.value(), readonly_key.value());
+    println!("  admin   : {}", admin_key.value());
+    println!("  readonly: {}", readonly_key.value());
+
+    // =========================================================================
+    // 5. Caching
+    // =========================================================================
+    let again = fx.token("my-api", TokenSpec::api_key());
+    assert_eq!(api_key.value(), again.value());
+    println!("\n✓ Cache hit verified: same label + spec → same token");
+}
+
+#[cfg(not(feature = "token"))]
+fn main() {
+    eprintln!("Enable 'token' feature:");
+    eprintln!("  cargo run -p uselesskey --example basic_token --features token");
+}


### PR DESCRIPTION
Add asic_hmac and asic_token examples to complete the examples/ directory coverage. All 10 requested example categories now have compilable examples:

- **basic_rsa** — RSA key generation (PEM, DER, JWK, tempfiles, caching)
- **basic_ecdsa** — P-256 and P-384 ECDSA fixtures
- **basic_ed25519** — Ed25519 fixtures with JWK output
- **basic_hmac** *(new)* — HS256/HS384/HS512 with JWK/JWKS output
- **basic_token** *(new)* — API key, bearer, OAuth token fixtures with variants
- **deterministic** — Seed-based reproducible fixtures, order independence
- **negative_fixtures** — Corrupt PEM, truncated DER, mismatched keys, X.509 negatives
- **jwk_jwks** — Individual JWKs, JwksBuilder multi-key sets, HMAC JWK
- **x509_certificates** — Self-signed certs, chains, SANs, chain negatives
- **adapter_jsonwebtoken** — JWT sign/verify with RSA, ECDSA, Ed25519, HMAC

All examples verified with \\cargo check -p uselesskey --examples --features full\\.