### PR TITLE
test: add insta snapshot tests for token-spec and core-keypair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,7 +3857,9 @@ dependencies = [
 name = "uselesskey-core-keypair"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
+ "serde",
  "uselesskey-core-keypair-material",
  "uselesskey-core-negative",
 ]
@@ -4280,6 +4282,10 @@ dependencies = [
 [[package]]
 name = "uselesskey-token-spec"
 version = "0.1.0"
+dependencies = [
+ "insta",
+ "serde",
+]
 
 [[package]]
 name = "uselesskey-tonic"

--- a/crates/uselesskey-core-keypair/Cargo.toml
+++ b/crates/uselesskey-core-keypair/Cargo.toml
@@ -18,7 +18,9 @@ authors.workspace = true
 uselesskey-core-keypair-material.workspace = true
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
+serde.workspace = true
 uselesskey-core-negative.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-core-keypair/tests/snapshots/snapshots_keypair__keypair_debug_safety.snap
+++ b/crates/uselesskey-core-keypair/tests/snapshots/snapshots_keypair__keypair_debug_safety.snap
@@ -1,0 +1,11 @@
+---
+source: crates/uselesskey-core-keypair/tests/snapshots_keypair.rs
+expression: result
+---
+contains_struct_name: true
+contains_pkcs8_der_len: true
+contains_spki_der_len: true
+leaks_private_pem_header: false
+leaks_public_pem_header: false
+leaks_pem_body: false
+uses_non_exhaustive: true

--- a/crates/uselesskey-core-keypair/tests/snapshots/snapshots_keypair__keypair_kid_determinism.snap
+++ b/crates/uselesskey-core-keypair/tests/snapshots/snapshots_keypair__keypair_kid_determinism.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-keypair/tests/snapshots_keypair.rs
+expression: result
+---
+same_material_matches: true
+different_spki_differs: true
+same_spki_different_pkcs8_matches: true

--- a/crates/uselesskey-core-keypair/tests/snapshots/snapshots_keypair__keypair_metadata.snap
+++ b/crates/uselesskey-core-keypair/tests/snapshots/snapshots_keypair__keypair_metadata.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-core-keypair/tests/snapshots_keypair.rs
+expression: result
+---
+pkcs8_der_len: 4
+pkcs8_pem_len: 59
+spki_der_len: 4
+spki_pem_len: 57
+kid_len: 16
+kid_is_ascii_alphanumeric: true

--- a/crates/uselesskey-core-keypair/tests/snapshots/snapshots_keypair__keypair_negative_fixtures.snap
+++ b/crates/uselesskey-core-keypair/tests/snapshots/snapshots_keypair__keypair_negative_fixtures.snap
@@ -1,0 +1,11 @@
+---
+source: crates/uselesskey-core-keypair/tests/snapshots_keypair.rs
+expression: result
+---
+bad_header_contains_corrupted: true
+bad_header_lacks_original: true
+bad_footer_contains_corrupted: true
+truncate_respects_length: true
+deterministic_pem_is_stable: true
+deterministic_der_is_stable: true
+different_variants_diverge: true

--- a/crates/uselesskey-core-keypair/tests/snapshots_keypair.rs
+++ b/crates/uselesskey-core-keypair/tests/snapshots_keypair.rs
@@ -1,0 +1,144 @@
+//! Insta snapshot tests for uselesskey-core-keypair.
+//!
+//! Snapshot keypair metadata shapes — field lengths, kid format, Debug safety.
+//! All secret material is redacted.
+
+use serde::Serialize;
+use uselesskey_core_keypair::Pkcs8SpkiKeyMaterial;
+
+fn sample() -> Pkcs8SpkiKeyMaterial {
+    Pkcs8SpkiKeyMaterial::new(
+        vec![0x30, 0x82, 0x01, 0x22],
+        "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n",
+        vec![0x30, 0x59, 0x30, 0x13],
+        "-----BEGIN PUBLIC KEY-----\nBBBB\n-----END PUBLIC KEY-----\n",
+    )
+}
+
+#[test]
+fn snapshot_keypair_metadata() {
+    #[derive(Serialize)]
+    struct KeypairMetadata {
+        pkcs8_der_len: usize,
+        pkcs8_pem_len: usize,
+        spki_der_len: usize,
+        spki_pem_len: usize,
+        kid_len: usize,
+        kid_is_ascii_alphanumeric: bool,
+    }
+
+    let m = sample();
+    let kid = m.kid();
+
+    let result = KeypairMetadata {
+        pkcs8_der_len: m.private_key_pkcs8_der().len(),
+        pkcs8_pem_len: m.private_key_pkcs8_pem().len(),
+        spki_der_len: m.public_key_spki_der().len(),
+        spki_pem_len: m.public_key_spki_pem().len(),
+        kid_len: kid.len(),
+        kid_is_ascii_alphanumeric: kid.chars().all(|c| c.is_ascii_alphanumeric()),
+    };
+
+    insta::assert_yaml_snapshot!("keypair_metadata", result);
+}
+
+#[test]
+fn snapshot_keypair_debug_safety() {
+    #[derive(Serialize)]
+    struct DebugSafety {
+        contains_struct_name: bool,
+        contains_pkcs8_der_len: bool,
+        contains_spki_der_len: bool,
+        leaks_private_pem_header: bool,
+        leaks_public_pem_header: bool,
+        leaks_pem_body: bool,
+        uses_non_exhaustive: bool,
+    }
+
+    let m = sample();
+    let dbg = format!("{m:?}");
+
+    let result = DebugSafety {
+        contains_struct_name: dbg.contains("Pkcs8SpkiKeyMaterial"),
+        contains_pkcs8_der_len: dbg.contains("pkcs8_der_len"),
+        contains_spki_der_len: dbg.contains("spki_der_len"),
+        leaks_private_pem_header: dbg.contains("BEGIN PRIVATE KEY"),
+        leaks_public_pem_header: dbg.contains("BEGIN PUBLIC KEY"),
+        leaks_pem_body: dbg.contains("AAAA") || dbg.contains("BBBB"),
+        uses_non_exhaustive: dbg.contains(".."),
+    };
+
+    insta::assert_yaml_snapshot!("keypair_debug_safety", result);
+}
+
+#[test]
+fn snapshot_keypair_kid_determinism() {
+    #[derive(Serialize)]
+    struct KidDeterminism {
+        same_material_matches: bool,
+        different_spki_differs: bool,
+        same_spki_different_pkcs8_matches: bool,
+    }
+
+    let m1 = sample();
+    let m2 = Pkcs8SpkiKeyMaterial::new(
+        vec![0xFF, 0xFE, 0xFD],
+        "-----BEGIN PRIVATE KEY-----\nXXXX\n-----END PRIVATE KEY-----\n",
+        vec![0xAA, 0xBB, 0xCC],
+        "-----BEGIN PUBLIC KEY-----\nYYYY\n-----END PUBLIC KEY-----\n",
+    );
+    // Same SPKI, different PKCS#8
+    let m3 = Pkcs8SpkiKeyMaterial::new(
+        vec![0x01, 0x02],
+        "other-private-pem",
+        vec![0x30, 0x59, 0x30, 0x13],
+        "-----BEGIN PUBLIC KEY-----\nBBBB\n-----END PUBLIC KEY-----\n",
+    );
+
+    let result = KidDeterminism {
+        same_material_matches: m1.kid() == m1.kid(),
+        different_spki_differs: m1.kid() != m2.kid(),
+        same_spki_different_pkcs8_matches: m1.kid() == m3.kid(),
+    };
+
+    insta::assert_yaml_snapshot!("keypair_kid_determinism", result);
+}
+
+#[test]
+fn snapshot_keypair_negative_fixtures() {
+    use uselesskey_core_negative::CorruptPem;
+
+    #[derive(Serialize)]
+    struct NegativeFixtures {
+        bad_header_contains_corrupted: bool,
+        bad_header_lacks_original: bool,
+        bad_footer_contains_corrupted: bool,
+        truncate_respects_length: bool,
+        deterministic_pem_is_stable: bool,
+        deterministic_der_is_stable: bool,
+        different_variants_diverge: bool,
+    }
+
+    let m = sample();
+
+    let bad_header = m.private_key_pkcs8_pem_corrupt(CorruptPem::BadHeader);
+    let bad_footer = m.private_key_pkcs8_pem_corrupt(CorruptPem::BadFooter);
+    let truncated = m.private_key_pkcs8_der_truncated(2);
+    let det_a = m.private_key_pkcs8_pem_corrupt_deterministic("v1");
+    let det_b = m.private_key_pkcs8_pem_corrupt_deterministic("v1");
+    let det_c = m.private_key_pkcs8_pem_corrupt_deterministic("v2");
+    let der_a = m.private_key_pkcs8_der_corrupt_deterministic("d1");
+    let der_b = m.private_key_pkcs8_der_corrupt_deterministic("d1");
+
+    let result = NegativeFixtures {
+        bad_header_contains_corrupted: bad_header.contains("CORRUPTED KEY"),
+        bad_header_lacks_original: !bad_header.contains("BEGIN PRIVATE KEY"),
+        bad_footer_contains_corrupted: bad_footer.contains("END CORRUPTED KEY"),
+        truncate_respects_length: truncated.len() == 2,
+        deterministic_pem_is_stable: det_a == det_b,
+        deterministic_der_is_stable: der_a == der_b,
+        different_variants_diverge: det_a != det_c,
+    };
+
+    insta::assert_yaml_snapshot!("keypair_negative_fixtures", result);
+}

--- a/crates/uselesskey-token-spec/Cargo.toml
+++ b/crates/uselesskey-token-spec/Cargo.toml
@@ -14,5 +14,9 @@ homepage.workspace = true
 documentation = "https://docs.rs/uselesskey-token-spec"
 authors.workspace = true
 
+[dev-dependencies]
+insta.workspace = true
+serde.workspace = true
+
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-token-spec/tests/snapshots/snapshots_token_spec__token_spec_all_variants.snap
+++ b/crates/uselesskey-token-spec/tests/snapshots/snapshots_token_spec__token_spec_all_variants.snap
@@ -1,0 +1,28 @@
+---
+source: crates/uselesskey-token-spec/tests/snapshots_token_spec.rs
+expression: results
+---
+- variant: ApiKey
+  kind_name: api_key
+  debug_repr: ApiKey
+  stable_bytes:
+    - 0
+    - 0
+    - 0
+    - 1
+- variant: Bearer
+  kind_name: bearer
+  debug_repr: Bearer
+  stable_bytes:
+    - 0
+    - 0
+    - 0
+    - 2
+- variant: OAuthAccessToken
+  kind_name: oauth_access_token
+  debug_repr: OAuthAccessToken
+  stable_bytes:
+    - 0
+    - 0
+    - 0
+    - 3

--- a/crates/uselesskey-token-spec/tests/snapshots/snapshots_token_spec__token_spec_kind_names.snap
+++ b/crates/uselesskey-token-spec/tests/snapshots/snapshots_token_spec__token_spec_kind_names.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-token-spec/tests/snapshots_token_spec.rs
+expression: result
+---
+api_key: api_key
+bearer: bearer
+oauth_access_token: oauth_access_token
+all_snake_case: true

--- a/crates/uselesskey-token-spec/tests/snapshots/snapshots_token_spec__token_spec_stable_bytes.snap
+++ b/crates/uselesskey-token-spec/tests/snapshots/snapshots_token_spec__token_spec_stable_bytes.snap
@@ -1,0 +1,20 @@
+---
+source: crates/uselesskey-token-spec/tests/snapshots_token_spec.rs
+expression: result
+---
+api_key:
+  - 0
+  - 0
+  - 0
+  - 1
+bearer:
+  - 0
+  - 0
+  - 0
+  - 2
+oauth_access_token:
+  - 0
+  - 0
+  - 0
+  - 3
+all_unique: true

--- a/crates/uselesskey-token-spec/tests/snapshots_token_spec.rs
+++ b/crates/uselesskey-token-spec/tests/snapshots_token_spec.rs
@@ -1,0 +1,87 @@
+//! Insta snapshot tests for uselesskey-token-spec.
+//!
+//! Snapshot spec variants, constructors, kind names, and stable bytes.
+
+use serde::Serialize;
+use uselesskey_token_spec::TokenSpec;
+
+#[derive(Serialize)]
+struct TokenSpecSnapshot {
+    variant: &'static str,
+    kind_name: &'static str,
+    debug_repr: String,
+    stable_bytes: [u8; 4],
+}
+
+#[test]
+fn snapshot_token_spec_all_variants() {
+    let specs = [
+        ("ApiKey", TokenSpec::api_key()),
+        ("Bearer", TokenSpec::bearer()),
+        ("OAuthAccessToken", TokenSpec::oauth_access_token()),
+    ];
+
+    let results: Vec<TokenSpecSnapshot> = specs
+        .iter()
+        .map(|(name, spec)| TokenSpecSnapshot {
+            variant: name,
+            kind_name: spec.kind_name(),
+            debug_repr: format!("{:?}", spec),
+            stable_bytes: spec.stable_bytes(),
+        })
+        .collect();
+
+    insta::assert_yaml_snapshot!("token_spec_all_variants", results);
+}
+
+#[test]
+fn snapshot_token_spec_stable_bytes_uniqueness() {
+    #[derive(Serialize)]
+    struct StableBytesCheck {
+        api_key: [u8; 4],
+        bearer: [u8; 4],
+        oauth_access_token: [u8; 4],
+        all_unique: bool,
+    }
+
+    let api = TokenSpec::api_key().stable_bytes();
+    let bearer = TokenSpec::bearer().stable_bytes();
+    let oauth = TokenSpec::oauth_access_token().stable_bytes();
+
+    let result = StableBytesCheck {
+        api_key: api,
+        bearer,
+        oauth_access_token: oauth,
+        all_unique: api != bearer && api != oauth && bearer != oauth,
+    };
+
+    insta::assert_yaml_snapshot!("token_spec_stable_bytes", result);
+}
+
+#[test]
+fn snapshot_token_spec_kind_names() {
+    #[derive(Serialize)]
+    struct KindNames {
+        api_key: &'static str,
+        bearer: &'static str,
+        oauth_access_token: &'static str,
+        all_snake_case: bool,
+    }
+
+    fn is_snake_case(s: &str) -> bool {
+        s.chars().all(|c| c.is_ascii_lowercase() || c == '_')
+    }
+
+    let api = TokenSpec::api_key().kind_name();
+    let bearer = TokenSpec::bearer().kind_name();
+    let oauth = TokenSpec::oauth_access_token().kind_name();
+
+    let result = KindNames {
+        api_key: api,
+        bearer,
+        oauth_access_token: oauth,
+        all_snake_case: is_snake_case(api) && is_snake_case(bearer) && is_snake_case(oauth),
+    };
+
+    insta::assert_yaml_snapshot!("token_spec_kind_names", result);
+}


### PR DESCRIPTION
Add insta snapshot tests for uselesskey-token-spec and uselesskey-core-keypair. All snapshots redact secret material.