### PR TITLE
test(uselesskey-tonic): add comprehensive adapter tests

### DIFF
--- a/crates/uselesskey-tonic/tests/chain_negative_tonic.rs
+++ b/crates/uselesskey-tonic/tests/chain_negative_tonic.rs
@@ -1,0 +1,253 @@
+//! Tests for tonic adapter integration with X.509 chain negative fixtures.
+//!
+//! Covers:
+//! - Expired leaf / intermediate certs build tonic configs (deferred validation)
+//! - Revoked leaf certs build tonic configs
+//! - Unknown CA chain builds tonic configs
+//! - Hostname mismatch chain builds tonic configs
+//! - CRL availability through negative chains
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_tonic::{TonicClientTlsExt, TonicIdentityExt, TonicMtlsExt, TonicServerTlsExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt};
+
+// =========================================================================
+// Expired leaf certificate
+// =========================================================================
+
+#[test]
+fn expired_leaf_chain_identity_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-expired-leaf", ChainSpec::new("expired.example.com"));
+    let expired = chain.expired_leaf();
+    let _identity = expired.identity_tonic();
+}
+
+#[test]
+fn expired_leaf_chain_server_tls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-exp-leaf-srv", ChainSpec::new("expired.example.com"));
+    let expired = chain.expired_leaf();
+    let _server = expired.server_tls_config_tonic();
+}
+
+#[test]
+fn expired_leaf_chain_client_tls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-exp-leaf-cli", ChainSpec::new("expired.example.com"));
+    let expired = chain.expired_leaf();
+    let _client = expired.client_tls_config_tonic("expired.example.com");
+}
+
+#[test]
+fn expired_leaf_chain_mtls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-exp-leaf-mtls", ChainSpec::new("expired.example.com"));
+    let expired = chain.expired_leaf();
+    let _server = expired.server_tls_config_mtls_tonic();
+    let _client = expired.client_tls_config_mtls_tonic("expired.example.com");
+}
+
+// =========================================================================
+// Expired intermediate certificate
+// =========================================================================
+
+#[test]
+fn expired_intermediate_chain_identity_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-exp-int", ChainSpec::new("expired-int.example.com"));
+    let expired = chain.expired_intermediate();
+    let _identity = expired.identity_tonic();
+}
+
+#[test]
+fn expired_intermediate_chain_server_tls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-exp-int-srv", ChainSpec::new("expired-int.example.com"));
+    let expired = chain.expired_intermediate();
+    let _server = expired.server_tls_config_tonic();
+}
+
+#[test]
+fn expired_intermediate_chain_mtls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain(
+        "neg-exp-int-mtls",
+        ChainSpec::new("expired-int.example.com"),
+    );
+    let expired = chain.expired_intermediate();
+    let _server = expired.server_tls_config_mtls_tonic();
+    let _client = expired.client_tls_config_mtls_tonic("expired-int.example.com");
+}
+
+// =========================================================================
+// Revoked leaf certificate
+// =========================================================================
+
+#[test]
+fn revoked_leaf_chain_identity_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-revoked", ChainSpec::new("revoked.example.com"));
+    let revoked = chain.revoked_leaf();
+    let _identity = revoked.identity_tonic();
+}
+
+#[test]
+fn revoked_leaf_chain_server_tls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-revoked-srv", ChainSpec::new("revoked.example.com"));
+    let revoked = chain.revoked_leaf();
+    let _server = revoked.server_tls_config_tonic();
+}
+
+#[test]
+fn revoked_leaf_chain_client_tls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-revoked-cli", ChainSpec::new("revoked.example.com"));
+    let revoked = chain.revoked_leaf();
+    let _client = revoked.client_tls_config_tonic("revoked.example.com");
+}
+
+#[test]
+fn revoked_leaf_chain_has_crl() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-revoked-crl", ChainSpec::new("revoked.example.com"));
+    let revoked = chain.revoked_leaf();
+    assert!(
+        revoked.crl_der().is_some(),
+        "Revoked leaf chain should have a CRL"
+    );
+    assert!(
+        revoked.crl_pem().is_some(),
+        "Revoked leaf chain should have a CRL PEM"
+    );
+}
+
+// =========================================================================
+// Unknown CA chain
+// =========================================================================
+
+#[test]
+fn unknown_ca_chain_identity_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-unknown-ca", ChainSpec::new("unknown.example.com"));
+    let unknown = chain.unknown_ca();
+    let _identity = unknown.identity_tonic();
+}
+
+#[test]
+fn unknown_ca_chain_server_tls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-uca-srv", ChainSpec::new("unknown.example.com"));
+    let unknown = chain.unknown_ca();
+    let _server = unknown.server_tls_config_tonic();
+}
+
+#[test]
+fn unknown_ca_chain_client_tls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-uca-cli", ChainSpec::new("unknown.example.com"));
+    let unknown = chain.unknown_ca();
+    let _client = unknown.client_tls_config_tonic("unknown.example.com");
+}
+
+#[test]
+fn unknown_ca_has_different_root() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-uca-diff", ChainSpec::new("unknown.example.com"));
+    let unknown = chain.unknown_ca();
+    assert_ne!(
+        chain.root_cert_der(),
+        unknown.root_cert_der(),
+        "Unknown CA should have a different root certificate"
+    );
+}
+
+// =========================================================================
+// Hostname mismatch chain
+// =========================================================================
+
+#[test]
+fn hostname_mismatch_chain_identity_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-hostname", ChainSpec::new("correct.example.com"));
+    let mismatched = chain.hostname_mismatch("wrong.example.com");
+    let _identity = mismatched.identity_tonic();
+}
+
+#[test]
+fn hostname_mismatch_chain_server_tls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-host-srv", ChainSpec::new("correct.example.com"));
+    let mismatched = chain.hostname_mismatch("wrong.example.com");
+    let _server = mismatched.server_tls_config_tonic();
+}
+
+#[test]
+fn hostname_mismatch_chain_mtls_builds() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-host-mtls", ChainSpec::new("correct.example.com"));
+    let mismatched = chain.hostname_mismatch("wrong.example.com");
+    let _server = mismatched.server_tls_config_mtls_tonic();
+    let _client = mismatched.client_tls_config_mtls_tonic("correct.example.com");
+}
+
+#[test]
+fn hostname_mismatch_has_different_leaf() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-host-diff", ChainSpec::new("correct.example.com"));
+    let mismatched = chain.hostname_mismatch("wrong.example.com");
+    assert_ne!(
+        chain.leaf_cert_der(),
+        mismatched.leaf_cert_der(),
+        "Hostname mismatch should produce a different leaf certificate"
+    );
+}
+
+// =========================================================================
+// Negative chain PEM structure still valid
+// =========================================================================
+
+#[test]
+fn expired_leaf_chain_pem_has_two_certs() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-pem-cnt", ChainSpec::new("pem.example.com"));
+    let expired = chain.expired_leaf();
+    let count = expired
+        .chain_pem()
+        .matches("-----BEGIN CERTIFICATE-----")
+        .count();
+    assert_eq!(
+        count, 2,
+        "expired leaf chain_pem should still contain 2 certs"
+    );
+}
+
+#[test]
+fn unknown_ca_full_chain_pem_has_three_certs() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-full-pem", ChainSpec::new("pem.example.com"));
+    let unknown = chain.unknown_ca();
+    let count = unknown
+        .full_chain_pem()
+        .matches("-----BEGIN CERTIFICATE-----")
+        .count();
+    assert_eq!(
+        count, 3,
+        "unknown CA full_chain_pem should still contain 3 certs"
+    );
+}
+
+#[test]
+fn revoked_leaf_key_pem_has_correct_header() {
+    let fx = fx();
+    let chain = fx.x509_chain("neg-key-hdr", ChainSpec::new("key.example.com"));
+    let revoked = chain.revoked_leaf();
+    assert!(
+        revoked
+            .leaf_private_key_pkcs8_pem()
+            .starts_with("-----BEGIN PRIVATE KEY-----")
+    );
+}

