### PR TITLE
test(rng): pin crypto-edge deterministic fingerprints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,6 +4125,7 @@ name = "uselesskey-integration-tests"
 version = "0.0.0"
 dependencies = [
  "base64",
+ "blake3",
  "der-parser",
  "ed25519-dalek",
  "insta",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["testing", "integration", "fixtures", "crypto", "deterministic"]
 [dependencies]
 # Core
 uselesskey-core = { path = "../crates/uselesskey-core", version = "0.4.0" }
+blake3.workspace = true
 
 # Key types (all optional features)
 uselesskey-rsa = { path = "../crates/uselesskey-rsa", version = "0.4.0", optional = true, features = ["jwk"] }

--- a/tests/determinism_regression.rs
+++ b/tests/determinism_regression.rs
@@ -10,6 +10,7 @@
 
 #![cfg(feature = "determinism-regression")]
 
+use serde::Serialize;
 use uselesskey::jwk::JwksBuilder;
 use uselesskey::prelude::*;
 
@@ -26,6 +27,53 @@ fn fx() -> Factory {
 /// Extract just the first line (PEM header) from a PEM string.
 fn pem_header(pem: &str) -> &str {
     pem.lines().next().unwrap_or("")
+}
+
+fn blake3_hex(bytes: &[u8]) -> String {
+    blake3::hash(bytes).to_hex().to_string()
+}
+
+#[derive(Serialize)]
+struct KeyMaterialFingerprint<'a> {
+    label: &'a str,
+    private_der_len: usize,
+    private_der_blake3: String,
+    public_der_len: usize,
+    public_der_blake3: String,
+    kid: String,
+}
+
+#[derive(Serialize)]
+struct X509MaterialFingerprint<'a> {
+    label: &'a str,
+    cert_der_len: usize,
+    cert_der_blake3: String,
+    key_der_len: usize,
+    key_der_blake3: String,
+    cert_pem_header: String,
+}
+
+#[derive(Serialize)]
+struct CryptoEdgeKeyFingerprints<'a> {
+    rsa: KeyMaterialFingerprint<'a>,
+    ecdsa_p256: KeyMaterialFingerprint<'a>,
+    ecdsa_p384: KeyMaterialFingerprint<'a>,
+    ed25519: KeyMaterialFingerprint<'a>,
+}
+
+#[derive(Serialize)]
+struct X509ChainFingerprint<'a> {
+    label: &'a str,
+    chain_pem_cert_count: usize,
+    leaf_cert_der_len: usize,
+    leaf_cert_der_blake3: String,
+    intermediate_cert_der_len: usize,
+    intermediate_cert_der_blake3: String,
+    root_cert_der_len: usize,
+    root_cert_der_blake3: String,
+    leaf_key_der_blake3: String,
+    intermediate_key_der_blake3: String,
+    root_key_der_blake3: String,
 }
 
 // =========================================================================
@@ -160,6 +208,51 @@ fn seed_stability_ed25519() {
             ),
         ])
     );
+}
+
+#[test]
+fn seed_stability_crypto_edge_key_fingerprints() {
+    let rsa = fx().rsa("fingerprint-rsa", RsaSpec::rs256());
+    let ecdsa_p256 = fx().ecdsa("fingerprint-ecdsa-p256", EcdsaSpec::es256());
+    let ecdsa_p384 = fx().ecdsa("fingerprint-ecdsa-p384", EcdsaSpec::es384());
+    let ed25519 = fx().ed25519("fingerprint-ed25519", Ed25519Spec::new());
+
+    let snapshot = CryptoEdgeKeyFingerprints {
+        rsa: KeyMaterialFingerprint {
+            label: "fingerprint-rsa",
+            private_der_len: rsa.private_key_pkcs8_der().len(),
+            private_der_blake3: blake3_hex(rsa.private_key_pkcs8_der()),
+            public_der_len: rsa.public_key_spki_der().len(),
+            public_der_blake3: blake3_hex(rsa.public_key_spki_der()),
+            kid: rsa.kid(),
+        },
+        ecdsa_p256: KeyMaterialFingerprint {
+            label: "fingerprint-ecdsa-p256",
+            private_der_len: ecdsa_p256.private_key_pkcs8_der().len(),
+            private_der_blake3: blake3_hex(ecdsa_p256.private_key_pkcs8_der()),
+            public_der_len: ecdsa_p256.public_key_spki_der().len(),
+            public_der_blake3: blake3_hex(ecdsa_p256.public_key_spki_der()),
+            kid: ecdsa_p256.kid(),
+        },
+        ecdsa_p384: KeyMaterialFingerprint {
+            label: "fingerprint-ecdsa-p384",
+            private_der_len: ecdsa_p384.private_key_pkcs8_der().len(),
+            private_der_blake3: blake3_hex(ecdsa_p384.private_key_pkcs8_der()),
+            public_der_len: ecdsa_p384.public_key_spki_der().len(),
+            public_der_blake3: blake3_hex(ecdsa_p384.public_key_spki_der()),
+            kid: ecdsa_p384.kid(),
+        },
+        ed25519: KeyMaterialFingerprint {
+            label: "fingerprint-ed25519",
+            private_der_len: ed25519.private_key_pkcs8_der().len(),
+            private_der_blake3: blake3_hex(ed25519.private_key_pkcs8_der()),
+            public_der_len: ed25519.public_key_spki_der().len(),
+            public_der_blake3: blake3_hex(ed25519.public_key_spki_der()),
+            kid: ed25519.kid(),
+        },
+    };
+
+    insta::assert_yaml_snapshot!("crypto_edge_key_fingerprints", snapshot);
 }
 
 #[test]
