### PR TITLE
test: kill surviving mutants in core microcrates

### DIFF
--- a/crates/uselesskey-core-base62/src/lib.rs
+++ b/crates/uselesskey-core-base62/src/lib.rs
@@ -104,4 +104,53 @@ mod tests {
         assert_eq!(value.len(), 32);
         assert!(value.chars().all(|c| c.is_ascii_alphanumeric()));
     }
+
+    #[test]
+    fn output_uses_diverse_alphabet() {
+        // Catches `% 62` → `/ 62` mutation: division would yield only
+        // indices 0–3, producing at most 4 distinct characters.
+        let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+        let out = random_base62(&mut rng, 256);
+        let unique: std::collections::HashSet<char> = out.chars().collect();
+        assert!(
+            unique.len() > 10,
+            "expected diverse output, got {} unique chars",
+            unique.len()
+        );
+    }
+
+    #[test]
+    fn fallback_path_uses_modulo_not_division() {
+        // All bytes = 255 → rejected by accept path → fallback runs.
+        // Correct: (255 % 62) = 7 → alphabet[7] = 'H'.
+        // Mutation / 62: (255 / 62) = 4 → alphabet[4] = 'E'.
+        struct AllMaxRng;
+
+        impl RngCore for AllMaxRng {
+            fn next_u32(&mut self) -> u32 {
+                u32::MAX
+            }
+
+            fn next_u64(&mut self) -> u64 {
+                u64::MAX
+            }
+
+            fn fill_bytes(&mut self, dest: &mut [u8]) {
+                dest.fill(255);
+            }
+
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+                self.fill_bytes(dest);
+                Ok(())
+            }
+        }
+
+        let mut rng = AllMaxRng;
+        let out = random_base62(&mut rng, 4);
+        // 255 % 62 = 7, BASE62_ALPHABET[7] = 'H'
+        assert!(
+            out.chars().all(|c| c == 'H'),
+            "expected all 'H' from fallback, got {out}"
+        );
+    }
 }

--- a/crates/uselesskey-core-negative-der/src/lib.rs
+++ b/crates/uselesskey-core-negative-der/src/lib.rs
@@ -164,6 +164,42 @@ mod tests {
         assert_ne!(out1, out2);
     }
 
+    #[test]
+    fn truncate_der_noop_when_len_exceeds_input() {
+        let der = vec![0x30, 0x82];
+        let out = truncate_der(&der, 100);
+        assert_eq!(
+            out, der,
+            "truncate with len >= der.len() must return original"
+        );
+    }
+
+    #[test]
+    fn flip_byte_noop_when_offset_exceeds_input() {
+        let der = vec![0x30, 0x82];
+        let out = flip_byte(&der, 100);
+        assert_eq!(
+            out, der,
+            "flip with offset >= der.len() must return original"
+        );
+    }
+
+    #[test]
+    fn derived_truncate_len_bytes_nonzero_for_large_input() {
+        // Catches `return 0` and `return 1` mutations when tested
+        // through corrupt_der_deterministic arm 0.
+        let mut digest = [0u8; 32];
+        digest[2] = 50;
+        // len=10, span=9, 50%9=5
+        assert_eq!(derived_truncate_len_bytes(10, &digest), 5);
+    }
+
+    #[test]
+    fn derived_truncate_len_bytes_zero_len_returns_zero() {
+        let digest = [0xFF; 32];
+        assert_eq!(derived_truncate_len_bytes(0, &digest), 0);
+    }
+
     fn find_der_variant(target: u8) -> String {
         use uselesskey_core_hash::hash32;
 

--- a/crates/uselesskey-core-negative-pem/src/lib.rs
+++ b/crates/uselesskey-core-negative-pem/src/lib.rs
@@ -258,4 +258,68 @@ mod tests {
         let out = corrupt_pem_deterministic(pem, &find_variant(4));
         assert!(out.len() < pem.len());
     }
+
+    #[test]
+    fn bad_base64_inserts_after_header_in_normal_pem() {
+        // Catches `< 3` → `== 3` and `<= 3`: those would take the early-return
+        // path for a 3-line PEM, appending at end instead of inserting after line 1.
+        let pem = "-----BEGIN TEST-----\nAAA=\n-----END TEST-----\n";
+        let out = corrupt_pem(pem, CorruptPem::BadBase64);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[0], "-----BEGIN TEST-----");
+        assert_eq!(lines[1], "THIS_IS_NOT_BASE64!!!");
+        assert_eq!(lines[2], "AAA=");
+    }
+
+    #[test]
+    fn bad_base64_two_line_pem_appends() {
+        // Catches `< 3` → `> 3`: with `> 3`, a 2-line input would insert
+        // instead of taking the early-return append path.
+        let pem = "line1\nline2";
+        let out = corrupt_pem(pem, CorruptPem::BadBase64);
+        assert_eq!(out, "line1\nline2\nTHIS_IS_NOT_BASE64!!!\n");
+    }
+
+    #[test]
+    fn blank_line_inserts_after_header_in_normal_pem() {
+        // Same boundary check as inject_bad_base64_line.
+        let pem = "-----BEGIN TEST-----\nAAA=\n-----END TEST-----\n";
+        let out = corrupt_pem(pem, CorruptPem::ExtraBlankLine);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[0], "-----BEGIN TEST-----");
+        assert_eq!(lines[1], "");
+        assert_eq!(lines[2], "AAA=");
+    }
+
+    #[test]
+    fn blank_line_two_line_pem_appends() {
+        let pem = "line1\nline2";
+        let out = corrupt_pem(pem, CorruptPem::ExtraBlankLine);
+        assert_eq!(out, "line1\nline2\n\n");
+    }
+
+    #[test]
+    fn derived_truncate_len_exact_arithmetic() {
+        // Catches `return 0`, `return 1`, `+ → *`, and arithmetic mutations
+        // on the span / modulo computation.
+        let mut digest = [0u8; 32];
+        digest[1] = 0x0A;
+        digest[2] = 0x0B;
+        // chars=10, span=9, u16=0x0A0B=2571, 2571%9=6, result=1+6=7
+        assert_eq!(derived_truncate_len("0123456789", &digest), 7);
+    }
+
+    #[test]
+    fn derived_truncate_len_empty_returns_zero() {
+        let digest = [0u8; 32];
+        assert_eq!(derived_truncate_len("", &digest), 0);
+    }
+
+    #[test]
+    fn derived_truncate_len_single_char_returns_zero() {
+        let digest = [0xFF; 32];
+        assert_eq!(derived_truncate_len("x", &digest), 0);
+    }
 }


### PR DESCRIPTION
Add targeted tests to kill surviving mutants in core microcrates.

Changes:
- uselesskey-core-base62: output diversity and fallback modulo tests
- uselesskey-core-negative-pem: structural assertions and exact arithmetic tests
- uselesskey-core-negative-der: boundary and arithmetic tests