### PR TITLE
feat: add insta snapshot tests for JWK-related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,9 @@ dependencies = [
 name = "uselesskey-core-jwk"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
+ "serde",
  "serde_json",
  "uselesskey-core-jwk-builder",
  "uselesskey-core-jwk-shape",
@@ -3869,7 +3871,9 @@ dependencies = [
 name = "uselesskey-core-jwk-builder"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
+ "serde",
  "serde_json",
  "uselesskey-core-jwk-shape",
  "uselesskey-core-jwks-order",
@@ -3879,6 +3883,7 @@ dependencies = [
 name = "uselesskey-core-jwk-shape"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
  "serde",
  "serde_json",
@@ -3888,7 +3893,9 @@ dependencies = [
 name = "uselesskey-core-jwks-order"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
+ "serde",
 ]
 
 [[package]]
@@ -4209,6 +4216,8 @@ dependencies = [
 name = "uselesskey-jwk"
 version = "0.1.0"
 dependencies = [
+ "insta",
+ "serde",
  "serde_json",
  "uselesskey-core-jwk",
  "uselesskey-core-jwk-builder",

--- a/crates/uselesskey-core-jwk-builder/Cargo.toml
+++ b/crates/uselesskey-core-jwk-builder/Cargo.toml
@@ -20,7 +20,9 @@ uselesskey-core-jwks-order = { path = "../uselesskey-core-jwks-order", version =
 serde_json.workspace = true
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_add_any.snap
+++ b/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_add_any.snap
@@ -1,0 +1,11 @@
+---
+source: crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs
+expression: snapshot_from_builder(builder)
+---
+key_count: 2
+kids:
+  - a-key
+  - z-key
+ktys:
+  - oct
+  - RSA

--- a/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_empty.snap
+++ b/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_empty.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs
+expression: snapshot_from_builder(builder)
+---
+key_count: 0
+kids: []
+ktys: []

--- a/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_jwks_serialized.snap
+++ b/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_jwks_serialized.snap
@@ -1,0 +1,18 @@
+---
+source: crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs
+expression: value
+---
+keys:
+  - alg: ES256
+    crv: P-256
+    kid: ec-1
+    kty: EC
+    use: sig
+    x: "[REDACTED]"
+    y: "[REDACTED]"
+  - alg: RS256
+    e: "[REDACTED]"
+    kid: rsa-1
+    kty: RSA
+    n: "[REDACTED]"
+    use: sig

--- a/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_mixed_public_private.snap
+++ b/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_mixed_public_private.snap
@@ -1,0 +1,11 @@
+---
+source: crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs
+expression: snapshot_from_builder(builder)
+---
+key_count: 2
+kids:
+  - key-a
+  - key-b
+ktys:
+  - oct
+  - RSA

--- a/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_push_methods.snap
+++ b/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_push_methods.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs
+expression: snapshot_from_builder(builder)
+---
+key_count: 3
+kids:
+  - any-key
+  - priv-key
+  - pub-key
+ktys:
+  - OKP
+  - oct
+  - EC

--- a/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_sorts_by_kid.snap
+++ b/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_sorts_by_kid.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs
+expression: snapshot_from_builder(builder)
+---
+key_count: 3
+kids:
+  - alpha
+  - bravo
+  - charlie
+ktys:
+  - EC
+  - OKP
+  - RSA

--- a/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_stable_duplicate_kids.snap
+++ b/crates/uselesskey-core-jwk-builder/tests/snapshots/snapshots_jwk_builder__builder_stable_duplicate_kids.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs
+expression: snapshot_from_builder(builder)
+---
+key_count: 3
+kids:
+  - same
+  - same
+  - same
+ktys:
+  - RSA
+  - EC
+  - OKP

--- a/crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs
+++ b/crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs
@@ -1,0 +1,149 @@
+//! Insta snapshot tests for uselesskey-core-jwk-builder.
+//!
+//! Snapshot JWKS builder ordering and composition with key material redacted.
+
+use serde::Serialize;
+use uselesskey_core_jwk_builder::JwksBuilder;
+use uselesskey_core_jwk_shape::{
+    AnyJwk, EcPublicJwk, OctJwk, OkpPublicJwk, PrivateJwk, PublicJwk, RsaPublicJwk,
+};
+
+fn rsa_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.into(),
+        n: "modulus-data".into(),
+        e: "AQAB".into(),
+    })
+}
+
+fn ec_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Ec(EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.into(),
+        x: "ec-x-data".into(),
+        y: "ec-y-data".into(),
+    })
+}
+
+fn okp_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Okp(OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.into(),
+        x: "okp-x-data".into(),
+    })
+}
+
+fn oct_priv(kid: &str) -> PrivateJwk {
+    PrivateJwk::Oct(OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: kid.into(),
+        k: "secret-key-data".into(),
+    })
+}
+
+#[derive(Serialize)]
+struct JwksSnapshot {
+    key_count: usize,
+    kids: Vec<String>,
+    ktys: Vec<String>,
+}
+
+fn snapshot_from_builder(builder: JwksBuilder) -> JwksSnapshot {
+    let jwks = builder.build();
+    JwksSnapshot {
+        key_count: jwks.keys.len(),
+        kids: jwks.keys.iter().map(|k| k.kid().to_string()).collect(),
+        ktys: jwks
+            .keys
+            .iter()
+            .map(|k| k.to_value()["kty"].as_str().unwrap().to_string())
+            .collect(),
+    }
+}
+
+#[test]
+fn snapshot_builder_sorts_by_kid() {
+    let builder = JwksBuilder::new()
+        .add_public(rsa_pub("charlie"))
+        .add_public(ec_pub("alpha"))
+        .add_public(okp_pub("bravo"));
+
+    insta::assert_yaml_snapshot!("builder_sorts_by_kid", snapshot_from_builder(builder));
+}
+
+#[test]
+fn snapshot_builder_stable_duplicate_kids() {
+    let builder = JwksBuilder::new()
+        .add_public(rsa_pub("same"))
+        .add_public(ec_pub("same"))
+        .add_public(okp_pub("same"));
+
+    insta::assert_yaml_snapshot!(
+        "builder_stable_duplicate_kids",
+        snapshot_from_builder(builder)
+    );
+}
+
+#[test]
+fn snapshot_builder_mixed_public_private() {
+    let builder = JwksBuilder::new()
+        .add_public(rsa_pub("key-b"))
+        .add_private(oct_priv("key-a"));
+
+    insta::assert_yaml_snapshot!(
+        "builder_mixed_public_private",
+        snapshot_from_builder(builder)
+    );
+}
+
+#[test]
+fn snapshot_builder_add_any() {
+    let builder = JwksBuilder::new()
+        .add_any(AnyJwk::from(rsa_pub("z-key")))
+        .add_any(AnyJwk::from(oct_priv("a-key")));
+
+    insta::assert_yaml_snapshot!("builder_add_any", snapshot_from_builder(builder));
+}
+
+#[test]
+fn snapshot_builder_push_methods() {
+    let mut builder = JwksBuilder::new();
+    builder.push_public(ec_pub("pub-key"));
+    builder.push_private(oct_priv("priv-key"));
+    builder.push_any(AnyJwk::from(okp_pub("any-key")));
+
+    insta::assert_yaml_snapshot!("builder_push_methods", snapshot_from_builder(builder));
+}
+
+#[test]
+fn snapshot_builder_empty() {
+    let builder = JwksBuilder::new();
+    insta::assert_yaml_snapshot!("builder_empty", snapshot_from_builder(builder));
+}
+
+#[test]
+fn snapshot_builder_jwks_serialized_shape() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("rsa-1"))
+        .add_public(ec_pub("ec-1"))
+        .build();
+
+    let value = jwks.to_value();
+    insta::assert_yaml_snapshot!("builder_jwks_serialized", value, {
+        ".keys[].n" => "[REDACTED]",
+        ".keys[].e" => "[REDACTED]",
+        ".keys[].x" => "[REDACTED]",
+        ".keys[].y" => "[REDACTED]",
+    });
+}

