### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-03-13
+
+### Changed
+
+- Public RNG-facing APIs are now seed-oriented instead of exposing `rand` or
+  `rand_core` types through the published surface.
+- Seed/core/helper crates now use the newer `rand 0.10` line internally,
+  while the stable crypto-edge crates remain on the intentional legacy island
+  until a later convergence pass.
+- Support crates and fuzz targets were updated to consume the seed-oriented
+  helper APIs instead of the old RNG-shaped entry points.
+
+### Added
+
+- `Seed::fill_bytes(&mut [u8])` as the stable byte-oriented boundary for
+  deterministic helper and fixture code.
+
+### Notes
+
+- This release does not claim full RNG convergence across every crypto-edge
+  crate yet. Stable RSA and Ed25519 generation paths remain intentionally
+  isolated on the legacy RNG line for now.
+
 ## [0.3.0] - 2026-03-12
 
 ### Changed
@@ -267,7 +290,8 @@ Repository organised into four layers:
 - **Determinism regression** — hardcoded expected-value snapshots ensure
   derivation stability across releases
 
-[Unreleased]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/EffortlessMetrics/uselesskey/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3650,7 +3650,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uselesskey"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "insta",
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-aws-lc-rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aws-lc-rs",
  "hex",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-bdd-steps"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-base62"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-cache"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "dashmap",
  "insta",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-factory"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-hash"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "insta",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-hmac-spec"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-id"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwk-builder"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwk-shape"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwks-order"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-keypair"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-keypair-material"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-kid"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "blake3",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative-der"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative-pem"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-rustls-pki"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "rustls-pki-types",
@@ -3948,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-seed"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "insta",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-sink"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-token"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "insta",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-token-shape"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "insta",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-chain-negative"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-derive"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-negative"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-spec"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ecdsa"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "elliptic-curve",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ed25519"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -4102,11 +4102,11 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-feature-grid"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "uselesskey-hmac"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "insta",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jsonwebtoken"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "jsonwebtoken",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jwk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "serde",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pgp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "pgp",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ring"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hex",
  "insta",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rsa"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "insta",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustcrypto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustls"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hex",
  "insta",
@@ -4300,14 +4300,14 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-test-grid"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "uselesskey-feature-grid",
 ]
 
 [[package]]
 name = "uselesskey-token"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "insta",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-token-spec"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "serde",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-tonic"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-x509"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,33 +67,33 @@ authors = ["Effortless Metrics <opensource@effortlessmetrics.com>"]
 # error handling
 thiserror = "2.0.18"
 