--- a/crates/uselesskey-tonic/tests/feature_gating.rs
+++ b/crates/uselesskey-tonic/tests/feature_gating.rs
@@ -1,0 +1,113 @@
+//! Feature flag gating tests for uselesskey-tonic.
+//!
+//! When the `x509` feature is enabled, all extension traits should be available.
+//! This file tests that the traits are importable, usable, and produce the expected types.
+
+// This test module is only meaningful when the x509 feature is active.
+#[cfg(feature = "x509")]
+mod with_x509_feature {
+    use uselesskey_core::Factory;
+    use uselesskey_tonic::{TonicClientTlsExt, TonicIdentityExt, TonicMtlsExt, TonicServerTlsExt};
+    use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+    /// Verify all four extension traits are importable and callable.
+    #[test]
+    fn all_traits_available_with_x509_feature() {
+        let fx = Factory::random();
+        let cert = fx.x509_self_signed("feat-ss", X509Spec::self_signed("localhost"));
+        let chain = fx.x509_chain("feat-chain", ChainSpec::new("feat.example.com"));
+
+        // TonicIdentityExt
+        let _id_cert = cert.identity_tonic();
+        let _id_chain = chain.identity_tonic();
+
+        // TonicServerTlsExt
+        let _srv_cert = cert.server_tls_config_tonic();
+        let _srv_chain = chain.server_tls_config_tonic();
+
+        // TonicClientTlsExt
+        let _cli_cert = cert.client_tls_config_tonic("localhost");
+        let _cli_chain = chain.client_tls_config_tonic("feat.example.com");
+
+        // TonicMtlsExt (only on X509Chain)
+        let _mtls_srv = chain.server_tls_config_mtls_tonic();
+        let _mtls_cli = chain.client_tls_config_mtls_tonic("feat.example.com");
+    }
+
+    /// Verify traits work with both &str and String domain names.
+    #[test]
+    fn domain_name_accepts_str_and_string() {
+        let fx = Factory::random();
+        let chain = fx.x509_chain("feat-domain", ChainSpec::new("domain.example.com"));
+
+        // &str
+        let _client_str = chain.client_tls_config_tonic("domain.example.com");
+
+        // String
+        let domain = String::from("domain.example.com");
+        let _client_string = chain.client_tls_config_tonic(domain);
+
+        // mTLS with &str
+        let _mtls_str = chain.client_tls_config_mtls_tonic("domain.example.com");
+
+        // mTLS with String
+        let domain2 = String::from("domain.example.com");
+        let _mtls_string = chain.client_tls_config_mtls_tonic(domain2);
+    }
+
+    /// Verify self-signed and chain implement the same traits.
+    #[test]
+    fn self_signed_and_chain_share_identity_and_server_traits() {
+        let fx = Factory::random();
+        let cert = fx.x509_self_signed("feat-shared", X509Spec::self_signed("localhost"));
+        let chain = fx.x509_chain("feat-shared-chain", ChainSpec::new("shared.example.com"));
+
+        // Both implement TonicIdentityExt
+        fn assert_identity<T: TonicIdentityExt>(t: &T) {
+            let _id = t.identity_tonic();
+        }
+        assert_identity(&cert);
+        assert_identity(&chain);
+
+        // Both implement TonicServerTlsExt
+        fn assert_server<T: TonicServerTlsExt>(t: &T) {
+            let _srv = t.server_tls_config_tonic();
+        }
+        assert_server(&cert);
+        assert_server(&chain);
+
+        // Both implement TonicClientTlsExt
+        fn assert_client<T: TonicClientTlsExt>(t: &T) {
+            let _cli = t.client_tls_config_tonic("localhost");
+        }
+        assert_client(&cert);
+        assert_client(&chain);
+    }
+
+    /// Verify that TonicMtlsExt is only implemented for X509Chain (not X509Cert).
+    /// This is a compile-time check: X509Cert should NOT impl TonicMtlsExt.
+    #[test]
+    fn mtls_ext_only_on_chain() {
+        fn assert_mtls<T: TonicMtlsExt>(t: &T) {
+            let _srv = t.server_tls_config_mtls_tonic();
+            let _cli = t.client_tls_config_mtls_tonic("localhost");
+        }
+        let fx = Factory::random();
+        let chain = fx.x509_chain("feat-mtls-only", ChainSpec::new("mtls.example.com"));
+        assert_mtls(&chain);
+        // Note: X509Cert does NOT implement TonicMtlsExt by design
+    }
+}
+
+/// When x509 feature is disabled, the tonic crate should still compile
+/// but without X.509-related extension traits.
+/// This module verifies the crate remains importable.
+#[cfg(not(feature = "x509"))]
+mod without_x509_feature {
+    #[test]
+    fn crate_compiles_without_x509_feature() {
+        // The crate should compile; just verify we can reference the crate
+        // The extension traits should NOT be available here.
+        // This test passes if it compiles.
+    }
+}