--- a/crates/uselesskey-core-jwk-shape/Cargo.toml
+++ b/crates/uselesskey-core-jwk-shape/Cargo.toml
@@ -19,7 +19,10 @@ serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__ec_private_jwk_shape.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__ec_private_jwk_shape.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: value
+---
+alg: ES256
+crv: P-256
+d: "[REDACTED]"
+kid: ec-priv-1
+kty: EC
+use: sig
+x: "[REDACTED]"
+y: "[REDACTED]"

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__ec_public_jwk_shape.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__ec_public_jwk_shape.snap
@@ -1,0 +1,11 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: value
+---
+alg: ES256
+crv: P-256
+kid: ec-pub-1
+kty: EC
+use: sig
+x: "[REDACTED]"
+y: "[REDACTED]"

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__jwks_display_check.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__jwks_display_check.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: check
+---
+has_keys_array: true
+key_count: 1

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__jwks_structure.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__jwks_structure.snap
@@ -1,0 +1,23 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: value
+---
+keys:
+  - alg: RS256
+    e: "[REDACTED]"
+    kid: key-a
+    kty: RSA
+    n: "[REDACTED]"
+    use: sig
+  - alg: ES256
+    crv: P-256
+    kid: key-b
+    kty: EC
+    use: sig
+    x: "[REDACTED]"
+    y: "[REDACTED]"
+  - alg: HS256
+    k: "[REDACTED]"
+    kid: key-c
+    kty: oct
+    use: sig

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__oct_jwk_shape.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__oct_jwk_shape.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: value
+---
+alg: HS256
+k: "[REDACTED]"
+kid: oct-1
+kty: oct
+use: sig

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__okp_private_jwk_shape.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__okp_private_jwk_shape.snap
@@ -1,0 +1,11 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: value
+---
+alg: EdDSA
+crv: Ed25519
+d: "[REDACTED]"
+kid: okp-priv-1
+kty: OKP
+use: sig
+x: "[REDACTED]"

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__okp_public_jwk_shape.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__okp_public_jwk_shape.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: value
+---
+alg: EdDSA
+crv: Ed25519
+kid: okp-pub-1
+kty: OKP
+use: sig
+x: "[REDACTED]"

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__private_debug_redaction.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__private_debug_redaction.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: infos
+---
+- variant: RsaPrivateJwk
+  debug_output: "RsaPrivateJwk { kid: \"k\", alg: \"RS256\", .. }"
+  contains_secret: false
+- variant: EcPrivateJwk
+  debug_output: "EcPrivateJwk { kid: \"k\", alg: \"ES256\", crv: \"P-256\", .. }"
+  contains_secret: false
+- variant: OkpPrivateJwk
+  debug_output: "OkpPrivateJwk { kid: \"k\", alg: \"EdDSA\", crv: \"Ed25519\", .. }"
+  contains_secret: false
+- variant: OctJwk
+  debug_output: "OctJwk { kid: \"k\", alg: \"HS256\", .. }"
+  contains_secret: false

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__private_jwk_enum_variants.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__private_jwk_enum_variants.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: infos
+---
+- variant: Rsa
+  kid: rsa-p-1
+  kty: RSA
+- variant: Ec
+  kid: ec-p-1
+  kty: EC
+- variant: Okp
+  kid: okp-p-1
+  kty: OKP
+- variant: Oct
+  kid: oct-p-1
+  kty: oct

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__public_jwk_enum_variants.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__public_jwk_enum_variants.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: infos
+---
+- variant: Rsa
+  kid: rsa-1
+  kty: RSA
+- variant: Ec
+  kid: ec-1
+  kty: EC
+- variant: Okp
+  kid: okp-1
+  kty: OKP

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__rsa_private_jwk_shape.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__rsa_private_jwk_shape.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: value
+---
+alg: RS256
+d: "[REDACTED]"
+dp: "[REDACTED]"
+dq: "[REDACTED]"
+e: "[REDACTED]"
+kid: rsa-priv-1
+kty: RSA
+n: "[REDACTED]"
+p: "[REDACTED]"
+q: "[REDACTED]"
+qi: "[REDACTED]"
+use: sig

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__rsa_public_jwk_shape.snap
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots/snapshots_jwk_shape__rsa_public_jwk_shape.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+expression: value
+---
+alg: RS256
+e: "[REDACTED]"
+kid: rsa-pub-1
+kty: RSA
+n: "[REDACTED]"
+use: sig

