### PR TITLE
fix(xtask): add publish resume/retry infra and fix 429 parser

### DIFF
--- a/.github/workflows/publish-retry.yml
+++ b/.github/workflows/publish-retry.yml
@@ -1,0 +1,68 @@
+name: Publish Retry
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to check out (e.g. v0.5.0)"
+        required: false
+        type: string
+        default: ""
+      resume_from:
+        description: "Crate name to resume from (skip earlier crates)"
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Dry-run only (publish-check instead of publish)"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-retry
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install NASM (for aws-lc-rs)
+        run: sudo apt-get update && sudo apt-get install -y nasm
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Publish crates
+        if: ${{ !inputs.dry_run }}
+        run: |
+          if [ -n "${{ inputs.resume_from }}" ]; then
+            cargo xtask publish --from "${{ inputs.resume_from }}"
+          else
+            cargo xtask publish
+          fi
+
+      - name: Publish dry-run
+        if: ${{ inputs.dry_run }}
+        run: cargo xtask publish-check
+
+      - name: Upload publish state
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-state
+          path: target/xtask/publish-state.json
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  ci:
+  preflight:
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:
@@ -26,8 +26,6 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - uses: dtolnay/rust-toolchain@nightly
-
       - name: Install NASM (for aws-lc-rs)
         run: sudo apt-get update && sudo apt-get install -y nasm
 
@@ -36,24 +34,19 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Install tools
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-fuzz,cargo-mutants,typos-cli,cargo-deny
+      - name: Quality gate
+        run: cargo xtask gate
 
-      - name: Toolchain diagnostics
-        run: |
-          rustc -vV
-          cargo +nightly -vV
-          cargo fuzz --version || true
+      - name: Publish preflight
+        run: cargo xtask publish-preflight
 
-      - name: xtask ci
-        run: cargo xtask ci
+      - name: Publish dry-run
+        run: cargo xtask publish-check
 
   publish:
-    needs: ci
+    needs: preflight
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 180
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
@@ -69,6 +62,14 @@ jobs:
 
       - name: Publish all crates
         run: cargo xtask publish
+
+      - name: Upload publish state
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-state
+          path: target/xtask/publish-state.json
+          if-no-files-found: ignore
 
   release:
     needs: publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +460,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +621,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -1581,6 +1609,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4464,10 +4516,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -4774,6 +4879,7 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "indicatif",
  "owo-colors",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["xtask", "build", "automation", "ci", "testing"]
 
 [dependencies]
 anyhow.workspace = true
+chrono = "0.4"
 clap.workspace = true
 indicatif = "0.18"
 owo-colors = "4.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -69,7 +69,14 @@ enum Cmd {
     /// Validate publish metadata and run `cargo package --no-verify` for all crates.
     PublishPreflight,
     /// Publish all crates to crates.io in dependency order (with retry logic).
