### PR TITLE
test: add comprehensive tests for jwk-builder and jwk-shape crates

### DIFF
--- a/crates/uselesskey-core-jwk-builder/tests/comprehensive.rs
+++ b/crates/uselesskey-core-jwk-builder/tests/comprehensive.rs
@@ -1,0 +1,561 @@
+//! Comprehensive tests for `uselesskey-core-jwk-builder`.
+//!
+//! Covers: fluent API chaining, JWKS building with multiple keys,
+//! kid-sorted ordering, insertion-order for duplicates, serde roundtrips,
+//! and edge cases (empty JWKS, duplicate kids, single-key sets, large sets).
+
+use serde_json::Value;
+use uselesskey_core_jwk_builder::JwksBuilder;
+use uselesskey_core_jwk_shape::{
+    AnyJwk, EcPrivateJwk, EcPublicJwk, Jwks, OctJwk, OkpPrivateJwk, OkpPublicJwk, PrivateJwk,
+    PublicJwk, RsaPrivateJwk, RsaPublicJwk,
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn rsa_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.to_string(),
+        n: format!("n-{kid}"),
+        e: "AQAB".to_string(),
+    })
+}
+
+fn ec_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Ec(EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.to_string(),
+        x: format!("x-{kid}"),
+        y: format!("y-{kid}"),
+    })
+}
+
+fn okp_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Okp(OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.to_string(),
+        x: format!("x-{kid}"),
+    })
+}
+
+fn rsa_priv(kid: &str) -> PrivateJwk {
+    PrivateJwk::Rsa(RsaPrivateJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.to_string(),
+        n: "n".to_string(),
+        e: "e".to_string(),
+        d: "d".to_string(),
+        p: "p".to_string(),
+        q: "q".to_string(),
+        dp: "dp".to_string(),
+        dq: "dq".to_string(),
+        qi: "qi".to_string(),
+    })
+}
+
+fn ec_priv(kid: &str) -> PrivateJwk {
+    PrivateJwk::Ec(EcPrivateJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.to_string(),
+        x: "x".to_string(),
+        y: "y".to_string(),
+        d: "d".to_string(),
+    })
+}
+
+fn okp_priv(kid: &str) -> PrivateJwk {
+    PrivateJwk::Okp(OkpPrivateJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.to_string(),
+        x: "x".to_string(),
+        d: "d".to_string(),
+    })
+}
+
+fn oct_priv(kid: &str) -> PrivateJwk {
+    PrivateJwk::Oct(OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: kid.to_string(),
+        k: format!("k-{kid}"),
+    })
+}
+
+// ── 1. Fluent API chaining ──────────────────────────────────────────────
+
+#[test]
+fn fluent_add_public_returns_builder() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("a"))
+        .add_public(ec_pub("b"))
+        .add_public(okp_pub("c"))
+        .build();
+    assert_eq!(jwks.keys.len(), 3);
+}
+
+#[test]
+fn fluent_add_private_returns_builder() {
+    let jwks = JwksBuilder::new()
+        .add_private(rsa_priv("a"))
+        .add_private(ec_priv("b"))
+        .add_private(okp_priv("c"))
+        .add_private(oct_priv("d"))
+        .build();
+    assert_eq!(jwks.keys.len(), 4);
+}
+
+#[test]
+fn fluent_add_any_returns_builder() {
+    let jwks = JwksBuilder::new()
+        .add_any(AnyJwk::from(rsa_pub("a")))
+        .add_any(AnyJwk::from(oct_priv("b")))
+        .build();
+    assert_eq!(jwks.keys.len(), 2);
+}
+
+#[test]
+fn fluent_mixed_add_methods_chain() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("pub-1"))
+        .add_private(oct_priv("priv-1"))
+        .add_any(AnyJwk::from(ec_pub("any-1")))
+        .add_public(okp_pub("pub-2"))
+        .add_private(ec_priv("priv-2"))
+        .build();
+    assert_eq!(jwks.keys.len(), 5);
+}
+
+#[test]
+fn push_methods_return_mutable_self() {
+    let mut builder = JwksBuilder::new();
+    builder
+        .push_public(rsa_pub("a"))
+        .push_private(oct_priv("b"))
+        .push_any(AnyJwk::from(ec_pub("c")));
+    let jwks = builder.build();
+    assert_eq!(jwks.keys.len(), 3);
+}
+
+// ── 2. Key ordering (kid-sorted) ────────────────────────────────────────
+
+#[test]
+fn keys_sorted_lexicographically_by_kid() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("zebra"))
+        .add_public(ec_pub("apple"))
+        .add_public(okp_pub("mango"))
+        .build();
+
+    let kids: Vec<&str> = jwks.keys.iter().map(AnyJwk::kid).collect();
+    assert_eq!(kids, ["apple", "mango", "zebra"]);
+}
+
+#[test]
+fn numeric_kids_sorted_lexicographically() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("10"))
+        .add_public(rsa_pub("2"))
+        .add_public(rsa_pub("1"))
+        .build();
+
+    let kids: Vec<&str> = jwks.keys.iter().map(AnyJwk::kid).collect();
+    // Lexicographic: "1" < "10" < "2"
+    assert_eq!(kids, ["1", "10", "2"]);
+}
+
+#[test]
+fn mixed_case_kids_sorted_case_sensitive() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("Bravo"))
+        .add_public(rsa_pub("alpha"))
+        .add_public(rsa_pub("Charlie"))
+        .build();
+
+    let kids: Vec<&str> = jwks.keys.iter().map(AnyJwk::kid).collect();
+    // ASCII: uppercase < lowercase
+    assert_eq!(kids, ["Bravo", "Charlie", "alpha"]);
+}
+
+#[test]
+fn single_key_preserved() {
+    let jwks = JwksBuilder::new().add_public(rsa_pub("only")).build();
+    assert_eq!(jwks.keys.len(), 1);
+    assert_eq!(jwks.keys[0].kid(), "only");
+}
+
+// ── 3. Duplicate kid insertion-order preservation ───────────────────────
+
+#[test]
+fn duplicate_kids_preserve_insertion_order() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("same"))
+        .add_public(ec_pub("same"))
+        .add_public(okp_pub("same"))
+        .build();
+
+    assert_eq!(jwks.keys.len(), 3);
+    // All have same kid
+    for key in &jwks.keys {
+        assert_eq!(key.kid(), "same");
+    }
+    // Insertion order preserved: RSA first, then EC, then OKP
+    assert_eq!(jwks.keys[0].to_value()["kty"], "RSA");
+    assert_eq!(jwks.keys[1].to_value()["kty"], "EC");
+    assert_eq!(jwks.keys[2].to_value()["kty"], "OKP");
+}
+
+#[test]
+fn duplicate_kids_interleaved_with_unique_kids() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("dup"))
+        .add_public(ec_pub("alpha"))
+        .add_public(okp_pub("dup"))
+        .add_private(oct_priv("zulu"))
+        .build();
+
+    let kids: Vec<&str> = jwks.keys.iter().map(AnyJwk::kid).collect();
+    assert_eq!(kids, ["alpha", "dup", "dup", "zulu"]);
+
+    // Within the "dup" group, RSA came first in insertion order
+    let dup_keys: Vec<&AnyJwk> = jwks.keys.iter().filter(|k| k.kid() == "dup").collect();
+    assert_eq!(dup_keys[0].to_value()["kty"], "RSA");
+    assert_eq!(dup_keys[1].to_value()["kty"], "OKP");
+}
+
+#[test]
+fn many_duplicates_all_preserved() {
+    let mut builder = JwksBuilder::new();
+    for i in 0..10 {
+        builder.push_public(PublicJwk::Rsa(RsaPublicJwk {
+            kty: "RSA",
+            use_: "sig",
+            alg: "RS256",
+            kid: "repeat".to_string(),
+            n: format!("n-{i}"),
+            e: "AQAB".to_string(),
+        }));
+    }
+    let jwks = builder.build();
+    assert_eq!(jwks.keys.len(), 10);
+
+    // Verify insertion order via the n field
+    for (i, key) in jwks.keys.iter().enumerate() {
+        let v = key.to_value();
+        assert_eq!(v["n"], format!("n-{i}"));
+    }
+}
+
+// ── 4. JWKS building with multiple key types ────────────────────────────
+
+#[test]
+fn all_key_types_in_single_jwks() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("k-rsa-pub"))
+        .add_public(ec_pub("k-ec-pub"))
+        .add_public(okp_pub("k-okp-pub"))
+        .add_private(rsa_priv("k-rsa-priv"))
+        .add_private(ec_priv("k-ec-priv"))
+        .add_private(okp_priv("k-okp-priv"))
+        .add_private(oct_priv("k-oct"))
+        .build();
+
+    assert_eq!(jwks.keys.len(), 7);
+
+    // Verify sorted order
+    let kids: Vec<&str> = jwks.keys.iter().map(AnyJwk::kid).collect();
+    let mut sorted_kids = kids.clone();
+    sorted_kids.sort();
+    assert_eq!(kids, sorted_kids);
+}
+
+#[test]
+fn large_jwks_correctly_sorted() {
+    let mut builder = JwksBuilder::new();
+    let labels: Vec<String> = (0..50).rev().map(|i| format!("key-{i:03}")).collect();
+    for label in &labels {
+        builder.push_public(rsa_pub(label));
+    }
+    let jwks = builder.build();
+
+    assert_eq!(jwks.keys.len(), 50);
+
+    let kids: Vec<&str> = jwks.keys.iter().map(AnyJwk::kid).collect();
+    let mut sorted = kids.clone();
+    sorted.sort();
+    assert_eq!(kids, sorted);
+}
+
+// ── 5. Serialization roundtrips ─────────────────────────────────────────
+
+#[test]
+fn builder_output_to_value_roundtrip() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("rt-1"))
+        .add_private(oct_priv("rt-2"))
+        .build();
+
+    let v = jwks.to_value();
+    let json_str = serde_json::to_string(&jwks).unwrap();
+    let parsed: Value = serde_json::from_str(&json_str).unwrap();
+
+    assert_eq!(v, parsed);
+}
+
+#[test]
+fn builder_output_display_roundtrip() {
+    let jwks = JwksBuilder::new()
+        .add_public(ec_pub("disp-1"))
+        .add_public(okp_pub("disp-2"))
+        .build();
+
+    let display_str = jwks.to_string();
+    let parsed: Value = serde_json::from_str(&display_str).unwrap();
+    let to_value = jwks.to_value();
+
+    assert_eq!(parsed, to_value);
+}
+
+#[test]
+fn builder_deterministic_across_builds() {
+    let build_jwks = || {
+        JwksBuilder::new()
+            .add_public(rsa_pub("c"))
+            .add_public(ec_pub("a"))
+            .add_private(oct_priv("b"))
+            .build()
+    };
+
+    let json1 = serde_json::to_string(&build_jwks()).unwrap();
+    let json2 = serde_json::to_string(&build_jwks()).unwrap();
+    assert_eq!(json1, json2);
+}
+
+#[test]
+fn jwks_json_contains_keys_array_key() {
+    let jwks = JwksBuilder::new().add_public(rsa_pub("k")).build();
+    let v = jwks.to_value();
+
+    assert!(v.is_object());
+    assert!(v.as_object().unwrap().contains_key("keys"));
+    assert!(v["keys"].is_array());
+}
+
+#[test]
+fn each_key_in_jwks_json_has_kty_and_kid() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("k1"))
+        .add_public(ec_pub("k2"))
+        .add_public(okp_pub("k3"))
+        .add_private(oct_priv("k4"))
+        .build();
+
+    let v = jwks.to_value();
+    let keys = v["keys"].as_array().unwrap();
+    for key in keys {
+        assert!(key["kty"].is_string(), "kty must be present");
+        assert!(key["kid"].is_string(), "kid must be present");
+    }
+}
+
+#[test]
+fn serialized_kty_values_match_key_types() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("rsa"))
+        .add_public(ec_pub("ec"))
+        .add_public(okp_pub("okp"))
+        .add_private(oct_priv("oct"))
+        .build();
+
+    let v = jwks.to_value();
+    let keys = v["keys"].as_array().unwrap();
+    let ktys: Vec<&str> = keys.iter().map(|k| k["kty"].as_str().unwrap()).collect();
+
+    assert!(ktys.contains(&"RSA"));
+    assert!(ktys.contains(&"EC"));
+    assert!(ktys.contains(&"OKP"));
+    assert!(ktys.contains(&"oct"));
+}
+
+// ── 6. Edge cases ───────────────────────────────────────────────────────
+
+#[test]
+fn empty_builder_produces_empty_jwks() {
+    let jwks = JwksBuilder::new().build();
+    assert!(jwks.keys.is_empty());
+}
+
+#[test]
+fn empty_jwks_serializes_to_empty_keys_array() {
+    let jwks = JwksBuilder::new().build();
+    let v = jwks.to_value();
+    assert_eq!(v["keys"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn empty_jwks_display_is_valid_json() {
+    let jwks = JwksBuilder::new().build();
+    let json = jwks.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert!(parsed["keys"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn builder_default_is_equivalent_to_new() {
+    let from_new = JwksBuilder::new().build();
+    let from_default = JwksBuilder::default().build();
+    assert_eq!(from_new.keys.len(), from_default.keys.len());
+    assert!(from_new.keys.is_empty());
+}
+
+#[test]
+fn single_public_key_jwks() {
+    let jwks = JwksBuilder::new().add_public(rsa_pub("solo")).build();
+    let v = jwks.to_value();
+    let keys = v["keys"].as_array().unwrap();
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0]["kid"], "solo");
+}
+
+#[test]
+fn single_private_key_jwks() {
+    let jwks = JwksBuilder::new().add_private(oct_priv("solo")).build();
+    let v = jwks.to_value();
+    let keys = v["keys"].as_array().unwrap();
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0]["kid"], "solo");
+    assert_eq!(keys[0]["kty"], "oct");
+}
+
+#[test]
+fn kid_with_special_characters() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("key/with/slashes"))
+        .add_public(rsa_pub("key.with.dots"))
+        .add_public(rsa_pub("key-with-dashes"))
+        .add_public(rsa_pub("key_with_underscores"))
+        .build();
+
+    assert_eq!(jwks.keys.len(), 4);
+    let v = jwks.to_value();
+    let keys = v["keys"].as_array().unwrap();
+    for key in keys {
+        assert!(key["kid"].is_string());
+    }
+}
+
+#[test]
+fn kid_with_empty_string() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub(""))
+        .add_public(rsa_pub("a"))
+        .build();
+
+    // Empty string sorts before "a"
+    assert_eq!(jwks.keys[0].kid(), "");
+    assert_eq!(jwks.keys[1].kid(), "a");
+}
+
+#[test]
+fn builder_clone_produces_independent_copy() {
+    let builder = JwksBuilder::new()
+        .add_public(rsa_pub("a"))
+        .add_public(ec_pub("b"));
+
+    let clone = builder.clone();
+    let jwks1 = builder.build();
+    let jwks2 = clone.build();
+
+    assert_eq!(jwks1.keys.len(), jwks2.keys.len());
+    assert_eq!(
+        serde_json::to_string(&jwks1).unwrap(),
+        serde_json::to_string(&jwks2).unwrap(),
+    );
+}
+
+// ── 7. JWKS Display matches to_value for complex sets ───────────────────
+
+#[test]
+fn complex_jwks_display_matches_to_value() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("z-rsa"))
+        .add_public(ec_pub("a-ec"))
+        .add_private(okp_priv("m-okp"))
+        .add_private(oct_priv("b-oct"))
+        .add_public(okp_pub("c-okp"))
+        .build();
+
+    let from_display: Value = serde_json::from_str(&jwks.to_string()).unwrap();
+    let from_to_value = jwks.to_value();
+    assert_eq!(from_display, from_to_value);
+}
+
+// ── 8. Private key data preserved in serialization ──────────────────────
+
+#[test]
+fn rsa_private_key_fields_present_in_jwks() {
+    let jwks = JwksBuilder::new().add_private(rsa_priv("rsa-k")).build();
+    let v = jwks.to_value();
+    let key = &v["keys"][0];
+
+    for field in [
+        "kty", "use", "alg", "kid", "n", "e", "d", "p", "q", "dp", "dq", "qi",
+    ] {
+        assert!(key.get(field).is_some(), "missing field: {field}");
+    }
+}
+
+#[test]
+fn ec_private_key_d_field_present_in_jwks() {
+    let jwks = JwksBuilder::new().add_private(ec_priv("ec-k")).build();
+    let v = jwks.to_value();
+    let key = &v["keys"][0];
+    assert!(key["d"].is_string());
+    assert!(key["x"].is_string());
+    assert!(key["y"].is_string());
+}
+
+#[test]
+fn okp_private_key_d_field_present_in_jwks() {
+    let jwks = JwksBuilder::new().add_private(okp_priv("okp-k")).build();
+    let v = jwks.to_value();
+    let key = &v["keys"][0];
+    assert!(key["d"].is_string());
+    assert!(key["x"].is_string());
+}
+
+#[test]
+fn oct_private_key_k_field_present_in_jwks() {
+    let jwks = JwksBuilder::new().add_private(oct_priv("oct-k")).build();
+    let v = jwks.to_value();
+    let key = &v["keys"][0];
+    assert!(key["k"].is_string());
+}
+
+// ── 9. Jwks struct direct construction vs builder ───────────────────────
+
+#[test]
+fn builder_output_type_is_jwks() {
+    let jwks: Jwks = JwksBuilder::new().add_public(rsa_pub("t")).build();
+    // Verify the Jwks struct is usable
+    assert_eq!(jwks.keys.len(), 1);
+    let _ = jwks.to_value();
+    let _ = jwks.to_string();
+}

