### PR TITLE
docs: add missing rustdoc to public API items

### DIFF
--- a/crates/uselesskey-core-id/src/lib.rs
+++ b/crates/uselesskey-core-id/src/lib.rs
@@ -22,20 +22,30 @@ pub type ArtifactDomain = &'static str;
 pub struct DerivationVersion(pub u16);
 
 impl DerivationVersion {
+    /// The initial (and currently only) derivation scheme version.
     pub const V1: Self = Self(1);
 }
 
 /// Identifier used for deterministic artifact cache entries.
+///
+/// Each field contributes to the derived seed, so two artifacts with the
+/// same `ArtifactId` are guaranteed to be identical across runs.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct ArtifactId {
+    /// Namespace that separates unrelated fixture types (e.g. `"rsa"`, `"ecdsa"`).
     pub domain: ArtifactDomain,
+    /// User-supplied label for this fixture (e.g. `"issuer"`, `"audience"`).
     pub label: String,
+    /// BLAKE3 hash of the spec's stable byte representation.
     pub spec_fingerprint: [u8; 32],
+    /// Variant tag (e.g. `"default"`, `"mismatch"`, `"corrupt:bad-header"`).
     pub variant: String,
+    /// Which derivation algorithm version to use.
     pub derivation_version: DerivationVersion,
 }
 
 impl ArtifactId {
+    /// Create a new artifact identifier by hashing `spec_bytes` into a fingerprint.
     pub fn new(
         domain: ArtifactDomain,
         label: impl Into<String>,

--- a/crates/uselesskey-core-jwk-builder/src/lib.rs
+++ b/crates/uselesskey-core-jwk-builder/src/lib.rs
@@ -9,6 +9,10 @@
 use uselesskey_core_jwk_shape::{AnyJwk, Jwks, PrivateJwk, PublicJwk};
 use uselesskey_core_jwks_order::{HasKid, KidSorted};
 
+/// Incrementally assembles a [`Jwks`] set with deterministic `kid`-based ordering.
+///
+/// Keys are sorted lexicographically by `kid`; duplicate `kid` values
+/// preserve insertion order.
 #[derive(Clone, Default)]
 pub struct JwksBuilder {
     entries: KidSorted<OrderedJwk>,
@@ -24,38 +28,46 @@ impl HasKid for OrderedJwk {
 }
 
 impl JwksBuilder {
+    /// Create an empty builder.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Append a public JWK and return `self` for chaining.
     pub fn add_public(mut self, jwk: PublicJwk) -> Self {
         self.push_public(jwk);
         self
     }
 
+    /// Append a private JWK and return `self` for chaining.
     pub fn add_private(mut self, jwk: PrivateJwk) -> Self {
         self.push_private(jwk);
         self
     }
 
+    /// Append any JWK variant and return `self` for chaining.
     pub fn add_any(mut self, jwk: AnyJwk) -> Self {
         self.push_any(jwk);
         self
     }
 
+    /// Append a public JWK by mutable reference.
     pub fn push_public(&mut self, jwk: PublicJwk) -> &mut Self {
         self.push_any(AnyJwk::from(jwk))
     }
 
+    /// Append a private JWK by mutable reference.
     pub fn push_private(&mut self, jwk: PrivateJwk) -> &mut Self {
         self.push_any(AnyJwk::from(jwk))
     }
 
+    /// Append any JWK variant by mutable reference.
     pub fn push_any(&mut self, jwk: AnyJwk) -> &mut Self {
         self.entries.push(OrderedJwk(jwk));
         self
     }
 
+    /// Consume the builder and return the sorted [`Jwks`] set.
     pub fn build(self) -> Jwks {
         Jwks {
             keys: self.entries.build().into_iter().map(|jwk| jwk.0).collect(),

--- a/crates/uselesskey-core-jwk-shape/src/lib.rs
+++ b/crates/uselesskey-core-jwk-shape/src/lib.rs
@@ -37,12 +37,15 @@ use serde::Serialize;
 use serde_json::Value;
 use std::fmt;
 
+/// A JSON Web Key Set containing zero or more JWK entries.
 #[derive(Clone, Serialize)]
 pub struct Jwks {
+    /// The `"keys"` array of the JWKS.
     pub keys: Vec<AnyJwk>,
 }
 
 impl Jwks {
+    /// Serialize to a [`serde_json::Value`].
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).expect("serialize JWKS")
     }
@@ -55,6 +58,7 @@ impl fmt::Display for Jwks {
     }
 }
 
+/// RSA public key in JWK format (contains `n` and `e`).
 #[derive(Clone, Serialize)]
 pub struct RsaPublicJwk {
     pub kty: &'static str,
@@ -67,11 +71,13 @@ pub struct RsaPublicJwk {
 }
 
 impl RsaPublicJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         &self.kid
     }
 }
 
+/// RSA private key in JWK format (includes CRT parameters `p`, `q`, `dp`, `dq`, `qi`).
 #[derive(Clone, Serialize)]
 pub struct RsaPrivateJwk {
     pub kty: &'static str,
@@ -91,6 +97,7 @@ pub struct RsaPrivateJwk {
 }
 
 impl RsaPrivateJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         &self.kid
     }
@@ -105,6 +112,7 @@ impl fmt::Debug for RsaPrivateJwk {
     }
 }
 
+/// Elliptic-curve public key in JWK format (P-256 / P-384).
 #[derive(Clone, Serialize)]
 pub struct EcPublicJwk {
     pub kty: &'static str,
@@ -118,11 +126,13 @@ pub struct EcPublicJwk {
 }
 
 impl EcPublicJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         &self.kid
     }
 }
 
+/// Elliptic-curve private key in JWK format (P-256 / P-384, includes `d`).
 #[derive(Clone, Serialize)]
 pub struct EcPrivateJwk {
     pub kty: &'static str,
@@ -137,6 +147,7 @@ pub struct EcPrivateJwk {
 }
 
 impl EcPrivateJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         &self.kid
     }
@@ -152,6 +163,7 @@ impl fmt::Debug for EcPrivateJwk {
     }
 }
 