-uselesskey-test-grid = { path = "crates/uselesskey-test-grid", version = "0.3.0" }
-uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid", version = "0.3.0" }
-uselesskey-core-base62 = { path = "crates/uselesskey-core-base62", version = "0.3.0" }
-uselesskey-core-cache = { path = "crates/uselesskey-core-cache", version = "0.3.0", default-features = false }
-uselesskey-core-factory = { path = "crates/uselesskey-core-factory", version = "0.3.0" }
-uselesskey-core-jwks-order = { path = "crates/uselesskey-core-jwks-order", version = "0.3.0" }
-uselesskey-core-hash = { path = "crates/uselesskey-core-hash", version = "0.3.0", default-features = false }
-uselesskey-core-token-shape = { path = "crates/uselesskey-core-token-shape", version = "0.3.0" }
-uselesskey-core-id = { path = "crates/uselesskey-core-id", version = "0.3.0", default-features = false }
-uselesskey-core-seed = { path = "crates/uselesskey-core-seed", version = "0.3.0", default-features = false }
-uselesskey-core-kid = { path = "crates/uselesskey-core-kid", version = "0.3.0" }
-uselesskey-core-keypair = { path = "crates/uselesskey-core-keypair", version = "0.3.0" }
-uselesskey-core-keypair-material = { path = "crates/uselesskey-core-keypair-material", version = "0.3.0" }
-uselesskey-core-negative = { path = "crates/uselesskey-core-negative", version = "0.3.0", default-features = false }
-uselesskey-core-negative-der = { path = "crates/uselesskey-core-negative-der", version = "0.3.0", default-features = false }
-uselesskey-core-negative-pem = { path = "crates/uselesskey-core-negative-pem", version = "0.3.0", default-features = false }
-uselesskey-core-token = { path = "crates/uselesskey-core-token", version = "0.3.0" }
-uselesskey-token-spec = { path = "crates/uselesskey-token-spec", version = "0.3.0" }
-uselesskey-core-jwk-builder = { path = "crates/uselesskey-core-jwk-builder", version = "0.3.0" }
-uselesskey-core-jwk = { path = "crates/uselesskey-core-jwk", version = "0.3.0" }
-uselesskey-core-hmac-spec = { path = "crates/uselesskey-core-hmac-spec", version = "0.3.0" }
-uselesskey-core-jwk-shape = { path = "crates/uselesskey-core-jwk-shape", version = "0.3.0" }
-uselesskey-core-x509-derive = { path = "crates/uselesskey-core-x509-derive", version = "0.3.0" }
-uselesskey-core-x509-chain-negative = { path = "crates/uselesskey-core-x509-chain-negative", version = "0.3.0" }
-uselesskey-core-x509-negative = { path = "crates/uselesskey-core-x509-negative", version = "0.3.0" }
-uselesskey-core-x509-spec = { path = "crates/uselesskey-core-x509-spec", version = "0.3.0" }
-uselesskey-core-x509 = { path = "crates/uselesskey-core-x509", version = "0.3.0" }
+uselesskey-test-grid = { path = "crates/uselesskey-test-grid", version = "0.4.0" }
+uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid", version = "0.4.0" }
+uselesskey-core-base62 = { path = "crates/uselesskey-core-base62", version = "0.4.0" }
+uselesskey-core-cache = { path = "crates/uselesskey-core-cache", version = "0.4.0", default-features = false }
+uselesskey-core-factory = { path = "crates/uselesskey-core-factory", version = "0.4.0" }
+uselesskey-core-jwks-order = { path = "crates/uselesskey-core-jwks-order", version = "0.4.0" }
+uselesskey-core-hash = { path = "crates/uselesskey-core-hash", version = "0.4.0", default-features = false }
+uselesskey-core-token-shape = { path = "crates/uselesskey-core-token-shape", version = "0.4.0" }
+uselesskey-core-id = { path = "crates/uselesskey-core-id", version = "0.4.0", default-features = false }
+uselesskey-core-seed = { path = "crates/uselesskey-core-seed", version = "0.4.0", default-features = false }
+uselesskey-core-kid = { path = "crates/uselesskey-core-kid", version = "0.4.0" }
+uselesskey-core-keypair = { path = "crates/uselesskey-core-keypair", version = "0.4.0" }
+uselesskey-core-keypair-material = { path = "crates/uselesskey-core-keypair-material", version = "0.4.0" }
+uselesskey-core-negative = { path = "crates/uselesskey-core-negative", version = "0.4.0", default-features = false }
+uselesskey-core-negative-der = { path = "crates/uselesskey-core-negative-der", version = "0.4.0", default-features = false }
+uselesskey-core-negative-pem = { path = "crates/uselesskey-core-negative-pem", version = "0.4.0", default-features = false }
+uselesskey-core-token = { path = "crates/uselesskey-core-token", version = "0.4.0" }
+uselesskey-token-spec = { path = "crates/uselesskey-token-spec", version = "0.4.0" }
+uselesskey-core-jwk-builder = { path = "crates/uselesskey-core-jwk-builder", version = "0.4.0" }
+uselesskey-core-jwk = { path = "crates/uselesskey-core-jwk", version = "0.4.0" }
+uselesskey-core-hmac-spec = { path = "crates/uselesskey-core-hmac-spec", version = "0.4.0" }
+uselesskey-core-jwk-shape = { path = "crates/uselesskey-core-jwk-shape", version = "0.4.0" }
+uselesskey-core-x509-derive = { path = "crates/uselesskey-core-x509-derive", version = "0.4.0" }
+uselesskey-core-x509-chain-negative = { path = "crates/uselesskey-core-x509-chain-negative", version = "0.4.0" }
+uselesskey-core-x509-negative = { path = "crates/uselesskey-core-x509-negative", version = "0.4.0" }
+uselesskey-core-x509-spec = { path = "crates/uselesskey-core-x509-spec", version = "0.4.0" }
+uselesskey-core-x509 = { path = "crates/uselesskey-core-x509", version = "0.4.0" }
 
 # determinism / hashing
 blake3 = "1.8.3"