--- a/crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
+++ b/crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs
@@ -1,0 +1,371 @@
+//! Insta snapshot tests for uselesskey-core-jwk-shape.
+//!
+//! Snapshot JWK struct serialization shapes with key material redacted.
+
+use serde::Serialize;
+use uselesskey_core_jwk_shape::{
+    AnyJwk, EcPrivateJwk, EcPublicJwk, Jwks, OctJwk, OkpPrivateJwk, OkpPublicJwk, PrivateJwk,
+    PublicJwk, RsaPrivateJwk, RsaPublicJwk,
+};
+
+fn rsa_public(kid: &str) -> RsaPublicJwk {
+    RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.into(),
+        n: "test-modulus".into(),
+        e: "AQAB".into(),
+    }
+}
+
+fn rsa_private(kid: &str) -> RsaPrivateJwk {
+    RsaPrivateJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.into(),
+        n: "test-modulus".into(),
+        e: "AQAB".into(),
+        d: "test-d".into(),
+        p: "test-p".into(),
+        q: "test-q".into(),
+        dp: "test-dp".into(),
+        dq: "test-dq".into(),
+        qi: "test-qi".into(),
+    }
+}
+
+fn ec_public(kid: &str) -> EcPublicJwk {
+    EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.into(),
+        x: "test-x".into(),
+        y: "test-y".into(),
+    }
+}
+
+fn ec_private(kid: &str) -> EcPrivateJwk {
+    EcPrivateJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.into(),
+        x: "test-x".into(),
+        y: "test-y".into(),
+        d: "test-d".into(),
+    }
+}
+
+fn okp_public(kid: &str) -> OkpPublicJwk {
+    OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.into(),
+        x: "test-x".into(),
+    }
+}
+
+fn okp_private(kid: &str) -> OkpPrivateJwk {
+    OkpPrivateJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.into(),
+        x: "test-x".into(),
+        d: "test-d".into(),
+    }
+}
+
+fn oct_jwk(kid: &str) -> OctJwk {
+    OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: kid.into(),
+        k: "test-secret".into(),
+    }
+}
+
+// --- RSA ---
+
+#[test]
+fn snapshot_rsa_public_jwk() {
+    let jwk = rsa_public("rsa-pub-1");
+    let value = serde_json::to_value(&jwk).unwrap();
+    insta::assert_yaml_snapshot!("rsa_public_jwk_shape", value, {
+        ".n" => "[REDACTED]",
+        ".e" => "[REDACTED]",
+    });
+}
+
+#[test]
+fn snapshot_rsa_private_jwk() {
+    let jwk = rsa_private("rsa-priv-1");
+    let value = serde_json::to_value(&jwk).unwrap();
+    insta::assert_yaml_snapshot!("rsa_private_jwk_shape", value, {
+        ".n" => "[REDACTED]",
+        ".e" => "[REDACTED]",
+        ".d" => "[REDACTED]",
+        ".p" => "[REDACTED]",
+        ".q" => "[REDACTED]",
+        ".dp" => "[REDACTED]",
+        ".dq" => "[REDACTED]",
+        ".qi" => "[REDACTED]",
+    });
+}
+
+// --- EC ---
+
+#[test]
+fn snapshot_ec_public_jwk() {
+    let jwk = ec_public("ec-pub-1");
+    let value = serde_json::to_value(&jwk).unwrap();
+    insta::assert_yaml_snapshot!("ec_public_jwk_shape", value, {
+        ".x" => "[REDACTED]",
+        ".y" => "[REDACTED]",
+    });
+}
+
+#[test]
+fn snapshot_ec_private_jwk() {
+    let jwk = ec_private("ec-priv-1");
+    let value = serde_json::to_value(&jwk).unwrap();
+    insta::assert_yaml_snapshot!("ec_private_jwk_shape", value, {
+        ".x" => "[REDACTED]",
+        ".y" => "[REDACTED]",
+        ".d" => "[REDACTED]",
+    });
+}
+
+// --- OKP ---
+
+#[test]
+fn snapshot_okp_public_jwk() {
+    let jwk = okp_public("okp-pub-1");
+    let value = serde_json::to_value(&jwk).unwrap();
+    insta::assert_yaml_snapshot!("okp_public_jwk_shape", value, {
+        ".x" => "[REDACTED]",
+    });
+}
+
+#[test]
+fn snapshot_okp_private_jwk() {
+    let jwk = okp_private("okp-priv-1");
+    let value = serde_json::to_value(&jwk).unwrap();
+    insta::assert_yaml_snapshot!("okp_private_jwk_shape", value, {
+        ".x" => "[REDACTED]",
+        ".d" => "[REDACTED]",
+    });
+}
+
+// --- Oct ---
+
+#[test]
+fn snapshot_oct_jwk() {
+    let jwk = oct_jwk("oct-1");
+    let value = serde_json::to_value(&jwk).unwrap();
+    insta::assert_yaml_snapshot!("oct_jwk_shape", value, {
+        ".k" => "[REDACTED]",
+    });
+}
+
+// --- Enums ---
+
+#[test]
+fn snapshot_public_jwk_enum_variants() {
+    #[derive(Serialize)]
+    struct VariantInfo {
+        variant: &'static str,
+        kid: String,
+        kty: String,
+    }
+
+    let variants = [
+        ("Rsa", PublicJwk::Rsa(rsa_public("rsa-1"))),
+        ("Ec", PublicJwk::Ec(ec_public("ec-1"))),
+        ("Okp", PublicJwk::Okp(okp_public("okp-1"))),
+    ];
+
+    let infos: Vec<VariantInfo> = variants
+        .iter()
+        .map(|(name, jwk)| VariantInfo {
+            variant: name,
+            kid: jwk.kid().to_string(),
+            kty: jwk.to_value()["kty"].as_str().unwrap().to_string(),
+        })
+        .collect();
+
+    insta::assert_yaml_snapshot!("public_jwk_enum_variants", infos);
+}
+
+#[test]
+fn snapshot_private_jwk_enum_variants() {
+    #[derive(Serialize)]
+    struct VariantInfo {
+        variant: &'static str,
+        kid: String,
+        kty: String,
+    }
+
+    let variants: [(&str, PrivateJwk); 4] = [
+        ("Rsa", PrivateJwk::Rsa(rsa_private("rsa-p-1"))),
+        ("Ec", PrivateJwk::Ec(ec_private("ec-p-1"))),
+        ("Okp", PrivateJwk::Okp(okp_private("okp-p-1"))),
+        ("Oct", PrivateJwk::Oct(oct_jwk("oct-p-1"))),
+    ];
+
+    let infos: Vec<VariantInfo> = variants
+        .iter()
+        .map(|(name, jwk)| VariantInfo {
+            variant: name,
+            kid: jwk.kid().to_string(),
+            kty: jwk.to_value()["kty"].as_str().unwrap().to_string(),
+        })
+        .collect();
+
+    insta::assert_yaml_snapshot!("private_jwk_enum_variants", infos);
+}
+
+// --- Debug redaction ---
+
+#[test]
+fn snapshot_private_debug_redaction() {
+    #[derive(Serialize)]
+    struct DebugInfo {
+        variant: &'static str,
+        debug_output: String,
+        contains_secret: bool,
+    }
+
+    let secret = "SUPER-SECRET-VALUE";
+    let variants: [(&str, String); 4] = [
+        (
+            "RsaPrivateJwk",
+            format!(
+                "{:?}",
+                RsaPrivateJwk {
+                    kty: "RSA",
+                    use_: "sig",
+                    alg: "RS256",
+                    kid: "k".into(),
+                    n: secret.into(),
+                    e: secret.into(),
+                    d: secret.into(),
+                    p: secret.into(),
+                    q: secret.into(),
+                    dp: secret.into(),
+                    dq: secret.into(),
+                    qi: secret.into(),
+                }
+            ),
+        ),
+        (
+            "EcPrivateJwk",
+            format!(
+                "{:?}",
+                EcPrivateJwk {
+                    kty: "EC",
+                    use_: "sig",
+                    alg: "ES256",
+                    crv: "P-256",
+                    kid: "k".into(),
+                    x: secret.into(),
+                    y: secret.into(),
+                    d: secret.into(),
+                }
+            ),
+        ),
+        (
+            "OkpPrivateJwk",
+            format!(
+                "{:?}",
+                OkpPrivateJwk {
+                    kty: "OKP",
+                    use_: "sig",
+                    alg: "EdDSA",
+                    crv: "Ed25519",
+                    kid: "k".into(),
+                    x: secret.into(),
+                    d: secret.into(),
+                }
+            ),
+        ),
+        (
+            "OctJwk",
+            format!(
+                "{:?}",
+                OctJwk {
+                    kty: "oct",
+                    use_: "sig",
+                    alg: "HS256",
+                    kid: "k".into(),
+                    k: secret.into(),
+                }
+            ),
+        ),
+    ];
+
+    let infos: Vec<DebugInfo> = variants
+        .iter()
+        .map(|(name, dbg)| DebugInfo {
+            variant: name,
+            debug_output: dbg.clone(),
+            contains_secret: dbg.contains(secret),
+        })
+        .collect();
+
+    insta::assert_yaml_snapshot!("private_debug_redaction", infos);
+}
+
+// --- JWKS ---
+
+#[test]
+fn snapshot_jwks_structure() {
+    let jwks = Jwks {
+        keys: vec![
+            AnyJwk::Public(PublicJwk::Rsa(rsa_public("key-a"))),
+            AnyJwk::Public(PublicJwk::Ec(ec_public("key-b"))),
+            AnyJwk::Private(PrivateJwk::Oct(oct_jwk("key-c"))),
+        ],
+    };
+
+    let value = jwks.to_value();
+    insta::assert_yaml_snapshot!("jwks_structure", value, {
+        ".keys[].n" => "[REDACTED]",
+        ".keys[].e" => "[REDACTED]",
+        ".keys[].x" => "[REDACTED]",
+        ".keys[].y" => "[REDACTED]",
+        ".keys[].k" => "[REDACTED]",
+    });
+}
+
+#[test]
+fn snapshot_jwks_display_is_valid_json() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::Public(PublicJwk::Okp(okp_public("disp-1")))],
+    };
+
+    let display = jwks.to_string();
+    let parsed: serde_json::Value = serde_json::from_str(&display).unwrap();
+
+    #[derive(Serialize)]
+    struct DisplayCheck {
+        has_keys_array: bool,
+        key_count: usize,
+    }
+
+    let check = DisplayCheck {
+        has_keys_array: parsed["keys"].is_array(),
+        key_count: parsed["keys"].as_array().unwrap().len(),
+    };
+
+    insta::assert_yaml_snapshot!("jwks_display_check", check);
+}