--- a/crates/uselesskey-core-jwk-shape/tests/comprehensive.rs
+++ b/crates/uselesskey-core-jwk-shape/tests/comprehensive.rs
@@ -1,0 +1,821 @@
+//! Comprehensive tests for `uselesskey-core-jwk-shape`.
+//!
+//! Covers: shape construction for all key types, serialization roundtrips,
+//! JWKS building, serde field renaming, Debug safety (no key leakage),
+//! Display/to_value consistency, From conversions, Clone, and edge cases.
+
+use serde_json::Value;
+use uselesskey_core_jwk_shape::{
+    AnyJwk, EcPrivateJwk, EcPublicJwk, Jwks, OctJwk, OkpPrivateJwk, OkpPublicJwk, PrivateJwk,
+    PublicJwk, RsaPrivateJwk, RsaPublicJwk,
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+fn rsa_public(kid: &str) -> RsaPublicJwk {
+    RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.to_string(),
+        n: format!("n-{kid}"),
+        e: "AQAB".to_string(),
+    }
+}
+
+fn rsa_private(kid: &str) -> RsaPrivateJwk {
+    RsaPrivateJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.to_string(),
+        n: "modulus".to_string(),
+        e: "AQAB".to_string(),
+        d: "priv-d".to_string(),
+        p: "prime-p".to_string(),
+        q: "prime-q".to_string(),
+        dp: "dp-exp".to_string(),
+        dq: "dq-exp".to_string(),
+        qi: "qi-coeff".to_string(),
+    }
+}
+
+fn ec_public(kid: &str) -> EcPublicJwk {
+    EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.to_string(),
+        x: format!("x-{kid}"),
+        y: format!("y-{kid}"),
+    }
+}
+
+fn ec_private(kid: &str) -> EcPrivateJwk {
+    EcPrivateJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.to_string(),
+        x: "ec-x".to_string(),
+        y: "ec-y".to_string(),
+        d: "ec-d-secret".to_string(),
+    }
+}
+
+fn okp_public(kid: &str) -> OkpPublicJwk {
+    OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.to_string(),
+        x: format!("x-{kid}"),
+    }
+}
+
+fn okp_private(kid: &str) -> OkpPrivateJwk {
+    OkpPrivateJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.to_string(),
+        x: "okp-x".to_string(),
+        d: "okp-d-secret".to_string(),
+    }
+}
+
+fn oct_jwk(kid: &str) -> OctJwk {
+    OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: kid.to_string(),
+        k: format!("k-{kid}"),
+    }
+}
+
+// ── 1. Shape construction: all key types ────────────────────────────────
+
+#[test]
+fn rsa_public_construction_and_accessors() {
+    let jwk = rsa_public("rsa-1");
+    assert_eq!(jwk.kty, "RSA");
+    assert_eq!(jwk.use_, "sig");
+    assert_eq!(jwk.alg, "RS256");
+    assert_eq!(jwk.kid(), "rsa-1");
+    assert_eq!(jwk.n, "n-rsa-1");
+    assert_eq!(jwk.e, "AQAB");
+}
+
+#[test]
+fn rsa_private_construction_and_crt_fields() {
+    let jwk = rsa_private("rsa-priv-1");
+    assert_eq!(jwk.kty, "RSA");
+    assert_eq!(jwk.kid(), "rsa-priv-1");
+    assert_eq!(jwk.d, "priv-d");
+    assert_eq!(jwk.p, "prime-p");
+    assert_eq!(jwk.q, "prime-q");
+    assert_eq!(jwk.dp, "dp-exp");
+    assert_eq!(jwk.dq, "dq-exp");
+    assert_eq!(jwk.qi, "qi-coeff");
+}
+
+#[test]
+fn ec_public_construction_with_curve() {
+    let jwk = ec_public("ec-1");
+    assert_eq!(jwk.kty, "EC");
+    assert_eq!(jwk.crv, "P-256");
+    assert_eq!(jwk.alg, "ES256");
+    assert_eq!(jwk.kid(), "ec-1");
+    assert_eq!(jwk.x, "x-ec-1");
+    assert_eq!(jwk.y, "y-ec-1");
+}
+
+#[test]
+fn ec_p384_construction() {
+    let jwk = EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES384",
+        crv: "P-384",
+        kid: "ec-384".to_string(),
+        x: "x384".to_string(),
+        y: "y384".to_string(),
+    };
+    assert_eq!(jwk.crv, "P-384");
+    assert_eq!(jwk.alg, "ES384");
+}
+
+#[test]
+fn okp_public_construction() {
+    let jwk = okp_public("okp-1");
+    assert_eq!(jwk.kty, "OKP");
+    assert_eq!(jwk.crv, "Ed25519");
+    assert_eq!(jwk.alg, "EdDSA");
+    assert_eq!(jwk.kid(), "okp-1");
+}
+
+#[test]
+fn okp_private_construction() {
+    let jwk = okp_private("okp-priv-1");
+    assert_eq!(jwk.kty, "OKP");
+    assert_eq!(jwk.crv, "Ed25519");
+    assert_eq!(jwk.kid(), "okp-priv-1");
+    assert_eq!(jwk.d, "okp-d-secret");
+}
+
+#[test]
+fn oct_construction() {
+    let jwk = oct_jwk("oct-1");
+    assert_eq!(jwk.kty, "oct");
+    assert_eq!(jwk.alg, "HS256");
+    assert_eq!(jwk.kid(), "oct-1");
+    assert_eq!(jwk.k, "k-oct-1");
+}
+
+#[test]
+fn oct_hs384_construction() {
+    let jwk = OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS384",
+        kid: "hs384".to_string(),
+        k: "secret384".to_string(),
+    };
+    assert_eq!(jwk.alg, "HS384");
+}
+
+#[test]
+fn oct_hs512_construction() {
+    let jwk = OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS512",
+        kid: "hs512".to_string(),
+        k: "secret512".to_string(),
+    };
+    assert_eq!(jwk.alg, "HS512");
+}
+
+// ── 2. PublicJwk / PrivateJwk / AnyJwk enum wrappers ────────────────────
+
+#[test]
+fn public_jwk_kid_dispatches_to_inner() {
+    assert_eq!(PublicJwk::Rsa(rsa_public("r")).kid(), "r");
+    assert_eq!(PublicJwk::Ec(ec_public("e")).kid(), "e");
+    assert_eq!(PublicJwk::Okp(okp_public("o")).kid(), "o");
+}
+
+#[test]
+fn private_jwk_kid_dispatches_to_inner() {
+    assert_eq!(PrivateJwk::Rsa(rsa_private("r")).kid(), "r");
+    assert_eq!(PrivateJwk::Ec(ec_private("e")).kid(), "e");
+    assert_eq!(PrivateJwk::Okp(okp_private("o")).kid(), "o");
+    assert_eq!(PrivateJwk::Oct(oct_jwk("h")).kid(), "h");
+}
+
+#[test]
+fn any_jwk_kid_dispatches_through_public() {
+    let any = AnyJwk::Public(PublicJwk::Rsa(rsa_public("pub-k")));
+    assert_eq!(any.kid(), "pub-k");
+}
+
+#[test]
+fn any_jwk_kid_dispatches_through_private() {
+    let any = AnyJwk::Private(PrivateJwk::Oct(oct_jwk("priv-k")));
+    assert_eq!(any.kid(), "priv-k");
+}
+
+// ── 3. Serialization roundtrips ─────────────────────────────────────────
+
+#[test]
+fn rsa_public_serde_roundtrip() {
+    let jwk = PublicJwk::Rsa(rsa_public("rt-rsa"));
+    let json = jwk.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(jwk.to_value(), parsed);
+}
+
+#[test]
+fn rsa_private_serde_roundtrip() {
+    let jwk = PrivateJwk::Rsa(rsa_private("rt-rsa-priv"));
+    let json = jwk.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(jwk.to_value(), parsed);
+}
+
+#[test]
+fn ec_public_serde_roundtrip() {
+    let jwk = PublicJwk::Ec(ec_public("rt-ec"));
+    let json = jwk.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(jwk.to_value(), parsed);
+}
+
+#[test]
+fn ec_private_serde_roundtrip() {
+    let jwk = PrivateJwk::Ec(ec_private("rt-ec-priv"));
+    let json = jwk.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(jwk.to_value(), parsed);
+}
+
+#[test]
+fn okp_public_serde_roundtrip() {
+    let jwk = PublicJwk::Okp(okp_public("rt-okp"));
+    let json = jwk.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(jwk.to_value(), parsed);
+}
+
+#[test]
+fn okp_private_serde_roundtrip() {
+    let jwk = PrivateJwk::Okp(okp_private("rt-okp-priv"));
+    let json = jwk.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(jwk.to_value(), parsed);
+}
+
+#[test]
+fn oct_serde_roundtrip() {
+    let jwk = PrivateJwk::Oct(oct_jwk("rt-oct"));
+    let json = jwk.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(jwk.to_value(), parsed);
+}
+
+#[test]
+fn any_jwk_public_serde_roundtrip() {
+    let any = AnyJwk::from(PublicJwk::Ec(ec_public("any-rt")));
+    let json = any.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(any.to_value(), parsed);
+}
+
+#[test]
+fn any_jwk_private_serde_roundtrip() {
+    let any = AnyJwk::from(PrivateJwk::Oct(oct_jwk("any-priv-rt")));
+    let json = any.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(any.to_value(), parsed);
+}
+
+#[test]
+fn deterministic_serialization_all_types() {
+    let items: Vec<Box<dyn Fn() -> String>> = vec![
+        Box::new(|| serde_json::to_string(&rsa_public("d")).unwrap()),
+        Box::new(|| serde_json::to_string(&rsa_private("d")).unwrap()),
+        Box::new(|| serde_json::to_string(&ec_public("d")).unwrap()),
+        Box::new(|| serde_json::to_string(&ec_private("d")).unwrap()),
+        Box::new(|| serde_json::to_string(&okp_public("d")).unwrap()),
+        Box::new(|| serde_json::to_string(&okp_private("d")).unwrap()),
+        Box::new(|| serde_json::to_string(&oct_jwk("d")).unwrap()),
+    ];
+
+    for make_json in &items {
+        assert_eq!(
+            make_json(),
+            make_json(),
+            "deterministic serialization failed"
+        );
+    }
+}
+
+// ── 4. Serde rename attributes ──────────────────────────────────────────
+
+#[test]
+fn use_field_serialized_as_use_for_rsa_public() {
+    let v = serde_json::to_value(rsa_public("u")).unwrap();
+    assert!(v.get("use").is_some());
+    assert!(v.get("use_").is_none());
+}
+
+#[test]
+fn use_field_serialized_as_use_for_ec_public() {
+    let v = serde_json::to_value(ec_public("u")).unwrap();
+    assert!(v.get("use").is_some());
+    assert!(v.get("use_").is_none());
+}
+
+#[test]
+fn use_field_serialized_as_use_for_okp_public() {
+    let v = serde_json::to_value(okp_public("u")).unwrap();
+    assert!(v.get("use").is_some());
+    assert!(v.get("use_").is_none());
+}
+
+#[test]
+fn use_field_serialized_as_use_for_oct() {
+    let v = serde_json::to_value(oct_jwk("u")).unwrap();
+    assert!(v.get("use").is_some());
+    assert!(v.get("use_").is_none());
+}
+
+#[test]
+fn qi_field_serialized_correctly_in_rsa_private() {
+    let v = serde_json::to_value(rsa_private("qi")).unwrap();
+    assert!(v.get("qi").is_some());
+}
+
+#[test]
+fn untagged_serialization_no_variant_wrapper() {
+    let pub_v = serde_json::to_value(PublicJwk::Rsa(rsa_public("u"))).unwrap();
+    assert!(pub_v.get("Rsa").is_none());
+
+    let priv_v = serde_json::to_value(PrivateJwk::Oct(oct_jwk("u"))).unwrap();
+    assert!(priv_v.get("Oct").is_none());
+
+    let any_v = serde_json::to_value(AnyJwk::from(PublicJwk::Ec(ec_public("u")))).unwrap();
+    assert!(any_v.get("Public").is_none());
+}
+
+// ── 5. JSON field counts (structural correctness) ───────────────────────
+
+#[test]
+fn rsa_public_has_six_fields() {
+    let v = serde_json::to_value(rsa_public("fc")).unwrap();
+    assert_eq!(v.as_object().unwrap().len(), 6);
+}
+
+#[test]
+fn rsa_private_has_twelve_fields() {
+    let v = serde_json::to_value(rsa_private("fc")).unwrap();
+    assert_eq!(v.as_object().unwrap().len(), 12);
+}
+
+#[test]
+fn ec_public_has_seven_fields() {
+    let v = serde_json::to_value(ec_public("fc")).unwrap();
+    assert_eq!(v.as_object().unwrap().len(), 7);
+}
+
+#[test]
+fn ec_private_has_eight_fields() {
+    let v = serde_json::to_value(ec_private("fc")).unwrap();
+    assert_eq!(v.as_object().unwrap().len(), 8);
+}
+
+#[test]
+fn okp_public_has_six_fields() {
+    let v = serde_json::to_value(okp_public("fc")).unwrap();
+    assert_eq!(v.as_object().unwrap().len(), 6);
+}
+
+#[test]
+fn okp_private_has_seven_fields() {
+    let v = serde_json::to_value(okp_private("fc")).unwrap();
+    assert_eq!(v.as_object().unwrap().len(), 7);
+}
+
+#[test]
+fn oct_has_five_fields() {
+    let v = serde_json::to_value(oct_jwk("fc")).unwrap();
+    assert_eq!(v.as_object().unwrap().len(), 5);
+}
+
+// ── 6. Debug safety: no key material leakage ────────────────────────────
+
+#[test]
+fn rsa_private_debug_omits_all_secrets() {
+    let jwk = rsa_private("dbg-rsa");
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("RsaPrivateJwk"));
+    assert!(dbg.contains("dbg-rsa"));
+    for secret in [
+        "priv-d", "prime-p", "prime-q", "dp-exp", "dq-exp", "qi-coeff",
+    ] {
+        assert!(!dbg.contains(secret), "leaked {secret}");
+    }
+}
+
+#[test]
+fn ec_private_debug_omits_d() {
+    let jwk = ec_private("dbg-ec");
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("EcPrivateJwk"));
+    assert!(!dbg.contains("ec-d-secret"));
+}
+
+#[test]
+fn okp_private_debug_omits_d() {
+    let jwk = okp_private("dbg-okp");
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("OkpPrivateJwk"));
+    assert!(!dbg.contains("okp-d-secret"));
+}
+
+#[test]
+fn oct_debug_omits_k() {
+    let jwk = oct_jwk("dbg-oct");
+    let dbg = format!("{jwk:?}");
+    assert!(dbg.contains("OctJwk"));
+    assert!(!dbg.contains("k-dbg-oct"));
+}
+
+#[test]
+fn private_jwk_enum_debug_delegates_to_inner() {
+    let rsa = PrivateJwk::Rsa(rsa_private("d-rsa"));
+    assert!(format!("{rsa:?}").contains("RsaPrivateJwk"));
+
+    let ec = PrivateJwk::Ec(ec_private("d-ec"));
+    assert!(format!("{ec:?}").contains("EcPrivateJwk"));
+
+    let okp = PrivateJwk::Okp(okp_private("d-okp"));
+    assert!(format!("{okp:?}").contains("OkpPrivateJwk"));
+
+    let oct = PrivateJwk::Oct(oct_jwk("d-oct"));
+    assert!(format!("{oct:?}").contains("OctJwk"));
+}
+
+#[test]
+fn debug_uses_finish_non_exhaustive() {
+    // finish_non_exhaustive produces `..` in output
+    let dbg = format!("{:?}", rsa_private("ne"));
+    assert!(dbg.contains(".."), "expected finish_non_exhaustive marker");
+}
+
+// ── 7. Display produces valid JSON ──────────────────────────────────────
+
+#[test]
+fn public_jwk_display_all_variants_valid_json() {
+    let variants: Vec<PublicJwk> = vec![
+        PublicJwk::Rsa(rsa_public("d1")),
+        PublicJwk::Ec(ec_public("d2")),
+        PublicJwk::Okp(okp_public("d3")),
+    ];
+    for jwk in &variants {
+        let json = jwk.to_string();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["kid"], jwk.kid());
+    }
+}
+
+#[test]
+fn private_jwk_display_all_variants_valid_json() {
+    let variants: Vec<PrivateJwk> = vec![
+        PrivateJwk::Rsa(rsa_private("d1")),
+        PrivateJwk::Ec(ec_private("d2")),
+        PrivateJwk::Okp(okp_private("d3")),
+        PrivateJwk::Oct(oct_jwk("d4")),
+    ];
+    for jwk in &variants {
+        let json = jwk.to_string();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["kid"], jwk.kid());
+    }
+}
+
+#[test]
+fn any_jwk_display_valid_json() {
+    let any_pub = AnyJwk::from(PublicJwk::Rsa(rsa_public("dp")));
+    let parsed: Value = serde_json::from_str(&any_pub.to_string()).unwrap();
+    assert_eq!(parsed["kid"], "dp");
+
+    let any_priv = AnyJwk::from(PrivateJwk::Oct(oct_jwk("dpr")));
+    let parsed: Value = serde_json::from_str(&any_priv.to_string()).unwrap();
+    assert_eq!(parsed["kid"], "dpr");
+}
+
+// ── 8. Display and to_value consistency ─────────────────────────────────
+
+#[test]
+fn display_and_to_value_agree_for_public_jwk() {
+    let jwk = PublicJwk::Okp(okp_public("agree"));
+    let from_display: Value = serde_json::from_str(&jwk.to_string()).unwrap();
+    assert_eq!(from_display, jwk.to_value());
+}
+
+#[test]
+fn display_and_to_value_agree_for_private_jwk() {
+    let jwk = PrivateJwk::Ec(ec_private("agree"));
+    let from_display: Value = serde_json::from_str(&jwk.to_string()).unwrap();
+    assert_eq!(from_display, jwk.to_value());
+}
+
+#[test]
+fn display_and_to_value_agree_for_any_jwk() {
+    let any = AnyJwk::from(PublicJwk::Rsa(rsa_public("agree")));
+    let from_display: Value = serde_json::from_str(&any.to_string()).unwrap();
+    assert_eq!(from_display, any.to_value());
+}
+
+// ── 9. JWKS collection ──────────────────────────────────────────────────
+
+#[test]
+fn jwks_empty_collection() {
+    let jwks = Jwks { keys: vec![] };
+    let v = jwks.to_value();
+    assert!(v["keys"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn jwks_single_public_key() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(PublicJwk::Rsa(rsa_public("single")))],
+    };
+    let v = jwks.to_value();
+    assert_eq!(v["keys"].as_array().unwrap().len(), 1);
+    assert_eq!(v["keys"][0]["kid"], "single");
+}
+
+#[test]
+fn jwks_single_private_key() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(PrivateJwk::Oct(oct_jwk("single-priv")))],
+    };
+    let v = jwks.to_value();
+    assert_eq!(v["keys"].as_array().unwrap().len(), 1);
+    assert_eq!(v["keys"][0]["kty"], "oct");
+}
+
+#[test]
+fn jwks_mixed_public_and_private_keys() {
+    let jwks = Jwks {
+        keys: vec![
+            AnyJwk::from(PublicJwk::Rsa(rsa_public("pub-rsa"))),
+            AnyJwk::from(PublicJwk::Ec(ec_public("pub-ec"))),
+            AnyJwk::from(PublicJwk::Okp(okp_public("pub-okp"))),
+            AnyJwk::from(PrivateJwk::Rsa(rsa_private("priv-rsa"))),
+            AnyJwk::from(PrivateJwk::Ec(ec_private("priv-ec"))),
+            AnyJwk::from(PrivateJwk::Okp(okp_private("priv-okp"))),
+            AnyJwk::from(PrivateJwk::Oct(oct_jwk("priv-oct"))),
+        ],
+    };
+    let v = jwks.to_value();
+    assert_eq!(v["keys"].as_array().unwrap().len(), 7);
+}
+
+#[test]
+fn jwks_display_is_valid_json() {
+    let jwks = Jwks {
+        keys: vec![
+            AnyJwk::from(PublicJwk::Rsa(rsa_public("j1"))),
+            AnyJwk::from(PrivateJwk::Oct(oct_jwk("j2"))),
+        ],
+    };
+    let json = jwks.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert!(parsed["keys"].is_array());
+    assert_eq!(parsed["keys"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn jwks_display_and_to_value_agree() {
+    let jwks = Jwks {
+        keys: vec![
+            AnyJwk::from(PublicJwk::Ec(ec_public("ag1"))),
+            AnyJwk::from(PublicJwk::Okp(okp_public("ag2"))),
+        ],
+    };
+    let from_display: Value = serde_json::from_str(&jwks.to_string()).unwrap();
+    assert_eq!(from_display, jwks.to_value());
+}
+
+#[test]
+fn jwks_serde_roundtrip() {
+    let jwks = Jwks {
+        keys: vec![
+            AnyJwk::from(PublicJwk::Rsa(rsa_public("sr1"))),
+            AnyJwk::from(PrivateJwk::Ec(ec_private("sr2"))),
+            AnyJwk::from(PublicJwk::Okp(okp_public("sr3"))),
+        ],
+    };
+    let json_str = serde_json::to_string(&jwks).unwrap();
+    let parsed: Value = serde_json::from_str(&json_str).unwrap();
+    let direct = jwks.to_value();
+    assert_eq!(parsed, direct);
+}
+
+#[test]
+fn jwks_deterministic_serialization() {
+    let build = || Jwks {
+        keys: vec![
+            AnyJwk::from(PublicJwk::Rsa(rsa_public("det-1"))),
+            AnyJwk::from(PrivateJwk::Oct(oct_jwk("det-2"))),
+        ],
+    };
+    assert_eq!(
+        serde_json::to_string(&build()).unwrap(),
+        serde_json::to_string(&build()).unwrap(),
+    );
+}
+
+#[test]
+fn jwks_duplicate_kids_serialized_as_separate_entries() {
+    let jwks = Jwks {
+        keys: vec![
+            AnyJwk::from(PublicJwk::Rsa(rsa_public("dup"))),
+            AnyJwk::from(PublicJwk::Ec(ec_public("dup"))),
+        ],
+    };
+    let v = jwks.to_value();
+    let keys = v["keys"].as_array().unwrap();
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0]["kid"], "dup");
+    assert_eq!(keys[1]["kid"], "dup");
+    // Distinct kty values prove they are different keys
+    assert_ne!(keys[0]["kty"], keys[1]["kty"]);
+}
+
+// ── 10. From conversions ────────────────────────────────────────────────
+
+#[test]
+fn from_public_to_any_preserves_value() {
+    let public = PublicJwk::Rsa(rsa_public("from-rsa"));
+    let original_value = public.to_value();
+    let any = AnyJwk::from(public);
+    assert_eq!(any.to_value(), original_value);
+}
+
+#[test]
+fn from_private_to_any_preserves_value() {
+    let private = PrivateJwk::Oct(oct_jwk("from-oct"));
+    let original_value = private.to_value();
+    let any = AnyJwk::from(private);
+    assert_eq!(any.to_value(), original_value);
+}
+
+#[test]
+fn into_any_jwk_from_public() {
+    let public = PublicJwk::Ec(ec_public("into-ec"));
+    let any: AnyJwk = public.into();
+    assert_eq!(any.kid(), "into-ec");
+}
+
+#[test]
+fn into_any_jwk_from_private() {
+    let private = PrivateJwk::Okp(okp_private("into-okp"));
+    let any: AnyJwk = private.into();
+    assert_eq!(any.kid(), "into-okp");
+}
+
+// ── 11. Clone ───────────────────────────────────────────────────────────
+
+#[test]
+fn rsa_public_clone_is_equal() {
+    let jwk = rsa_public("clone");
+    let cloned = jwk.clone();
+    assert_eq!(jwk.kid(), cloned.kid());
+    assert_eq!(
+        serde_json::to_value(jwk).unwrap(),
+        serde_json::to_value(cloned).unwrap(),
+    );
+}
+
+#[test]
+fn public_jwk_enum_clone_preserves_value() {
+    let jwk = PublicJwk::Ec(ec_public("clone-ec"));
+    let cloned = jwk.clone();
+    assert_eq!(jwk.to_value(), cloned.to_value());
+}
+
+#[test]
+fn private_jwk_enum_clone_preserves_value() {
+    let jwk = PrivateJwk::Oct(oct_jwk("clone-oct"));
+    let cloned = jwk.clone();
+    assert_eq!(jwk.to_value(), cloned.to_value());
+}
+
+#[test]
+fn any_jwk_clone_preserves_value() {
+    let any = AnyJwk::from(PublicJwk::Okp(okp_public("clone-any")));
+    let cloned = any.clone();
+    assert_eq!(any.to_value(), cloned.to_value());
+}
+
+#[test]
+fn jwks_clone_preserves_keys() {
+    let jwks = Jwks {
+        keys: vec![
+            AnyJwk::from(PublicJwk::Rsa(rsa_public("c1"))),
+            AnyJwk::from(PrivateJwk::Oct(oct_jwk("c2"))),
+        ],
+    };
+    let cloned = jwks.clone();
+    assert_eq!(jwks.keys.len(), cloned.keys.len());
+    assert_eq!(
+        serde_json::to_string(&jwks).unwrap(),
+        serde_json::to_string(&cloned).unwrap(),
+    );
+}
+
+// ── 12. Edge cases ──────────────────────────────────────────────────────
+
+#[test]
+fn kid_with_unicode_characters() {
+    let jwk = PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: "キー-1".to_string(),
+        n: "n".to_string(),
+        e: "AQAB".to_string(),
+    });
+    assert_eq!(jwk.kid(), "キー-1");
+    let v = jwk.to_value();
+    assert_eq!(v["kid"], "キー-1");
+}
+
+#[test]
+fn kid_with_empty_string() {
+    let jwk = PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: String::new(),
+        n: "n".to_string(),
+        e: "AQAB".to_string(),
+    });
+    assert_eq!(jwk.kid(), "");
+    let v = jwk.to_value();
+    assert_eq!(v["kid"], "");
+}
+
+#[test]
+fn large_jwks_with_many_keys() {
+    let keys: Vec<AnyJwk> = (0..100)
+        .map(|i| AnyJwk::from(PublicJwk::Rsa(rsa_public(&format!("key-{i:03}")))))
+        .collect();
+    let jwks = Jwks { keys };
+
+    let v = jwks.to_value();
+    assert_eq!(v["keys"].as_array().unwrap().len(), 100);
+
+    // Verify roundtrip
+    let json = jwks.to_string();
+    let parsed: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["keys"].as_array().unwrap().len(), 100);
+}
+
+#[test]
+fn jwks_json_structure_has_only_keys_field() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(PublicJwk::Rsa(rsa_public("s")))],
+    };
+    let v = jwks.to_value();
+    let obj = v.as_object().unwrap();
+    assert_eq!(obj.len(), 1, "JWKS should only have 'keys' field");
+    assert!(obj.contains_key("keys"));
+}
+
+#[test]
+fn to_value_returns_object_for_all_jwk_types() {
+    let vals: Vec<Value> = vec![
+        PublicJwk::Rsa(rsa_public("v")).to_value(),
+        PublicJwk::Ec(ec_public("v")).to_value(),
+        PublicJwk::Okp(okp_public("v")).to_value(),
+        PrivateJwk::Rsa(rsa_private("v")).to_value(),
+        PrivateJwk::Ec(ec_private("v")).to_value(),
+        PrivateJwk::Okp(okp_private("v")).to_value(),
+        PrivateJwk::Oct(oct_jwk("v")).to_value(),
+        AnyJwk::from(PublicJwk::Rsa(rsa_public("v"))).to_value(),
+        AnyJwk::from(PrivateJwk::Oct(oct_jwk("v"))).to_value(),
+    ];
+    for v in &vals {
+        assert!(v.is_object(), "to_value must return a JSON object");
+    }
+}