--- a/crates/uselesskey-tonic/tests/pem_structure.rs
+++ b/crates/uselesskey-tonic/tests/pem_structure.rs
@@ -1,0 +1,250 @@
+//! Deep PEM structure validation and chain ordering tests for tonic adapter.
+//!
+//! Verifies that the PEM output passed to tonic has the correct structure
+//! and ordering for TLS handshakes to succeed.
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_tonic::{TonicClientTlsExt, TonicIdentityExt, TonicServerTlsExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+// =========================================================================
+// PEM header/footer validation
+// =========================================================================
+
+#[test]
+fn self_signed_cert_pem_has_matching_begin_end() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("pem-be-ss", X509Spec::self_signed("localhost"));
+    let pem = cert.cert_pem();
+    let begins = pem.matches("-----BEGIN CERTIFICATE-----").count();
+    let ends = pem.matches("-----END CERTIFICATE-----").count();
+    assert_eq!(begins, ends, "BEGIN and END counts should match");
+    assert_eq!(
+        begins, 1,
+        "Self-signed cert should have exactly one certificate"
+    );
+}
+
+#[test]
+fn self_signed_key_pem_has_matching_begin_end() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("pem-key-ss", X509Spec::self_signed("localhost"));
+    let pem = cert.private_key_pkcs8_pem();
+    let begins = pem.matches("-----BEGIN PRIVATE KEY-----").count();
+    let ends = pem.matches("-----END PRIVATE KEY-----").count();
+    assert_eq!(begins, ends, "Key PEM BEGIN and END should match");
+    assert_eq!(begins, 1, "Should have exactly one key block");
+}
+
+#[test]
+fn chain_pem_each_cert_has_matching_begin_end() {
+    let fx = fx();
+    let chain = fx.x509_chain("pem-be-chain", ChainSpec::new("chain.example.com"));
+    let pem = chain.chain_pem();
+    let begins = pem.matches("-----BEGIN CERTIFICATE-----").count();
+    let ends = pem.matches("-----END CERTIFICATE-----").count();
+    assert_eq!(begins, ends, "chain_pem BEGIN and END counts should match");
+    assert_eq!(begins, 2, "chain_pem should have 2 certs");
+}
+
+#[test]
+fn full_chain_pem_each_cert_has_matching_begin_end() {
+    let fx = fx();
+    let chain = fx.x509_chain("pem-full-be", ChainSpec::new("chain.example.com"));
+    let pem = chain.full_chain_pem();
+    let begins = pem.matches("-----BEGIN CERTIFICATE-----").count();
+    let ends = pem.matches("-----END CERTIFICATE-----").count();
+    assert_eq!(
+        begins, ends,
+        "full_chain_pem BEGIN and END counts should match"
+    );
+    assert_eq!(begins, 3, "full_chain_pem should have 3 certs");
+}
+
+// =========================================================================
+// Chain ordering: leaf first, then intermediate, then root (in full chain)
+// =========================================================================
+
+#[test]
+fn chain_pem_leaf_comes_before_intermediate() {
+    let fx = fx();
+    let chain = fx.x509_chain("pem-order", ChainSpec::new("order.example.com"));
+
+    let chain_pem = chain.chain_pem();
+    let leaf_pem = chain.leaf_cert_pem();
+    let intermediate_pem = chain.intermediate_cert_pem();
+
+    // Leaf should appear first in chain_pem
+    let leaf_pos = chain_pem
+        .find(leaf_pem)
+        .expect("leaf should appear in chain_pem");
+    let intermediate_pos = chain_pem
+        .find(intermediate_pem)
+        .expect("intermediate should appear in chain_pem");
+
+    assert!(
+        leaf_pos < intermediate_pos,
+        "Leaf should come before intermediate in chain_pem"
+    );
+}
+
+#[test]
+fn full_chain_pem_ordering_leaf_intermediate_root() {
+    let fx = fx();
+    let chain = fx.x509_chain("pem-full-order", ChainSpec::new("order.example.com"));
+
+    let full_pem = chain.full_chain_pem();
+    let leaf_pem = chain.leaf_cert_pem();
+    let intermediate_pem = chain.intermediate_cert_pem();
+    let root_pem = chain.root_cert_pem();
+
+    let leaf_pos = full_pem
+        .find(leaf_pem)
+        .expect("leaf should appear in full_chain_pem");
+    let intermediate_pos = full_pem
+        .find(intermediate_pem)
+        .expect("intermediate should appear in full_chain_pem");
+    let root_pos = full_pem
+        .find(root_pem)
+        .expect("root should appear in full_chain_pem");
+
+    assert!(
+        leaf_pos < intermediate_pos,
+        "Leaf should come before intermediate"
+    );
+    assert!(
+        intermediate_pos < root_pos,
+        "Intermediate should come before root"
+    );
+}
+
+// =========================================================================
+// DER sizes are reasonable
+// =========================================================================
+
+#[test]
+fn self_signed_der_sizes_reasonable() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("pem-der-sz", X509Spec::self_signed("localhost"));
+    let cert_der = cert.cert_der();
+    let key_der = cert.private_key_pkcs8_der();
+
+    // RSA 2048 cert DER is typically 600-1200 bytes; key DER ~1200 bytes
+    assert!(
+        cert_der.len() > 100,
+        "cert DER should be at least 100 bytes, got {}",
+        cert_der.len()
+    );
+    assert!(
+        key_der.len() > 100,
+        "key DER should be at least 100 bytes, got {}",
+        key_der.len()
+    );
+}
+
+#[test]
+fn chain_der_sizes_all_reasonable() {
+    let fx = fx();
+    let chain = fx.x509_chain("pem-chain-sz", ChainSpec::new("size.example.com"));
+
+    assert!(chain.root_cert_der().len() > 100);
+    assert!(chain.intermediate_cert_der().len() > 100);
+    assert!(chain.leaf_cert_der().len() > 100);
+    assert!(chain.leaf_private_key_pkcs8_der().len() > 100);
+}
+
+#[test]
+fn larger_rsa_key_produces_larger_artifacts() {
+    let fx = fx();
+    let chain_2k = fx.x509_chain(
+        "pem-sz-2k",
+        ChainSpec::new("size.example.com").with_rsa_bits(2048),
+    );
+    let chain_4k = fx.x509_chain(
+        "pem-sz-4k",
+        ChainSpec::new("size.example.com").with_rsa_bits(4096),
+    );
+
+    assert!(
+        chain_4k.leaf_private_key_pkcs8_der().len() > chain_2k.leaf_private_key_pkcs8_der().len(),
+        "4096-bit key DER should be larger than 2048-bit"
+    );
+    assert!(
+        chain_4k.leaf_cert_der().len() > chain_2k.leaf_cert_der().len(),
+        "4096-bit cert DER should be larger than 2048-bit"
+    );
+}
+
+// =========================================================================
+// Root and intermediate keys are accessible (for advanced setups)
+// =========================================================================
+
+#[test]
+fn root_private_key_accessible() {
+    let fx = fx();
+    let chain = fx.x509_chain("pem-root-key", ChainSpec::new("root.example.com"));
+    let root_key_pem = chain.root_private_key_pkcs8_pem();
+    assert!(root_key_pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    assert!(!chain.root_private_key_pkcs8_der().is_empty());
+}
+
+#[test]
+fn intermediate_private_key_accessible() {
+    let fx = fx();
+    let chain = fx.x509_chain("pem-int-key", ChainSpec::new("int.example.com"));
+    let int_key_pem = chain.intermediate_private_key_pkcs8_pem();
+    assert!(int_key_pem.starts_with("-----BEGIN PRIVATE KEY-----"));
+    assert!(!chain.intermediate_private_key_pkcs8_der().is_empty());
+}
+
+#[test]
+fn intermediate_cert_pem_accessible() {
+    let fx = fx();
+    let chain = fx.x509_chain("pem-int-cert", ChainSpec::new("int.example.com"));
+    let int_cert_pem = chain.intermediate_cert_pem();
+    assert!(int_cert_pem.starts_with("-----BEGIN CERTIFICATE-----"));
+}
+
+// =========================================================================
+// Tonic config from various chain configurations
+// =========================================================================
+
+#[test]
+fn identity_from_chain_with_sans() {
+    let fx = fx();
+    let chain = fx.x509_chain(
+        "pem-sans",
+        ChainSpec::new("primary.example.com")
+            .with_sans(vec!["alt1.example.com".into(), "alt2.example.com".into()]),
+    );
+    let _identity = chain.identity_tonic();
+    let _server = chain.server_tls_config_tonic();
+    let _client = chain.client_tls_config_tonic("alt1.example.com");
+}
+
+#[test]
+fn identity_from_chain_with_custom_cns() {
+    let fx = fx();
+    let chain = fx.x509_chain(
+        "pem-cns",
+        ChainSpec::new("leaf.example.com")
+            .with_root_cn("Test Root CA")
+            .with_intermediate_cn("Test Intermediate CA"),
+    );
+    let _identity = chain.identity_tonic();
+    let _server = chain.server_tls_config_tonic();
+}
+
+#[test]
+fn self_signed_with_custom_validity() {
+    let fx = fx();
+    let cert = fx.x509_self_signed(
+        "pem-validity",
+        X509Spec::self_signed("localhost").with_validity_days(1),
+    );
+    let _identity = cert.identity_tonic();
+    let _server = cert.server_tls_config_tonic();
+    let _client = cert.client_tls_config_tonic("localhost");
+}

--- a/crates/uselesskey-tonic/tests/self_signed_negative.rs
+++ b/crates/uselesskey-tonic/tests/self_signed_negative.rs
@@ -1,0 +1,218 @@
+//! Self-signed certificate negative fixture tests through tonic adapters.
+//!
+//! Covers:
+//! - wrong_key_usage certs build tonic configs
+//! - not_yet_valid certs build all tonic configs including mTLS-like setups
+//! - corrupt PEM and truncated DER through tonic adapter layer
+//! - identity_pem() integration with tonic
+
+mod testutil;
+
+use testutil::fx;
+use uselesskey_core::negative::CorruptPem;
+use uselesskey_tonic::{TonicClientTlsExt, TonicIdentityExt, TonicServerTlsExt};
+use uselesskey_x509::{X509FactoryExt, X509Spec};
+
+// =========================================================================
+// wrong_key_usage through tonic
+// =========================================================================
+
+#[test]
+fn wrong_key_usage_identity_builds() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-wku", X509Spec::self_signed("localhost"));
+    let wrong = cert.wrong_key_usage();
+    let _identity = wrong.identity_tonic();
+}
+
+#[test]
+fn wrong_key_usage_server_tls_builds() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-wku-srv", X509Spec::self_signed("localhost"));
+    let wrong = cert.wrong_key_usage();
+    let _server = wrong.server_tls_config_tonic();
+}
+
+#[test]
+fn wrong_key_usage_client_tls_builds() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-wku-cli", X509Spec::self_signed("localhost"));
+    let wrong = cert.wrong_key_usage();
+    let _client = wrong.client_tls_config_tonic("localhost");
+}
+
+// =========================================================================
+// not_yet_valid through tonic
+// =========================================================================
+
+#[test]
+fn not_yet_valid_server_tls_builds() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-nyv-srv", X509Spec::self_signed("future.example.com"));
+    let future = cert.not_yet_valid();
+    let _server = future.server_tls_config_tonic();
+}
+
+#[test]
+fn not_yet_valid_client_tls_builds() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-nyv-cli", X509Spec::self_signed("future.example.com"));
+    let future = cert.not_yet_valid();
+    let _client = future.client_tls_config_tonic("future.example.com");
+}
+
+// =========================================================================
+// Corrupt PEM variants
+// =========================================================================
+
+#[test]
+fn corrupt_pem_bad_base64_differs_from_original() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-corrupt-b64", X509Spec::self_signed("localhost"));
+    let corrupt = cert.corrupt_cert_pem(CorruptPem::BadBase64);
+    assert_ne!(cert.cert_pem(), &corrupt);
+    assert!(corrupt.contains("-----BEGIN CERTIFICATE-----"));
+}
+
+#[test]
+fn corrupt_pem_bad_footer_differs() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-corrupt-ftr", X509Spec::self_signed("localhost"));
+    let corrupt = cert.corrupt_cert_pem(CorruptPem::BadFooter);
+    assert_ne!(cert.cert_pem(), &corrupt);
+    assert!(
+        corrupt.contains("-----END CORRUPTED KEY-----"),
+        "BadFooter should replace the footer"
+    );
+}
+
+#[test]
+fn corrupt_pem_bad_header_differs() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-corrupt-hdr", X509Spec::self_signed("localhost"));
+    let corrupt = cert.corrupt_cert_pem(CorruptPem::BadHeader);
+    assert_ne!(cert.cert_pem(), &corrupt);
+    assert!(
+        corrupt.contains("-----BEGIN CORRUPTED KEY-----"),
+        "BadHeader should replace the header"
+    );
+}
+
+#[test]
+fn corrupt_pem_extra_blank_line_differs() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-corrupt-blank", X509Spec::self_signed("localhost"));
+    let corrupt = cert.corrupt_cert_pem(CorruptPem::ExtraBlankLine);
+    assert_ne!(cert.cert_pem(), &corrupt);
+}
+
+#[test]
+fn corrupt_pem_deterministic_produces_consistent_output() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-det-corrupt", X509Spec::self_signed("localhost"));
+    let a = cert.corrupt_cert_pem_deterministic("variant-1");
+    let b = cert.corrupt_cert_pem_deterministic("variant-1");
+    assert_eq!(a, b, "Same variant should produce same corrupt PEM");
+}
+
+#[test]
+fn corrupt_pem_different_variants_produce_different_output() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-det-diff", X509Spec::self_signed("localhost"));
+    let a = cert.corrupt_cert_pem_deterministic("variant-a");
+    let b = cert.corrupt_cert_pem_deterministic("variant-b");
+    assert_ne!(
+        a, b,
+        "Different variants should produce different corrupt PEM"
+    );
+}
+
+// =========================================================================
+// Truncated DER
+// =========================================================================
+
+#[test]
+fn truncated_der_is_shorter_than_original() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-trunc-len", X509Spec::self_signed("localhost"));
+    let original = cert.cert_der();
+    let half = original.len() / 2;
+    let truncated = cert.truncate_cert_der(half);
+    assert_eq!(truncated.len(), half);
+}
+
+#[test]
+fn truncated_der_to_zero_is_empty() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-trunc-zero", X509Spec::self_signed("localhost"));
+    let truncated = cert.truncate_cert_der(0);
+    assert!(truncated.is_empty());
+}
+
+#[test]
+fn corrupt_der_deterministic_produces_consistent_output() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-det-der", X509Spec::self_signed("localhost"));
+    let a = cert.corrupt_cert_der_deterministic("variant-1");
+    let b = cert.corrupt_cert_der_deterministic("variant-1");
+    assert_eq!(a, b, "Same variant should produce same corrupt DER");
+}
+
+// =========================================================================
+// identity_pem() integration
+// =========================================================================
+
+#[test]
+fn identity_pem_contains_cert_and_key() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-idpem", X509Spec::self_signed("localhost"));
+    let pem = cert.identity_pem();
+    assert!(
+        pem.contains("-----BEGIN CERTIFICATE-----"),
+        "identity_pem should contain certificate"
+    );
+    assert!(
+        pem.contains("-----BEGIN PRIVATE KEY-----"),
+        "identity_pem should contain private key"
+    );
+}
+
+// =========================================================================
+// Negative self-signed certs produce different material from originals
+// =========================================================================
+
+#[test]
+fn expired_cert_differs_from_original() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-diff-exp", X509Spec::self_signed("localhost"));
+    let expired = cert.expired();
+    assert_ne!(
+        cert.cert_der(),
+        expired.cert_der(),
+        "Expired cert should differ from original"
+    );
+}
+
+#[test]
+fn not_yet_valid_cert_differs_from_original() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-diff-nyv", X509Spec::self_signed("localhost"));
+    let future = cert.not_yet_valid();
+    assert_ne!(
+        cert.cert_der(),
+        future.cert_der(),
+        "Not-yet-valid cert should differ from original"
+    );
+}
+
+#[test]
+fn wrong_key_usage_cert_differs_from_original() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("neg-diff-wku", X509Spec::self_signed("localhost"));
+    let wrong = cert.wrong_key_usage();
+    assert_ne!(
+        cert.cert_der(),
+        wrong.cert_der(),
+        "Wrong key usage cert should differ from original"
+    );
+}