--- a/crates/uselesskey-core-jwk/Cargo.toml
+++ b/crates/uselesskey-core-jwk/Cargo.toml
@@ -19,7 +19,9 @@ uselesskey-core-jwk-shape = { path = "../uselesskey-core-jwk-shape", version = "
 uselesskey-core-jwk-builder = { path = "../uselesskey-core-jwk-builder", version = "0.1.0" }
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-core-jwk/tests/snapshots/snapshots_jwk__facade_jwks_builder_ordering.snap
+++ b/crates/uselesskey-core-jwk/tests/snapshots/snapshots_jwk__facade_jwks_builder_ordering.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-core-jwk/tests/snapshots_jwk.rs
+expression: info
+---
+key_count: 3
+kids:
+  - alpha
+  - mike
+  - zulu

--- a/crates/uselesskey-core-jwk/tests/snapshots/snapshots_jwk__facade_jwks_serialized.snap
+++ b/crates/uselesskey-core-jwk/tests/snapshots/snapshots_jwk__facade_jwks_serialized.snap
@@ -1,0 +1,17 @@
+---
+source: crates/uselesskey-core-jwk/tests/snapshots_jwk.rs
+expression: value
+---
+keys:
+  - alg: RS256
+    e: "[REDACTED]"
+    kid: key-1
+    kty: RSA
+    n: "[REDACTED]"
+    use: sig
+  - alg: EdDSA
+    crv: Ed25519
+    kid: key-2
+    kty: OKP
+    use: sig
+    x: "[REDACTED]"

--- a/crates/uselesskey-core-jwk/tests/snapshots/snapshots_jwk__facade_public_jwk_value.snap
+++ b/crates/uselesskey-core-jwk/tests/snapshots/snapshots_jwk__facade_public_jwk_value.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-core-jwk/tests/snapshots_jwk.rs
+expression: value
+---
+alg: RS256
+e: "[REDACTED]"
+kid: test-key
+kty: RSA
+n: "[REDACTED]"
+use: sig

--- a/crates/uselesskey-core-jwk/tests/snapshots/snapshots_jwk__facade_reexports_types.snap
+++ b/crates/uselesskey-core-jwk/tests/snapshots/snapshots_jwk__facade_reexports_types.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-jwk/tests/snapshots_jwk.rs
+expression: check
+---
+rsa_kty: RSA
+ec_kty: EC
+okp_kty: OKP

--- a/crates/uselesskey-core-jwk/tests/snapshots_jwk.rs
+++ b/crates/uselesskey-core-jwk/tests/snapshots_jwk.rs
@@ -1,0 +1,131 @@
+//! Insta snapshot tests for uselesskey-core-jwk.
+//!
+//! Verifies the facade re-exports and JwksBuilder integration
+//! with key material redacted.
+
+use serde::Serialize;
+use uselesskey_core_jwk::{EcPublicJwk, JwksBuilder, OkpPublicJwk, PublicJwk, RsaPublicJwk};
+
+fn rsa_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.into(),
+        n: "modulus-data".into(),
+        e: "AQAB".into(),
+    })
+}
+
+fn ec_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Ec(EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.into(),
+        x: "ec-x".into(),
+        y: "ec-y".into(),
+    })
+}
+
+fn okp_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Okp(OkpPublicJwk {
+        kty: "OKP",
+        use_: "sig",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        kid: kid.into(),
+        x: "okp-x".into(),
+    })
+}
+
+#[test]
+fn snapshot_facade_jwks_builder_ordering() {
+    #[derive(Serialize)]
+    struct JwksInfo {
+        key_count: usize,
+        kids: Vec<String>,
+    }
+
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("zulu"))
+        .add_public(ec_pub("alpha"))
+        .add_public(okp_pub("mike"))
+        .build();
+
+    let info = JwksInfo {
+        key_count: jwks.keys.len(),
+        kids: jwks.keys.iter().map(|k| k.kid().to_string()).collect(),
+    };
+
+    insta::assert_yaml_snapshot!("facade_jwks_builder_ordering", info);
+}
+
+#[test]
+fn snapshot_facade_jwks_serialized() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("key-1"))
+        .add_public(okp_pub("key-2"))
+        .build();
+
+    let value = jwks.to_value();
+    insta::assert_yaml_snapshot!("facade_jwks_serialized", value, {
+        ".keys[].n" => "[REDACTED]",
+        ".keys[].e" => "[REDACTED]",
+        ".keys[].x" => "[REDACTED]",
+    });
+}
+
+#[test]
+fn snapshot_facade_public_jwk_to_value() {
+    let jwk = rsa_pub("test-key");
+    let value = jwk.to_value();
+    insta::assert_yaml_snapshot!("facade_public_jwk_value", value, {
+        ".n" => "[REDACTED]",
+        ".e" => "[REDACTED]",
+    });
+}
+
+#[test]
+fn snapshot_facade_reexports_all_types() {
+    #[derive(Serialize)]
+    struct TypeCheck {
+        rsa_kty: &'static str,
+        ec_kty: &'static str,
+        okp_kty: &'static str,
+    }
+
+    let check = TypeCheck {
+        rsa_kty: RsaPublicJwk {
+            kty: "RSA",
+            use_: "sig",
+            alg: "RS256",
+            kid: "k".into(),
+            n: "n".into(),
+            e: "e".into(),
+        }
+        .kty,
+        ec_kty: EcPublicJwk {
+            kty: "EC",
+            use_: "sig",
+            alg: "ES256",
+            crv: "P-256",
+            kid: "k".into(),
+            x: "x".into(),
+            y: "y".into(),
+        }
+        .kty,
+        okp_kty: OkpPublicJwk {
+            kty: "OKP",
+            use_: "sig",
+            alg: "EdDSA",
+            crv: "Ed25519",
+            kid: "k".into(),
+            x: "x".into(),
+        }
+        .kty,
+    };
+
+    insta::assert_yaml_snapshot!("facade_reexports_types", check);
+}

