### PR TITLE
test: add dependency guard and license policy tests

### DIFF
--- a/crates/uselesskey/tests/dep_guard_policy.rs
+++ b/crates/uselesskey/tests/dep_guard_policy.rs
@@ -168,7 +168,7 @@ fn parse_deny_allowed_licenses(root: &Path) -> Vec<String> {
 /// - Parentheses are stripped before evaluation.
 fn license_expression_allowed(expr: &str, allowed: &[String]) -> bool {
     // Strip all parentheses for a simple flat evaluation.
-    let flat = expr.replace('(', "").replace(')', "");
+    let flat = expr.replace(['(', ')'], "");
 
     // Split on " AND " first — every conjunct must be satisfied.
     flat.split(" AND ").all(|conjunct| {
@@ -280,14 +280,14 @@ fn all_direct_deps_use_approved_licenses() {
     // Collect all direct dependency names from workspace crates
     let mut direct_dep_names: Vec<String> = Vec::new();
     for member_id in &workspace_members {
-        if let Some(pkg) = pkg_by_id.get(member_id) {
-            if let Some(deps) = pkg["dependencies"].as_array() {
-                for dep in deps {
-                    if let Some(name) = dep["name"].as_str() {
-                        if !direct_dep_names.contains(&name.to_string()) {
-                            direct_dep_names.push(name.to_string());
-                        }
-                    }
+        if let Some(pkg) = pkg_by_id.get(member_id)
+            && let Some(deps) = pkg["dependencies"].as_array()
+        {
+            for dep in deps {
+                if let Some(name) = dep["name"].as_str()
+                    && !direct_dep_names.contains(&name.to_string())
+                {
+                    direct_dep_names.push(name.to_string());
                 }
             }
         }
@@ -307,10 +307,10 @@ fn all_direct_deps_use_approved_licenses() {
         {
             continue;
         }
-        if let Some(license) = pkg["license"].as_str() {
-            if !license_expression_allowed(license, &allowed) {
-                violations.push(format!("{name}: {license}"));
-            }
+        if let Some(license) = pkg["license"].as_str()
+            && !license_expression_allowed(license, &allowed)
+        {
+            violations.push(format!("{name}: {license}"));
         }
         // Packages with `license = null` are typically path deps; skip them.
     }


### PR DESCRIPTION
## Summary

Adds dep_guard_policy.rs integration test to the uselesskey facade crate that programmatically verifies dependency and license policies.

### Tests added (7 total)

**RNG dependency guard:**
- no_duplicate_major_versions_of_rng_deps - ensures rand, rand_core, and rand_chacha each resolve to a single semver-major version (critical for deterministic derivation stability)

**Crypto dependency guard:**
- no_duplicate_major_versions_of_crypto_deps - ensures blake3, sha2, hmac, and digest each resolve to a single semver-major version

**License policy:**
- deny_toml_license_allowlist_is_nonempty - sanity check that deny.toml has a non-empty license allowlist
- deny_toml_includes_expected_core_licenses - verifies the core licenses (MIT, Apache-2.0, BSD-3-Clause, ISC, CC0-1.0) are in the allowlist
- all_direct_deps_use_approved_licenses - uses cargo metadata to check every direct dependency's SPDX expression against the deny.toml allowlist (handles AND, OR, WITH operators and parentheses)

**Cargo.lock parsing sanity:**
- cargo_lock_contains_uselesskey_core - verifies the lock file is parseable and contains uselesskey-core
- cargo_lock_has_no_empty_names - validates no entries have empty names or versions

### Approach

- Parses Cargo.lock directly (no external TOML parser dependency needed)
- Uses cargo metadata for license information
- Parses deny.toml allowlist to stay in sync with actual policy
- SPDX expression evaluation handles AND, OR, WITH, and parentheses