+/// OKP (Octet Key Pair) public key in JWK format (Ed25519).
 #[derive(Clone, Serialize)]
 pub struct OkpPublicJwk {
     pub kty: &'static str,
@@ -164,11 +176,13 @@ pub struct OkpPublicJwk {
 }
 
 impl OkpPublicJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         &self.kid
     }
 }
 
+/// OKP (Octet Key Pair) private key in JWK format (Ed25519, includes `d`).
 #[derive(Clone, Serialize)]
 pub struct OkpPrivateJwk {
     pub kty: &'static str,
@@ -182,6 +196,7 @@ pub struct OkpPrivateJwk {
 }
 
 impl OkpPrivateJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         &self.kid
     }
@@ -197,6 +212,7 @@ impl fmt::Debug for OkpPrivateJwk {
     }
 }
 
+/// Symmetric (octet) key in JWK format (HMAC `HS256`/`HS384`/`HS512`).
 #[derive(Clone, Serialize)]
 pub struct OctJwk {
     pub kty: &'static str,
@@ -208,6 +224,7 @@ pub struct OctJwk {
 }
 
 impl OctJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         &self.kid
     }
@@ -222,15 +239,20 @@ impl fmt::Debug for OctJwk {
     }
 }
 
+/// A public JWK of any supported key type.
 #[derive(Clone, Serialize)]
 #[serde(untagged)]
 pub enum PublicJwk {
+    /// RSA public key.
     Rsa(RsaPublicJwk),
+    /// Elliptic-curve public key.
     Ec(EcPublicJwk),
+    /// OKP (Ed25519) public key.
     Okp(OkpPublicJwk),
 }
 
 impl PublicJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         match self {
             PublicJwk::Rsa(jwk) => jwk.kid(),
@@ -239,6 +261,7 @@ impl PublicJwk {
         }
     }
 
+    /// Serialize to a [`serde_json::Value`].
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).expect("serialize JWK")
     }
@@ -251,16 +274,22 @@ impl fmt::Display for PublicJwk {
     }
 }
 
+/// A private (or symmetric) JWK of any supported key type.
 #[derive(Clone, Serialize)]
 #[serde(untagged)]
 pub enum PrivateJwk {
+    /// RSA private key.
     Rsa(RsaPrivateJwk),
+    /// Elliptic-curve private key.
     Ec(EcPrivateJwk),
+    /// OKP (Ed25519) private key.
     Okp(OkpPrivateJwk),
+    /// Symmetric (HMAC) key.
     Oct(OctJwk),
 }
 
 impl PrivateJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         match self {
             PrivateJwk::Rsa(jwk) => jwk.kid(),
@@ -270,6 +299,7 @@ impl PrivateJwk {
         }
     }
 
+    /// Serialize to a [`serde_json::Value`].
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).expect("serialize JWK")
     }
@@ -293,14 +323,18 @@ impl fmt::Debug for PrivateJwk {
     }
 }
 
+/// Either a public or private JWK.
 #[derive(Clone, Serialize)]
 #[serde(untagged)]
 pub enum AnyJwk {
+    /// A public-only JWK.
     Public(PublicJwk),
+    /// A private (or symmetric) JWK.
     Private(PrivateJwk),
 }
 
 impl AnyJwk {
+    /// Return the key identifier.
     pub fn kid(&self) -> &str {
         match self {
             AnyJwk::Public(jwk) => jwk.kid(),
@@ -308,6 +342,7 @@ impl AnyJwk {
         }
     }
 
+    /// Serialize to a [`serde_json::Value`].
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).expect("serialize JWK")
     }

