### PR TITLE
feat: add insta snapshot tests for 4 core crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3832,7 +3832,9 @@ name = "uselesskey-core-hash"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "insta",
  "proptest",
+ "serde",
 ]
 
 [[package]]
@@ -3906,7 +3908,9 @@ dependencies = [
 name = "uselesskey-core-keypair-material"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
+ "serde",
  "uselesskey-core",
  "uselesskey-core-kid",
 ]
@@ -3939,8 +3943,10 @@ dependencies = [
 name = "uselesskey-core-negative-der"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
  "rstest",
+ "serde",
  "uselesskey-core-hash",
 ]
 
@@ -3993,8 +3999,11 @@ name = "uselesskey-core-token"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "insta",
  "proptest",
  "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "serde",
  "serde_json",
  "uselesskey-core-token-shape",
 ]

--- a/crates/uselesskey-core-hash/Cargo.toml
+++ b/crates/uselesskey-core-hash/Cargo.toml
@@ -18,7 +18,9 @@ authors.workspace = true
 blake3.workspace = true
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
+serde.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/uselesskey-core-hash/tests/snapshots/snapshots_hash__hash_boundary_separation.snap
+++ b/crates/uselesskey-core-hash/tests/snapshots/snapshots_hash__hash_boundary_separation.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-hash/tests/snapshots_hash.rs
+expression: result
+---
+split_a: "[a] + [bc]"
+split_b: "[ab] + [c]"
+digests_differ: true

--- a/crates/uselesskey-core-hash/tests/snapshots/snapshots_hash__hash_determinism.snap
+++ b/crates/uselesskey-core-hash/tests/snapshots/snapshots_hash__hash_determinism.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-hash/tests/snapshots_hash.rs
+expression: result
+---
+input_description: test-key-material
+same_input_matches: true
+different_inputs_differ: true

--- a/crates/uselesskey-core-hash/tests/snapshots/snapshots_hash__hash_hasher_reexport.snap
+++ b/crates/uselesskey-core-hash/tests/snapshots/snapshots_hash__hash_hasher_reexport.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uselesskey-core-hash/tests/snapshots_hash.rs
+expression: result
+---
+new_hasher_digest_len: 32
+update_then_finalize_len: 32

--- a/crates/uselesskey-core-hash/tests/snapshots/snapshots_hash__hash_output_sizes.snap
+++ b/crates/uselesskey-core-hash/tests/snapshots/snapshots_hash__hash_output_sizes.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uselesskey-core-hash/tests/snapshots_hash.rs
+expression: results
+---
+- input_description: empty
+  digest_byte_len: 32
+  hex_len: 64
+- input_description: single_byte
+  digest_byte_len: 32
+  hex_len: 64
+- input_description: short_string
+  digest_byte_len: 32
+  hex_len: 64
+- input_description: fixture_label
+  digest_byte_len: 32
+  hex_len: 64

