### PR TITLE
feat: add insta snapshot tests for X.509 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,7 +3958,9 @@ dependencies = [
 name = "uselesskey-core-rustls-pki"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "rustls-pki-types",
+ "serde",
  "uselesskey-core",
  "uselesskey-ecdsa",
  "uselesskey-ed25519",
@@ -4017,10 +4019,12 @@ dependencies = [
 name = "uselesskey-core-x509"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rstest",
+ "serde",
  "uselesskey-core-x509-derive",
  "uselesskey-core-x509-negative",
  "uselesskey-core-x509-spec",
@@ -4041,9 +4045,11 @@ dependencies = [
 name = "uselesskey-core-x509-derive"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rcgen",
+ "serde",
  "time",
  "uselesskey-core-hash",
 ]
@@ -4052,8 +4058,10 @@ dependencies = [
 name = "uselesskey-core-x509-negative"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proptest",
  "rstest",
+ "serde",
  "uselesskey-core-x509-chain-negative",
  "uselesskey-core-x509-spec",
 ]

--- a/crates/uselesskey-core-rustls-pki/Cargo.toml
+++ b/crates/uselesskey-core-rustls-pki/Cargo.toml
@@ -32,6 +32,8 @@ ed25519 = ["dep:uselesskey-ed25519"]
 all = ["x509", "rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
+insta.workspace = true
+serde = { workspace = true, features = ["derive"] }
 uselesskey-core = { path = "../uselesskey-core", version = "0.1.0" }
 uselesskey-x509 = { path = "../uselesskey-x509", version = "0.1.0" }
 uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.1.0" }

--- a/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__chain_rustls_conversion.snap
+++ b/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__chain_rustls_conversion.snap
@@ -1,0 +1,11 @@
+---
+source: crates/uselesskey-core-rustls-pki/tests/snapshots_rustls_pki.rs
+expression: snap
+---
+leaf_private_key_der_len: 1217
+leaf_cert_der_len: 806
+chain_cert_count: 2
+root_cert_der_len: 796
+private_key_matches_source: true
+leaf_cert_matches_source: true
+root_cert_matches_source: true

--- a/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__ecdsa_rustls_conversion.snap
+++ b/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__ecdsa_rustls_conversion.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uselesskey-core-rustls-pki/tests/snapshots_rustls_pki.rs
+expression: results
+---
+- curve: P-256
+  private_key_der_len: 138
+  matches_source: true
+- curve: P-384
+  private_key_der_len: 185
+  matches_source: true

--- a/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__ed25519_rustls_conversion.snap
+++ b/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__ed25519_rustls_conversion.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uselesskey-core-rustls-pki/tests/snapshots_rustls_pki.rs
+expression: snap
+---
+private_key_der_len: 83
+matches_source: true

--- a/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__rsa_rustls_conversion.snap
+++ b/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__rsa_rustls_conversion.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uselesskey-core-rustls-pki/tests/snapshots_rustls_pki.rs
+expression: snap
+---
+private_key_der_len: 1219
+matches_source: true

--- a/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__self_signed_rustls_conversion.snap
+++ b/crates/uselesskey-core-rustls-pki/tests/snapshots/snapshots_rustls_pki__self_signed_rustls_conversion.snap
@@ -1,0 +1,8 @@
+---
+source: crates/uselesskey-core-rustls-pki/tests/snapshots_rustls_pki.rs
+expression: snap
+---
+private_key_der_len: 1218
+cert_der_len: 758
+private_key_matches_source: true
+cert_matches_source: true

--- a/crates/uselesskey-core-rustls-pki/tests/snapshots_rustls_pki.rs
+++ b/crates/uselesskey-core-rustls-pki/tests/snapshots_rustls_pki.rs
@@ -1,0 +1,170 @@
+//! Insta snapshot tests for uselesskey-core-rustls-pki.
+//!
+//! These tests snapshot PKI type conversion metadata (DER lengths,
+//! chain counts) to detect unintended changes. All key material
+//! and certificate bytes are redacted.
+
+mod testutil;
+
+use serde::Serialize;
+use testutil::fx;
+use uselesskey_core_rustls_pki::{RustlsCertExt, RustlsChainExt, RustlsPrivateKeyExt};
+use uselesskey_x509::{ChainSpec, X509FactoryExt, X509Spec};
+
+// ---------------------------------------------------------------------------
+// Self-signed certificate conversions
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct SelfSignedConversion {
+    private_key_der_len: usize,
+    cert_der_len: usize,
+    private_key_matches_source: bool,
+    cert_matches_source: bool,
+}
+
+#[test]
+fn snapshot_self_signed_rustls_conversion() {
+    let fx = fx();
+    let cert = fx.x509_self_signed("snap-ss", X509Spec::self_signed("snap.example.com"));
+
+    let key = cert.private_key_der_rustls();
+    let cert_der = cert.certificate_der_rustls();
+
+    let snap = SelfSignedConversion {
+        private_key_der_len: key.secret_der().len(),
+        cert_der_len: cert_der.as_ref().len(),
+        private_key_matches_source: key.secret_der() == cert.private_key_pkcs8_der(),
+        cert_matches_source: cert_der.as_ref() == cert.cert_der(),
+    };
+    insta::assert_yaml_snapshot!("self_signed_rustls_conversion", snap);
+}
+
+// ---------------------------------------------------------------------------
+// Chain conversions
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ChainConversion {
+    leaf_private_key_der_len: usize,
+    leaf_cert_der_len: usize,
+    chain_cert_count: usize,
+    root_cert_der_len: usize,
+    private_key_matches_source: bool,
+    leaf_cert_matches_source: bool,
+    root_cert_matches_source: bool,
+}
+
+#[test]
+fn snapshot_chain_rustls_conversion() {
+    let fx = fx();
+    let chain = fx.x509_chain("snap-chain", ChainSpec::new("chain.example.com"));
+
+    let key = chain.private_key_der_rustls();
+    let leaf_cert = chain.certificate_der_rustls();
+    let chain_certs = chain.chain_der_rustls();
+    let root_cert = chain.root_certificate_der_rustls();
+
+    let snap = ChainConversion {
+        leaf_private_key_der_len: key.secret_der().len(),
+        leaf_cert_der_len: leaf_cert.as_ref().len(),
+        chain_cert_count: chain_certs.len(),
+        root_cert_der_len: root_cert.as_ref().len(),
+        private_key_matches_source: key.secret_der() == chain.leaf_private_key_pkcs8_der(),
+        leaf_cert_matches_source: leaf_cert.as_ref() == chain.leaf_cert_der(),
+        root_cert_matches_source: root_cert.as_ref() == chain.root_cert_der(),
+    };
+    insta::assert_yaml_snapshot!("chain_rustls_conversion", snap);
+}
+
+// ---------------------------------------------------------------------------
+// RSA key conversion
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct RsaConversion {
+    private_key_der_len: usize,
+    matches_source: bool,
+}
+
+#[test]
+fn snapshot_rsa_rustls_conversion() {
+    use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+    let fx = fx();
+    let kp = fx.rsa("snap-rsa", RsaSpec::rs256());
+
+    let key = kp.private_key_der_rustls();
+
+    let snap = RsaConversion {
+        private_key_der_len: key.secret_der().len(),
+        matches_source: key.secret_der() == kp.private_key_pkcs8_der(),
+    };
+    insta::assert_yaml_snapshot!("rsa_rustls_conversion", snap);
+}
+
+// ---------------------------------------------------------------------------
+// ECDSA key conversion
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct EcdsaConversion {
+    curve: &'static str,
+    private_key_der_len: usize,
+    matches_source: bool,
+}
+
+#[test]
+fn snapshot_ecdsa_rustls_conversion() {
+    use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
+
+    let fx = fx();
+
+    let results: Vec<EcdsaConversion> = vec![
+        {
+            let kp = fx.ecdsa("snap-p256", EcdsaSpec::es256());
+            let key = kp.private_key_der_rustls();
+            EcdsaConversion {
+                curve: "P-256",
+                private_key_der_len: key.secret_der().len(),
+                matches_source: key.secret_der() == kp.private_key_pkcs8_der(),
+            }
+        },
+        {
+            let kp = fx.ecdsa("snap-p384", EcdsaSpec::es384());
+            let key = kp.private_key_der_rustls();
+            EcdsaConversion {
+                curve: "P-384",
+                private_key_der_len: key.secret_der().len(),
+                matches_source: key.secret_der() == kp.private_key_pkcs8_der(),
+            }
+        },
+    ];
+    insta::assert_yaml_snapshot!("ecdsa_rustls_conversion", results);
+}
+
+// ---------------------------------------------------------------------------
+// Ed25519 key conversion
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct Ed25519Conversion {
+    private_key_der_len: usize,
+    matches_source: bool,
+}
+
+#[test]
+fn snapshot_ed25519_rustls_conversion() {
+    use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
+
+    let fx = fx();
+    let kp = fx.ed25519("snap-ed25519", Ed25519Spec::new());
+
+    let key = kp.private_key_der_rustls();
+
+    let snap = Ed25519Conversion {
+        private_key_der_len: key.secret_der().len(),
+        matches_source: key.secret_der() == kp.private_key_pkcs8_der(),
+    };
+    insta::assert_yaml_snapshot!("ed25519_rustls_conversion", snap);
+}

--- a/crates/uselesskey-core-rustls-pki/tests/testutil.rs
+++ b/crates/uselesskey-core-rustls-pki/tests/testutil.rs
@@ -1,0 +1,14 @@
+use std::sync::OnceLock;
+
+use uselesskey_core::{Factory, Seed};
+
+static FX: OnceLock<Factory> = OnceLock::new();
+
+pub fn fx() -> Factory {
+    FX.get_or_init(|| {
+        let seed = Seed::from_env_value("uselesskey-rustls-pki-snap-seed-v1")
+            .expect("test seed should always parse");
+        Factory::deterministic(seed)
+    })
+    .clone()
+}

--- a/crates/uselesskey-core-x509-derive/Cargo.toml
+++ b/crates/uselesskey-core-x509-derive/Cargo.toml
@@ -21,7 +21,9 @@ rcgen = "0.13"
 time = "0.3"
 
 [dev-dependencies]
+insta.workspace = true
 rand_chacha.workspace = true
+serde = { workspace = true, features = ["derive"] }
 uselesskey-core-hash = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__base_time_boundary_safety.snap
+++ b/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__base_time_boundary_safety.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-x509-derive/tests/snapshots_derive.rs
+expression: snap
+---
+ab_c_ordinal: 284
+a_bc_ordinal: 52
+differ: true

--- a/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__base_time_known_inputs.snap
+++ b/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__base_time_known_inputs.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uselesskey-core-x509-derive/tests/snapshots_derive.rs
+expression: results
+---
+- label: leaf-label
+  year: 2025
+  ordinal_day: 219
+- label: root-ca
+  year: 2025
+  ordinal_day: 16
+- label: empty-parts
+  year: 2025
+  ordinal_day: 313
+- label: single-part
+  year: 2025
+  ordinal_day: 289

--- a/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__derive_constants.snap
+++ b/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__derive_constants.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-x509-derive/tests/snapshots_derive.rs
+expression: c
+---
+base_time_epoch_unix: 1735689600
+base_time_window_days: 365
+serial_number_bytes: 16

--- a/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__serial_determinism.snap
+++ b/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__serial_determinism.snap
@@ -1,0 +1,6 @@
+---
+source: crates/uselesskey-core-x509-derive/tests/snapshots_derive.rs
+expression: snap
+---
+same_seed_same_serial: true
+byte_count: 16

--- a/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__serial_numbers.snap
+++ b/crates/uselesskey-core-x509-derive/tests/snapshots/snapshots_derive__serial_numbers.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uselesskey-core-x509-derive/tests/snapshots_derive.rs
+expression: results
+---
+- seed_byte: 0
+  byte_count: 16
+  high_bit_cleared: true
+  serial_hex: "[REDACTED]"
+- seed_byte: 42
+  byte_count: 16
+  high_bit_cleared: true
+  serial_hex: "[REDACTED]"
+- seed_byte: 255
+  byte_count: 16
+  high_bit_cleared: true
+  serial_hex: "[REDACTED]"

--- a/crates/uselesskey-core-x509-derive/tests/snapshots_derive.rs
+++ b/crates/uselesskey-core-x509-derive/tests/snapshots_derive.rs
@@ -1,0 +1,136 @@
+//! Insta snapshot tests for uselesskey-core-x509-derive.
+//!
+//! These tests snapshot deterministic base-time derivation and
+//! serial-number generation to detect unintended changes.
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use serde::Serialize;
+use uselesskey_core_x509_derive::{
+    BASE_TIME_EPOCH_UNIX, BASE_TIME_WINDOW_DAYS, SERIAL_NUMBER_BYTES,
+    deterministic_base_time_from_parts, deterministic_serial_number,
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct Constants {
+    base_time_epoch_unix: i64,
+    base_time_window_days: u32,
+    serial_number_bytes: usize,
+}
+
+#[test]
+fn snapshot_constants() {
+    let c = Constants {
+        base_time_epoch_unix: BASE_TIME_EPOCH_UNIX,
+        base_time_window_days: BASE_TIME_WINDOW_DAYS,
+        serial_number_bytes: SERIAL_NUMBER_BYTES,
+    };
+    insta::assert_yaml_snapshot!("derive_constants", c);
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic base-time
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct BaseTimeSnapshot {
+    label: &'static str,
+    year: i32,
+    ordinal_day: u16,
+}
+
+fn base_time_snap(label: &'static str, parts: &[&[u8]]) -> BaseTimeSnapshot {
+    let t = deterministic_base_time_from_parts(parts);
+    BaseTimeSnapshot {
+        label,
+        year: t.year(),
+        ordinal_day: t.ordinal(),
+    }
+}
+
+#[test]
+fn snapshot_base_time_known_inputs() {
+    let results: Vec<BaseTimeSnapshot> = vec![
+        base_time_snap("leaf-label", &[b"leaf-label", b"leaf"]),
+        base_time_snap("root-ca", &[b"root-ca", b"root", b"2048"]),
+        base_time_snap("empty-parts", &[]),
+        base_time_snap("single-part", &[b"only"]),
+    ];
+    insta::assert_yaml_snapshot!("base_time_known_inputs", results);
+}
+
+#[test]
+fn snapshot_base_time_boundary_safety() {
+    let a = deterministic_base_time_from_parts(&[b"ab", b"c"]);
+    let b = deterministic_base_time_from_parts(&[b"a", b"bc"]);
+
+    #[derive(Serialize)]
+    struct BoundarySafety {
+        ab_c_ordinal: u16,
+        a_bc_ordinal: u16,
+        differ: bool,
+    }
+
+    let snap = BoundarySafety {
+        ab_c_ordinal: a.ordinal(),
+        a_bc_ordinal: b.ordinal(),
+        differ: a != b,
+    };
+    insta::assert_yaml_snapshot!("base_time_boundary_safety", snap);
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic serial number
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct SerialSnapshot {
+    seed_byte: u8,
+    byte_count: usize,
+    high_bit_cleared: bool,
+    serial_hex: String,
+}
+
+#[test]
+fn snapshot_serial_numbers() {
+    let results: Vec<SerialSnapshot> = [0u8, 42, 255]
+        .into_iter()
+        .map(|seed_byte| {
+            let mut rng = ChaCha20Rng::from_seed([seed_byte; 32]);
+            let serial = deterministic_serial_number(&mut rng);
+            let bytes = serial.to_bytes();
+            SerialSnapshot {
+                seed_byte,
+                byte_count: bytes.len(),
+                high_bit_cleared: bytes[0] & 0x80 == 0,
+                serial_hex: "[REDACTED]".to_string(),
+            }
+        })
+        .collect();
+    insta::assert_yaml_snapshot!("serial_numbers", results);
+}
+
+#[test]
+fn snapshot_serial_determinism() {
+    let mut rng_a = ChaCha20Rng::from_seed([42u8; 32]);
+    let mut rng_b = ChaCha20Rng::from_seed([42u8; 32]);
+
+    let serial_a = deterministic_serial_number(&mut rng_a);
+    let serial_b = deterministic_serial_number(&mut rng_b);
+
+    #[derive(Serialize)]
+    struct Determinism {
+        same_seed_same_serial: bool,
+        byte_count: usize,
+    }
+
+    let snap = Determinism {
+        same_seed_same_serial: serial_a.to_bytes() == serial_b.to_bytes(),
+        byte_count: serial_a.to_bytes().len(),
+    };
+    insta::assert_yaml_snapshot!("serial_determinism", snap);
+}

--- a/crates/uselesskey-core-x509-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-negative/Cargo.toml
@@ -19,8 +19,10 @@ uselesskey-core-x509-chain-negative = { path = "../uselesskey-core-x509-chain-ne
 uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.1.0" }
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
 rstest.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/crates/uselesskey-core-x509-negative/tests/snapshots/snapshots_negative__chain_negative_applied_specs.snap
+++ b/crates/uselesskey-core-x509-negative/tests/snapshots/snapshots_negative__chain_negative_applied_specs.snap
@@ -1,0 +1,49 @@
+---
+source: crates/uselesskey-core-x509-negative/tests/snapshots_negative.rs
+expression: specs
+---
+- variant: "hostname_mismatch:evil.example.com"
+  leaf_cn: evil.example.com
+  leaf_sans:
+    - evil.example.com
+  root_cn: chain.example.com Root CA
+  leaf_validity_days: 3650
+  intermediate_validity_days: 1825
+  leaf_not_before_offset_days: ~
+  intermediate_not_before_offset_days: ~
+- variant: unknown_ca
+  leaf_cn: chain.example.com
+  leaf_sans:
+    - chain.example.com
+  root_cn: chain.example.com Unknown Root CA
+  leaf_validity_days: 3650
+  intermediate_validity_days: 1825
+  leaf_not_before_offset_days: ~
+  intermediate_not_before_offset_days: ~
+- variant: expired_leaf
+  leaf_cn: chain.example.com
+  leaf_sans:
+    - chain.example.com
+  root_cn: chain.example.com Root CA
+  leaf_validity_days: 1
+  intermediate_validity_days: 1825
+  leaf_not_before_offset_days: 730
+  intermediate_not_before_offset_days: ~
+- variant: expired_intermediate
+  leaf_cn: chain.example.com
+  leaf_sans:
+    - chain.example.com
+  root_cn: chain.example.com Root CA
+  leaf_validity_days: 3650
+  intermediate_validity_days: 1
+  leaf_not_before_offset_days: ~
+  intermediate_not_before_offset_days: 730
+- variant: revoked_leaf
+  leaf_cn: chain.example.com
+  leaf_sans:
+    - chain.example.com
+  root_cn: chain.example.com Root CA
+  leaf_validity_days: 3650
+  intermediate_validity_days: 1825
+  leaf_not_before_offset_days: ~
+  intermediate_not_before_offset_days: ~

--- a/crates/uselesskey-core-x509-negative/tests/snapshots/snapshots_negative__chain_negative_variant_names.snap
+++ b/crates/uselesskey-core-x509-negative/tests/snapshots/snapshots_negative__chain_negative_variant_names.snap
@@ -1,0 +1,14 @@
+---
+source: crates/uselesskey-core-x509-negative/tests/snapshots_negative.rs
+expression: metas
+---
+- variant: HostnameMismatch
+  variant_name: "hostname_mismatch:evil.example.com"
+- variant: UnknownCa
+  variant_name: unknown_ca
+- variant: ExpiredLeaf
+  variant_name: expired_leaf
+- variant: ExpiredIntermediate
+  variant_name: expired_intermediate
+- variant: RevokedLeaf
+  variant_name: revoked_leaf

--- a/crates/uselesskey-core-x509-negative/tests/snapshots/snapshots_negative__x509_negative_applied_specs.snap
+++ b/crates/uselesskey-core-x509-negative/tests/snapshots/snapshots_negative__x509_negative_applied_specs.snap
@@ -1,0 +1,40 @@
+---
+source: crates/uselesskey-core-x509-negative/tests/snapshots_negative.rs
+expression: specs
+---
+- variant: Expired
+  subject_cn: neg.example.com
+  not_before_offset: DaysAgo(395)
+  validity_days: 365
+  is_ca: false
+  key_cert_sign: false
+  crl_sign: false
+  digital_signature: true
+  key_encipherment: true
+- variant: NotYetValid
+  subject_cn: neg.example.com
+  not_before_offset: DaysFromNow(30)
+  validity_days: 365
+  is_ca: false
+  key_cert_sign: false
+  crl_sign: false
+  digital_signature: true
+  key_encipherment: true
+- variant: WrongKeyUsage
+  subject_cn: neg.example.com
+  not_before_offset: DaysAgo(1)
+  validity_days: 3650
+  is_ca: true
+  key_cert_sign: false
+  crl_sign: false
+  digital_signature: true
+  key_encipherment: true
+- variant: SelfSignedButClaimsCA
+  subject_cn: neg.example.com
+  not_before_offset: DaysAgo(1)
+  validity_days: 3650
+  is_ca: true
+  key_cert_sign: true
+  crl_sign: true
+  digital_signature: true
+  key_encipherment: false

--- a/crates/uselesskey-core-x509-negative/tests/snapshots/snapshots_negative__x509_negative_variant_metadata.snap
+++ b/crates/uselesskey-core-x509-negative/tests/snapshots/snapshots_negative__x509_negative_variant_metadata.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uselesskey-core-x509-negative/tests/snapshots_negative.rs
+expression: metas
+---
+- variant: Expired
+  variant_name: expired
+  description: Certificate with not_after in the past (expired)
+- variant: NotYetValid
+  variant_name: not_yet_valid
+  description: Certificate with not_before in the future (not yet valid)
+- variant: WrongKeyUsage
+  variant_name: wrong_key_usage
+  description: Certificate marked as CA but without keyCertSign key usage
+- variant: SelfSignedButClaimsCA
+  variant_name: self_signed_ca
+  description: Self-signed certificate that claims to be a CA

--- a/crates/uselesskey-core-x509-negative/tests/snapshots_negative.rs
+++ b/crates/uselesskey-core-x509-negative/tests/snapshots_negative.rs
@@ -1,0 +1,182 @@
+//! Insta snapshot tests for uselesskey-core-x509-negative.
+//!
+//! These tests snapshot negative-fixture policy application and
+//! variant metadata to detect unintended changes.
+
+use serde::Serialize;
+use uselesskey_core_x509_negative::{ChainNegative, X509Negative};
+use uselesskey_core_x509_spec::{NotBeforeOffset, X509Spec};
+
+// ---------------------------------------------------------------------------
+// X509Negative variant metadata
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct VariantMeta {
+    variant: &'static str,
+    variant_name: &'static str,
+    description: &'static str,
+}
+
+#[test]
+fn snapshot_x509_negative_variant_metadata() {
+    let metas: Vec<VariantMeta> = vec![
+        VariantMeta {
+            variant: "Expired",
+            variant_name: X509Negative::Expired.variant_name(),
+            description: X509Negative::Expired.description(),
+        },
+        VariantMeta {
+            variant: "NotYetValid",
+            variant_name: X509Negative::NotYetValid.variant_name(),
+            description: X509Negative::NotYetValid.description(),
+        },
+        VariantMeta {
+            variant: "WrongKeyUsage",
+            variant_name: X509Negative::WrongKeyUsage.variant_name(),
+            description: X509Negative::WrongKeyUsage.description(),
+        },
+        VariantMeta {
+            variant: "SelfSignedButClaimsCA",
+            variant_name: X509Negative::SelfSignedButClaimsCA.variant_name(),
+            description: X509Negative::SelfSignedButClaimsCA.description(),
+        },
+    ];
+    insta::assert_yaml_snapshot!("x509_negative_variant_metadata", metas);
+}
+
+// ---------------------------------------------------------------------------
+// X509Negative::apply_to_spec — full spec output
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct AppliedSpecSnapshot {
+    variant: &'static str,
+    subject_cn: String,
+    not_before_offset: String,
+    validity_days: u32,
+    is_ca: bool,
+    key_cert_sign: bool,
+    crl_sign: bool,
+    digital_signature: bool,
+    key_encipherment: bool,
+}
+
+fn fmt_offset(o: &NotBeforeOffset) -> String {
+    match o {
+        NotBeforeOffset::DaysAgo(d) => format!("DaysAgo({d})"),
+        NotBeforeOffset::DaysFromNow(d) => format!("DaysFromNow({d})"),
+    }
+}
+
+fn apply_snapshot(variant: &'static str, neg: X509Negative) -> AppliedSpecSnapshot {
+    let base = X509Spec::self_signed("neg.example.com");
+    let spec = neg.apply_to_spec(&base);
+    AppliedSpecSnapshot {
+        variant,
+        subject_cn: spec.subject_cn,
+        not_before_offset: fmt_offset(&spec.not_before_offset),
+        validity_days: spec.validity_days,
+        is_ca: spec.is_ca,
+        key_cert_sign: spec.key_usage.key_cert_sign,
+        crl_sign: spec.key_usage.crl_sign,
+        digital_signature: spec.key_usage.digital_signature,
+        key_encipherment: spec.key_usage.key_encipherment,
+    }
+}
+
+#[test]
+fn snapshot_x509_negative_applied_specs() {
+    let specs: Vec<AppliedSpecSnapshot> = vec![
+        apply_snapshot("Expired", X509Negative::Expired),
+        apply_snapshot("NotYetValid", X509Negative::NotYetValid),
+        apply_snapshot("WrongKeyUsage", X509Negative::WrongKeyUsage),
+        apply_snapshot("SelfSignedButClaimsCA", X509Negative::SelfSignedButClaimsCA),
+    ];
+    insta::assert_yaml_snapshot!("x509_negative_applied_specs", specs);
+}
+
+// ---------------------------------------------------------------------------
+// ChainNegative variant metadata
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ChainVariantMeta {
+    variant: &'static str,
+    variant_name: String,
+}
+
+#[test]
+fn snapshot_chain_negative_variant_names() {
+    let metas: Vec<ChainVariantMeta> = vec![
+        ChainVariantMeta {
+            variant: "HostnameMismatch",
+            variant_name: ChainNegative::HostnameMismatch {
+                wrong_hostname: "evil.example.com".to_string(),
+            }
+            .variant_name(),
+        },
+        ChainVariantMeta {
+            variant: "UnknownCa",
+            variant_name: ChainNegative::UnknownCa.variant_name(),
+        },
+        ChainVariantMeta {
+            variant: "ExpiredLeaf",
+            variant_name: ChainNegative::ExpiredLeaf.variant_name(),
+        },
+        ChainVariantMeta {
+            variant: "ExpiredIntermediate",
+            variant_name: ChainNegative::ExpiredIntermediate.variant_name(),
+        },
+        ChainVariantMeta {
+            variant: "RevokedLeaf",
+            variant_name: ChainNegative::RevokedLeaf.variant_name(),
+        },
+    ];
+    insta::assert_yaml_snapshot!("chain_negative_variant_names", metas);
+}
+
+// ---------------------------------------------------------------------------
+// ChainNegative::apply_to_spec
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ChainAppliedSnapshot {
+    variant: String,
+    leaf_cn: String,
+    leaf_sans: Vec<String>,
+    root_cn: String,
+    leaf_validity_days: u32,
+    intermediate_validity_days: u32,
+    leaf_not_before_offset_days: Option<i64>,
+    intermediate_not_before_offset_days: Option<i64>,
+}
+
+fn chain_apply_snapshot(neg: &ChainNegative) -> ChainAppliedSnapshot {
+    let base = uselesskey_core_x509_spec::ChainSpec::new("chain.example.com");
+    let spec = neg.apply_to_spec(&base);
+    ChainAppliedSnapshot {
+        variant: neg.variant_name(),
+        leaf_cn: spec.leaf_cn,
+        leaf_sans: spec.leaf_sans,
+        root_cn: spec.root_cn,
+        leaf_validity_days: spec.leaf_validity_days,
+        intermediate_validity_days: spec.intermediate_validity_days,
+        leaf_not_before_offset_days: spec.leaf_not_before_offset_days,
+        intermediate_not_before_offset_days: spec.intermediate_not_before_offset_days,
+    }
+}
+
+#[test]
+fn snapshot_chain_negative_applied_specs() {
+    let specs: Vec<ChainAppliedSnapshot> = vec![
+        chain_apply_snapshot(&ChainNegative::HostnameMismatch {
+            wrong_hostname: "evil.example.com".to_string(),
+        }),
+        chain_apply_snapshot(&ChainNegative::UnknownCa),
+        chain_apply_snapshot(&ChainNegative::ExpiredLeaf),
+        chain_apply_snapshot(&ChainNegative::ExpiredIntermediate),
+        chain_apply_snapshot(&ChainNegative::RevokedLeaf),
+    ];
+    insta::assert_yaml_snapshot!("chain_negative_applied_specs", specs);
+}

--- a/crates/uselesskey-core-x509/Cargo.toml
+++ b/crates/uselesskey-core-x509/Cargo.toml
@@ -20,10 +20,12 @@ uselesskey-core-x509-derive = { path = "../uselesskey-core-x509-derive", version
 uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.1.0" }
 
 [dev-dependencies]
+insta.workspace = true
 proptest.workspace = true
 rand_chacha.workspace = true
 rand_core.workspace = true
 rstest.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__chain_negative_all_variants.snap
+++ b/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__chain_negative_all_variants.snap
@@ -1,0 +1,49 @@
+---
+source: crates/uselesskey-core-x509/tests/snapshots_core_x509.rs
+expression: variants
+---
+- variant: "hostname_mismatch:evil.example.com"
+  leaf_cn: evil.example.com
+  leaf_sans:
+    - evil.example.com
+  root_cn: chain.example.com Root CA
+  leaf_validity_days: 3650
+  intermediate_validity_days: 1825
+  leaf_not_before_offset_days: ~
+  intermediate_not_before_offset_days: ~
+- variant: unknown_ca
+  leaf_cn: chain.example.com
+  leaf_sans:
+    - chain.example.com
+  root_cn: chain.example.com Unknown Root CA
+  leaf_validity_days: 3650
+  intermediate_validity_days: 1825
+  leaf_not_before_offset_days: ~
+  intermediate_not_before_offset_days: ~
+- variant: expired_leaf
+  leaf_cn: chain.example.com
+  leaf_sans:
+    - chain.example.com
+  root_cn: chain.example.com Root CA
+  leaf_validity_days: 1
+  intermediate_validity_days: 1825
+  leaf_not_before_offset_days: 730
+  intermediate_not_before_offset_days: ~
+- variant: expired_intermediate
+  leaf_cn: chain.example.com
+  leaf_sans:
+    - chain.example.com
+  root_cn: chain.example.com Root CA
+  leaf_validity_days: 3650
+  intermediate_validity_days: 1
+  leaf_not_before_offset_days: ~
+  intermediate_not_before_offset_days: 730
+- variant: revoked_leaf
+  leaf_cn: chain.example.com
+  leaf_sans:
+    - chain.example.com
+  root_cn: chain.example.com Root CA
+  leaf_validity_days: 3650
+  intermediate_validity_days: 1825
+  leaf_not_before_offset_days: ~
+  intermediate_not_before_offset_days: ~

--- a/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__derive_constants.snap
+++ b/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__derive_constants.snap
@@ -1,0 +1,7 @@
+---
+source: crates/uselesskey-core-x509/tests/snapshots_core_x509.rs
+expression: c
+---
+base_time_epoch_unix: 1735689600
+base_time_window_days: 365
+serial_number_bytes: 16

--- a/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__key_usage_leaf_vs_ca.snap
+++ b/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__key_usage_leaf_vs_ca.snap
@@ -1,0 +1,14 @@
+---
+source: crates/uselesskey-core-x509/tests/snapshots_core_x509.rs
+expression: cmp
+---
+leaf:
+  - 0
+  - 0
+  - 1
+  - 1
+ca:
+  - 1
+  - 1
+  - 1
+  - 0

--- a/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__self_signed_ca_spec_defaults.snap
+++ b/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__self_signed_ca_spec_defaults.snap
@@ -1,0 +1,15 @@
+---
+source: crates/uselesskey-core-x509/tests/snapshots_core_x509.rs
+expression: spec_snapshot(&spec)
+---
+subject_cn: Snap Root CA
+issuer_cn: Snap Root CA
+not_before_offset: DaysAgo(1)
+validity_days: 3650
+is_ca: true
+rsa_bits: 2048
+key_cert_sign: true
+crl_sign: true
+digital_signature: true
+key_encipherment: false
+sans: []

--- a/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__self_signed_spec_defaults.snap
+++ b/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__self_signed_spec_defaults.snap
@@ -1,0 +1,15 @@
+---
+source: crates/uselesskey-core-x509/tests/snapshots_core_x509.rs
+expression: spec_snapshot(&spec)
+---
+subject_cn: snap.example.com
+issuer_cn: snap.example.com
+not_before_offset: DaysAgo(1)
+validity_days: 3650
+is_ca: false
+rsa_bits: 2048
+key_cert_sign: false
+crl_sign: false
+digital_signature: true
+key_encipherment: true
+sans: []

--- a/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__x509_negative_all_variants.snap
+++ b/crates/uselesskey-core-x509/tests/snapshots/snapshots_core_x509__x509_negative_all_variants.snap
@@ -1,0 +1,40 @@
+---
+source: crates/uselesskey-core-x509/tests/snapshots_core_x509.rs
+expression: variants
+---
+- variant: Expired
+  subject_cn: neg.example.com
+  not_before_offset: DaysAgo(395)
+  validity_days: 365
+  is_ca: false
+  key_cert_sign: false
+  crl_sign: false
+  digital_signature: true
+  key_encipherment: true
+- variant: NotYetValid
+  subject_cn: neg.example.com
+  not_before_offset: DaysFromNow(30)
+  validity_days: 365
+  is_ca: false
+  key_cert_sign: false
+  crl_sign: false
+  digital_signature: true
+  key_encipherment: true
+- variant: WrongKeyUsage
+  subject_cn: neg.example.com
+  not_before_offset: DaysAgo(1)
+  validity_days: 3650
+  is_ca: true
+  key_cert_sign: false
+  crl_sign: false
+  digital_signature: true
+  key_encipherment: true
+- variant: SelfSignedButClaimsCA
+  subject_cn: neg.example.com
+  not_before_offset: DaysAgo(1)
+  validity_days: 3650
+  is_ca: true
+  key_cert_sign: true
+  crl_sign: true
+  digital_signature: true
+  key_encipherment: false

--- a/crates/uselesskey-core-x509/tests/snapshots_core_x509.rs
+++ b/crates/uselesskey-core-x509/tests/snapshots_core_x509.rs
@@ -1,0 +1,188 @@
+//! Insta snapshot tests for uselesskey-core-x509.
+//!
+//! These tests snapshot the facade re-exports and negative-policy
+//! application to detect unintended changes.
+
+use serde::Serialize;
+use uselesskey_core_x509::{
+    BASE_TIME_EPOCH_UNIX, BASE_TIME_WINDOW_DAYS, ChainNegative, ChainSpec, KeyUsage,
+    NotBeforeOffset, SERIAL_NUMBER_BYTES, X509Negative, X509Spec,
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct DeriveConstants {
+    base_time_epoch_unix: i64,
+    base_time_window_days: u32,
+    serial_number_bytes: usize,
+}
+
+#[test]
+fn snapshot_derive_constants() {
+    let c = DeriveConstants {
+        base_time_epoch_unix: BASE_TIME_EPOCH_UNIX,
+        base_time_window_days: BASE_TIME_WINDOW_DAYS,
+        serial_number_bytes: SERIAL_NUMBER_BYTES,
+    };
+    insta::assert_yaml_snapshot!("derive_constants", c);
+}
+
+// ---------------------------------------------------------------------------
+// X509Negative::apply_to_spec
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct NegativeSpecSnapshot {
+    variant: &'static str,
+    subject_cn: String,
+    not_before_offset: String,
+    validity_days: u32,
+    is_ca: bool,
+    key_cert_sign: bool,
+    crl_sign: bool,
+    digital_signature: bool,
+    key_encipherment: bool,
+}
+
+fn fmt_offset(o: &NotBeforeOffset) -> String {
+    match o {
+        NotBeforeOffset::DaysAgo(d) => format!("DaysAgo({d})"),
+        NotBeforeOffset::DaysFromNow(d) => format!("DaysFromNow({d})"),
+    }
+}
+
+fn neg_snapshot(variant: &'static str, neg: X509Negative) -> NegativeSpecSnapshot {
+    let base = X509Spec::self_signed("neg.example.com");
+    let spec = neg.apply_to_spec(&base);
+    NegativeSpecSnapshot {
+        variant,
+        subject_cn: spec.subject_cn,
+        not_before_offset: fmt_offset(&spec.not_before_offset),
+        validity_days: spec.validity_days,
+        is_ca: spec.is_ca,
+        key_cert_sign: spec.key_usage.key_cert_sign,
+        crl_sign: spec.key_usage.crl_sign,
+        digital_signature: spec.key_usage.digital_signature,
+        key_encipherment: spec.key_usage.key_encipherment,
+    }
+}
+
+#[test]
+fn snapshot_x509_negative_all_variants() {
+    let variants: Vec<NegativeSpecSnapshot> = vec![
+        neg_snapshot("Expired", X509Negative::Expired),
+        neg_snapshot("NotYetValid", X509Negative::NotYetValid),
+        neg_snapshot("WrongKeyUsage", X509Negative::WrongKeyUsage),
+        neg_snapshot("SelfSignedButClaimsCA", X509Negative::SelfSignedButClaimsCA),
+    ];
+    insta::assert_yaml_snapshot!("x509_negative_all_variants", variants);
+}
+
+// ---------------------------------------------------------------------------
+// ChainNegative::apply_to_spec
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ChainNegativeSpecSnapshot {
+    variant: String,
+    leaf_cn: String,
+    leaf_sans: Vec<String>,
+    root_cn: String,
+    leaf_validity_days: u32,
+    intermediate_validity_days: u32,
+    leaf_not_before_offset_days: Option<i64>,
+    intermediate_not_before_offset_days: Option<i64>,
+}
+
+fn chain_neg_snapshot(neg: &ChainNegative) -> ChainNegativeSpecSnapshot {
+    let base = ChainSpec::new("chain.example.com");
+    let spec = neg.apply_to_spec(&base);
+    ChainNegativeSpecSnapshot {
+        variant: neg.variant_name(),
+        leaf_cn: spec.leaf_cn,
+        leaf_sans: spec.leaf_sans,
+        root_cn: spec.root_cn,
+        leaf_validity_days: spec.leaf_validity_days,
+        intermediate_validity_days: spec.intermediate_validity_days,
+        leaf_not_before_offset_days: spec.leaf_not_before_offset_days,
+        intermediate_not_before_offset_days: spec.intermediate_not_before_offset_days,
+    }
+}
+
+#[test]
+fn snapshot_chain_negative_all_variants() {
+    let variants: Vec<ChainNegativeSpecSnapshot> = vec![
+        chain_neg_snapshot(&ChainNegative::HostnameMismatch {
+            wrong_hostname: "evil.example.com".to_string(),
+        }),
+        chain_neg_snapshot(&ChainNegative::UnknownCa),
+        chain_neg_snapshot(&ChainNegative::ExpiredLeaf),
+        chain_neg_snapshot(&ChainNegative::ExpiredIntermediate),
+        chain_neg_snapshot(&ChainNegative::RevokedLeaf),
+    ];
+    insta::assert_yaml_snapshot!("chain_negative_all_variants", variants);
+}
+
+// ---------------------------------------------------------------------------
+// X509Spec defaults and builder
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct SpecDefaults {
+    subject_cn: String,
+    issuer_cn: String,
+    not_before_offset: String,
+    validity_days: u32,
+    is_ca: bool,
+    rsa_bits: usize,
+    key_cert_sign: bool,
+    crl_sign: bool,
+    digital_signature: bool,
+    key_encipherment: bool,
+    sans: Vec<String>,
+}
+
+fn spec_snapshot(spec: &X509Spec) -> SpecDefaults {
+    SpecDefaults {
+        subject_cn: spec.subject_cn.clone(),
+        issuer_cn: spec.issuer_cn.clone(),
+        not_before_offset: fmt_offset(&spec.not_before_offset),
+        validity_days: spec.validity_days,
+        is_ca: spec.is_ca,
+        rsa_bits: spec.rsa_bits,
+        key_cert_sign: spec.key_usage.key_cert_sign,
+        crl_sign: spec.key_usage.crl_sign,
+        digital_signature: spec.key_usage.digital_signature,
+        key_encipherment: spec.key_usage.key_encipherment,
+        sans: spec.sans.clone(),
+    }
+}
+
+#[test]
+fn snapshot_self_signed_spec_defaults() {
+    let spec = X509Spec::self_signed("snap.example.com");
+    insta::assert_yaml_snapshot!("self_signed_spec_defaults", spec_snapshot(&spec));
+}
+
+#[test]
+fn snapshot_self_signed_ca_spec_defaults() {
+    let spec = X509Spec::self_signed_ca("Snap Root CA");
+    insta::assert_yaml_snapshot!("self_signed_ca_spec_defaults", spec_snapshot(&spec));
+}
+
+#[test]
+fn snapshot_key_usage_leaf_vs_ca() {
+    #[derive(Serialize)]
+    struct UsageComparison {
+        leaf: [u8; 4],
+        ca: [u8; 4],
+    }
+    let cmp = UsageComparison {
+        leaf: KeyUsage::leaf().stable_bytes(),
+        ca: KeyUsage::ca().stable_bytes(),
+    };
+    insta::assert_yaml_snapshot!("key_usage_leaf_vs_ca", cmp);
+}


### PR DESCRIPTION
## Summary

Add insta snapshot tests for four X.509-related crates that were missing them:

### Crates covered

- **uselesskey-core-x509** (6 tests): Facade re-exports, negative-policy application, spec defaults, key-usage stable bytes, derive constants
- **uselesskey-core-x509-derive** (5 tests): Deterministic base-time derivation, serial number generation, boundary safety, constants
- **uselesskey-core-x509-negative** (4 tests): Variant metadata, applied spec output, chain-negative variant names and applied specs
- **uselesskey-core-rustls-pki** (5 tests): Self-signed/chain/RSA/ECDSA/Ed25519 PKI type conversion metadata

### Design

- All tests capture **metadata only** — no key material or certificate bytes in snapshots
- Uses `insta` with `yaml` + `redactions` features (workspace dependency)
- Added `insta.workspace = true` and `serde` dev-dependencies to each crate
- Follows existing snapshot test patterns from `uselesskey-rsa`, `uselesskey-ecdsa`, `uselesskey-x509`