### PR TITLE
fix(xtask): move adapters before facade in PUBLISH_CRATES order

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -367,9 +367,7 @@ const PUBLISH_CRATES: &[&str] = &[
     "uselesskey-token",
     "uselesskey-pgp",
     "uselesskey-x509",
-    // Facade
-    "uselesskey",
-    // Adapters (depend on facade / key crates)
+    // Adapters (depend on key crates, NOT on facade)
     "uselesskey-core-rustls-pki",
     "uselesskey-jsonwebtoken",
     "uselesskey-rustls",
@@ -377,6 +375,8 @@ const PUBLISH_CRATES: &[&str] = &[
     "uselesskey-ring",
     "uselesskey-rustcrypto",
     "uselesskey-aws-lc-rs",
+    // Facade (dev-depends on adapters above)
+    "uselesskey",
 ];
 
 /// Subset of `PUBLISH_CRATES` for CI-wide mutation testing.
@@ -1958,7 +1958,7 @@ end_of_record
 
     #[test]
     fn resolve_start_index_from_last_crate() {
-        let idx = resolve_start_index(Some("uselesskey-aws-lc-rs"), false).unwrap();
+        let idx = resolve_start_index(Some("uselesskey"), false).unwrap();
         assert_eq!(idx, PUBLISH_CRATES.len() - 1);
     }
 


### PR DESCRIPTION
## Summary
- Moves adapter crates (`uselesskey-jsonwebtoken`, `uselesskey-rustls`, etc.) before the `uselesskey` facade in `PUBLISH_CRATES`
- The facade has dev-dependencies on these adapters, so `cargo publish` fails if they're not yet on crates.io
- Adapters only depend on key crates (not the facade), so this reorder is safe

## Context
Publishing v0.2.0 failed at the `uselesskey` facade because `uselesskey-jsonwebtoken` (a dev-dependency) wasn't published yet. 35 of 43 crates are on crates.io; this unblocks the remaining 8.

## Test plan
- [x] `cargo test -p xtask resolve_start_index` passes