### PR TITLE
fix(fmt): align rustfmt.toml edition with workspace edition 2024

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 newline_style = "Unix"
 use_field_init_shorthand = true
 use_try_shorthand = true


### PR DESCRIPTION
## Summary
- `rustfmt.toml` declared `edition = "2021"` but the workspace `Cargo.toml` uses `edition = "2024"`
- Updated to `edition = "2024"` so formatting rules match the actual edition in use

## Test plan
- [x] `cargo fmt --check` passes