### PR TITLE
ci: use taiki-e/install-action and increase main timeout to 75min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,10 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
-
-      - name: Install cargo-mutants
-        run: cargo install cargo-mutants --locked
-
-      - name: Install typos-cli
-        run: cargo install typos-cli --locked
-
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
+      - name: Install tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz,cargo-mutants,typos-cli,cargo-deny
 
       - name: Fetch base branch
         if: github.base_ref != ''
@@ -70,7 +63,7 @@ jobs:
   main:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
         with:
@@ -90,17 +83,10 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
-
-      - name: Install cargo-mutants
-        run: cargo install cargo-mutants --locked
-
-      - name: Install typos-cli
-        run: cargo install typos-cli --locked
-
-      - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
+      - name: Install tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz,cargo-mutants,typos-cli,cargo-deny
 
       - name: xtask ci
         run: cargo xtask ci


### PR DESCRIPTION
## What changed

1. Replaced four separate cargo install --locked steps with a single taiki-e/install-action step
2. Increased main CI timeout from 60 to 75 minutes

## Why

1. Each cargo install compiles from source on cold cache, adding minutes to CI. taiki-e/install-action downloads pre-built binaries.
2. With PR #219's mutants scoping fix, the full CI pipeline now completes mutants within time, but the total pipeline (fmt + clippy + tests + matrix + dep-guard + bdd + no-blob + mutants + fuzz + coverage + preflight) still needs ~65 minutes. The 75 min timeout gives adequate headroom.

## Receipt

- Ran locally: N/A (CI-only change)
- CI: Relying on PR CI + post-merge main CI for validation
- Determinism impact: None
- No-blob impact: None
- Debug leakage risk: None
- Docs touched: None
- Recommended disposition: MERGE