--- a/crates/uselesskey-core-hash/tests/snapshots_hash.rs
+++ b/crates/uselesskey-core-hash/tests/snapshots_hash.rs
@@ -1,0 +1,107 @@
+//! Insta snapshot tests for uselesskey-core-hash.
+//!
+//! Snapshot hash output sizes and determinism properties.
+//! No actual hash values are captured — only metadata.
+
+use serde::Serialize;
+use uselesskey_core_hash::{Hasher, hash32, write_len_prefixed};
+
+#[derive(Serialize)]
+struct HashOutputShape {
+    input_description: &'static str,
+    digest_byte_len: usize,
+    hex_len: usize,
+}
+
+#[test]
+fn snapshot_hash32_output_sizes() {
+    let inputs: Vec<(&str, &[u8])> = vec![
+        ("empty", b""),
+        ("single_byte", b"\x00"),
+        ("short_string", b"hello"),
+        ("fixture_label", b"deterministic-fixture-hash"),
+    ];
+
+    let results: Vec<HashOutputShape> = inputs
+        .into_iter()
+        .map(|(desc, data)| {
+            let h = hash32(data);
+            HashOutputShape {
+                input_description: desc,
+                digest_byte_len: h.as_bytes().len(),
+                hex_len: h.to_hex().len(),
+            }
+        })
+        .collect();
+
+    insta::assert_yaml_snapshot!("hash_output_sizes", results);
+}
+
+#[test]
+fn snapshot_hash32_determinism() {
+    #[derive(Serialize)]
+    struct HashDeterminism {
+        input_description: &'static str,
+        same_input_matches: bool,
+        different_inputs_differ: bool,
+    }
+
+    let a1 = hash32(b"test-key-material");
+    let a2 = hash32(b"test-key-material");
+    let b = hash32(b"different-material");
+
+    let result = HashDeterminism {
+        input_description: "test-key-material",
+        same_input_matches: a1 == a2,
+        different_inputs_differ: a1 != b,
+    };
+
+    insta::assert_yaml_snapshot!("hash_determinism", result);
+}
+
+#[test]
+fn snapshot_write_len_prefixed_boundary_separation() {
+    #[derive(Serialize)]
+    struct BoundarySeparation {
+        split_a: &'static str,
+        split_b: &'static str,
+        digests_differ: bool,
+    }
+
+    let mut h1 = Hasher::new();
+    write_len_prefixed(&mut h1, b"a");
+    write_len_prefixed(&mut h1, b"bc");
+
+    let mut h2 = Hasher::new();
+    write_len_prefixed(&mut h2, b"ab");
+    write_len_prefixed(&mut h2, b"c");
+
+    let result = BoundarySeparation {
+        split_a: "[a] + [bc]",
+        split_b: "[ab] + [c]",
+        digests_differ: h1.finalize() != h2.finalize(),
+    };
+
+    insta::assert_yaml_snapshot!("hash_boundary_separation", result);
+}
+
+#[test]
+fn snapshot_hasher_reexport() {
+    #[derive(Serialize)]
+    struct HasherMeta {
+        new_hasher_digest_len: usize,
+        update_then_finalize_len: usize,
+    }
+
+    let empty = Hasher::new().finalize();
+    let mut h = Hasher::new();
+    h.update(b"data");
+    let with_data = h.finalize();
+
+    let result = HasherMeta {
+        new_hasher_digest_len: empty.as_bytes().len(),
+        update_then_finalize_len: with_data.as_bytes().len(),
+    };
+
+    insta::assert_yaml_snapshot!("hash_hasher_reexport", result);
+}

--- a/crates/uselesskey-core-keypair-material/Cargo.toml
+++ b/crates/uselesskey-core-keypair-material/Cargo.toml
@@ -19,7 +19,9 @@ uselesskey-core = { path = "../uselesskey-core", version = "0.1.0" }
 uselesskey-core-kid.workspace = true
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
+serde.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_corrupt_pem.snap
+++ b/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_corrupt_pem.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-keypair-material/tests/snapshots_keypair_material.rs
+expression: result
+---
+variant: BadHeader
+original_pem_len: 59
+corrupted_pem_len: 61
+differs_from_original: true

--- a/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_debug_redaction.snap
+++ b/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_debug_redaction.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-keypair-material/tests/snapshots_keypair_material.rs
+expression: result
+---
+contains_struct_name: true
+leaks_private_key: false
+leaks_public_key: false
+contains_len_fields: true

--- a/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_deterministic_corruption.snap
+++ b/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_deterministic_corruption.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-core-keypair-material/tests/snapshots_keypair_material.rs
+expression: result
+---
+variant: "snapshot:v1"
+pem_is_deterministic: true
+pem_differs_from_original: true
+der_is_deterministic: true
+der_differs_from_original: true

--- a/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_field_lengths.snap
+++ b/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_field_lengths.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-keypair-material/tests/snapshots_keypair_material.rs
+expression: result
+---
+pkcs8_der_len: 4
+pkcs8_pem_len: 59
+spki_der_len: 4
+spki_pem_len: 57

