### PR TITLE
Extract JWT-shaped OAuth access-token logic into new `uselesskey-core-jwt-shape` microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3791,6 +3791,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uselesskey-core-jwt-shape"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "serde_json",
+]
+
+[[package]]
 name = "uselesskey-core-keypair"
 version = "0.1.0"
 dependencies = [
@@ -3919,6 +3929,7 @@ dependencies = [
  "serde",
  "serde_json",
  "uselesskey-core-base62",
+ "uselesskey-core-jwt-shape",
  "uselesskey-token-spec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "crates/uselesskey-core-sink",
   "crates/uselesskey-core-token",
   "crates/uselesskey-core-token-shape",
+  "crates/uselesskey-core-jwt-shape",
   "crates/uselesskey-core-jwk-builder",
   "crates/uselesskey-core-jwks-order",
   "crates/uselesskey-core-jwk",
@@ -75,6 +76,7 @@ uselesskey-core-factory = { path = "crates/uselesskey-core-factory", version = "
 uselesskey-core-jwks-order = { path = "crates/uselesskey-core-jwks-order", version = "0.1.0" }
 uselesskey-core-hash = { path = "crates/uselesskey-core-hash", version = "0.1.0", default-features = false }
 uselesskey-core-token-shape = { path = "crates/uselesskey-core-token-shape", version = "0.1.0" }
+uselesskey-core-jwt-shape = { path = "crates/uselesskey-core-jwt-shape", version = "0.1.0" }
 uselesskey-core-id = { path = "crates/uselesskey-core-id", version = "0.1.0", default-features = false }
 uselesskey-core-seed = { path = "crates/uselesskey-core-seed", version = "0.1.0", default-features = false }
 uselesskey-core-kid = { path = "crates/uselesskey-core-kid", version = "0.1.0" }

--- a/crates/uselesskey-core-jwt-shape/Cargo.toml
+++ b/crates/uselesskey-core-jwt-shape/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "uselesskey-core-jwt-shape"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+description = "JWT-shaped OAuth token primitives for uselesskey test fixtures."
+categories.workspace = true
+keywords = ["jwt", "oauth", "token", "fixtures", "testing"]
+readme = "README.md"
+exclude = ["fuzz/**", "corpus/**", "**/*.der", "**/*.pem"]
+homepage.workspace = true
+documentation = "https://docs.rs/uselesskey-core-jwt-shape"
+authors.workspace = true
+
+[dependencies]
+base64.workspace = true
+rand_core.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+rand_chacha.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/uselesskey-core-jwt-shape/README.md
+++ b/crates/uselesskey-core-jwt-shape/README.md
@@ -1,0 +1,11 @@
+# uselesskey-core-jwt-shape
+
+JWT-shaped OAuth access token primitives for `uselesskey`.
+
+## Purpose
+
+- Generate realistic `header.payload.signature` access-token shapes for tests.
+- Keep OAuth/JWT-shape logic isolated from API-key and opaque bearer token helpers.
+- Preserve deterministic output when driven by seeded RNGs.
+
+This crate only models token **shape** and does not sign or validate JWTs.

--- a/crates/uselesskey-core-jwt-shape/src/lib.rs
+++ b/crates/uselesskey-core-jwt-shape/src/lib.rs
@@ -1,0 +1,42 @@
+#![forbid(unsafe_code)]
+
+//! JWT-shaped OAuth access token primitives.
+//!
+//! Generates deterministic (for seeded RNGs) OAuth access-token strings in
+//! `header.payload.signature` form without cryptographic signing.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use rand_core::RngCore;
+use serde_json::json;
+
+/// Number of random bytes used for OAuth `jti`.
+pub const OAUTH_JTI_BYTES: usize = 16;
+
+/// Number of random bytes used for OAuth signature-like segment.
+pub const OAUTH_SIGNATURE_BYTES: usize = 32;
+
+/// Generate a JWT-shaped OAuth access token (`header.payload.signature`).
+pub fn generate_oauth_access_token(label: &str, rng: &mut impl RngCore) -> String {
+    let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"RS256","typ":"JWT"}"#);
+
+    let mut jti = [0u8; OAUTH_JTI_BYTES];
+    rng.fill_bytes(&mut jti);
+
+    let payload = json!({
+        "iss": "uselesskey",
+        "sub": label,
+        "aud": "tests",
+        "scope": "fixture.read",
+        "jti": URL_SAFE_NO_PAD.encode(jti),
+        "exp": 2_000_000_000u64,
+    });
+    let payload_json = serde_json::to_vec(&payload).expect("payload JSON");
+    let payload_segment = URL_SAFE_NO_PAD.encode(payload_json);
+
+    let mut signature = [0u8; OAUTH_SIGNATURE_BYTES];
+    rng.fill_bytes(&mut signature);
+    let signature_segment = URL_SAFE_NO_PAD.encode(signature);
+
+    format!("{header}.{payload_segment}.{signature_segment}")
+}

--- a/crates/uselesskey-core-jwt-shape/tests/jwt_shape.rs
+++ b/crates/uselesskey-core-jwt-shape/tests/jwt_shape.rs
@@ -1,0 +1,47 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use uselesskey_core_jwt_shape::{
+    OAUTH_JTI_BYTES, OAUTH_SIGNATURE_BYTES, generate_oauth_access_token,
+};
+
+fn rng(seed_byte: u8) -> ChaCha20Rng {
+    ChaCha20Rng::from_seed([seed_byte; 32])
+}
+
+#[test]
+fn oauth_shape_has_three_segments_and_expected_claims() {
+    let token = generate_oauth_access_token("issuer", &mut rng(11));
+    let parts: Vec<&str> = token.split('.').collect();
+    assert_eq!(parts.len(), 3);
+
+    let payload = URL_SAFE_NO_PAD
+        .decode(parts[1])
+        .expect("decode payload segment");
+    let json: serde_json::Value = serde_json::from_slice(&payload).expect("parse payload");
+
+    assert_eq!(json["sub"], "issuer");
+    assert_eq!(json["iss"], "uselesskey");
+    assert_eq!(json["aud"], "tests");
+}
+
+#[test]
+fn signature_and_jti_lengths_match_constants() {
+    let token = generate_oauth_access_token("svc", &mut rng(33));
+    let parts: Vec<&str> = token.split('.').collect();
+
+    let payload = URL_SAFE_NO_PAD
+        .decode(parts[1])
+        .expect("decode payload segment");
+    let json: serde_json::Value = serde_json::from_slice(&payload).expect("parse payload");
+    let jti = json["jti"].as_str().expect("jti string");
+
+    let decoded_jti = URL_SAFE_NO_PAD.decode(jti).expect("decode jti");
+    let decoded_signature = URL_SAFE_NO_PAD
+        .decode(parts[2])
+        .expect("decode signature");
+
+    assert_eq!(decoded_jti.len(), OAUTH_JTI_BYTES);
+    assert_eq!(decoded_signature.len(), OAUTH_SIGNATURE_BYTES);
+}

--- a/crates/uselesskey-core-token-shape/Cargo.toml
+++ b/crates/uselesskey-core-token-shape/Cargo.toml
@@ -18,7 +18,7 @@ authors.workspace = true
 base64.workspace = true
 rand_core.workspace = true
 uselesskey-core-base62.workspace = true
-serde_json.workspace = true
+uselesskey-core-jwt-shape.workspace = true
 uselesskey-token-spec.workspace = true
 
 [dev-dependencies]
@@ -26,6 +26,7 @@ insta.workspace = true
 proptest.workspace = true
 rand_chacha.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-token-shape/README.md
+++ b/crates/uselesskey-core-token-shape/README.md
@@ -6,7 +6,7 @@ Low-level token shape primitives for `uselesskey`.
 
 - Generate deterministic and realistic API key shapes.
 - Generate opaque bearer token shapes.
-- Generate OAuth-like JWT-access-token shapes without signing.
+- Delegate OAuth-like JWT-access-token shapes to `uselesskey-core-jwt-shape`.
 
 This crate intentionally contains only token-shape construction and is used by
 `uselesskey-core-token` and higher-level token fixture crates.

--- a/crates/uselesskey-core-token-shape/src/lib.rs
+++ b/crates/uselesskey-core-token-shape/src/lib.rs
@@ -32,8 +32,10 @@ use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use rand_core::RngCore;
 
-use serde_json::json;
 pub use uselesskey_core_base62::random_base62;
+pub use uselesskey_core_jwt_shape::{
+    OAUTH_JTI_BYTES, OAUTH_SIGNATURE_BYTES, generate_oauth_access_token,
+};
 
 /// Prefix used for API-key token fixtures.
 pub const API_KEY_PREFIX: &str = "uk_test_";
@@ -43,12 +45,6 @@ pub const API_KEY_RANDOM_LEN: usize = 32;
 
 /// Number of raw random bytes in opaque bearer tokens.
 pub const BEARER_RANDOM_BYTES: usize = 32;
-
-/// Number of random bytes used for OAuth `jti`.
-pub const OAUTH_JTI_BYTES: usize = 16;
-
-/// Number of random bytes used for OAuth signature-like segment.
-pub const OAUTH_SIGNATURE_BYTES: usize = 32;
 
 /// Token shape kind.
 pub use uselesskey_token_spec::TokenSpec as TokenKind;
@@ -79,31 +75,6 @@ pub fn generate_bearer_token(rng: &mut impl RngCore) -> String {
     let mut bytes = [0u8; BEARER_RANDOM_BYTES];
     rng.fill_bytes(&mut bytes);
     URL_SAFE_NO_PAD.encode(bytes)
-}
-
-/// Generate an OAuth access token fixture in JWT shape (`header.payload.signature`).
-pub fn generate_oauth_access_token(label: &str, rng: &mut impl RngCore) -> String {
-    let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"RS256","typ":"JWT"}"#);
-
-    let mut jti = [0u8; OAUTH_JTI_BYTES];
-    rng.fill_bytes(&mut jti);
-
-    let payload = json!({
-        "iss": "uselesskey",
-        "sub": label,
-        "aud": "tests",
-        "scope": "fixture.read",
-        "jti": URL_SAFE_NO_PAD.encode(jti),
-        "exp": 2_000_000_000u64,
-    });
-    let payload_json = serde_json::to_vec(&payload).expect("payload JSON");
-    let payload_segment = URL_SAFE_NO_PAD.encode(payload_json);
-
-    let mut signature = [0u8; OAUTH_SIGNATURE_BYTES];
-    rng.fill_bytes(&mut signature);
-    let signature_segment = URL_SAFE_NO_PAD.encode(signature);
-
-    format!("{header}.{payload_segment}.{signature_segment}")
 }
 
 #[cfg(test)]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Workspace layout
 
-The workspace contains **48 crates** organized in four layers:
+The workspace contains **49 crates** organized in four layers:
 facade → algorithm crates → core microcrates → adapter crates, plus
 testing/tooling crates that live outside the publish graph.
 
@@ -83,7 +83,8 @@ set of focused microcrates that each own a single concern:
 - `uselesskey-core-token` — compatibility facade for token shape
   primitives
 - `uselesskey-core-token-shape` — token generation primitives (API keys,
-  bearer tokens, OAuth)
+  bearer tokens)
+- `uselesskey-core-jwt-shape` — JWT-shaped OAuth access-token primitives
 
 **Negative fixtures**
 


