### PR TITLE
chore: dependency audit and deny/dep-guard cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4834,9 +4834,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"


### PR DESCRIPTION
## Summary

Dependency audit and cleanup for the uselesskey workspace.

### Changes

- Updated `Cargo.lock` with latest compatible dependency versions via `cargo update`
  - `tokio-macros` 2.6.0 → 2.6.1
  - `zlib-rs` 0.6.2 → 0.6.3

### Verification

- ✅ `cargo deny check` passes clean (advisories ok, bans ok, licenses ok, sources ok)
- ✅ `cargo xtask dep-guard` passes clean (no duplicate pinned deps)
- ✅ `cargo check --workspace --all-features` builds successfully
- ✅ `deny.toml` reviewed: all licenses in use are allowed, advisory ignore for RUSTSEC-2023-0071 (Marvin Attack) is appropriate for test-fixture library

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>