--- a/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_kid.snap
+++ b/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_kid.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-keypair-material/tests/snapshots_keypair_material.rs
+expression: result
+---
+kid_len: 16
+is_base64url: true
+is_deterministic: true

--- a/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_truncation.snap
+++ b/crates/uselesskey-core-keypair-material/tests/snapshots/snapshots_keypair_material__keypair_material_truncation.snap
@@ -1,0 +1,19 @@
+---
+source: crates/uselesskey-core-keypair-material/tests/snapshots_keypair_material.rs
+expression: results
+---
+- original_der_len: 4
+  requested_len: 0
+  result_len: 0
+- original_der_len: 4
+  requested_len: 1
+  result_len: 1
+- original_der_len: 4
+  requested_len: 2
+  result_len: 2
+- original_der_len: 4
+  requested_len: 4
+  result_len: 4
+- original_der_len: 4
+  requested_len: 10
+  result_len: 4

--- a/crates/uselesskey-core-keypair-material/tests/snapshots_keypair_material.rs
+++ b/crates/uselesskey-core-keypair-material/tests/snapshots_keypair_material.rs
@@ -1,0 +1,158 @@
+//! Insta snapshot tests for uselesskey-core-keypair-material.
+//!
+//! Snapshot material type metadata — field lengths, Debug redaction,
+//! corruption shapes. All key material is redacted.
+
+use serde::Serialize;
+use uselesskey_core_keypair_material::Pkcs8SpkiKeyMaterial;
+
+fn sample_material() -> Pkcs8SpkiKeyMaterial {
+    Pkcs8SpkiKeyMaterial::new(
+        vec![0x30, 0x82, 0x01, 0x22],
+        "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n",
+        vec![0x30, 0x59, 0x30, 0x13],
+        "-----BEGIN PUBLIC KEY-----\nBBBB\n-----END PUBLIC KEY-----\n",
+    )
+}
+
+#[derive(Serialize)]
+struct MaterialShape {
+    pkcs8_der_len: usize,
+    pkcs8_pem_len: usize,
+    spki_der_len: usize,
+    spki_pem_len: usize,
+}
+
+#[test]
+fn snapshot_material_field_lengths() {
+    let m = sample_material();
+    let result = MaterialShape {
+        pkcs8_der_len: m.private_key_pkcs8_der().len(),
+        pkcs8_pem_len: m.private_key_pkcs8_pem().len(),
+        spki_der_len: m.public_key_spki_der().len(),
+        spki_pem_len: m.public_key_spki_pem().len(),
+    };
+    insta::assert_yaml_snapshot!("keypair_material_field_lengths", result);
+}
+
+#[test]
+fn snapshot_debug_redaction() {
+    let m = sample_material();
+    let dbg = format!("{m:?}");
+
+    #[derive(Serialize)]
+    struct DebugShape {
+        contains_struct_name: bool,
+        leaks_private_key: bool,
+        leaks_public_key: bool,
+        contains_len_fields: bool,
+    }
+
+    let result = DebugShape {
+        contains_struct_name: dbg.contains("Pkcs8SpkiKeyMaterial"),
+        leaks_private_key: dbg.contains("BEGIN PRIVATE KEY"),
+        leaks_public_key: dbg.contains("BEGIN PUBLIC KEY"),
+        contains_len_fields: dbg.contains("pkcs8_der_len") && dbg.contains("spki_der_len"),
+    };
+    insta::assert_yaml_snapshot!("keypair_material_debug_redaction", result);
+}
+
+#[test]
+fn snapshot_kid_metadata() {
+    let m = sample_material();
+    let kid = m.kid();
+
+    #[derive(Serialize)]
+    struct KidMeta {
+        kid_len: usize,
+        is_base64url: bool,
+        is_deterministic: bool,
+    }
+
+    let result = KidMeta {
+        kid_len: kid.len(),
+        is_base64url: kid
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+        is_deterministic: m.kid() == kid,
+    };
+    insta::assert_yaml_snapshot!("keypair_material_kid", result);
+}
+
+#[test]
+fn snapshot_truncation_behavior() {
+    let m = sample_material();
+
+    #[derive(Serialize)]
+    struct TruncationShape {
+        original_der_len: usize,
+        requested_len: usize,
+        result_len: usize,
+    }
+
+    let lengths = [0, 1, 2, 4, 10];
+    let results: Vec<TruncationShape> = lengths
+        .iter()
+        .map(|&req| {
+            let truncated = m.private_key_pkcs8_der_truncated(req);
+            TruncationShape {
+                original_der_len: m.private_key_pkcs8_der().len(),
+                requested_len: req,
+                result_len: truncated.len(),
+            }
+        })
+        .collect();
+    insta::assert_yaml_snapshot!("keypair_material_truncation", results);
+}
+
+#[test]
+fn snapshot_corrupt_pem_shape() {
+    use uselesskey_core::negative::CorruptPem;
+
+    let m = sample_material();
+    let corrupted = m.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+
+    #[derive(Serialize)]
+    struct CorruptPemShape {
+        variant: &'static str,
+        original_pem_len: usize,
+        corrupted_pem_len: usize,
+        differs_from_original: bool,
+    }
+
+    let result = CorruptPemShape {
+        variant: "BadHeader",
+        original_pem_len: m.private_key_pkcs8_pem().len(),
+        corrupted_pem_len: corrupted.len(),
+        differs_from_original: corrupted != m.private_key_pkcs8_pem(),
+    };
+    insta::assert_yaml_snapshot!("keypair_material_corrupt_pem", result);
+}
+
+#[test]
+fn snapshot_deterministic_corruption_stability() {
+    let m = sample_material();
+
+    #[derive(Serialize)]
+    struct DeterministicShape {
+        variant: &'static str,
+        pem_is_deterministic: bool,
+        pem_differs_from_original: bool,
+        der_is_deterministic: bool,
+        der_differs_from_original: bool,
+    }
+
+    let pem_a = m.private_key_pkcs8_pem_corrupt_deterministic("snapshot:v1");
+    let pem_b = m.private_key_pkcs8_pem_corrupt_deterministic("snapshot:v1");
+    let der_a = m.private_key_pkcs8_der_corrupt_deterministic("snapshot:v1");
+    let der_b = m.private_key_pkcs8_der_corrupt_deterministic("snapshot:v1");
+
+    let result = DeterministicShape {
+        variant: "snapshot:v1",
+        pem_is_deterministic: pem_a == pem_b,
+        pem_differs_from_original: pem_a != m.private_key_pkcs8_pem(),
+        der_is_deterministic: der_a == der_b,
+        der_differs_from_original: der_a != m.private_key_pkcs8_der(),
+    };
+    insta::assert_yaml_snapshot!("keypair_material_deterministic_corruption", result);
+}