-    Publish,
+    Publish {
+        /// Resume from this crate (skip all crates before it in publish order).
+        #[arg(long)]
+        from: Option<String>,
+        /// Resume from the last failure recorded in target/xtask/publish-state.json.
+        #[arg(long)]
+        resume: bool,
+    },
     /// Run fuzz targets (requires `cargo-fuzz` installed).
     Fuzz {
         /// Name of the fuzz target (e.g. `rsa_pkcs8_pem_parse`).
@@ -137,7 +144,7 @@ fn main() -> Result<()> {
         Cmd::BddMatrix => bdd_matrix(),
         Cmd::Coverage => coverage(),
         Cmd::PublishPreflight => publish_preflight(),
-        Cmd::Publish => publish(),
+        Cmd::Publish { from, resume } => publish(from, resume),
         Cmd::Mutants => run_mutants(PUBLISH_CRATES),
         Cmd::Fuzz { target, args } => fuzz(target.as_deref(), &args),
         Cmd::LintFix { check, no_clippy } => lint_fix(check, no_clippy),
@@ -450,15 +457,143 @@ fn typos(fix: bool) -> Result<()> {
     run(&mut cmd)
 }
 
-fn publish() -> Result<()> {
+const PUBLISH_STATE_PATH: &str = "target/xtask/publish-state.json";
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct PublishState {
+    timestamp: u64,
+    crates: Vec<PublishCrateState>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct PublishCrateState {
+    name: String,
+    status: String, // "published", "already_published", "skipped", "failed", "pending"
+}
+
+/// Parse a crates.io 429 "try again after" timestamp and return seconds to wait.
+///
+/// crates.io returns messages like:
+/// > Please try again after Sun, 08 Mar 2026 06:57:08 GMT
+///
+/// Returns `None` if parsing fails (caller falls back to exponential backoff).
+fn parse_retry_after(stderr: &str) -> Option<u64> {
+    let re = regex::Regex::new(
+        r"try again after ([A-Z][a-z]{2}, \d{2} [A-Z][a-z]{2} \d{4} \d{2}:\d{2}:\d{2} GMT)",
+    )
+    .ok()?;
+    let caps = re.captures(stderr)?;
+    let timestamp_str = caps.get(1)?.as_str();
+    let retry_at = chrono::DateTime::parse_from_rfc2822(timestamp_str).ok()?;
+    let now = chrono::Utc::now();
+    let delta = retry_at.signed_duration_since(now).num_seconds();
+    // Add 15s buffer; minimum 5s wait
+    let wait = (delta + 15).max(5) as u64;
+    Some(wait)
+}
+
+fn write_publish_state(state: &PublishState) -> Result<()> {
+    let dir = Path::new(PUBLISH_STATE_PATH).parent().unwrap();
+    fs::create_dir_all(dir).context("failed to create publish state directory")?;
+    let json = serde_json::to_string_pretty(state).context("failed to serialize publish state")?;
+    fs::write(PUBLISH_STATE_PATH, json).context("failed to write publish state file")?;
+    Ok(())
+}
+
+fn read_publish_state() -> Result<PublishState> {
+    let json =
+        fs::read_to_string(PUBLISH_STATE_PATH).context("failed to read publish state file")?;
+    let state: PublishState =
+        serde_json::from_str(&json).context("failed to parse publish state file")?;
+    Ok(state)
+}
+
+fn resolve_start_index(from: Option<&str>, resume: bool) -> Result<usize> {
+    if from.is_some() && resume {
+        bail!("--from and --resume are mutually exclusive; use one or the other");
+    }
+
+    if let Some(name) = from {
+        match PUBLISH_CRATES.iter().position(|c| *c == name) {
+            Some(idx) => return Ok(idx),
+            None => {
+                let list = PUBLISH_CRATES
+                    .iter()
+                    .enumerate()
+                    .map(|(i, c)| format!("  {i}: {c}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                bail!("crate {name:?} not found in publish order. Valid crates:\n{list}");
+            }
+        }
+    }
+
+    if resume {
+        let state = read_publish_state().context(
+            "failed to read publish state for --resume; run a publish first or use --from",
+        )?;
+        for (i, cs) in state.crates.iter().enumerate() {
+            if cs.status != "published" && cs.status != "already_published" {
+                return Ok(i);
+            }
+        }
+        // All crates already succeeded
+        return Ok(PUBLISH_CRATES.len());
+    }
+
+    Ok(0)
+}
+
+fn publish(from: Option<String>, resume: bool) -> Result<()> {
+    let start_index = resolve_start_index(from.as_deref(), resume)?;
+
+    if start_index >= PUBLISH_CRATES.len() {
+        eprintln!("all crates already published; nothing to do");
+        return Ok(());
+    }
+
+    if start_index > 0 {
+        eprintln!(
+            "starting from crate {} ({}/{})",
+            PUBLISH_CRATES[start_index],
+            start_index + 1,
+            PUBLISH_CRATES.len()
+        );
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let mut state = PublishState {
+        timestamp: now,
+        crates: PUBLISH_CRATES
+            .iter()
+            .enumerate()
+            .map(|(i, name)| PublishCrateState {
+                name: name.to_string(),
+                status: if i < start_index {
+                    "skipped".to_string()
+                } else {
+                    "pending".to_string()
+                },
+            })
+            .collect(),
+    };
+
     let pb = ProgressBar::new(PUBLISH_CRATES.len() as u64);
     pb.set_style(
         ProgressStyle::with_template("[{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} {msg}")
             .unwrap()
             .progress_chars("#>-"),
     );
+    pb.set_position(start_index as u64);
 
-    for name in PUBLISH_CRATES {
+    for (i, name) in PUBLISH_CRATES.iter().enumerate() {
+        if i < start_index {
+            continue;
+        }
         pb.set_message(format!("publishing {name}"));
         let mut success = false;
         let mut already_published = false;
@@ -499,7 +634,8 @@ fn publish() -> Result<()> {
 
             if index_race || rate_limited || server_error {
                 let (reason, wait) = if rate_limited {
-                    ("rate-limited", 120 * attempt as u64)
+                    let wait = parse_retry_after(&stderr).unwrap_or(120 * attempt as u64);
+                    ("rate-limited", wait)
                 } else if server_error {
                     ("server error", 60 * attempt as u64)
                 } else {
@@ -512,20 +648,27 @@ fn publish() -> Result<()> {
                 std::thread::sleep(std::time::Duration::from_secs(wait));
             } else {
                 eprint!("{stderr}");
+                state.crates[i].status = "failed".to_string();
+                let _ = write_publish_state(&state);
                 pb.finish_with_message(format!("failed {name}"));
                 bail!("{name} publish failed with a non-retriable error");
             }
         }
         if !success {
+            state.crates[i].status = "failed".to_string();
+            let _ = write_publish_state(&state);
             pb.finish_with_message(format!("failed {name} after 5 attempts"));
             bail!("{name} failed after 5 attempts");
         }
         if already_published {
+            state.crates[i].status = "already_published".to_string();
             pb.set_message(format!("{name} already published, skipping indexing wait"));
         } else {
+            state.crates[i].status = "published".to_string();
             pb.set_message(format!("published {name}, waiting for indexing"));
             std::thread::sleep(std::time::Duration::from_secs(60));
         }
+        let _ = write_publish_state(&state);
         pb.inc(1);
     }
     pb.finish_with_message("all crates published successfully");
@@ -1805,5 +1948,154 @@ end_of_record
         let paths = parse_null_delimited_paths(staged);
         assert_eq!(paths.len(), 1);
         assert_eq!(paths[0], PathBuf::from("one.rs"));
+    }
+
+    #[test]
+    fn resolve_start_index_from_first_crate() {
+        let idx = resolve_start_index(Some("uselesskey-core-base62"), false).unwrap();
+        assert_eq!(idx, 0);
+    }
+
+    #[test]
+    fn resolve_start_index_from_last_crate() {
+        let idx = resolve_start_index(Some("uselesskey-aws-lc-rs"), false).unwrap();
+        assert_eq!(idx, PUBLISH_CRATES.len() - 1);
+    }
+
+    #[test]
+    fn resolve_start_index_from_nonexistent() {
+        let err = resolve_start_index(Some("nonexistent"), false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not found in publish order"), "got: {msg}");
+        // Should list valid crate names
+        assert!(msg.contains("uselesskey-core-base62"), "got: {msg}");
+    }
+
+    #[test]
+    fn resolve_start_index_neither_flag() {
+        let idx = resolve_start_index(None, false).unwrap();
+        assert_eq!(idx, 0);
+    }
+
+    #[test]
+    fn publish_state_serde_roundtrip() {
+        let state = PublishState {
+            timestamp: 1234567890,
+            crates: vec![
+                PublishCrateState {
+                    name: "uselesskey-core".to_string(),
+                    status: "published".to_string(),
+                },
+                PublishCrateState {
+                    name: "uselesskey-rsa".to_string(),
+                    status: "failed".to_string(),
+                },
+            ],
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let parsed: PublishState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.timestamp, state.timestamp);
+        assert_eq!(parsed.crates.len(), 2);
+        assert_eq!(parsed.crates[0].name, "uselesskey-core");
+        assert_eq!(parsed.crates[0].status, "published");
+        assert_eq!(parsed.crates[1].name, "uselesskey-rsa");
+        assert_eq!(parsed.crates[1].status, "failed");
+    }
+
+    #[test]
+    fn resolve_start_index_from_and_resume_mutual_exclusion() {
+        let err = resolve_start_index(Some("uselesskey-core-base62"), true).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("mutually exclusive"),
+            "expected mutual exclusion error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_valid_timestamp() {
+        // Use a future timestamp to get a positive wait
+        let future = chrono::Utc::now() + chrono::Duration::seconds(60);
+        let ts = future.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+        let stderr = format!("Please try again after {ts}");
+        let wait = parse_retry_after(&stderr);
+        assert!(wait.is_some(), "should parse valid timestamp");
+        let w = wait.unwrap();
+        // ~60s + 15s buffer = ~75s, allow some clock drift
+        assert!((60..=90).contains(&w), "expected ~75s wait, got {w}s");
+    }
+
+    #[test]
+    fn parse_retry_after_no_match() {
+        let stderr = "some random error message without a timestamp";
+        assert!(parse_retry_after(stderr).is_none());
+    }
+
+    #[test]
+    fn parse_retry_after_malformed_timestamp() {
+        let stderr = "try again after not-a-real-timestamp";
+        assert!(parse_retry_after(stderr).is_none());
+    }
+
+    #[test]
+    fn parse_retry_after_past_timestamp_clamps_to_minimum() {
+        // A past timestamp should still return at least 5s (our minimum)
+        let past = chrono::Utc::now() - chrono::Duration::seconds(300);
+        let ts = past.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+        let stderr = format!("Please try again after {ts}");
+        let wait = parse_retry_after(&stderr);
+        assert!(wait.is_some());
+        assert_eq!(
+            wait.unwrap(),
+            5,
+            "past timestamp should clamp to 5s minimum"
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_real_crates_io_message() {
+        // Real crates.io 429 error message — the regex must stop at GMT and not
+        // greedily capture the trailing "and see https://..." text.
+        let stderr = "Please try again after Sun, 08 Mar 2026 06:57:08 GMT and see https://crates.io/docs/rate-limits for more details.";
+        let wait = parse_retry_after(stderr);
+        assert!(
+            wait.is_some(),
+            "should parse the real crates.io 429 message"
+        );
+    }
+
+    #[test]
+    fn resolve_start_index_resume_from_state_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state_path = dir.path().join("publish-state.json");
+        let state = PublishState {
+            timestamp: 1234567890,
+            crates: vec![
+                PublishCrateState {
+                    name: "uselesskey-core-base62".to_string(),
+                    status: "published".to_string(),
+                },
+                PublishCrateState {
+                    name: "uselesskey-core-seed".to_string(),
+                    status: "already_published".to_string(),
+                },
+                PublishCrateState {
+                    name: "uselesskey-core-hash".to_string(),
+                    status: "failed".to_string(),
+                },
+            ],
+        };
+        let json = serde_json::to_string_pretty(&state).unwrap();
+        fs::write(&state_path, &json).unwrap();
+
+        // We can't easily test resume with the hardcoded path,
+        // but we can test the serde and state logic directly.
+        // Find first non-success crate:
+        let first_pending = state
+            .crates
+            .iter()
+            .position(|c| c.status != "published" && c.status != "already_published");
+        assert_eq!(first_pending, Some(2));
     }
 }


### PR DESCRIPTION
## Summary

- **Fix 429 parser**: `parse_retry_after()` regex was too greedy — captured trailing `and see https://crates.io/docs/rate-limits for more details.` text, causing RFC 2822 parsing to fail silently. Now uses a precise pattern that stops at `GMT`.
- **Add `--from` / `--resume` to `cargo xtask publish`**: `--from <crate>` skips all crates before the named one; `--resume` reads `target/xtask/publish-state.json` and picks up from the first non-success crate. Mutually exclusive.
- **Persist publish state**: writes `publish-state.json` after each crate, uploaded as a GitHub Actions artifact (`if: always()`).
- **Slim release preflight**: replaces full `cargo xtask ci` at tag time with `gate` + `publish-preflight` + `publish-check` (15 min vs 75 min).
- **Add `publish-retry.yml`**: `workflow_dispatch` with `tag`, `resume_from`, and `dry_run` inputs for operator-driven recovery.
- **Raise publish timeout to 180 minutes**: 43 crates with 60s indexing delays + rate-limit sleeps needs headroom.

## Test plan

- [x] `cargo test -p xtask` — 88 tests pass including new `parse_retry_after_real_crates_io_message`
- [x] `cargo fmt -p xtask -- --check` — clean
- [x] `cargo clippy -p xtask -- -D warnings` — clean
- [ ] Verify `publish-retry.yml` workflow appears in Actions tab after merge
- [ ] Use `publish-retry` workflow with `resume_from` to finish v0.2.0 publish