### PR TITLE
ci: add workflow_dispatch trigger for manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 # Cancel redundant runs: on PRs cancel previous runs for the same PR;
 # on main each push gets its own run.
@@ -67,7 +68,7 @@ jobs:
         if: always()
 
   main:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## What changed
Added \workflow_dispatch\ trigger to \.github/workflows/ci.yml\.

## Why
The main CI runs for commits aec06f4 (#216) and 477d91d (#215) were either
cancelled (timeout) or failed to trigger. Having a manual trigger enables
re-running CI on demand via the Actions UI or \gh workflow run ci.yml\.

This PR will also trigger the PR CI run for the current main state,
validating the 36 PRs merged this session.

## What I ran locally
- \cargo xtask gate --check\ (4/4 passed)

## CI jobs relied on as truth
- PR CI run (pending — this PR serves as trigger)

## Determinism impact: None
## No-blob impact: None
## Debug leakage risk: None
## Docs touched: None
## Recommended disposition: MERGE