### PR TITLE
Refactor token authorization scheme into token-spec microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4011,6 +4011,7 @@ dependencies = [
  "serde",
  "serde_json",
  "uselesskey-core-base62",
+ "uselesskey-token-spec",
 ]
 
 [[package]]

--- a/crates/uselesskey-core-token-shape/Cargo.toml
+++ b/crates/uselesskey-core-token-shape/Cargo.toml
@@ -19,6 +19,7 @@ base64.workspace = true
 rand_core.workspace = true
 uselesskey-core-base62.workspace = true
 serde_json.workspace = true
+uselesskey-token-spec.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-token-shape/src/lib.rs
+++ b/crates/uselesskey-core-token-shape/src/lib.rs
@@ -51,12 +51,7 @@ pub const OAUTH_JTI_BYTES: usize = 16;
 pub const OAUTH_SIGNATURE_BYTES: usize = 32;
 
 /// Token shape kind.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum TokenKind {
-    ApiKey,
-    Bearer,
-    OAuthAccessToken,
-}
+pub use uselesskey_token_spec::TokenSpec as TokenKind;
 
 /// Generate a token value for the provided shape kind.
 pub fn generate_token(label: &str, kind: TokenKind, rng: &mut impl RngCore) -> String {
@@ -69,10 +64,7 @@ pub fn generate_token(label: &str, kind: TokenKind, rng: &mut impl RngCore) -> S
 
 /// Return HTTP authorization scheme for the token kind.
 pub fn authorization_scheme(kind: TokenKind) -> &'static str {
-    match kind {
-        TokenKind::ApiKey => "ApiKey",
-        TokenKind::Bearer | TokenKind::OAuthAccessToken => "Bearer",
-    }
+    kind.authorization_scheme()
 }
 
 /// Generate an API-key style token fixture (`uk_test_<base62>`).

--- a/crates/uselesskey-token-spec/src/lib.rs
+++ b/crates/uselesskey-token-spec/src/lib.rs
@@ -49,6 +49,14 @@ impl TokenSpec {
             Self::OAuthAccessToken => [0, 0, 0, 3],
         }
     }
+
+    /// HTTP authorization scheme associated with this token shape.
+    pub const fn authorization_scheme(&self) -> &'static str {
+        match self {
+            Self::ApiKey => "ApiKey",
+            Self::Bearer | Self::OAuthAccessToken => "Bearer",
+        }
+    }
 }
 
 #[cfg(test)]
@@ -73,6 +81,16 @@ mod tests {
         assert_eq!(
             TokenSpec::oauth_access_token().kind_name(),
             "oauth_access_token"
+        );
+    }
+
+    #[test]
+    fn authorization_schemes_are_stable() {
+        assert_eq!(TokenSpec::api_key().authorization_scheme(), "ApiKey");
+        assert_eq!(TokenSpec::bearer().authorization_scheme(), "Bearer");
+        assert_eq!(
+            TokenSpec::oauth_access_token().authorization_scheme(),
+            "Bearer"
         );
     }
 }

--- a/crates/uselesskey-token/src/token.rs
+++ b/crates/uselesskey-token/src/token.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use uselesskey_core::Factory;
-use uselesskey_core_token::{TokenKind, authorization_scheme, generate_token};
+use uselesskey_core_token::generate_token;
 
 use crate::TokenSpec;
 
@@ -161,7 +161,7 @@ impl TokenFixture {
     /// assert!(api.authorization_header().starts_with("ApiKey "));
     /// ```
     pub fn authorization_header(&self) -> String {
-        let scheme = authorization_scheme(token_kind(self.spec));
+        let scheme = self.spec.authorization_scheme();
         format!("{scheme} {}", self.value())
     }
 }
@@ -170,17 +170,9 @@ fn load_inner(factory: &Factory, label: &str, spec: TokenSpec, variant: &str) ->
     let spec_bytes = spec.stable_bytes();
 
     factory.get_or_init(DOMAIN_TOKEN_FIXTURE, label, &spec_bytes, variant, |rng| {
-        let value = generate_token(label, token_kind(spec), rng);
+        let value = generate_token(label, spec, rng);
         Inner { value }
     })
-}
-
-fn token_kind(spec: TokenSpec) -> TokenKind {
-    match spec {
-        TokenSpec::ApiKey => TokenKind::ApiKey,
-        TokenSpec::Bearer => TokenKind::Bearer,
-        TokenSpec::OAuthAccessToken => TokenKind::OAuthAccessToken,
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation

- Centralize token shape metadata so the token specification owns HTTP-scheme semantics and reduce duplicated mapping logic across token crates.
- Tighten single-responsibility boundaries by making `uselesskey-core-token-shape` delegate spec-level decisions to a focused `uselesskey-token-spec` microcrate.

### Description

- Added `TokenSpec::authorization_scheme()` to `crates/uselesskey-token-spec/src/lib.rs` to expose the HTTP auth scheme for each token shape (`ApiKey` or `Bearer`).
- Rewired `crates/uselesskey-core-token-shape` to `pub use uselesskey_token_spec::TokenSpec as TokenKind` and delegate scheme lookup to `TokenSpec`, removing local duplicate mapping logic.
- Simplified `crates/uselesskey-token` to pass `TokenSpec` directly into `generate_token` and use the new `TokenSpec::authorization_scheme()` for `authorization_header` construction.
- Updated `crates/uselesskey-core-token-shape/Cargo.toml` to depend on `uselesskey-token-spec` and refreshed workspace lockfile entries accordingly.

### Testing

- Ran formatting with `cargo fmt` and then unit/integration/doctests via `cargo test -p uselesskey-token-spec -p uselesskey-core-token-shape -p uselesskey-token` which completed successfully.
- All exercised tests (unit, integration and doctests) for the three crates passed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a92138fbe4833383ca59f236aa4794)