### PR TITLE
test(core-kid): add unicode, collision-resistance, and edge-case tests

### DIFF
--- a/crates/uselesskey-core-kid/tests/edge_cases.rs
+++ b/crates/uselesskey-core-kid/tests/edge_cases.rs
@@ -107,3 +107,68 @@ fn kid_has_no_padding() {
     let kid = kid_from_bytes(b"test");
     assert!(!kid.contains('='), "KID should not contain padding");
 }
+
+// ── Unicode inputs ──────────────────────────────────────────────────
+
+#[test]
+fn kid_from_unicode_bytes() {
+    let kid = kid_from_bytes("héllo wörld".as_bytes());
+    assert!(!kid.is_empty());
+    assert!(
+        kid.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+        "KID from unicode should still be base64url"
+    );
+}
+
+#[test]
+fn kid_from_unicode_is_deterministic() {
+    let input = "日本語テスト🔑".as_bytes();
+    let k1 = kid_from_bytes(input);
+    let k2 = kid_from_bytes(input);
+    assert_eq!(k1, k2);
+}
+
+#[test]
+fn kid_from_emoji_bytes() {
+    let kid = kid_from_bytes("🔐🔑🗝️".as_bytes());
+    assert!(!kid.is_empty());
+}
+
+#[test]
+fn kid_different_unicode_inputs_differ() {
+    let k1 = kid_from_bytes("café".as_bytes());
+    let k2 = kid_from_bytes("cafe".as_bytes());
+    assert_ne!(k1, k2, "unicode vs ascii should differ");
+}
+
+#[test]
+fn kid_from_nul_bytes() {
+    let kid = kid_from_bytes(&[0x00, 0x00, 0x00]);
+    assert!(!kid.is_empty());
+}
+
+// ── All-same-byte patterns ──────────────────────────────────────────
+
+#[test]
+fn kid_from_all_zeros_vs_all_ones() {
+    let k1 = kid_from_bytes(&[0x00; 32]);
+    let k2 = kid_from_bytes(&[0xFF; 32]);
+    assert_ne!(k1, k2);
+}
+
+// ── Prefix length affects output ────────────────────────────────────
+
+#[test]
+fn different_prefix_lengths_produce_different_kid_lengths() {
+    let short = kid_from_bytes_with_prefix(b"key", 4);
+    let long = kid_from_bytes_with_prefix(b"key", 16);
+    assert!(short.len() < long.len());
+}
+
+#[test]
+fn kid_from_bytes_equals_default_prefix() {
+    let k1 = kid_from_bytes(b"test-key-material");
+    let k2 = kid_from_bytes_with_prefix(b"test-key-material", DEFAULT_KID_PREFIX_BYTES);
+    assert_eq!(k1, k2);
+}

--- a/crates/uselesskey-core-kid/tests/prop_kid.rs
+++ b/crates/uselesskey-core-kid/tests/prop_kid.rs
@@ -59,4 +59,53 @@ proptest! {
             );
         }
     }
+
+    /// Flipping any single bit in the input should change the KID.
+    #[test]
+    fn single_bit_flip_changes_kid(
+        input in proptest::collection::vec(any::<u8>(), 1..64),
+        bit_index in 0usize..512,
+    ) {
+        let byte_idx = bit_index / 8;
+        let bit_pos = bit_index % 8;
+        prop_assume!(byte_idx < input.len());
+
+        let mut flipped = input.clone();
+        flipped[byte_idx] ^= 1 << bit_pos;
+
+        let kid_orig = kid_from_bytes(&input);
+        let kid_flip = kid_from_bytes(&flipped);
+        prop_assert_ne!(kid_orig, kid_flip, "bit flip at byte {} bit {} should change KID", byte_idx, bit_pos);
+    }
+
+    /// Appending a byte to the input should change the KID.
+    #[test]
+    fn appending_byte_changes_kid(
+        input in proptest::collection::vec(any::<u8>(), 0..64),
+        extra in any::<u8>(),
+    ) {
+        let mut extended = input.clone();
+        extended.push(extra);
+
+        let kid_orig = kid_from_bytes(&input);
+        let kid_ext = kid_from_bytes(&extended);
+        prop_assert_ne!(kid_orig, kid_ext, "appending a byte should change KID");
+    }
+
+    /// KID string length is always exactly 16 chars for default prefix (12 bytes).
+    #[test]
+    fn kid_string_length_is_always_16(input in any::<Vec<u8>>()) {
+        let kid = kid_from_bytes(&input);
+        prop_assert_eq!(kid.len(), 16, "default KID should always be 16 chars");
+    }
+
+    /// KID never contains base64 padding characters.
+    #[test]
+    fn kid_never_contains_padding(
+        input in any::<Vec<u8>>(),
+        prefix_bytes in 1usize..=32,
+    ) {
+        let kid = kid_from_bytes_with_prefix(&input, prefix_bytes);
+        prop_assert!(!kid.contains('='), "KID should never have padding");
+    }
 }


### PR DESCRIPTION
Adds comprehensive tests to uselesskey-core-kid covering unicode inputs, collision resistance property tests, and additional edge cases. All 73 tests pass. No changes to production code.