### PR TITLE
chore(deps): ignore rng major bumps pending convergence decision

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "rand"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "rand_core"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "rand_chacha"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Ignore Dependabot major-version bumps for `rand`, `rand_core`, and `rand_chacha` until the convergence decision in `#257` is made.

## Why

The current workspace intentionally keeps a split RNG topology:
- helper/core crates are already on the newer rand line where RNG is an implementation detail
- the stable crypto-edge island still carries the legacy line by design

Repeated major-bump PRs for these three crates just reopen the same deferred decision and add queue churn without changing policy.

## Scope

- update `.github/dependabot.yml`
- ignore only `version-update:semver-major` for `rand`, `rand_core`, and `rand_chacha`
- leave all other cargo and GitHub Actions updates alone
