### PR TITLE
chore: complete Cargo.toml metadata for crates.io readiness

### DIFF
--- a/crates/uselesskey-bdd-steps/Cargo.toml
+++ b/crates/uselesskey-bdd-steps/Cargo.toml
@@ -5,8 +5,12 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 repository.workspace = true
+homepage.workspace = true
 authors.workspace = true
 publish = false
+description = "Cucumber BDD step definitions for uselesskey fixture crates."
+categories.workspace = true
+keywords = ["testing", "bdd", "cucumber", "fixtures", "crypto"]
 
 [dependencies]
 cucumber.workspace = true

--- a/crates/uselesskey-bdd/Cargo.toml
+++ b/crates/uselesskey-bdd/Cargo.toml
@@ -5,6 +5,12 @@ publish = false
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Cucumber BDD test runner for uselesskey fixture crates."
+categories.workspace = true
+keywords = ["testing", "bdd", "cucumber", "fixtures", "crypto"]
 
 [dependencies]
 uselesskey-bdd-steps = { path = "../uselesskey-bdd-steps", default-features = false, features = [] }

--- a/crates/uselesskey-interop-tests/Cargo.toml
+++ b/crates/uselesskey-interop-tests/Cargo.toml
@@ -5,6 +5,12 @@ publish = false
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Cross-adapter interoperability tests for uselesskey fixture crates."
+categories.workspace = true
+keywords = ["testing", "interop", "fixtures", "crypto", "adapter"]
 
 [dependencies]
 # Adapter crates — optional, gated behind features

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,6 +5,12 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 publish = false
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Integration and cross-crate tests for the uselesskey workspace."
+categories.workspace = true
+keywords = ["testing", "integration", "fixtures", "crypto", "deterministic"]
 
 [dependencies]
 # Core

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,6 +5,12 @@ publish = false
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Build automation tasks (CI, test, lint, publish) for the uselesskey workspace."
+categories.workspace = true
+keywords = ["xtask", "build", "automation", "ci", "testing"]
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
## Summary

Add missing Cargo.toml metadata fields to 5 non-published workspace crates for consistency:

- **uselesskey-interop-tests**: Added description, categories, keywords, repository, homepage, authors
- **uselesskey-bdd**: Added description, categories, keywords, repository, homepage, authors  
- **uselesskey-bdd-steps**: Added description, categories, keywords, homepage
- **xtask**: Added description, categories, keywords, repository, homepage, authors
- **uselesskey-integration-tests** (tests/): Added description, categories, keywords, repository, homepage, authors

## Audit Results

All 44 publishable crates already had complete metadata (description, keywords, categories, license, repository, documentation, readme, homepage, authors). The only crates missing metadata were the 5 \publish = false\ crates listed above.

## Verification

- \cargo check -p xtask\ ✅
- \cargo check -p uselesskey-interop-tests\ ✅
- \cargo check -p uselesskey\ ✅
- \cargo check -p uselesskey-core\ ✅
- \cargo xtask publish-preflight\ — all 44 packages passed ✅