--- a/crates/uselesskey-core-jwks-order/Cargo.toml
+++ b/crates/uselesskey-core-jwks-order/Cargo.toml
@@ -17,7 +17,9 @@ authors.workspace = true
 [dependencies]
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
+serde.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_already_sorted.snap
+++ b/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_already_sorted.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uselesskey-core-jwks-order/tests/snapshots_jwks_order.rs
+expression: result
+---
+kids:
+  - a
+  - b
+  - c
+tags:
+  - "1"
+  - "2"
+  - "3"

--- a/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_empty.snap
+++ b/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_empty.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uselesskey-core-jwks-order/tests/snapshots_jwks_order.rs
+expression: result
+---
+kids: []
+tags: []

--- a/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_lexicographic.snap
+++ b/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_lexicographic.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uselesskey-core-jwks-order/tests/snapshots_jwks_order.rs
+expression: result
+---
+kids:
+  - alpha
+  - bravo
+  - charlie
+tags:
+  - a
+  - b
+  - c

--- a/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_mixed.snap
+++ b/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_mixed.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uselesskey-core-jwks-order/tests/snapshots_jwks_order.rs
+expression: result
+---
+kids:
+  - a
+  - a
+  - m
+  - z
+  - z
+tags:
+  - a1
+  - a2
+  - m1
+  - z1
+  - z2