--- a/crates/uselesskey-core-negative-der/Cargo.toml
+++ b/crates/uselesskey-core-negative-der/Cargo.toml
@@ -19,8 +19,10 @@ documentation = "https://docs.rs/uselesskey-core-negative-der"
 uselesskey-core-hash = { workspace = true }
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
 rstest.workspace = true
+serde.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_deterministic_a.snap
+++ b/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_deterministic_a.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+expression: result
+---
+variant: "corrupt:variant-a"
+original_len: 8
+result_len: 3
+differs_from_original: true
+is_deterministic: true

--- a/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_deterministic_b.snap
+++ b/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_deterministic_b.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+expression: result
+---
+variant: "corrupt:variant-b"
+original_len: 8
+result_len: 8
+differs_from_original: true
+is_deterministic: true

--- a/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_flip_first.snap
+++ b/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_flip_first.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+expression: result
+---
+original_len: 8
+flip_offset: 0
+result_len: 8
+bytes_changed: 1

--- a/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_flip_last.snap
+++ b/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_flip_last.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+expression: result
+---
+original_len: 8
+flip_offset: 7
+result_len: 8
+bytes_changed: 1

--- a/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_flip_oob.snap
+++ b/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_flip_oob.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+expression: result
+---
+original_len: 8
+flip_offset: 100
+result_len: 8
+bytes_changed: 0