### PR DESCRIPTION
## Summary
Add comprehensive integration tests for `uselesskey-core-jwk-builder` and `uselesskey-core-jwk-shape` crates.

## Tests Added

### uselesskey-core-jwk-builder (35 new tests)
- Fluent API chaining (add_public/add_private/add_any)
- Key ordering (kid-sorted lexicographic, numeric, case-sensitive)
- Duplicate kid insertion-order preservation
- JWKS building with all key types (RSA, EC, OKP, Oct)
- Serialization roundtrips (to_value, Display, serde_json)
- Edge cases (empty JWKS, single keys, large sets, special characters, empty kids)
- Builder clone independence
- Deterministic output across builds

### uselesskey-core-jwk-shape (71 new tests)
- Shape construction for all key types (RSA/EC/OKP/Oct, public+private)
- PublicJwk/PrivateJwk/AnyJwk enum dispatching
- Serialization roundtrips for every variant
- Serde rename verification (use_ -> use, qi)
- JSON field count correctness
- Debug safety (no private key material leakage)
- Display/to_value consistency
- JWKS collection (empty, single, mixed, duplicate kids)
- From conversions and Clone behavior
- Edge cases (unicode kids, empty kids, large collections)

## Verification
- All 271 tests pass (106 new + 165 existing)
- cargo clippy passes with -D warnings
- cargo fmt produces no changes