--- a/crates/uselesskey-tonic/tests/thread_safety.rs
+++ b/crates/uselesskey-tonic/tests/thread_safety.rs
@@ -1,0 +1,151 @@
+//! Thread safety tests for uselesskey-tonic adapter.
+//!
+//! Verifies that tonic TLS config construction is safe under concurrent access
+//! from multiple threads sharing the same Factory and X.509 fixtures.
+
+mod testutil;
+
+use std::sync::Arc;
+use std::thread;
+use testutil::fx;
+use uselesskey_tonic::{TonicClientTlsExt, TonicIdentityExt, TonicMtlsExt, TonicServerTlsExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+#[test]
+fn concurrent_identity_from_shared_chain() {
+    let fx = fx();
+    let chain = Arc::new(fx.x509_chain("thread-id", ChainSpec::new("thread.example.com")));
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let chain = Arc::clone(&chain);
+            thread::spawn(move || {
+                let _identity = chain.identity_tonic();
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+}
+
+#[test]
+fn concurrent_server_tls_from_shared_chain() {
+    let fx = fx();
+    let chain = Arc::new(fx.x509_chain("thread-srv", ChainSpec::new("thread.example.com")));
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let chain = Arc::clone(&chain);
+            thread::spawn(move || {
+                let _server = chain.server_tls_config_tonic();
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+}
+
+#[test]
+fn concurrent_client_tls_from_shared_chain() {
+    let fx = fx();
+    let chain = Arc::new(fx.x509_chain("thread-cli", ChainSpec::new("thread.example.com")));
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let chain = Arc::clone(&chain);
+            thread::spawn(move || {
+                let _client = chain.client_tls_config_tonic("thread.example.com");
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+}
+
+#[test]
+fn concurrent_mtls_from_shared_chain() {
+    let fx = fx();
+    let chain = Arc::new(fx.x509_chain("thread-mtls", ChainSpec::new("thread.example.com")));
+
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let chain = Arc::clone(&chain);
+            thread::spawn(move || {
+                let _server = chain.server_tls_config_mtls_tonic();
+                let _client = chain.client_tls_config_mtls_tonic("thread.example.com");
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+}
+
+#[test]
+fn concurrent_mixed_configs_from_shared_cert() {
+    let fx = fx();
+    let cert = Arc::new(fx.x509_self_signed("thread-ss", X509Spec::self_signed("localhost")));
+
+    let handles: Vec<_> = (0..4)
+        .map(|i| {
+            let cert = Arc::clone(&cert);
+            thread::spawn(move || match i % 3 {
+                0 => {
+                    let _identity = cert.identity_tonic();
+                }
+                1 => {
+                    let _server = cert.server_tls_config_tonic();
+                }
+                _ => {
+                    let _client = cert.client_tls_config_tonic("localhost");
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().expect("thread should not panic");
+    }
+}
+
+#[test]
+fn concurrent_factory_generates_different_chains() {
+    let fx = Arc::new(fx());
+
+    let handles: Vec<_> = (0..4)
+        .map(|i| {
+            let fx = Arc::clone(&fx);
+            thread::spawn(move || {
+                let chain = fx.x509_chain(
+                    format!("thread-gen-{i}"),
+                    ChainSpec::new(format!("svc{i}.example.com")),
+                );
+                let _server = chain.server_tls_config_tonic();
+                let _client = chain.client_tls_config_tonic(format!("svc{i}.example.com"));
+                chain.leaf_cert_der().to_vec()
+            })
+        })
+        .collect();
+
+    let results: Vec<Vec<u8>> = handles
+        .into_iter()
+        .map(|h| h.join().expect("thread should not panic"))
+        .collect();
+
+    // All chains from different labels should differ
+    for i in 0..results.len() {
+        for j in (i + 1)..results.len() {
+            assert_ne!(
+                results[i], results[j],
+                "Chains {i} and {j} should be different"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add comprehensive tests to crates/uselesskey-tonic/ covering areas not previously tested by the existing test suite.

## New test files

### chain_negative_tonic.rs (22 tests)
Tests tonic adapter integration with X.509 chain negative fixtures:
- Expired leaf/intermediate certificates build tonic configs (deferred validation)
- Revoked leaf certificates + CRL availability
- Unknown CA chains with different root certificates
- Hostname mismatch chains with different leaf certificates
- PEM structure validation for negative chain variants

### 	hread_safety.rs (6 tests)
Concurrent access verification:
- Multiple threads sharing the same chain/cert via Arc
- Concurrent identity, server TLS, client TLS, and mTLS config construction
- Concurrent factory usage producing distinct chains

### eature_gating.rs (4 tests)
Feature flag gating validation:
- All four traits available when x509 feature is enabled
- Domain name accepts both \&str\ and \String\
- Self-signed and chain share Identity/Server/Client traits
- mTLS ext only on X509Chain (not X509Cert)
- Compilation without x509 feature (cfg-gated)

### self_signed_negative.rs (18 tests)
Self-signed negative fixture tests through tonic:
- wrong_key_usage, not_yet_valid through all tonic adapters
- Corrupt PEM variants (BadBase64, BadFooter, BadHeader, ExtraBlankLine)
- Deterministic corrupt PEM consistency
- Truncated DER edge cases (zero length, half length)
- identity_pem() integration
- Negative fixtures produce different material from originals

### pem_structure.rs (15 tests)
Deep PEM structure validation:
- Header/footer matching for certs and keys
- Chain ordering: leaf before intermediate, before root
- DER size reasonableness assertions
- Larger RSA keys produce larger artifacts
- Root/intermediate private key accessibility
- Various chain configurations (SANs, custom CNs, custom validity)

## Test results
All **174 tests** pass (including 55 new tests across 5 files):
- \cargo test -p uselesskey-tonic --all-features\ ✅
- \cargo fmt --all\ ✅
- \cargo clippy -p uselesskey-tonic --all-features -- -D warnings\ ✅