@@ -113,7 +113,7 @@ rand_chacha10 = { package = "rand_chacha", version = "0.10.0", default-features 
 
 # sinks
 tempfile = "3.26.0"
-uselesskey-core-sink = { path = "crates/uselesskey-core-sink", version = "0.3.0" }
+uselesskey-core-sink = { path = "crates/uselesskey-core-sink", version = "0.4.0" }
 
 # testing
 proptest = "1.10.0"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Choose the fixture families you need explicitly. For RSA fixtures:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.3.0", features = ["rsa"] }
+uselesskey = { version = "0.4.0", features = ["rsa"] }
 ```
 
 Generate keys:
@@ -92,7 +92,7 @@ For token-only fixtures without pulling RSA:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.3.0", default-features = false, features = ["token"] }
+uselesskey = { version = "0.4.0", default-features = false, features = ["token"] }
 ```
 
 ### JWK / JWKS
@@ -214,7 +214,7 @@ With the `tls-config` feature, build rustls configs in one line:
 
 ```toml
 [dev-dependencies]
-uselesskey-rustls = { version = "0.3.0", features = ["tls-config", "rustls-ring"] }
+uselesskey-rustls = { version = "0.4.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```rust
@@ -233,7 +233,7 @@ let client_config = chain.client_config_rustls();    // ClientConfig (trusts roo
 
 ```toml
 [dev-dependencies]
-uselesskey-ring = { version = "0.3.0", features = ["all"] }
+uselesskey-ring = { version = "0.4.0", features = ["all"] }
 ```
 
 ```rust
@@ -250,7 +250,7 @@ let ring_kp = rsa.rsa_key_pair_ring();  // ring::rsa::KeyPair
 
 ```toml
 [dev-dependencies]
-uselesskey-rustcrypto = { version = "0.3.0", features = ["all"] }
+uselesskey-rustcrypto = { version = "0.4.0", features = ["all"] }
 ```
 
 ```rust
@@ -267,7 +267,7 @@ let rsa_pk = rsa.rsa_private_key(); // rsa::RsaPrivateKey
 
 ```toml
 [dev-dependencies]
-uselesskey-aws-lc-rs = { version = "0.3.0", features = ["native", "all"] }
+uselesskey-aws-lc-rs = { version = "0.4.0", features = ["native", "all"] }
 ```
 
 ```rust
@@ -284,7 +284,7 @@ let lc_kp = rsa.rsa_key_pair_aws_lc_rs();  // aws_lc_rs::rsa::KeyPair
 
 ```toml
 [dev-dependencies]
-uselesskey-tonic = "0.3.0"
+uselesskey-tonic = "0.4.0"
 ```
 
 ```rust

--- a/crates/uselesskey-aws-lc-rs/Cargo.toml
+++ b/crates/uselesskey-aws-lc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-aws-lc-rs"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,9 +18,9 @@ authors.workspace = true
 aws-lc-rs = { version = "1", optional = true }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -38,10 +38,10 @@ ed25519 = ["dep:uselesskey-ed25519"]
 all = ["native", "rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0" }
 aws-lc-rs = "1"
 hex = "0.4"
 serde.workspace = true

--- a/crates/uselesskey-aws-lc-rs/README.md
+++ b/crates/uselesskey-aws-lc-rs/README.md
@@ -20,7 +20,7 @@ When `native` is disabled, this crate builds as a no-op and exports no adapter t
 
 ```toml
 [dev-dependencies]
-uselesskey-aws-lc-rs = { version = "0.3.0", features = ["native", "rsa"] }
+uselesskey-aws-lc-rs = { version = "0.4.0", features = ["native", "rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-bdd-steps/Cargo.toml
+++ b/crates/uselesskey-bdd-steps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-bdd-steps"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -36,11 +36,11 @@ x509-parser = "0.18.1"
 serde_json.workspace = true
 base64.workspace = true
 pgp = { version = "0.19.0", default-features = false }
-uselesskey-aws-lc-rs = { path = "../uselesskey-aws-lc-rs", version = "0.3.0", optional = true, default-features = false, features = ["all"] }
-uselesskey-ring = { path = "../uselesskey-ring", version = "0.3.0", optional = true, default-features = false, features = ["all"] }
-uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", version = "0.3.0", optional = true, default-features = false, features = ["all"] }
-uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.3.0", optional = true, default-features = false, features = ["x509", "tls-config", "rustls-ring"] }
-uselesskey-tonic = { path = "../uselesskey-tonic", version = "0.3.0", optional = true, default-features = false, features = ["x509"] }
+uselesskey-aws-lc-rs = { path = "../uselesskey-aws-lc-rs", version = "0.4.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-ring = { path = "../uselesskey-ring", version = "0.4.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", version = "0.4.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.4.0", optional = true, default-features = false, features = ["x509", "tls-config", "rustls-ring"] }
+uselesskey-tonic = { path = "../uselesskey-tonic", version = "0.4.0", optional = true, default-features = false, features = ["x509"] }
 hmac = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }
 aws-lc-rs = { version = "1", optional = true }

--- a/crates/uselesskey-core-base62/Cargo.toml
+++ b/crates/uselesskey-core-base62/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-base62"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-cache/Cargo.toml
+++ b/crates/uselesskey-core-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-cache"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -17,7 +17,7 @@ authors.workspace = true
 [dependencies]
 dashmap = { workspace = true, optional = true }
 spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex"] }
-uselesskey-core-id = { path = "../uselesskey-core-id", version = "0.3.0", default-features = false }
+uselesskey-core-id = { path = "../uselesskey-core-id", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-factory/Cargo.toml
+++ b/crates/uselesskey-core-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-factory"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -16,8 +16,8 @@ authors.workspace = true
 
 [dependencies]
 rand10 = { workspace = true }
-uselesskey-core-cache = { path = "../uselesskey-core-cache", version = "0.3.0", default-features = false }
-uselesskey-core-id = { path = "../uselesskey-core-id", version = "0.3.0", default-features = false }
+uselesskey-core-cache = { path = "../uselesskey-core-cache", version = "0.4.0", default-features = false }
+uselesskey-core-id = { path = "../uselesskey-core-id", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-hash/Cargo.toml
+++ b/crates/uselesskey-core-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-hash"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-hmac-spec/Cargo.toml
+++ b/crates/uselesskey-core-hmac-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-hmac-spec"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-id/Cargo.toml
+++ b/crates/uselesskey-core-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-id"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ authors.workspace = true
 
 [dependencies]
 uselesskey-core-hash = { workspace = true }
-uselesskey-core-seed = { path = "../uselesskey-core-seed", version = "0.3.0", default-features = false }
+uselesskey-core-seed = { path = "../uselesskey-core-seed", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-jwk-builder/Cargo.toml
+++ b/crates/uselesskey-core-jwk-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-jwk-builder"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,8 +15,8 @@ documentation = "https://docs.rs/uselesskey-core-jwk-builder"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core-jwk-shape = { path = "../uselesskey-core-jwk-shape", version = "0.3.0" }
-uselesskey-core-jwks-order = { path = "../uselesskey-core-jwks-order", version = "0.3.0" }
+uselesskey-core-jwk-shape = { path = "../uselesskey-core-jwk-shape", version = "0.4.0" }
+uselesskey-core-jwks-order = { path = "../uselesskey-core-jwks-order", version = "0.4.0" }
 serde_json.workspace = true
 
 [dev-dependencies]

--- a/crates/uselesskey-core-jwk-shape/Cargo.toml
+++ b/crates/uselesskey-core-jwk-shape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-jwk-shape"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-jwk/Cargo.toml
+++ b/crates/uselesskey-core-jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-jwk"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,8 +15,8 @@ documentation = "https://docs.rs/uselesskey-core-jwk"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core-jwk-shape = { path = "../uselesskey-core-jwk-shape", version = "0.3.0" }
-uselesskey-core-jwk-builder = { path = "../uselesskey-core-jwk-builder", version = "0.3.0" }
+uselesskey-core-jwk-shape = { path = "../uselesskey-core-jwk-shape", version = "0.4.0" }
+uselesskey-core-jwk-builder = { path = "../uselesskey-core-jwk-builder", version = "0.4.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-jwks-order/Cargo.toml
+++ b/crates/uselesskey-core-jwks-order/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-jwks-order"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-keypair-material/Cargo.toml
+++ b/crates/uselesskey-core-keypair-material/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-keypair-material"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-keypair-material"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
 uselesskey-core-kid.workspace = true
 
 [dev-dependencies]

--- a/crates/uselesskey-core-keypair/Cargo.toml
+++ b/crates/uselesskey-core-keypair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-keypair"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-kid/Cargo.toml
+++ b/crates/uselesskey-core-kid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-kid"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-negative-der/Cargo.toml
+++ b/crates/uselesskey-core-negative-der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-negative-der"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-negative-pem/Cargo.toml
+++ b/crates/uselesskey-core-negative-pem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-negative-pem"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-negative/Cargo.toml
+++ b/crates/uselesskey-core-negative/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-negative"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-rustls-pki/Cargo.toml
+++ b/crates/uselesskey-core-rustls-pki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-rustls-pki"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,10 +18,10 @@ authors.workspace = true
 rustls-pki-types = "1"
 
 # Key type crates (all optional)
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.4.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0", optional = true }
 
 [features]
 default = ["x509"]
@@ -34,11 +34,11 @@ all = ["x509", "rsa", "ecdsa", "ed25519"]
 [dev-dependencies]
 insta.workspace = true
 serde = { workspace = true, features = ["derive"] }
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.4.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0" }
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/crates/uselesskey-core-seed/Cargo.toml
+++ b/crates/uselesskey-core-seed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-seed"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-sink/Cargo.toml
+++ b/crates/uselesskey-core-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-sink"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-token-shape/Cargo.toml
+++ b/crates/uselesskey-core-token-shape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-token-shape"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-token/Cargo.toml
+++ b/crates/uselesskey-core-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-token"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-x509-chain-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-chain-negative/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509-chain-negative"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-x509-chain-negative"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.3.0" }
+uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.4.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-x509-derive/Cargo.toml
+++ b/crates/uselesskey-core-x509-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509-derive"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-x509-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-negative/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509-negative"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,8 +15,8 @@ documentation = "https://docs.rs/uselesskey-core-x509-negative"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core-x509-chain-negative = { path = "../uselesskey-core-x509-chain-negative", version = "0.3.0" }
-uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.3.0" }
+uselesskey-core-x509-chain-negative = { path = "../uselesskey-core-x509-chain-negative", version = "0.4.0" }
+uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.4.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-x509-spec/Cargo.toml
+++ b/crates/uselesskey-core-x509-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509-spec"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-x509/Cargo.toml
+++ b/crates/uselesskey-core-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,9 +15,9 @@ documentation = "https://docs.rs/uselesskey-core-x509"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core-x509-negative = { path = "../uselesskey-core-x509-negative", version = "0.3.0" }
-uselesskey-core-x509-derive = { path = "../uselesskey-core-x509-derive", version = "0.3.0" }
-uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.3.0" }
+uselesskey-core-x509-negative = { path = "../uselesskey-core-x509-negative", version = "0.4.0" }
+uselesskey-core-x509-derive = { path = "../uselesskey-core-x509-derive", version = "0.4.0" }
+uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.4.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core/Cargo.toml
+++ b/crates/uselesskey-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -27,12 +27,12 @@ std = [
 
 [dependencies]
 thiserror = { version = "2.0.18", default-features = false }
-uselesskey-core-factory = { path = "../uselesskey-core-factory", version = "0.3.0", default-features = false }
-uselesskey-core-sink = { path = "../uselesskey-core-sink", version = "0.3.0", optional = true }
+uselesskey-core-factory = { path = "../uselesskey-core-factory", version = "0.4.0", default-features = false }
+uselesskey-core-sink = { path = "../uselesskey-core-sink", version = "0.4.0", optional = true }
 
-uselesskey-core-cache = { path = "../uselesskey-core-cache", version = "0.3.0", default-features = false }
-uselesskey-core-id = { path = "../uselesskey-core-id", version = "0.3.0", default-features = false }
-uselesskey-core-negative = { path = "../uselesskey-core-negative", version = "0.3.0", default-features = false }
+uselesskey-core-cache = { path = "../uselesskey-core-cache", version = "0.4.0", default-features = false }
+uselesskey-core-id = { path = "../uselesskey-core-id", version = "0.4.0", default-features = false }
+uselesskey-core-negative = { path = "../uselesskey-core-negative", version = "0.4.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-ecdsa/Cargo.toml
+++ b/crates/uselesskey-ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ecdsa"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-ecdsa"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
 uselesskey-core-keypair-material.workspace = true
 
 # Elliptic curve support from RustCrypto
@@ -28,7 +28,7 @@ rand_core.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.3.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.4.0", optional = true }
 
 [features]
 default = []

--- a/crates/uselesskey-ed25519/Cargo.toml
+++ b/crates/uselesskey-ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ed25519"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-ed25519"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
 uselesskey-core-keypair-material.workspace = true
 ed25519-dalek.workspace = true
 pkcs8.workspace = true
@@ -23,7 +23,7 @@ pkcs8.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.3.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.4.0", optional = true }
 
 [features]
 default = []

--- a/crates/uselesskey-feature-grid/Cargo.toml
+++ b/crates/uselesskey-feature-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-feature-grid"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-hmac/Cargo.toml
+++ b/crates/uselesskey-hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-hmac"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,14 +15,14 @@ documentation = "https://docs.rs/uselesskey-hmac"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
 uselesskey-core-kid.workspace = true
 uselesskey-core-hmac-spec.workspace = true
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 
 # Optional JWK/JWKS support
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.3.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.4.0", optional = true }
 base64 = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-jsonwebtoken/Cargo.toml
+++ b/crates/uselesskey-jsonwebtoken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-jsonwebtoken"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -20,10 +20,10 @@ authors.workspace = true
 jsonwebtoken = { version = "10", features = ["use_pem"] }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.3.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.4.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -37,11 +37,11 @@ hmac = ["dep:uselesskey-hmac"]
 all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.4.0" }
 serde.workspace = true
 insta.workspace = true
 proptest.workspace = true

--- a/crates/uselesskey-jsonwebtoken/README.md
+++ b/crates/uselesskey-jsonwebtoken/README.md
@@ -24,7 +24,7 @@ Implements `JwtKeyExt` so fixture types return `jsonwebtoken::EncodingKey` and
 
 ```toml
 [dev-dependencies]
-uselesskey-jsonwebtoken = { version = "0.3.0", features = ["rsa"] }
+uselesskey-jsonwebtoken = { version = "0.4.0", features = ["rsa"] }
 jsonwebtoken = { version = "10", features = ["use_pem", "rust_crypto"] }
 ```
 

--- a/crates/uselesskey-jwk/Cargo.toml
+++ b/crates/uselesskey-jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-jwk"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,8 +15,8 @@ documentation = "https://docs.rs/uselesskey-jwk"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core-jwk = { path = "../uselesskey-core-jwk", version = "0.3.0" }
-uselesskey-core-jwk-builder = { path = "../uselesskey-core-jwk-builder", version = "0.3.0" }
+uselesskey-core-jwk = { path = "../uselesskey-core-jwk", version = "0.4.0" }
+uselesskey-core-jwk-builder = { path = "../uselesskey-core-jwk-builder", version = "0.4.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-pgp"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-pgp"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
 pgp = { version = "0.19.0", default-features = false }
 rand_chacha.workspace = true
 rand_core.workspace = true

--- a/crates/uselesskey-ring/Cargo.toml
+++ b/crates/uselesskey-ring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ring"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,9 +18,9 @@ authors.workspace = true
 ring = "0.17"
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -33,7 +33,7 @@ ed25519 = ["dep:uselesskey-ed25519"]
 all = ["rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-ring/README.md
+++ b/crates/uselesskey-ring/README.md
@@ -17,7 +17,7 @@ Converts fixture keypairs into native ring signing key types for tests that call
 
 ```toml
 [dev-dependencies]
-uselesskey-ring = { version = "0.3.0", features = ["rsa"] }
+uselesskey-ring = { version = "0.4.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-rsa/Cargo.toml
+++ b/crates/uselesskey-rsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rsa"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-rsa"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
 uselesskey-core-keypair-material.workspace = true
 rsa.workspace = true
 rand_chacha.workspace = true
@@ -24,7 +24,7 @@ rand_core.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.3.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.4.0", optional = true }
 
 [features]
 default = []

--- a/crates/uselesskey-rustcrypto/Cargo.toml
+++ b/crates/uselesskey-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rustcrypto"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -23,10 +23,10 @@ hmac = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.3.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.4.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -40,11 +40,11 @@ hmac = ["dep:hmac", "dep:sha2", "dep:uselesskey-hmac"]
 all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.4.0" }
 proptest.workspace = true
 sha2 = "0.10"
 rsa = { workspace = true }

--- a/crates/uselesskey-rustcrypto/README.md
+++ b/crates/uselesskey-rustcrypto/README.md
@@ -18,7 +18,7 @@ Converts fixture key material into native RustCrypto types (`rsa`, `p256`/`p384`
 
 ```toml
 [dev-dependencies]
-uselesskey-rustcrypto = { version = "0.3.0", features = ["rsa"] }
+uselesskey-rustcrypto = { version = "0.4.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rustls"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,14 +15,14 @@ documentation = "https://docs.rs/uselesskey-rustls"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core-rustls-pki = { path = "../uselesskey-core-rustls-pki", version = "0.3.0", default-features = false }
+uselesskey-core-rustls-pki = { path = "../uselesskey-core-rustls-pki", version = "0.4.0", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"], optional = true }
 
 # Key type crates (all optional)
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.4.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all", "tls-config", "rustls-ring"]
@@ -42,11 +42,11 @@ rustls-aws-lc-rs = ["rustls?/aws_lc_rs"]
 
 [dev-dependencies]
 rustls-pki-types = "1"
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.4.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0" }
 rustls = { version = "0.23", features = ["ring"] }
 hex = "0.4"
 serde.workspace = true

--- a/crates/uselesskey-rustls/README.md
+++ b/crates/uselesskey-rustls/README.md
@@ -30,7 +30,7 @@ optional `ServerConfig` / `ClientConfig` builders (including mTLS support).
 
 ```toml
 [dev-dependencies]
-uselesskey-rustls = { version = "0.3.0", features = ["tls-config", "rustls-ring"] }
+uselesskey-rustls = { version = "0.4.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```rust

--- a/crates/uselesskey-test-grid/Cargo.toml
+++ b/crates/uselesskey-test-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-grid"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-token-spec/Cargo.toml
+++ b/crates/uselesskey-token-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-token-spec"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-token"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-token"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
 uselesskey-core-token.workspace = true
 uselesskey-token-spec.workspace = true
 

--- a/crates/uselesskey-tonic/Cargo.toml
+++ b/crates/uselesskey-tonic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-tonic"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ authors.workspace = true
 
 [dependencies]
 tonic = { version = "0.14.5", default-features = false, features = ["transport", "tls-ring"] }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.4.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["x509"]
@@ -26,8 +26,8 @@ default = ["x509"]
 x509 = ["dep:uselesskey-x509"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.4.0" }
 proptest.workspace = true
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-tonic/README.md
+++ b/crates/uselesskey-tonic/README.md
@@ -19,9 +19,9 @@ Converts fixture certs and chains into `tonic::transport` TLS types:
 
 ```toml
 [dev-dependencies]
-uselesskey-tonic = "0.3.0"
-uselesskey-core = "0.3.0"
-uselesskey-x509 = "0.3.0"
+uselesskey-tonic = "0.4.0"
+uselesskey-core = "0.4.0"
+uselesskey-x509 = "0.4.0"
 ```
 
 ```rust

--- a/crates/uselesskey-x509/Cargo.toml
+++ b/crates/uselesskey-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-x509"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,10 +15,10 @@ documentation = "https://docs.rs/uselesskey-x509"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
-uselesskey-core-x509 = { path = "../uselesskey-core-x509", version = "0.3.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0" }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.3.0", optional = true }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
+uselesskey-core-x509 = { path = "../uselesskey-core-x509", version = "0.4.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.4.0", optional = true }
 rcgen = "0.13"
 rustls-pki-types = "1"
 x509-parser = "0.18"

--- a/crates/uselesskey/Cargo.toml
+++ b/crates/uselesskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -22,17 +22,17 @@ maintenance = { status = "actively-developed" }
 features = ["full"]
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.4.0" }
 
 # Key type crates - all optional
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.3.0", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.3.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.3.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.3.0", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.3.0", optional = true }
-uselesskey-token = { path = "../uselesskey-token", version = "0.3.0", optional = true }
-uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.3.0", optional = true }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.3.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.4.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.4.0", optional = true }
+uselesskey-token = { path = "../uselesskey-token", version = "0.4.0", optional = true }
+uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.4.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.4.0", optional = true }
 
 [features]
 default = []
@@ -71,8 +71,8 @@ x509-parser = "0.18"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 jsonwebtoken = { workspace = true, features = ["rust_crypto"] }
-uselesskey-jsonwebtoken = { path = "../uselesskey-jsonwebtoken", version = "0.3.0", features = ["all"] }
-uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.3.0", features = ["all", "tls-config", "rustls-ring"] }
+uselesskey-jsonwebtoken = { path = "../uselesskey-jsonwebtoken", version = "0.4.0", features = ["all"] }
+uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.4.0", features = ["all", "tls-config", "rustls-ring"] }
 rustls-pki-types.workspace = true
 
 [[bench]]

--- a/crates/uselesskey/README.md
+++ b/crates/uselesskey/README.md
@@ -36,7 +36,7 @@ Token-only consumers can stay lightweight:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.3.0", default-features = false, features = ["token"] }
+uselesskey = { version = "0.4.0", default-features = false, features = ["token"] }
 ```
 
 ```rust
@@ -54,7 +54,7 @@ If you want RSA fixtures, enable `rsa` explicitly:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.3.0", features = ["rsa"] }
+uselesskey = { version = "0.4.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey/src/lib.rs
+++ b/crates/uselesskey/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! uselesskey = { version = "0.3.0", default-features = false, features = ["token"] }
+//! uselesskey = { version = "0.4.0", default-features = false, features = ["token"] }
 //! ```
 //!
 //! ```

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,27 +14,27 @@ keywords = ["testing", "integration", "fixtures", "crypto", "deterministic"]
 
 [dependencies]
 # Core
-uselesskey-core = { path = "../crates/uselesskey-core", version = "0.3.0" }
+uselesskey-core = { path = "../crates/uselesskey-core", version = "0.4.0" }
 
 # Key types (all optional features)
-uselesskey-rsa = { path = "../crates/uselesskey-rsa", version = "0.3.0", optional = true, features = ["jwk"] }
-uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa", version = "0.3.0", optional = true, features = ["jwk"] }
-uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519", version = "0.3.0", optional = true, features = ["jwk"] }
-uselesskey-hmac = { path = "../crates/uselesskey-hmac", version = "0.3.0", optional = true, features = ["jwk"] }
-uselesskey-x509 = { path = "../crates/uselesskey-x509", version = "0.3.0", optional = true }
-uselesskey-token = { path = "../crates/uselesskey-token", version = "0.3.0", optional = true }
+uselesskey-rsa = { path = "../crates/uselesskey-rsa", version = "0.4.0", optional = true, features = ["jwk"] }
+uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa", version = "0.4.0", optional = true, features = ["jwk"] }
+uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519", version = "0.4.0", optional = true, features = ["jwk"] }
+uselesskey-hmac = { path = "../crates/uselesskey-hmac", version = "0.4.0", optional = true, features = ["jwk"] }
+uselesskey-x509 = { path = "../crates/uselesskey-x509", version = "0.4.0", optional = true }
+uselesskey-token = { path = "../crates/uselesskey-token", version = "0.4.0", optional = true }
 
 # JWK/JWKS
-uselesskey-jwk = { path = "../crates/uselesskey-jwk", version = "0.3.0", optional = true }
+uselesskey-jwk = { path = "../crates/uselesskey-jwk", version = "0.4.0", optional = true }
 
 # Adapters
-uselesskey-jsonwebtoken = { path = "../crates/uselesskey-jsonwebtoken", version = "0.3.0", optional = true, features = ["all"] }
-uselesskey-rustls = { path = "../crates/uselesskey-rustls", version = "0.3.0", optional = true, features = ["server-config", "client-config"] }
-uselesskey-ring = { path = "../crates/uselesskey-ring", version = "0.3.0", optional = true, features = ["all"] }
-uselesskey-rustcrypto = { path = "../crates/uselesskey-rustcrypto", version = "0.3.0", optional = true, features = ["all"] }
+uselesskey-jsonwebtoken = { path = "../crates/uselesskey-jsonwebtoken", version = "0.4.0", optional = true, features = ["all"] }
+uselesskey-rustls = { path = "../crates/uselesskey-rustls", version = "0.4.0", optional = true, features = ["server-config", "client-config"] }
+uselesskey-ring = { path = "../crates/uselesskey-ring", version = "0.4.0", optional = true, features = ["all"] }
+uselesskey-rustcrypto = { path = "../crates/uselesskey-rustcrypto", version = "0.4.0", optional = true, features = ["all"] }
 
 # Facade crate (for determinism tests)
-uselesskey = { path = "../crates/uselesskey", version = "0.3.0", optional = true, features = ["full"] }
+uselesskey = { path = "../crates/uselesskey", version = "0.4.0", optional = true, features = ["full"] }
 
 # External dependencies
 jsonwebtoken = { workspace = true, optional = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2090,13 +2090,13 @@ end_of_record
 
     #[test]
     fn unpublished_workspace_dep_error_matches_no_matching_package() {
-        let stderr = "error: no matching package named `uselesskey-core-hash` found\nlocation searched: crates.io index\nrequired by package `uselesskey-core-id v0.3.0`";
+        let stderr = "error: no matching package named `uselesskey-core-hash` found\nlocation searched: crates.io index\nrequired by package `uselesskey-core-id v0.4.0`";
         assert!(is_unpublished_workspace_dep_error(stderr));
     }
 
     #[test]
     fn unpublished_workspace_dep_error_matches_version_mismatch_form() {
-        let stderr = "error: failed to prepare local package for uploading\n\nCaused by:\n  failed to select a version for the requirement `uselesskey-core-hash = \"^0.3.0\"`\n  candidate versions found which didn't match: 0.2.0\n  location searched: crates.io index\n  required by package `uselesskey-core-id v0.3.0`";
+        let stderr = "error: failed to prepare local package for uploading\n\nCaused by:\n  failed to select a version for the requirement `uselesskey-core-hash = \"^0.4.0\"`\n  candidate versions found which didn't match: 0.3.0\n  location searched: crates.io index\n  required by package `uselesskey-core-id v0.4.0`";
         assert!(is_unpublished_workspace_dep_error(stderr));
     }
 


### PR DESCRIPTION
## Summary

Prepare the `0.4.0` release after the RNG-boundary engineering stack landed in `#243`, `#244`, and `#245`.

### What changed
- bump publishable crates and internal workspace dependency references from `0.3.0` to `0.4.0`
- refresh `Cargo.lock` on the new release graph
- add the `0.4.0` changelog section centered on the seed-oriented RNG boundary
- stamp public dependency examples from `0.3.0` to `0.4.0`
- update the `xtask` unpublished-workspace-dependency fixture strings to the new release line

### Release story
- public RNG-facing APIs are now seed-oriented rather than rand-ABI-oriented
- helper/core crates now sit on the newer rand line internally
- support-layer cleanup from `#245` is included
- full crypto-edge RNG convergence remains intentionally deferred

## Testing
- `cargo xtask gate`
- `cargo xtask publish-preflight`
- `cargo xtask publish-check`