--- a/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_truncate_beyond.snap
+++ b/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_truncate_beyond.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+expression: result
+---
+original_len: 8
+requested_len: 18
+result_len: 8
+was_shortened: false

--- a/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_truncate_boundary.snap
+++ b/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_truncate_boundary.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+expression: result
+---
+original_len: 8
+requested_len: 8
+result_len: 8
+was_shortened: false

--- a/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_truncate_shorter.snap
+++ b/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_truncate_shorter.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+expression: result
+---
+original_len: 8
+requested_len: 3
+result_len: 3
+was_shortened: true

--- a/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_variants_differ.snap
+++ b/crates/uselesskey-core-negative-der/tests/snapshots/snapshots_negative_der__negative_der_variants_differ.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+expression: result
+---
+variant_a: "corrupt:variant-a"
+variant_b: "corrupt:variant-b"
+results_differ: true

--- a/crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
+++ b/crates/uselesskey-core-negative-der/tests/snapshots_negative_der.rs
@@ -1,0 +1,170 @@
+//! Insta snapshot tests for uselesskey-core-negative-der.
+//!
+//! Snapshot DER corruption variant shapes — lengths, strategies, determinism.
+//! No actual DER content is captured.
+
+use serde::Serialize;
+use uselesskey_core_negative_der::{corrupt_der_deterministic, flip_byte, truncate_der};
+
+const SAMPLE_DER: &[u8] = &[0x30, 0x82, 0x01, 0x22, 0x10, 0x20, 0x30, 0x40];
+
+#[derive(Serialize)]
+struct TruncateShape {
+    original_len: usize,
+    requested_len: usize,
+    result_len: usize,
+    was_shortened: bool,
+}
+
+#[test]
+fn snapshot_truncate_der_shorter() {
+    let out = truncate_der(SAMPLE_DER, 3);
+    let result = TruncateShape {
+        original_len: SAMPLE_DER.len(),
+        requested_len: 3,
+        result_len: out.len(),
+        was_shortened: out.len() < SAMPLE_DER.len(),
+    };
+    insta::assert_yaml_snapshot!("negative_der_truncate_shorter", result);
+}
+
+#[test]
+fn snapshot_truncate_der_at_boundary() {
+    let out = truncate_der(SAMPLE_DER, SAMPLE_DER.len());
+    let result = TruncateShape {
+        original_len: SAMPLE_DER.len(),
+        requested_len: SAMPLE_DER.len(),
+        result_len: out.len(),
+        was_shortened: out.len() < SAMPLE_DER.len(),
+    };
+    insta::assert_yaml_snapshot!("negative_der_truncate_boundary", result);
+}
+
+#[test]
+fn snapshot_truncate_der_beyond() {
+    let out = truncate_der(SAMPLE_DER, SAMPLE_DER.len() + 10);
+    let result = TruncateShape {
+        original_len: SAMPLE_DER.len(),
+        requested_len: SAMPLE_DER.len() + 10,
+        result_len: out.len(),
+        was_shortened: out.len() < SAMPLE_DER.len(),
+    };
+    insta::assert_yaml_snapshot!("negative_der_truncate_beyond", result);
+}
+
+#[derive(Serialize)]
+struct FlipByteShape {
+    original_len: usize,
+    flip_offset: usize,
+    result_len: usize,
+    bytes_changed: usize,
+}
+
+#[test]
+fn snapshot_flip_byte_first() {
+    let out = flip_byte(SAMPLE_DER, 0);
+    let diffs = out
+        .iter()
+        .zip(SAMPLE_DER.iter())
+        .filter(|(a, b)| a != b)
+        .count();
+    let result = FlipByteShape {
+        original_len: SAMPLE_DER.len(),
+        flip_offset: 0,
+        result_len: out.len(),
+        bytes_changed: diffs,
+    };
+    insta::assert_yaml_snapshot!("negative_der_flip_first", result);
+}
+
+#[test]
+fn snapshot_flip_byte_last() {
+    let offset = SAMPLE_DER.len() - 1;
+    let out = flip_byte(SAMPLE_DER, offset);
+    let diffs = out
+        .iter()
+        .zip(SAMPLE_DER.iter())
+        .filter(|(a, b)| a != b)
+        .count();
+    let result = FlipByteShape {
+        original_len: SAMPLE_DER.len(),
+        flip_offset: offset,
+        result_len: out.len(),
+        bytes_changed: diffs,
+    };
+    insta::assert_yaml_snapshot!("negative_der_flip_last", result);
+}
+
+#[test]
+fn snapshot_flip_byte_out_of_bounds() {
+    let out = flip_byte(SAMPLE_DER, 100);
+    let diffs = out
+        .iter()
+        .zip(SAMPLE_DER.iter())
+        .filter(|(a, b)| a != b)
+        .count();
+    let result = FlipByteShape {
+        original_len: SAMPLE_DER.len(),
+        flip_offset: 100,
+        result_len: out.len(),
+        bytes_changed: diffs,
+    };
+    insta::assert_yaml_snapshot!("negative_der_flip_oob", result);
+}
+
+#[derive(Serialize)]
+struct DeterministicCorruptShape {
+    variant: &'static str,
+    original_len: usize,
+    result_len: usize,
+    differs_from_original: bool,
+    is_deterministic: bool,
+}
+
+#[test]
+fn snapshot_corrupt_deterministic_variant_a() {
+    let a = corrupt_der_deterministic(SAMPLE_DER, "corrupt:variant-a");
+    let b = corrupt_der_deterministic(SAMPLE_DER, "corrupt:variant-a");
+    let result = DeterministicCorruptShape {
+        variant: "corrupt:variant-a",
+        original_len: SAMPLE_DER.len(),
+        result_len: a.len(),
+        differs_from_original: a != SAMPLE_DER,
+        is_deterministic: a == b,
+    };
+    insta::assert_yaml_snapshot!("negative_der_deterministic_a", result);
+}
+
+#[test]
+fn snapshot_corrupt_deterministic_variant_b() {
+    let a = corrupt_der_deterministic(SAMPLE_DER, "corrupt:variant-b");
+    let b = corrupt_der_deterministic(SAMPLE_DER, "corrupt:variant-b");
+    let result = DeterministicCorruptShape {
+        variant: "corrupt:variant-b",
+        original_len: SAMPLE_DER.len(),
+        result_len: a.len(),
+        differs_from_original: a != SAMPLE_DER,
+        is_deterministic: a == b,
+    };
+    insta::assert_yaml_snapshot!("negative_der_deterministic_b", result);
+}
+
+#[test]
+fn snapshot_corrupt_different_variants_differ() {
+    let a = corrupt_der_deterministic(SAMPLE_DER, "corrupt:variant-a");
+    let b = corrupt_der_deterministic(SAMPLE_DER, "corrupt:variant-b");
+
+    #[derive(Serialize)]
+    struct VariantDifference {
+        variant_a: &'static str,
+        variant_b: &'static str,
+        results_differ: bool,
+    }
+
+    let result = VariantDifference {
+        variant_a: "corrupt:variant-a",
+        variant_b: "corrupt:variant-b",
+        results_differ: a != b,
+    };
+    insta::assert_yaml_snapshot!("negative_der_variants_differ", result);
+}

