### PR TITLE
docs: add comprehensive usage examples

### DIFF
--- a/crates/uselesskey/examples/basic_usage.rs
+++ b/crates/uselesskey/examples/basic_usage.rs
@@ -1,0 +1,173 @@
+//! Basic fixture generation for RSA, ECDSA, and Ed25519.
+//!
+//! Shows how to create a deterministic factory and generate keypairs for
+//! all three asymmetric key types, accessing PEM, DER, and JWK outputs.
+//!
+//! Run with: cargo run -p uselesskey --example basic_usage --features full
+
+#[cfg(all(
+    feature = "rsa",
+    feature = "ecdsa",
+    feature = "ed25519",
+    feature = "jwk"
+))]
+fn main() {
+    use uselesskey::{
+        EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, RsaFactoryExt,
+        RsaSpec, Seed,
+    };
+
+    // Create a deterministic factory so output is reproducible across runs.
+    let seed = Seed::from_env_value("basic-usage-demo").unwrap();
+    let fx = Factory::deterministic(seed);
+
+    // =========================================================================
+    // 1. RSA (RS256) — 2048-bit keypair
+    // =========================================================================
+    println!("=== RSA (RS256) ===\n");
+
+    let rsa = fx.rsa("auth-service", RsaSpec::rs256());
+
+    println!(
+        "  Private PEM header : {}",
+        rsa.private_key_pkcs8_pem().lines().next().unwrap_or("")
+    );
+    println!(
+        "  Private PEM length : {} bytes",
+        rsa.private_key_pkcs8_pem().len()
+    );
+    println!(
+        "  Private DER length : {} bytes",
+        rsa.private_key_pkcs8_der().len()
+    );
+    println!(
+        "  Public PEM header  : {}",
+        rsa.public_key_spki_pem().lines().next().unwrap_or("")
+    );
+    println!(
+        "  Public DER length  : {} bytes",
+        rsa.public_key_spki_der().len()
+    );
+
+    let rsa_jwk = rsa.public_jwk().to_value();
+    println!("  JWK kty={}, alg={}", rsa_jwk["kty"], rsa_jwk["alg"]);
+    println!("  kid={}", rsa.kid());
+
+    // =========================================================================
+    // 2. ECDSA — P-256 (ES256) and P-384 (ES384)
+    // =========================================================================
+    println!("\n=== ECDSA P-256 (ES256) ===\n");
+
+    let ec256 = fx.ecdsa("token-signer", EcdsaSpec::es256());
+
+    println!(
+        "  Private PEM length : {} bytes",
+        ec256.private_key_pkcs8_pem().len()
+    );
+    println!(
+        "  Private DER length : {} bytes",
+        ec256.private_key_pkcs8_der().len()
+    );
+    println!(
+        "  Public DER length  : {} bytes",
+        ec256.public_key_spki_der().len()
+    );
+
+    let ec_jwk = ec256.public_jwk().to_value();
+    println!(
+        "  JWK kty={}, crv={}, alg={}",
+        ec_jwk["kty"], ec_jwk["crv"], ec_jwk["alg"]
+    );
+    println!("  kid={}", ec256.kid());
+
+    println!("\n=== ECDSA P-384 (ES384) ===\n");
+
+    let ec384 = fx.ecdsa("token-signer-384", EcdsaSpec::es384());
+
+    println!(
+        "  Private DER length : {} bytes",
+        ec384.private_key_pkcs8_der().len()
+    );
+    println!(
+        "  Public DER length  : {} bytes",
+        ec384.public_key_spki_der().len()
+    );
+
+    let ec384_jwk = ec384.public_jwk().to_value();
+    println!(
+        "  JWK kty={}, crv={}, alg={}",
+        ec384_jwk["kty"], ec384_jwk["crv"], ec384_jwk["alg"]
+    );
+
+    // =========================================================================
+    // 3. Ed25519 (EdDSA) — compact keys
+    // =========================================================================
+    println!("\n=== Ed25519 (EdDSA) ===\n");
+
+    let ed = fx.ed25519("signing-key", Ed25519Spec::default());
+
+    println!(
+        "  Private PEM length : {} bytes",
+        ed.private_key_pkcs8_pem().len()
+    );
+    println!(
+        "  Private DER length : {} bytes",
+        ed.private_key_pkcs8_der().len()
+    );
+    println!(
+        "  Public DER length  : {} bytes",
+        ed.public_key_spki_der().len()
+    );
+
+    let ed_jwk = ed.public_jwk().to_value();
+    println!(
+        "  JWK kty={}, crv={}, alg={}",
+        ed_jwk["kty"], ed_jwk["crv"], ed_jwk["alg"]
+    );
+    println!("  kid={}", ed.kid());
+
+    // =========================================================================
+    // 4. Caching: same label + spec → same key
+    // =========================================================================
+    println!("\n=== Cache Verification ===\n");
+
+    let rsa_again = fx.rsa("auth-service", RsaSpec::rs256());
+    assert_eq!(
+        rsa.private_key_pkcs8_pem(),
+        rsa_again.private_key_pkcs8_pem()
+    );
+    println!("  RSA cache hit     : ✓");
+
+    let ec_again = fx.ecdsa("token-signer", EcdsaSpec::es256());
+    assert_eq!(
+        ec256.private_key_pkcs8_pem(),
+        ec_again.private_key_pkcs8_pem()
+    );
+    println!("  ECDSA cache hit   : ✓");
+
+    let ed_again = fx.ed25519("signing-key", Ed25519Spec::default());
+    assert_eq!(ed.private_key_pkcs8_pem(), ed_again.private_key_pkcs8_pem());
+    println!("  Ed25519 cache hit : ✓");
+
+    // =========================================================================
+    // 5. Tempfile output (auto-cleaned on drop)
+    // =========================================================================
+    println!("\n=== Tempfile Output ===\n");
+
+    let temp = rsa.write_private_key_pkcs8_pem().expect("write tempfile");
+    println!("  Tempfile path   : {}", temp.path().display());
+    println!("  Tempfile exists : {}", temp.path().exists());
+
+    println!("\n=== All basic usage checks passed ===");
+}
+
+#[cfg(not(all(
+    feature = "rsa",
+    feature = "ecdsa",
+    feature = "ed25519",
+    feature = "jwk"
+)))]
+fn main() {
+    eprintln!("Enable required features:");
+    eprintln!("  cargo run -p uselesskey --example basic_usage --features full");
+}