--- a/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_reverse.snap
+++ b/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_reverse.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uselesskey-core-jwks-order/tests/snapshots_jwks_order.rs
+expression: result
+---
+kids:
+  - a
+  - b
+  - c
+tags:
+  - "1"
+  - "2"
+  - "3"

--- a/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_single.snap
+++ b/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_single.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-jwks-order/tests/snapshots_jwks_order.rs
+expression: result
+---
+kids:
+  - only
+tags:
+  - single

--- a/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_stable_ties.snap
+++ b/crates/uselesskey-core-jwks-order/tests/snapshots/snapshots_jwks_order__kid_sorted_stable_ties.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uselesskey-core-jwks-order/tests/snapshots_jwks_order.rs
+expression: result
+---
+kids:
+  - dup
+  - dup
+  - dup
+tags:
+  - first
+  - second
+  - third

--- a/crates/uselesskey-core-jwks-order/tests/snapshots_jwks_order.rs
+++ b/crates/uselesskey-core-jwks-order/tests/snapshots_jwks_order.rs
@@ -1,0 +1,99 @@
+//! Insta snapshot tests for uselesskey-core-jwks-order.
+//!
+//! Snapshot KidSorted ordering semantics.
+
+use serde::Serialize;
+use uselesskey_core_jwks_order::{HasKid, KidSorted};
+
+#[derive(Clone)]
+struct Item {
+    kid: String,
+    tag: String,
+}
+
+impl HasKid for Item {
+    fn kid(&self) -> &str {
+        &self.kid
+    }
+}
+
+fn item(kid: &str, tag: &str) -> Item {
+    Item {
+        kid: kid.into(),
+        tag: tag.into(),
+    }
+}
+
+#[derive(Serialize)]
+struct OrderResult {
+    kids: Vec<String>,
+    tags: Vec<String>,
+}
+
+fn build_result(items: Vec<Item>) -> OrderResult {
+    let mut sorter = KidSorted::new();
+    for i in items {
+        sorter.push(i);
+    }
+    let sorted = sorter.build();
+    OrderResult {
+        kids: sorted.iter().map(|i| i.kid.clone()).collect(),
+        tags: sorted.iter().map(|i| i.tag.clone()).collect(),
+    }
+}
+
+#[test]
+fn snapshot_lexicographic_sort() {
+    let result = build_result(vec![
+        item("charlie", "c"),
+        item("alpha", "a"),
+        item("bravo", "b"),
+    ]);
+    insta::assert_yaml_snapshot!("kid_sorted_lexicographic", result);
+}
+
+#[test]
+fn snapshot_stable_tie_breaking() {
+    let result = build_result(vec![
+        item("dup", "first"),
+        item("dup", "second"),
+        item("dup", "third"),
+    ]);
+    insta::assert_yaml_snapshot!("kid_sorted_stable_ties", result);
+}
+
+#[test]
+fn snapshot_mixed_duplicates_and_unique() {
+    let result = build_result(vec![
+        item("z", "z1"),
+        item("a", "a1"),
+        item("m", "m1"),
+        item("a", "a2"),
+        item("z", "z2"),
+    ]);
+    insta::assert_yaml_snapshot!("kid_sorted_mixed", result);
+}
+
+#[test]
+fn snapshot_single_item() {
+    let result = build_result(vec![item("only", "single")]);
+    insta::assert_yaml_snapshot!("kid_sorted_single", result);
+}
+
+#[test]
+fn snapshot_empty() {
+    let result = build_result(vec![]);
+    insta::assert_yaml_snapshot!("kid_sorted_empty", result);
+}
+
+#[test]
+fn snapshot_already_sorted() {
+    let result = build_result(vec![item("a", "1"), item("b", "2"), item("c", "3")]);
+    insta::assert_yaml_snapshot!("kid_sorted_already_sorted", result);
+}
+
+#[test]
+fn snapshot_reverse_order() {
+    let result = build_result(vec![item("c", "3"), item("b", "2"), item("a", "1")]);
+    insta::assert_yaml_snapshot!("kid_sorted_reverse", result);
+}

