### PR TITLE
fix(xtask): improve publish indexing tolerance for v0.2.0 re-publish

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -461,6 +461,7 @@ fn publish() -> Result<()> {
     for name in PUBLISH_CRATES {
         pb.set_message(format!("publishing {name}"));
         let mut success = false;
+        let mut already_published = false;
         for attempt in 1..=5 {
             let output = Command::new("cargo")
                 .args(["publish", "-p", name])
@@ -476,12 +477,13 @@ fn publish() -> Result<()> {
 
             let stderr = String::from_utf8_lossy(&output.stderr);
 
-            // Already published — treat as success
+            // Already published — treat as success, skip indexing delay
             if stderr.contains("already uploaded")
                 || stderr.contains("already exists")
                 || stderr.contains("is already published")
             {
                 success = true;
+                already_published = true;
                 break;
             }
 
@@ -518,8 +520,12 @@ fn publish() -> Result<()> {
             pb.finish_with_message(format!("failed {name} after 5 attempts"));
             bail!("{name} failed after 5 attempts");
         }
-        pb.set_message(format!("published {name}, waiting for indexing"));
-        std::thread::sleep(std::time::Duration::from_secs(30));
+        if already_published {
+            pb.set_message(format!("{name} already published, skipping indexing wait"));
+        } else {
+            pb.set_message(format!("published {name}, waiting for indexing"));
+            std::thread::sleep(std::time::Duration::from_secs(60));
+        }
         pb.inc(1);
     }
     pb.finish_with_message("all crates published successfully");


### PR DESCRIPTION
## Summary
- Skip 60s indexing delay for already-published crates (saves ~6.5 min when re-running after partial publish)
- Increase indexing delay from 30s to 60s for newly published crates (30s was insufficient — crate #14 wasn't indexed after 5 min of retries on crate #15)

## Context
v0.2.0 publish failed twice: first from 429 rate limits (fixed in #233), then from an indexing race after 5 retries. 13 of 43 crates are live. After merging this, we'll move the v0.2.0 tag to re-trigger the release workflow.

## Test plan
- [x] `cargo fmt -p xtask -- --check` passes
- [x] `cargo clippy -p xtask -- -D warnings` passes
- [ ] CI passes
- [ ] After merge: move v0.2.0 tag and verify release workflow publishes remaining 30 crates