--- a/crates/uselesskey/examples/deterministic_mode.rs
+++ b/crates/uselesskey/examples/deterministic_mode.rs
@@ -1,0 +1,142 @@
+//! Order-independent deterministic mode with seeds.
+//!
+//! Demonstrates the core deterministic derivation guarantee: the same seed,
+//! label, and spec always produce the same key — regardless of the order in
+//! which fixtures are requested.
+//!
+//! Run with: cargo run -p uselesskey --example deterministic_mode --features full
+
+#[cfg(all(feature = "rsa", feature = "ecdsa", feature = "ed25519"))]
+fn main() {
+    use uselesskey::{
+        EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, RsaFactoryExt,
+        RsaSpec, Seed,
+    };
+
+    // =========================================================================
+    // 1. Deterministic factory from a string seed
+    // =========================================================================
+    println!("=== Deterministic Mode ===\n");
+
+    let seed = Seed::from_env_value("demo-seed-v1").unwrap();
+    let fx = Factory::deterministic(seed);
+
+    // Generate three different key types.
+    let rsa_key = fx.rsa("issuer", RsaSpec::rs256());
+    let ec_key = fx.ecdsa("issuer", EcdsaSpec::es256());
+    let ed_key = fx.ed25519("issuer", Ed25519Spec::default());
+
+    println!(
+        "RSA     private DER : {} bytes",
+        rsa_key.private_key_pkcs8_der().len()
+    );
+    println!(
+        "ECDSA   private DER : {} bytes",
+        ec_key.private_key_pkcs8_der().len()
+    );
+    println!(
+        "Ed25519 private DER : {} bytes",
+        ed_key.private_key_pkcs8_der().len()
+    );
+
+    // =========================================================================
+    // 2. Same label + spec → cache hit
+    // =========================================================================
+    println!("\n=== Cache Identity ===\n");
+
+    let rsa_again = fx.rsa("issuer", RsaSpec::rs256());
+    assert_eq!(
+        rsa_key.private_key_pkcs8_pem(),
+        rsa_again.private_key_pkcs8_pem()
+    );
+    println!("Same label + spec → identical key : ✓");
+
+    // =========================================================================
+    // 3. Different label → different key
+    // =========================================================================
+    println!("\n=== Label Isolation ===\n");
+
+    let rsa_other = fx.rsa("verifier", RsaSpec::rs256());
+    assert_ne!(
+        rsa_key.private_key_pkcs8_pem(),
+        rsa_other.private_key_pkcs8_pem()
+    );
+    println!("'issuer' vs 'verifier' → different keys : ✓");
+
+    // =========================================================================
+    // 4. Order independence: reversed call order → same results
+    // =========================================================================
+    println!("\n=== Order Independence ===\n");
+
+    // Create a fresh factory with the same seed.
+    let fx2 = Factory::deterministic(Seed::from_env_value("demo-seed-v1").unwrap());
+
+    // Request keys in reverse order.
+    let ed_rev = fx2.ed25519("issuer", Ed25519Spec::default());
+    let ec_rev = fx2.ecdsa("issuer", EcdsaSpec::es256());
+    let rsa_rev = fx2.rsa("issuer", RsaSpec::rs256());
+
+    assert_eq!(
+        rsa_key.private_key_pkcs8_pem(),
+        rsa_rev.private_key_pkcs8_pem()
+    );
+    assert_eq!(
+        ec_key.private_key_pkcs8_pem(),
+        ec_rev.private_key_pkcs8_pem()
+    );
+    assert_eq!(
+        ed_key.private_key_pkcs8_pem(),
+        ed_rev.private_key_pkcs8_pem()
+    );
+    println!("Reversed call order → same RSA key     : ✓");
+    println!("Reversed call order → same ECDSA key   : ✓");
+    println!("Reversed call order → same Ed25519 key : ✓");
+
+    // =========================================================================
+    // 5. Cross-key-type independence
+    // =========================================================================
+    println!("\n=== Cross-Key-Type Independence ===\n");
+
+    // An ECDSA key with the same label does not affect the RSA key's derivation.
+    let fx3 = Factory::deterministic(Seed::from_env_value("demo-seed-v1").unwrap());
+    let rsa_only = fx3.rsa("issuer", RsaSpec::rs256());
+    assert_eq!(
+        rsa_key.private_key_pkcs8_pem(),
+        rsa_only.private_key_pkcs8_pem()
+    );
+    println!("ECDSA 'issuer' doesn't perturb RSA 'issuer' : ✓");
+
+    // =========================================================================
+    // 6. Different seed → different keys
+    // =========================================================================
+    println!("\n=== Seed Isolation ===\n");
+
+    let fx_other = Factory::deterministic(Seed::from_env_value("different-seed").unwrap());
+    let rsa_diff = fx_other.rsa("issuer", RsaSpec::rs256());
+    assert_ne!(
+        rsa_key.private_key_pkcs8_pem(),
+        rsa_diff.private_key_pkcs8_pem()
+    );
+    println!("Different seed → different key : ✓");
+
+    // =========================================================================
+    // 7. Raw byte seed (e.g. from a CI hash or HMAC)
+    // =========================================================================
+    println!("\n=== Raw Byte Seed ===\n");
+
+    let byte_seed = Seed::new([42u8; 32]);
+    let fx_bytes = Factory::deterministic(byte_seed);
+    let rsa_bytes = fx_bytes.rsa("from-bytes", RsaSpec::rs256());
+    println!(
+        "Byte-seed key DER length : {} bytes",
+        rsa_bytes.private_key_pkcs8_der().len()
+    );
+
+    println!("\n=== All deterministic mode checks passed ===");
+}
+
+#[cfg(not(all(feature = "rsa", feature = "ecdsa", feature = "ed25519")))]
+fn main() {
+    eprintln!("Enable required features:");
+    eprintln!("  cargo run -p uselesskey --example deterministic_mode --features full");
+}

