### PR TITLE
fix(ci): increase main job timeout from 45 to 60 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
   main:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## What changed
Increased \	imeout-minutes\ for the \main\ CI job from 45 to 60 minutes.

## Why
Both recent main CI runs (774, 776) were **cancelled due to timeout** after 45 minutes.
The full \cargo xtask ci\ pipeline now exceeds 45 minutes because 34 PRs were recently
merged, significantly expanding the test surface and mutant count. The \cargo-mutants\
step is the primary bottleneck.

## What I ran locally
- \cargo xtask gate --check\ (4/4 passed)
- \cargo xtask publish-preflight\ (44/44 passed)

## CI jobs relied on as truth
- PR CI run (pending)
- After merge: main CI run will validate with the new 60-min timeout

## Receipt
- CI-only change; no receipt artifact

## Determinism impact
None

## No-blob impact
None

## Debug leakage risk
None

## Docs touched
None

## What remains / risks
- If 60 minutes is still insufficient, consider splitting mutants into a separate job
- Monitor main CI run time after merge

## Recommended disposition
MERGE (P0 fix-forward)