--- a/crates/uselesskey-core-token/Cargo.toml
+++ b/crates/uselesskey-core-token/Cargo.toml
@@ -18,9 +18,12 @@ authors.workspace = true
 uselesskey-core-token-shape.workspace = true
 
 [dev-dependencies]
+insta.workspace = true
 rand_chacha.workspace = true
+rand_core.workspace = true
 proptest.workspace = true
 base64.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_all_kinds.snap
+++ b/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_all_kinds.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uselesskey-core-token/tests/snapshots_token_core.rs
+expression: results
+---
+- kind: ApiKey
+  total_len: 40
+  auth_scheme: ApiKey
+- kind: Bearer
+  total_len: 43
+  auth_scheme: Bearer
+- kind: OAuthAccessToken
+  total_len: 247
+  auth_scheme: Bearer

--- a/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_api_key_structure.snap
+++ b/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_api_key_structure.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-core-token/tests/snapshots_token_core.rs
+expression: result
+---
+prefix: uk_test_
+prefix_len: 8
+random_suffix_len: 32
+total_len: 40
+has_correct_prefix: true
+suffix_all_alphanumeric: true

--- a/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_bearer_structure.snap
+++ b/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_bearer_structure.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-token/tests/snapshots_token_core.rs
+expression: result
+---
+encoded_len: 43
+raw_random_bytes: 32
+is_base64url: true