--- a/crates/uselesskey/examples/jwk_generation.rs
+++ b/crates/uselesskey/examples/jwk_generation.rs
@@ -1,0 +1,156 @@
+//! JWK and JWKS generation with multiple key types.
+//!
+//! Demonstrates building individual JWKs, combining them into a JWKS using
+//! `JwksBuilder`, and inspecting key metadata — without printing key material.
+//!
+//! Run with: cargo run -p uselesskey --example jwk_generation --features full
+
+#[cfg(all(
+    feature = "jwk",
+    feature = "rsa",
+    feature = "ecdsa",
+    feature = "ed25519",
+    feature = "hmac"
+))]
+fn main() {
+    use uselesskey::jwk::JwksBuilder;
+    use uselesskey::{
+        EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, HmacFactoryExt,
+        HmacSpec, RsaFactoryExt, RsaSpec, Seed,
+    };
+
+    let fx = Factory::deterministic(Seed::from_env_value("jwk-generation-demo").unwrap());
+
+    // =========================================================================
+    // 1. Generate individual JWKs from each key type
+    // =========================================================================
+    println!("=== Individual JWKs ===\n");
+
+    // RSA (RS256)
+    let rsa = fx.rsa("api-auth", RsaSpec::rs256());
+    let rsa_jwk = rsa.public_jwk().to_value();
+    println!(
+        "RSA      : kty={}, alg={}, kid={}",
+        rsa_jwk["kty"],
+        rsa_jwk["alg"],
+        rsa.kid()
+    );
+
+    // ECDSA P-256 (ES256)
+    let ec256 = fx.ecdsa("token-ec", EcdsaSpec::es256());
+    let ec256_jwk = ec256.public_jwk().to_value();
+    println!(
+        "ECDSA    : kty={}, crv={}, alg={}, kid={}",
+        ec256_jwk["kty"],
+        ec256_jwk["crv"],
+        ec256_jwk["alg"],
+        ec256.kid()
+    );
+
+    // Ed25519 (EdDSA)
+    let ed = fx.ed25519("signing-ed", Ed25519Spec::default());
+    let ed_jwk = ed.public_jwk().to_value();
+    println!(
+        "Ed25519  : kty={}, crv={}, alg={}, kid={}",
+        ed_jwk["kty"],
+        ed_jwk["crv"],
+        ed_jwk["alg"],
+        ed.kid()
+    );
+
+    // HMAC (HS256) — symmetric, so no "public" vs "private" distinction
+    let hmac = fx.hmac("session-mac", HmacSpec::hs256());
+    let hmac_jwk = hmac.jwk().to_value();
+    println!(
+        "HMAC     : kty={}, alg={}, kid={}",
+        hmac_jwk["kty"],
+        hmac_jwk["alg"],
+        hmac.kid()
+    );
+
+    // =========================================================================
+    // 2. Build a multi-key JWKS with JwksBuilder (public keys only)
+    // =========================================================================
+    println!("\n=== Multi-Key JWKS (Public Keys) ===\n");
+
+    // JwksBuilder collects public JWKs and sorts them by kid for stable output.
+    let jwks = JwksBuilder::new()
+        .add_public(rsa.public_jwk())
+        .add_public(ec256.public_jwk())
+        .add_public(ed.public_jwk())
+        .build();
+
+    let jwks_val = jwks.to_value();
+    let keys = jwks_val["keys"].as_array().unwrap();
+    println!("JWKS contains {} public keys:", keys.len());
+    for key in keys {
+        println!(
+            "  kid={:<20} kty={:<4} alg={}",
+            key["kid"].as_str().unwrap_or("?"),
+            key["kty"].as_str().unwrap_or("?"),
+            key["alg"].as_str().unwrap_or("?"),
+        );
+    }
+
+    // Verify deterministic ordering: keys are sorted by kid.
+    let kids: Vec<&str> = keys.iter().filter_map(|k| k["kid"].as_str()).collect();
+    let mut sorted = kids.clone();
+    sorted.sort();
+    assert_eq!(kids, sorted, "JWKS keys must be sorted by kid");
+    println!("\n✓ Keys are sorted by kid (deterministic ordering)");
+
+    // =========================================================================
+    // 3. Per-key JWKS (single-key sets)
+    // =========================================================================
+    println!("\n=== Per-Key JWKS ===\n");
+
+    println!(
+        "RSA JWKS     : {} key(s)",
+        rsa.public_jwks().to_value()["keys"]
+            .as_array()
+            .unwrap()
+            .len()
+    );
+    println!(
+        "ECDSA JWKS   : {} key(s)",
+        ec256.public_jwks().to_value()["keys"]
+            .as_array()
+            .unwrap()
+            .len()
+    );
+    println!(
+        "Ed25519 JWKS : {} key(s)",
+        ed.public_jwks().to_value()["keys"]
+            .as_array()
+            .unwrap()
+            .len()
+    );
+    println!(
+        "HMAC JWKS    : {} key(s)",
+        hmac.jwks().to_value()["keys"].as_array().unwrap().len()
+    );
+
+    // =========================================================================
+    // 4. Serialize JWKS as JSON (for mock OIDC/JWKS endpoints)
+    // =========================================================================
+    println!("\n=== JWKS JSON for Mock Servers ===\n");
+
+    let json_str = jwks.to_string();
+    println!("JSON length    : {} bytes", json_str.len());
+    println!("Content-Type   : application/json");
+    println!("Serve at       : GET /.well-known/jwks.json");
+
+    println!("\n=== All JWK generation checks passed ===");
+}
+
+#[cfg(not(all(
+    feature = "jwk",
+    feature = "rsa",
+    feature = "ecdsa",
+    feature = "ed25519",
+    feature = "hmac"
+)))]
+fn main() {
+    eprintln!("Enable required features:");
+    eprintln!("  cargo run -p uselesskey --example jwk_generation --features full");
+}


### PR DESCRIPTION
## Summary

Adds three new well-documented, runnable examples to the examples/ directory:

- **basic_usage.rs** - Combined RSA, ECDSA, and Ed25519 fixture generation with deterministic mode, cache verification, and tempfile output
- **jwk_generation.rs** - JWK and JWKS building with multiple key types using JwksBuilder, demonstrating deterministic key ordering and JSON serialization for mock servers
- **deterministic_mode.rs** - Order-independent determinism across key types, seed isolation, label isolation, and raw byte seeds

All examples:
- Run with `cargo run -p uselesskey --example NAME --features full`
- Print only metadata (lengths, types, KIDs) - no key material
- Include assertions to verify behavior
- Have clear section comments

The existing `negative_fixtures.rs` and `x509_certificates.rs` examples already provided comprehensive coverage.

## Verification

- All 5 examples compile and run successfully
- `cargo clippy --workspace --all-features -- -D warnings` passes
- `cargo fmt --all` applied
