### PR TITLE
fix(ci): pin fuzz runs to host target and add toolchain diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
         with:
           tool: cargo-fuzz,cargo-mutants,typos-cli,cargo-deny
 
+      - name: Toolchain diagnostics
+        run: |
+          rustc -vV
+          cargo +nightly -vV
+          cargo fuzz --version || true
+
       - name: Fetch base branch
         if: github.base_ref != ''
         run: git fetch origin ${{ github.base_ref }}
@@ -87,6 +93,12 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-fuzz,cargo-mutants,typos-cli,cargo-deny
+
+      - name: Toolchain diagnostics
+        run: |
+          rustc -vV
+          cargo +nightly -vV
+          cargo fuzz --version || true
 
       - name: xtask ci
         run: cargo xtask ci

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -744,8 +744,9 @@ fn fuzz(target: Option<&str>, extra: &[String]) -> Result<()> {
 
     match status {
         Ok(s) if s.success() => {
+            let host = host_target_triple()?;
             let mut cmd = Command::new("cargo");
-            cmd.args(["+nightly", "fuzz", "run"]);
+            cmd.args(["+nightly", "fuzz", "run", "--target", &host]);
 
             if let Some(t) = target {
                 cmd.arg(t);
@@ -1031,12 +1032,15 @@ fn fuzz_pr() -> Result<()> {
             if targets.is_empty() {
                 return Ok(());
             }
+            let host = host_target_triple()?;
             for target in targets {
                 let mut cmd = Command::new("cargo");
                 cmd.args([
                     "+nightly",
                     "fuzz",
                     "run",
+                    "--target",
+                    &host,
                     &target,
                     "--",
                     "-runs=1000",
@@ -1177,6 +1181,24 @@ fn count_bdd_scenarios() -> Result<BTreeMap<String, usize>> {
         counts.insert(name, count);
     }
     Ok(counts)
+}
+
+/// Detect the host target triple from `rustc -vV`.
+fn host_target_triple() -> Result<String> {
+    let output = Command::new("rustc")
+        .args(["-vV"])
+        .output()
+        .context("failed to run rustc")?;
+    if !output.status.success() {
+        bail!("rustc -vV failed");
+    }
+    let stdout = String::from_utf8(output.stdout).context("rustc output not UTF-8")?;
+    for line in stdout.lines() {
+        if let Some(host) = line.strip_prefix("host: ") {
+            return Ok(host.to_string());
+        }
+    }
+    bail!("could not determine host target triple from rustc -vV")
 }
 
 fn workspace_path(rel: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- **Pin fuzz runs to host target**: `cargo-fuzz` can inherit or select a musl target in CI (e.g. `x86_64-unknown-linux-musl`), causing fuzz runs to fail because the sanitizer runtime is unavailable for that target. This change detects the host triple via `rustc -vV` and passes `--target <host>` explicitly to both `fuzz()` and `fuzz_pr()`.
- **Add `host_target_triple()` helper**: New function in xtask that parses `rustc -vV` output to extract the host target triple, with proper error handling.
- **Add toolchain diagnostics step**: Both the `pr` and `main` CI jobs now print `rustc -vV`, `cargo +nightly -vV`, and `cargo fuzz --version` before running xtask, making it easier to debug toolchain-related failures.

## Test plan

- [x] `cargo check -p xtask` passes
- [x] `cargo clippy -p xtask -- -D warnings` passes
- [ ] CI runs on this PR exercise the new diagnostics step
- [ ] Fuzz steps in CI use `--target` flag correctly