### PR DESCRIPTION
### Motivation
- Reduce responsibility in `uselesskey-core-token-shape` by separating JWT-shaped OAuth access-token construction to keep each crate SRP-focused.
- Make JWT-shape primitives reusable and easier to maintain and test in isolation.
- Improve composability for higher-level token fixtures by delegating JWT concerns to a small, focused microcrate.

### Description
- Add new crate `crates/uselesskey-core-jwt-shape` implementing `generate_oauth_access_token` and constants `OAUTH_JTI_BYTES` and `OAUTH_SIGNATURE_BYTES` with unit tests. 
- Refactor `crates/uselesskey-core-token-shape` to delegate OAuth/JWT generation via `pub use uselesskey_core_jwt_shape::{ ... }` while keeping the existing public API shape and token dispatch. 
- Wire the new crate into the workspace and dependency graph (`Cargo.toml` + `Cargo.lock`) and update `crates/uselesskey-core-token-shape/Cargo.toml` to depend on the new microcrate. 
- Update docs (`docs/architecture.md`) and the token-shape README to reflect the new SRP split.

### Testing
- Ran `cargo test -p uselesskey-core-jwt-shape` and its tests passed (`2` tests in the new crate passed).
- Ran `cargo test -p uselesskey-core-token-shape` and all tests in that crate passed (full test suite passed).
- Ran `cargo test -p uselesskey-core-token` and its integration tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab809c4f908333a6aae3bc0abe7caf)