--- a/crates/uselesskey-jwk/Cargo.toml
+++ b/crates/uselesskey-jwk/Cargo.toml
@@ -19,6 +19,8 @@ uselesskey-core-jwk = { path = "../uselesskey-core-jwk", version = "0.1.0" }
 uselesskey-core-jwk-builder = { path = "../uselesskey-core-jwk-builder", version = "0.1.0" }
 
 [dev-dependencies]
+insta.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-jwk/tests/snapshots/snapshots_jwk_facade__jwk_facade_any_conversion.snap
+++ b/crates/uselesskey-jwk/tests/snapshots/snapshots_jwk_facade__jwk_facade_any_conversion.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uselesskey-jwk/tests/snapshots_jwk_facade.rs
+expression: check
+---
+public_kid: from-pub
+private_kid: from-priv

--- a/crates/uselesskey-jwk/tests/snapshots/snapshots_jwk_facade__jwk_facade_builder_ordering.snap
+++ b/crates/uselesskey-jwk/tests/snapshots/snapshots_jwk_facade__jwk_facade_builder_ordering.snap
@@ -1,0 +1,9 @@
+---
+source: crates/uselesskey-jwk/tests/snapshots_jwk_facade.rs
+expression: info
+---
+key_count: 3
+kids:
+  - alpha
+  - beta
+  - gamma

--- a/crates/uselesskey-jwk/tests/snapshots/snapshots_jwk_facade__jwk_facade_display_roundtrip.snap
+++ b/crates/uselesskey-jwk/tests/snapshots/snapshots_jwk_facade__jwk_facade_display_roundtrip.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-jwk/tests/snapshots_jwk_facade.rs
+expression: check
+---
+is_valid_json: true
+has_keys_array: true
+key_count: 1