--- a/crates/uselesskey-core-negative-der/src/lib.rs
+++ b/crates/uselesskey-core-negative-der/src/lib.rs
@@ -14,6 +14,7 @@ use alloc::vec::Vec;
 
 use uselesskey_core_hash::hash32;
 
+/// Truncate `der` to at most `len` bytes, returning the original if already shorter.
 pub fn truncate_der(der: &[u8], len: usize) -> Vec<u8> {
     if len >= der.len() {
         return der.to_vec();
@@ -21,6 +22,7 @@ pub fn truncate_der(der: &[u8], len: usize) -> Vec<u8> {
     der[..len].to_vec()
 }
 
+/// XOR the byte at `offset` with `0x01`, returning the original if `offset` is out of range.
 pub fn flip_byte(der: &[u8], offset: usize) -> Vec<u8> {
     if offset >= der.len() {
         return der.to_vec();
@@ -31,6 +33,9 @@ pub fn flip_byte(der: &[u8], offset: usize) -> Vec<u8> {
     out
 }
 
+/// Choose a corruption strategy deterministically from `variant` and apply it to `der`.
+///
+/// The same `(der, variant)` pair always produces the same corrupted output.
 pub fn corrupt_der_deterministic(der: &[u8], variant: &str) -> Vec<u8> {
     let digest = hash32(variant.as_bytes());
     let bytes = digest.as_bytes();

--- a/crates/uselesskey-core-negative-pem/src/lib.rs
+++ b/crates/uselesskey-core-negative-pem/src/lib.rs
@@ -45,13 +45,22 @@ use uselesskey_core_hash::hash32;
 /// Strategies for corrupting PEM-encoded data.
 #[derive(Clone, Copy, Debug)]
 pub enum CorruptPem {
+    /// Replace the `-----BEGIN …-----` line with an invalid header.
     BadHeader,
+    /// Replace the `-----END …-----` line with an invalid footer.
     BadFooter,
+    /// Inject a non-base64 line into the body so decoders reject the payload.
     BadBase64,
-    Truncate { bytes: usize },
+    /// Keep only the first `bytes` characters of the PEM string.
+    Truncate {
+        /// Maximum number of characters to keep.
+        bytes: usize,
+    },
+    /// Insert a blank line after the header, breaking strict PEM parsers.
     ExtraBlankLine,
 }
 
+/// Apply a specific [`CorruptPem`] corruption strategy to the given PEM string.
 pub fn corrupt_pem(pem: &str, how: CorruptPem) -> String {
     match how {
         CorruptPem::BadHeader => replace_first_line(pem, "-----BEGIN CORRUPTED KEY-----"),
@@ -62,6 +71,9 @@ pub fn corrupt_pem(pem: &str, how: CorruptPem) -> String {
     }
 }
 
+/// Choose a corruption strategy deterministically from `variant` and apply it to `pem`.
+///
+/// The same `(pem, variant)` pair always produces the same corrupted output.
 pub fn corrupt_pem_deterministic(pem: &str, variant: &str) -> String {
     let digest = hash32(variant.as_bytes());
     let bytes = digest.as_bytes();

--- a/crates/uselesskey-token-spec/src/lib.rs
+++ b/crates/uselesskey-token-spec/src/lib.rs
@@ -19,18 +19,22 @@ pub enum TokenSpec {
 }
 
 impl TokenSpec {
+    /// Create an API-key spec (`uk_test_<base62>`).
     pub const fn api_key() -> Self {
         Self::ApiKey
     }
 
+    /// Create an opaque bearer-token spec (base64url body).
     pub const fn bearer() -> Self {
         Self::Bearer
     }
 
+    /// Create an OAuth access-token spec in JWT shape (`header.payload.signature`).
     pub const fn oauth_access_token() -> Self {
         Self::OAuthAccessToken
     }
 
+    /// Return a short, stable name for this token kind (e.g. `"api_key"`).
     pub const fn kind_name(&self) -> &'static str {
         match self {
             Self::ApiKey => "api_key",


### PR DESCRIPTION
Add `///` doc comments to undocumented public structs, enums, enum variants, struct fields, functions, methods, and constants across six crates:

- **uselesskey-core-id**: `ArtifactId` fields, `DerivationVersion::V1`, `ArtifactId::new`
- **uselesskey-core-jwk-builder**: `JwksBuilder` struct and all builder methods
- **uselesskey-core-jwk-shape**: All JWK types, enum variants, `kid()`/`to_value()` methods
- **uselesskey-core-negative-pem**: `CorruptPem` variants, `corrupt_pem` / `corrupt_pem_deterministic`
- **uselesskey-core-negative-der**: `truncate_der`, `flip_byte`, `corrupt_der_deterministic`
- **uselesskey-token-spec**: `TokenSpec` constructor and accessor methods

Verified:
- `cargo check` passes for all changed crates
- `cargo clippy --all-features -- -D warnings` passes
- `cargo doc --no-deps` builds cleanly