@@ -774,6 +867,24 @@ fn x509_metadata_snapshot() {
 }
 
 #[test]
+fn x509_self_signed_fingerprints_snapshot() {
+    let cert = fx().x509_self_signed(
+        "x509-fingerprint",
+        X509Spec::self_signed("fingerprint.local"),
+    );
+    let snapshot = X509MaterialFingerprint {
+        label: "x509-fingerprint",
+        cert_der_len: cert.cert_der().len(),
+        cert_der_blake3: blake3_hex(cert.cert_der()),
+        key_der_len: cert.private_key_pkcs8_der().len(),
+        key_der_blake3: blake3_hex(cert.private_key_pkcs8_der()),
+        cert_pem_header: pem_header(cert.cert_pem()).to_string(),
+    };
+
+    insta::assert_yaml_snapshot!("x509_self_signed_fingerprints", snapshot);
+}
+
+#[test]
 fn x509_negative_expired_deterministic() {
     let c1 = fx().x509_self_signed("x509-exp", X509Spec::self_signed("exp.local"));
     let c2 = fx().x509_self_signed("x509-exp", X509Spec::self_signed("exp.local"));
@@ -825,6 +936,29 @@ fn x509_chain_deterministic() {
     assert_eq!(ch1.leaf_cert_pem(), ch2.leaf_cert_pem());
     assert_eq!(ch1.root_cert_pem(), ch2.root_cert_pem());
     assert_eq!(ch1.chain_pem(), ch2.chain_pem());
+}
+
+#[test]
+fn x509_chain_fingerprints_snapshot() {
+    let chain = fx().x509_chain(
+        "x509-chain-fingerprint",
+        ChainSpec::new("fingerprint-chain.local"),
+    );
+    let snapshot = X509ChainFingerprint {
+        label: "x509-chain-fingerprint",
+        chain_pem_cert_count: chain.chain_pem().matches("BEGIN CERTIFICATE").count(),
+        leaf_cert_der_len: chain.leaf_cert_der().len(),
+        leaf_cert_der_blake3: blake3_hex(chain.leaf_cert_der()),
+        intermediate_cert_der_len: chain.intermediate_cert_der().len(),
+        intermediate_cert_der_blake3: blake3_hex(chain.intermediate_cert_der()),
+        root_cert_der_len: chain.root_cert_der().len(),
+        root_cert_der_blake3: blake3_hex(chain.root_cert_der()),
+        leaf_key_der_blake3: blake3_hex(chain.leaf_private_key_pkcs8_der()),
+        intermediate_key_der_blake3: blake3_hex(chain.intermediate_private_key_pkcs8_der()),
+        root_key_der_blake3: blake3_hex(chain.root_private_key_pkcs8_der()),
+    };
+
+    insta::assert_yaml_snapshot!("x509_chain_fingerprints", snapshot);
 }
 
 // =========================================================================

--- a/tests/snapshots/determinism_regression__crypto_edge_key_fingerprints.snap
+++ b/tests/snapshots/determinism_regression__crypto_edge_key_fingerprints.snap
@@ -1,0 +1,32 @@
+---
+source: tests/determinism_regression.rs
+expression: snapshot
+---
+rsa:
+  label: fingerprint-rsa
+  private_der_len: 1217
+  private_der_blake3: 1a1409b1aee0f015b5cb6eccc4f01692c65b021e8d5dec9364f95336e43ce1c8
+  public_der_len: 294
+  public_der_blake3: 41caac6abddeae375ee7d6cc09591a849071c9aba0341a7ce6a162c4f8bbc38e
+  kid: Qcqsar3erjde59bM
+ecdsa_p256:
+  label: fingerprint-ecdsa-p256
+  private_der_len: 138
+  private_der_blake3: a5bcd562e908a0b3710cec9664cf19f2218a8fae7f594a0f0f1f01a21816f4d6
+  public_der_len: 91
+  public_der_blake3: 93fb65c3ccd9e22f4d6c5d13dbeb305bc047b93b12098832d3db57e105fe2f9a
+  kid: k_tlw8zZ4i9NbF0T
+ecdsa_p384:
+  label: fingerprint-ecdsa-p384
+  private_der_len: 185
+  private_der_blake3: f87044617fd5be83da0697cd47e8679d844d35e877031291fb2e0e96a0030c19
+  public_der_len: 120
+  public_der_blake3: f136ec7e3a2604695879618f708bb141571e5e2e200a8de9bee2f3ad530ea05e
+  kid: 8TbsfjomBGlYeWGP
+ed25519:
+  label: fingerprint-ed25519
+  private_der_len: 83
+  private_der_blake3: a6db3785112b07d2ece76429ee3392f32dc956eafc736c516d995172b114d2a2
+  public_der_len: 44
+  public_der_blake3: 004da03e3111ff18e6f69aff4793e6987a76f7405a3c338c3f693af986741fc8
+  kid: AE2gPjER_xjm9pr_

--- a/tests/snapshots/determinism_regression__x509_chain_fingerprints.snap
+++ b/tests/snapshots/determinism_regression__x509_chain_fingerprints.snap
@@ -1,0 +1,15 @@
+---
+source: tests/determinism_regression.rs
+expression: snapshot
+---
+label: x509-chain-fingerprint
+chain_pem_cert_count: 2
+leaf_cert_der_len: 824
+leaf_cert_der_blake3: e7667729836f5479fcb211e0c815d3665ce4b3fde15ac84c0f238b71df4c857a
+intermediate_cert_der_len: 816
+intermediate_cert_der_blake3: 117bcd746286880cacaa996280f9f16fc0c01028da38b01b3e865ee856911bbd
+root_cert_der_len: 808
+root_cert_der_blake3: 6660f9cd580aa5d93194c41a98c53251ea2c9c044f467ba313048b7e24ea7fa0
+leaf_key_der_blake3: dd0e82c5e8689ed645320cb1fd5a90e5b76fb7c6dd32f22074b01806c1da5fed
+intermediate_key_der_blake3: 53d6a3769b3ea1c87effe0d11ef02593d325572f22fda94a220db3905064d0ab
+root_key_der_blake3: 8b704e3230145fe87bd5eef9e8a730961f25b13596f521214cbf48a6d51f6220

--- a/tests/snapshots/determinism_regression__x509_self_signed_fingerprints.snap
+++ b/tests/snapshots/determinism_regression__x509_self_signed_fingerprints.snap
@@ -1,0 +1,10 @@
+---
+source: tests/determinism_regression.rs
+expression: snapshot
+---
+label: x509-fingerprint
+cert_der_len: 760
+cert_der_blake3: 6399e18b8d0c7b591c108d2a0adc1d710d14580e4e32353ea0041f7a828608b1
+key_der_len: 1216
+key_der_blake3: 6286be49a20879bc99d3ce7f3d753c52afebac35f730d76ff7f8c8d8700c4437
+cert_pem_header: "-----BEGIN CERTIFICATE-----"


### PR DESCRIPTION
## Summary

Add the first execution guardrails for the crypto-edge RNG convergence lane.

This does not move any dependencies yet. It strengthens the existing determinism regression suite so later convergence work has exact fixture-identity canaries for the crypto-edge outputs.

## What changed

- added `blake3` to the integration test crate so regression tests can fingerprint DER output without snapshotting secret-shaped blobs
- added deterministic fingerprint snapshots for:
  - RSA private/public DER
  - ECDSA P-256 private/public DER
  - ECDSA P-384 private/public DER
  - Ed25519 private/public DER
  - X.509 self-signed cert/key DER
  - X.509 chain leaf/intermediate/root cert DER and key DER
- kept the new guardrails inside `tests/determinism_regression.rs` so the determinism contract stays in one place

## Why

The workspace already had broad determinism coverage, but the remaining gap for the convergence lane was exact crypto-edge fixture identity pinning, especially around X.509 material. These snapshots give us before/after proof for later RNG-topology changes without committing PEM/DER blobs.

## Verification

- `cargo test -p uselesskey-integration-tests --features determinism-regression --test determinism_regression`
- `cargo test -p uselesskey-integration-tests --features determinism --test cross_crate_determinism`
- `cargo xtask gate`

Refs #257