--- a/crates/uselesskey-jwk/tests/snapshots/snapshots_jwk_facade__jwk_facade_mixed_keys.snap
+++ b/crates/uselesskey-jwk/tests/snapshots/snapshots_jwk_facade__jwk_facade_mixed_keys.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uselesskey-jwk/tests/snapshots_jwk_facade.rs
+expression: value
+---
+keys:
+  - alg: HS256
+    k: "[REDACTED]"
+    kid: priv-key
+    kty: oct
+    use: sig
+  - alg: RS256
+    e: "[REDACTED]"
+    kid: pub-key
+    kty: RSA
+    n: "[REDACTED]"
+    use: sig

--- a/crates/uselesskey-jwk/tests/snapshots_jwk_facade.rs
+++ b/crates/uselesskey-jwk/tests/snapshots_jwk_facade.rs
@@ -1,0 +1,123 @@
+//! Insta snapshot tests for uselesskey-jwk (public facade).
+//!
+//! Verifies the top-level facade re-exports with key material redacted.
+
+use serde::Serialize;
+use uselesskey_jwk::{
+    AnyJwk, EcPublicJwk, JwksBuilder, OctJwk, OkpPublicJwk, PrivateJwk, PublicJwk, RsaPublicJwk,
+};
+
+fn rsa_pub(kid: &str) -> PublicJwk {
+    PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.into(),
+        n: "rsa-n".into(),
+        e: "AQAB".into(),
+    })
+}
+
+fn oct_priv(kid: &str) -> PrivateJwk {
+    PrivateJwk::Oct(OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: kid.into(),
+        k: "secret-k".into(),
+    })
+}
+
+#[test]
+fn snapshot_jwk_facade_builder_ordering() {
+    #[derive(Serialize)]
+    struct JwksInfo {
+        key_count: usize,
+        kids: Vec<String>,
+    }
+
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("beta"))
+        .add_public(PublicJwk::Ec(EcPublicJwk {
+            kty: "EC",
+            use_: "sig",
+            alg: "ES256",
+            crv: "P-256",
+            kid: "alpha".into(),
+            x: "x".into(),
+            y: "y".into(),
+        }))
+        .add_public(PublicJwk::Okp(OkpPublicJwk {
+            kty: "OKP",
+            use_: "sig",
+            alg: "EdDSA",
+            crv: "Ed25519",
+            kid: "gamma".into(),
+            x: "x".into(),
+        }))
+        .build();
+
+    let info = JwksInfo {
+        key_count: jwks.keys.len(),
+        kids: jwks.keys.iter().map(|k| k.kid().to_string()).collect(),
+    };
+
+    insta::assert_yaml_snapshot!("jwk_facade_builder_ordering", info);
+}
+
+#[test]
+fn snapshot_jwk_facade_mixed_keys() {
+    let jwks = JwksBuilder::new()
+        .add_public(rsa_pub("pub-key"))
+        .add_private(oct_priv("priv-key"))
+        .build();
+
+    let value = jwks.to_value();
+    insta::assert_yaml_snapshot!("jwk_facade_mixed_keys", value, {
+        ".keys[].n" => "[REDACTED]",
+        ".keys[].e" => "[REDACTED]",
+        ".keys[].k" => "[REDACTED]",
+    });
+}
+
+#[test]
+fn snapshot_jwk_facade_any_jwk_conversion() {
+    #[derive(Serialize)]
+    struct ConversionCheck {
+        public_kid: String,
+        private_kid: String,
+    }
+
+    let pub_any = AnyJwk::from(rsa_pub("from-pub"));
+    let priv_any = AnyJwk::from(oct_priv("from-priv"));
+
+    let check = ConversionCheck {
+        public_kid: pub_any.kid().to_string(),
+        private_kid: priv_any.kid().to_string(),
+    };
+
+    insta::assert_yaml_snapshot!("jwk_facade_any_conversion", check);
+}
+
+#[test]
+fn snapshot_jwk_facade_display_roundtrip() {
+    let jwks = JwksBuilder::new().add_public(rsa_pub("key-1")).build();
+
+    let display = jwks.to_string();
+    let parsed: serde_json::Value = serde_json::from_str(&display).unwrap();
+
+    #[derive(Serialize)]
+    struct RoundtripCheck {
+        is_valid_json: bool,
+        has_keys_array: bool,
+        key_count: usize,
+    }
+
+    let check = RoundtripCheck {
+        is_valid_json: true,
+        has_keys_array: parsed["keys"].is_array(),
+        key_count: parsed["keys"].as_array().unwrap().len(),
+    };
+
+    insta::assert_yaml_snapshot!("jwk_facade_display_roundtrip", check);
+}


### PR DESCRIPTION
Add insta snapshot tests for five JWK crates that previously lacked them: uselesskey-core-jwk-shape (12 tests), uselesskey-core-jwks-order (7 tests), uselesskey-core-jwk-builder (7 tests), uselesskey-core-jwk (4 tests), uselesskey-jwk (4 tests). Total: 34 new snapshot tests. All cryptographic key material is redacted with [REDACTED] in snapshots.