--- a/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_determinism.snap
+++ b/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_determinism.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-core-token/tests/snapshots_token_core.rs
+expression: results
+---
+- kind: ApiKey
+  same_seed_matches: true
+- kind: Bearer
+  same_seed_matches: true
+- kind: OAuthAccessToken
+  same_seed_matches: true

--- a/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_oauth_structure.snap
+++ b/crates/uselesskey-core-token/tests/snapshots/snapshots_token_core__token_core_oauth_structure.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-token/tests/snapshots_token_core.rs
+expression: result
+---
+segment_count: 3
+is_jwt_shaped: true
+total_len: 247

--- a/crates/uselesskey-core-token/tests/snapshots_token_core.rs
+++ b/crates/uselesskey-core-token/tests/snapshots_token_core.rs
@@ -1,0 +1,150 @@
+//! Insta snapshot tests for uselesskey-core-token.
+//!
+//! Snapshot token generation metadata — format shapes, lengths, schemes.
+//! All actual token values are redacted.
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use serde::Serialize;
+use uselesskey_core_token::{
+    API_KEY_PREFIX, API_KEY_RANDOM_LEN, BEARER_RANDOM_BYTES, TokenKind, authorization_scheme,
+    generate_token,
+};
+
+#[derive(Serialize)]
+struct TokenMetadata {
+    kind: &'static str,
+    total_len: usize,
+    auth_scheme: &'static str,
+}
+
+#[test]
+fn snapshot_all_token_kinds_metadata() {
+    let seed = [42u8; 32];
+    let kinds = [
+        ("ApiKey", TokenKind::ApiKey),
+        ("Bearer", TokenKind::Bearer),
+        ("OAuthAccessToken", TokenKind::OAuthAccessToken),
+    ];
+
+    let results: Vec<TokenMetadata> = kinds
+        .iter()
+        .map(|(name, kind)| {
+            let mut rng = ChaCha20Rng::from_seed(seed);
+            let token = generate_token("test-label", *kind, &mut rng);
+            TokenMetadata {
+                kind: name,
+                total_len: token.len(),
+                auth_scheme: authorization_scheme(*kind),
+            }
+        })
+        .collect();
+
+    insta::assert_yaml_snapshot!("token_core_all_kinds", results);
+}
+
+#[test]
+fn snapshot_api_key_structure() {
+    let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+    let token = generate_token("my-service", TokenKind::ApiKey, &mut rng);
+
+    #[derive(Serialize)]
+    struct ApiKeyStructure {
+        prefix: &'static str,
+        prefix_len: usize,
+        random_suffix_len: usize,
+        total_len: usize,
+        has_correct_prefix: bool,
+        suffix_all_alphanumeric: bool,
+    }
+
+    let suffix = &token[API_KEY_PREFIX.len()..];
+    let result = ApiKeyStructure {
+        prefix: API_KEY_PREFIX,
+        prefix_len: API_KEY_PREFIX.len(),
+        random_suffix_len: API_KEY_RANDOM_LEN,
+        total_len: token.len(),
+        has_correct_prefix: token.starts_with(API_KEY_PREFIX),
+        suffix_all_alphanumeric: suffix.chars().all(|c| c.is_ascii_alphanumeric()),
+    };
+
+    insta::assert_yaml_snapshot!("token_core_api_key_structure", result);
+}
+
+#[test]
+fn snapshot_bearer_token_structure() {
+    let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+    let token = generate_token("my-service", TokenKind::Bearer, &mut rng);
+
+    #[derive(Serialize)]
+    struct BearerStructure {
+        encoded_len: usize,
+        raw_random_bytes: usize,
+        is_base64url: bool,
+    }
+
+    let result = BearerStructure {
+        encoded_len: token.len(),
+        raw_random_bytes: BEARER_RANDOM_BYTES,
+        is_base64url: token
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+    };
+
+    insta::assert_yaml_snapshot!("token_core_bearer_structure", result);
+}
+
+#[test]
+fn snapshot_oauth_token_structure() {
+    let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+    let token = generate_token("my-service", TokenKind::OAuthAccessToken, &mut rng);
+
+    #[derive(Serialize)]
+    struct OAuthStructure {
+        segment_count: usize,
+        is_jwt_shaped: bool,
+        total_len: usize,
+    }
+
+    let segments: Vec<&str> = token.split('.').collect();
+    let result = OAuthStructure {
+        segment_count: segments.len(),
+        is_jwt_shaped: segments.len() == 3,
+        total_len: token.len(),
+    };
+
+    insta::assert_yaml_snapshot!("token_core_oauth_structure", result);
+}
+
+#[test]
+fn snapshot_token_determinism() {
+    let seed = [7u8; 32];
+
+    #[derive(Serialize)]
+    struct TokenDeterminism {
+        kind: &'static str,
+        same_seed_matches: bool,
+    }
+
+    let kinds = [
+        ("ApiKey", TokenKind::ApiKey),
+        ("Bearer", TokenKind::Bearer),
+        ("OAuthAccessToken", TokenKind::OAuthAccessToken),
+    ];
+
+    let results: Vec<TokenDeterminism> = kinds
+        .iter()
+        .map(|(name, kind)| {
+            let mut rng_a = ChaCha20Rng::from_seed(seed);
+            let mut rng_b = ChaCha20Rng::from_seed(seed);
+            let a = generate_token("label", *kind, &mut rng_a);
+            let b = generate_token("label", *kind, &mut rng_b);
+            TokenDeterminism {
+                kind: name,
+                same_seed_matches: a == b,
+            }
+        })
+        .collect();
+
+    insta::assert_yaml_snapshot!("token_core_determinism", results);
+}


### PR DESCRIPTION
## Summary

Add insta snapshot tests capturing metadata shapes (not key material) for four core crates that were missing them.

### Crates covered

- uselesskey-core-negative-der: 9 snapshots (truncation, byte flip, deterministic corruption)
- uselesskey-core-token: 5 snapshots (token kind metadata, format shapes, determinism)
- uselesskey-core-hash: 4 snapshots (output sizes, determinism, boundary separation)
- uselesskey-core-keypair-material: 6 snapshots (field lengths, Debug redaction, KID, corruption)

### Changes

- Created 4 snapshot test files following the established workspace pattern
- Added insta and serde as workspace dev-dependencies for each crate
- Generated and committed 24 snapshot files (all tests pass)

### Design

- Metadata only: Snapshots capture shapes (lengths, boolean properties, counts) - no key material
- Pattern consistency: Follows the same serializable struct + assert_yaml_snapshot! pattern used by existing snapshot tests
- All tests pass with cargo clippy -D warnings clean
