### PR TITLE
docs: align examples commands and cache wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,15 @@ For token-only fixtures without pulling RSA:
 uselesskey = { version = "0.4.1", default-features = false, features = ["token"] }
 ```
 
+Feature reminders for the snippets below:
+
+- `rsa` for PEM/DER, tempfile, and negative-key examples
+- `rsa` + `jwk` for `public_jwk()` / `public_jwks()`
+- `x509` for certificate, rustls, and tonic examples
+
 ### JWK / JWKS
+
+Requires `features = ["rsa", "jwk"]`.
 
 ```rust
 use uselesskey::{Factory, RsaSpec, RsaFactoryExt};
@@ -120,6 +128,8 @@ assert!(keyfile.path().exists());
 ```
 
 ### X.509 Certificates
+
+Requires `features = ["x509"]`.
 
 Self-signed certificates for simple TLS tests:
 
@@ -206,7 +216,7 @@ assert_eq!(oauth.value().split('.').count(), 3);
 
 ## Adapter Examples
 
-Adapter crates bridge uselesskey fixtures to third-party library types. They are separate crates (not features) to avoid coupling versioning. See the [Workspace Crates](#workspace-crates) section for the full list.
+Adapter crates bridge uselesskey fixtures to third-party library types. They are separate crates (not features) to avoid coupling versioning. See the [Workspace Crates](#workspace-crates) section below for the public crates and adapter overview.
 
 ### TLS Config Builders (uselesskey-rustls)
 
@@ -214,12 +224,12 @@ With the `tls-config` feature, build rustls configs in one line:
 
 ```toml
 [dev-dependencies]
+uselesskey = { version = "0.4.1", features = ["x509"] }
 uselesskey-rustls = { version = "0.4.1", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```rust
-use uselesskey_core::Factory;
-use uselesskey_x509::{X509FactoryExt, ChainSpec};
+use uselesskey::{ChainSpec, Factory, X509FactoryExt};
 use uselesskey_rustls::{RustlsServerConfigExt, RustlsClientConfigExt};
 
 let fx = Factory::random();
@@ -233,12 +243,12 @@ let client_config = chain.client_config_rustls();    // ClientConfig (trusts roo
 
 ```toml
 [dev-dependencies]
+uselesskey = { version = "0.4.1", features = ["rsa"] }
 uselesskey-ring = { version = "0.4.1", features = ["all"] }
 ```
 
 ```rust
-use uselesskey_core::Factory;
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
 use uselesskey_ring::RingRsaKeyPairExt;
 
 let fx = Factory::random();
@@ -250,12 +260,12 @@ let ring_kp = rsa.rsa_key_pair_ring();  // ring::rsa::KeyPair
 
 ```toml
 [dev-dependencies]
+uselesskey = { version = "0.4.1", features = ["rsa"] }
 uselesskey-rustcrypto = { version = "0.4.1", features = ["all"] }
 ```
 
 ```rust
-use uselesskey_core::Factory;
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
 use uselesskey_rustcrypto::RustCryptoRsaExt;
 
 let fx = Factory::random();
@@ -267,12 +277,12 @@ let rsa_pk = rsa.rsa_private_key(); // rsa::RsaPrivateKey
 
 ```toml
 [dev-dependencies]
+uselesskey = { version = "0.4.1", features = ["rsa"] }
 uselesskey-aws-lc-rs = { version = "0.4.1", features = ["native", "all"] }
 ```
 
 ```rust
-use uselesskey_core::Factory;
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
 use uselesskey_aws_lc_rs::AwsLcRsRsaKeyPairExt;
 
 let fx = Factory::random();
@@ -284,12 +294,12 @@ let lc_kp = rsa.rsa_key_pair_aws_lc_rs();  // aws_lc_rs::rsa::KeyPair
 
 ```toml
 [dev-dependencies]
+uselesskey = { version = "0.4.1", features = ["x509"] }
 uselesskey-tonic = "0.4.1"
 ```
 
 ```rust
-use uselesskey_core::Factory;
-use uselesskey_x509::{X509FactoryExt, ChainSpec};
+use uselesskey::{ChainSpec, Factory, X509FactoryExt};
 use uselesskey_tonic::{TonicClientTlsExt, TonicServerTlsExt};
 
 let fx = Factory::random();
@@ -301,32 +311,32 @@ let client_tls = chain.client_tls_config_tonic("test.example.com");
 
 ## Runnable Examples
 
-The [`crates/uselesskey/examples/`](crates/uselesskey/examples/) directory contains standalone programs you can run with `cargo run -p uselesskey --example`:
+The [`crates/uselesskey/examples/`](crates/uselesskey/examples/) directory contains standalone programs. Because the facade default feature set is empty, run them with `cargo run -p uselesskey --example <name> --features "<flags>"` using one working feature set below:
 
-| Example | Description |
-|---------|-------------|
-| [`adapter_jsonwebtoken`](crates/uselesskey/examples/adapter_jsonwebtoken.rs) | Sign and verify JWTs using `jsonwebtoken` crate integration |
-| [`adapter_rustls`](crates/uselesskey/examples/adapter_rustls.rs) | Convert X.509 fixtures into rustls `ServerConfig` / `ClientConfig` |
-| [`basic_ecdsa`](crates/uselesskey/examples/basic_ecdsa.rs) | Generate ECDSA keypairs for P-256 and P-384 in PEM, DER, JWK |
-| [`basic_ed25519`](crates/uselesskey/examples/basic_ed25519.rs) | Generate Ed25519 keypairs in PEM, DER, and JWK formats |
-| [`basic_hmac`](crates/uselesskey/examples/basic_hmac.rs) | Generate HMAC secrets for HS256, HS384, and HS512 |
-| [`basic_rsa`](crates/uselesskey/examples/basic_rsa.rs) | Generate RSA keypairs in PEM, DER, and JWK formats |
-| [`basic_token`](crates/uselesskey/examples/basic_token.rs) | Generate API key, bearer, and OAuth access-token fixtures |
-| [`basic_usage`](crates/uselesskey/examples/basic_usage.rs) | All-in-one: RSA, ECDSA, and Ed25519 fixture generation |
-| [`deterministic`](crates/uselesskey/examples/deterministic.rs) | Reproducible fixtures from seeds — same seed always yields same key |
-| [`deterministic_mode`](crates/uselesskey/examples/deterministic_mode.rs) | Order-independent deterministic derivation guarantees |
-| [`jwk_generation`](crates/uselesskey/examples/jwk_generation.rs) | Build JWKs and JWKS with `JwksBuilder` across key types |
-| [`jwk_jwks`](crates/uselesskey/examples/jwk_jwks.rs) | JWK Sets from multiple key types with metadata inspection |
-| [`jwks`](crates/uselesskey/examples/jwks.rs) | Build a JWKS from RSA and ECDSA public keys |
-| [`jwks_server_mock`](crates/uselesskey/examples/jwks_server_mock.rs) | Generate a JWKS response body for a mock `/.well-known/jwks.json` endpoint |
-| [`jwt_rs256_jwks`](crates/uselesskey/examples/jwt_rs256_jwks.rs) | RSA keypairs with JWK/JWKS extraction for JWT verification flows |
-| [`jwt_signing`](crates/uselesskey/examples/jwt_signing.rs) | JWT signing with deterministic RSA, ECDSA, and HMAC keys |
-| [`negative_fixtures`](crates/uselesskey/examples/negative_fixtures.rs) | Intentionally invalid certificates and keys for error-path testing |
-| [`tempfile_paths`](crates/uselesskey/examples/tempfile_paths.rs) | Write key fixtures to temporary files for path-based APIs |
-| [`tempfiles`](crates/uselesskey/examples/tempfiles.rs) | Write X.509 cert, key, and identity PEM to temp files |
-| [`tls_server`](crates/uselesskey/examples/tls_server.rs) | Certificate chain generation for TLS server testing |
-| [`token_generation`](crates/uselesskey/examples/token_generation.rs) | Realistic API keys, bearer tokens, and OAuth tokens for tests |
-| [`x509_certificates`](crates/uselesskey/examples/x509_certificates.rs) | Self-signed certs, cert chains, and negative X.509 fixtures |
+| Example | Feature(s) | Description |
+|---------|------------|-------------|
+| [`adapter_jsonwebtoken`](crates/uselesskey/examples/adapter_jsonwebtoken.rs) | `rsa,ecdsa,ed25519,hmac` | Sign and verify JWTs using `jsonwebtoken` crate integration |
+| [`adapter_rustls`](crates/uselesskey/examples/adapter_rustls.rs) | `x509` | Convert X.509 fixtures into rustls `ServerConfig` / `ClientConfig` |
+| [`basic_ecdsa`](crates/uselesskey/examples/basic_ecdsa.rs) | `ecdsa,jwk` | Generate ECDSA keypairs for P-256 and P-384 in PEM, DER, JWK |
+| [`basic_ed25519`](crates/uselesskey/examples/basic_ed25519.rs) | `ed25519,jwk` | Generate Ed25519 keypairs in PEM, DER, and JWK formats |
+| [`basic_hmac`](crates/uselesskey/examples/basic_hmac.rs) | `hmac,jwk` | Generate HMAC secrets for HS256, HS384, and HS512 |
+| [`basic_rsa`](crates/uselesskey/examples/basic_rsa.rs) | `rsa,jwk` | Generate RSA keypairs in PEM, DER, and JWK formats |
+| [`basic_token`](crates/uselesskey/examples/basic_token.rs) | `token` | Generate API key, bearer, and OAuth access-token fixtures |
+| [`basic_usage`](crates/uselesskey/examples/basic_usage.rs) | `ecdsa,ed25519,rsa,jwk` | All-in-one: RSA, ECDSA, and Ed25519 fixture generation |
+| [`deterministic`](crates/uselesskey/examples/deterministic.rs) | `rsa` | Reproducible fixtures from seeds - same seed always yields the same key |
+| [`deterministic_mode`](crates/uselesskey/examples/deterministic_mode.rs) | `rsa,ecdsa,ed25519` | Order-independent deterministic derivation guarantees |
+| [`jwk_generation`](crates/uselesskey/examples/jwk_generation.rs) | `ecdsa,ed25519,hmac,rsa,jwk` | Build JWKs and JWKS with `JwksBuilder` across key types |
+| [`jwk_jwks`](crates/uselesskey/examples/jwk_jwks.rs) | `ecdsa,ed25519,hmac,rsa,jwk` | JWK sets from multiple key types with metadata inspection |
+| [`jwks`](crates/uselesskey/examples/jwks.rs) | `rsa,ecdsa,jwk` | Build a JWKS from RSA and ECDSA public keys |
+| [`jwks_server_mock`](crates/uselesskey/examples/jwks_server_mock.rs) | `rsa,ecdsa,ed25519,jwk` | Generate a JWKS response body for a mock `/.well-known/jwks.json` endpoint |
+| [`jwt_rs256_jwks`](crates/uselesskey/examples/jwt_rs256_jwks.rs) | `rsa,jwk` | RSA keypairs with JWK/JWKS extraction for JWT verification flows |
+| [`jwt_signing`](crates/uselesskey/examples/jwt_signing.rs) | `rsa,jwk` | JWT signing with deterministic RSA, ECDSA, and HMAC keys (ECDSA/HMAC optional) |
+| [`negative_fixtures`](crates/uselesskey/examples/negative_fixtures.rs) | `x509` | Intentionally invalid certificates and keys for error-path testing |
+| [`tempfile_paths`](crates/uselesskey/examples/tempfile_paths.rs) | `rsa` or `ed25519` | Write key fixtures to temporary files for path-based APIs |
+| [`tempfiles`](crates/uselesskey/examples/tempfiles.rs) | `x509` | Write X.509 cert, key, and identity PEM to temp files |
+| [`tls_server`](crates/uselesskey/examples/tls_server.rs) | `x509` | Certificate chain generation for TLS server testing |
+| [`token_generation`](crates/uselesskey/examples/token_generation.rs) | `token` | Realistic API keys, bearer tokens, and OAuth tokens for tests |
+| [`x509_certificates`](crates/uselesskey/examples/x509_certificates.rs) | `x509` | Self-signed certs, cert chains, and negative X.509 fixtures |
 
 ## Workspace Crates
 
@@ -425,7 +435,7 @@ Adding new fixtures doesn't perturb existing ones. Test order doesn't matter.
 
 ### Cache-by-identity
 
-RSA keygen is expensive. Per-process caching by `(domain, label, spec, variant)` makes runtime generation cheap enough to replace committed fixtures.
+RSA keygen is expensive. Per-factory caching by `(domain, label, spec, variant)` makes runtime generation cheap enough to replace committed fixtures.
 
 ### Shape-first outputs
 

--- a/crates/uselesskey-core-cache/src/lib.rs
+++ b/crates/uselesskey-core-cache/src/lib.rs
@@ -1,4 +1,4 @@
-//! Per-process artifact cache keyed by [`ArtifactId`].
+//! Per-factory artifact cache keyed by [`ArtifactId`].
 //!
 //! Stores generated fixtures behind `Arc<dyn Any>` so expensive key generation
 //! (especially RSA) only happens once per unique identity tuple. Thread-safe:

--- a/crates/uselesskey-core-factory/README.md
+++ b/crates/uselesskey-core-factory/README.md
@@ -3,7 +3,7 @@
 This crate owns the `Factory` type for `uselesskey` and is focused on:
 
 - random vs deterministic modes
-- deterministic, thread-safe per-process cache lookup
+- deterministic, thread-safe per-factory cache lookup
 - id-driven RNG initialization
 - deterministic fixture reuse across repeated lookups
 

--- a/crates/uselesskey-core/README.md
+++ b/crates/uselesskey-core/README.md
@@ -16,7 +16,7 @@ primitives.
 
 - `Factory` in random and deterministic modes
 - Order-independent derivation from `(domain, label, spec, variant)`
-- Per-process cache for generated artifacts (powered by `uselesskey-core-cache`)
+- Per-factory cache for generated artifacts (powered by `uselesskey-core-cache`)
 - Generic negative helpers for corrupted PEM / truncated DER
 - Tempfile sinks when `std` is enabled (implemented in `uselesskey-core-sink`)
 
@@ -38,7 +38,7 @@ let fx = Factory::deterministic(seed);
 
 assert!(matches!(fx.mode(), Mode::Deterministic { .. }));
 
-// Random mode: different keys each run (still cached per-process)
+// Random mode: different keys each run (still cached per-factory)
 let fx = Factory::random();
 ```
 

--- a/crates/uselesskey-core/src/lib.rs
+++ b/crates/uselesskey-core/src/lib.rs
@@ -16,7 +16,7 @@
 //! The core concept is the [`Factory`], which manages artifact generation and caching.
 //! It operates in two modes:
 //!
-//! - **Random mode**: Artifacts are generated with OS randomness, cached per-process.
+//! - **Random mode**: Artifacts are generated with OS randomness, cached per-factory.
 //! - **Deterministic mode**: Artifacts are derived from a master seed using BLAKE3,
 //!   ensuring the same `(domain, label, spec, variant)` always produces the same artifact.
 //!

--- a/crates/uselesskey/examples/adapter_jsonwebtoken.rs
+++ b/crates/uselesskey/examples/adapter_jsonwebtoken.rs
@@ -3,7 +3,7 @@
 //! Demonstrates signing and verifying JWTs using uselesskey fixtures
 //! with the popular `jsonwebtoken` crate via `uselesskey-jsonwebtoken`.
 //!
-//! Run with: cargo run -p uselesskey --example adapter_jsonwebtoken --features full
+//! Run with: cargo run -p uselesskey --example adapter_jsonwebtoken --features "rsa,ecdsa,ed25519,hmac"
 
 #[cfg(all(
     feature = "rsa",
@@ -147,5 +147,7 @@ fn main() {
 )))]
 fn main() {
     eprintln!("Enable all key type features:");
-    eprintln!("  cargo run -p uselesskey --example adapter_jsonwebtoken --features full");
+    eprintln!(
+        "  cargo run -p uselesskey --example adapter_jsonwebtoken --features \"rsa,ecdsa,ed25519,hmac\""
+    );
 }

--- a/crates/uselesskey/examples/adapter_rustls.rs
+++ b/crates/uselesskey/examples/adapter_rustls.rs
@@ -3,7 +3,7 @@
 //! Demonstrates converting uselesskey X.509 fixtures into rustls types
 //! for building TLS server and client configurations.
 //!
-//! Run with: cargo run -p uselesskey --example adapter_rustls --features full
+//! Run with: cargo run -p uselesskey --example adapter_rustls --features x509
 
 #[cfg(feature = "x509")]
 fn main() {
@@ -99,5 +99,5 @@ fn main() {
 #[cfg(not(feature = "x509"))]
 fn main() {
     eprintln!("Enable 'x509' feature:");
-    eprintln!("  cargo run -p uselesskey --example adapter_rustls --features full");
+    eprintln!("  cargo run -p uselesskey --example adapter_rustls --features x509");
 }

--- a/crates/uselesskey/examples/basic_ecdsa.rs
+++ b/crates/uselesskey/examples/basic_ecdsa.rs
@@ -3,7 +3,7 @@
 //! Demonstrates generating ECDSA keypairs for P-256 (ES256) and P-384 (ES384),
 //! and accessing them in PEM, DER, and JWK formats.
 //!
-//! Run with: cargo run -p uselesskey --example basic_ecdsa --features full
+//! Run with: cargo run -p uselesskey --example basic_ecdsa --features "ecdsa,jwk"
 
 #[cfg(all(feature = "ecdsa", feature = "jwk"))]
 fn main() {
@@ -84,5 +84,5 @@ fn main() {
 #[cfg(not(all(feature = "ecdsa", feature = "jwk")))]
 fn main() {
     eprintln!("Enable 'ecdsa' and 'jwk' features:");
-    eprintln!("  cargo run -p uselesskey --example basic_ecdsa --features full");
+    eprintln!("  cargo run -p uselesskey --example basic_ecdsa --features \"ecdsa,jwk\"");
 }

--- a/crates/uselesskey/examples/basic_ed25519.rs
+++ b/crates/uselesskey/examples/basic_ed25519.rs
@@ -3,7 +3,7 @@
 //! Demonstrates generating Ed25519 keypairs and accessing them in
 //! PEM, DER, and JWK formats.
 //!
-//! Run with: cargo run -p uselesskey --example basic_ed25519 --features full
+//! Run with: cargo run -p uselesskey --example basic_ed25519 --features "ed25519,jwk"
 
 #[cfg(all(feature = "ed25519", feature = "jwk"))]
 fn main() {
@@ -68,5 +68,5 @@ fn main() {
 #[cfg(not(all(feature = "ed25519", feature = "jwk")))]
 fn main() {
     eprintln!("Enable 'ed25519' and 'jwk' features:");
-    eprintln!("  cargo run -p uselesskey --example basic_ed25519 --features full");
+    eprintln!("  cargo run -p uselesskey --example basic_ed25519 --features \"ed25519,jwk\"");
 }

--- a/crates/uselesskey/examples/basic_hmac.rs
+++ b/crates/uselesskey/examples/basic_hmac.rs
@@ -3,7 +3,7 @@
 //! Demonstrates generating HMAC secrets of different sizes and
 //! accessing them as raw bytes and (with `jwk` feature) as JWK/JWKS.
 //!
-//! Run with: cargo run -p uselesskey --example basic_hmac --features full
+//! Run with: cargo run -p uselesskey --example basic_hmac --features "hmac,jwk"
 
 #[cfg(all(feature = "hmac", feature = "jwk"))]
 fn main() {
@@ -67,5 +67,5 @@ fn main() {
 #[cfg(not(all(feature = "hmac", feature = "jwk")))]
 fn main() {
     eprintln!("Enable 'hmac' and 'jwk' features:");
-    eprintln!("  cargo run -p uselesskey --example basic_hmac --features full");
+    eprintln!("  cargo run -p uselesskey --example basic_hmac --features \"hmac,jwk\"");
 }

--- a/crates/uselesskey/examples/basic_rsa.rs
+++ b/crates/uselesskey/examples/basic_rsa.rs
@@ -3,7 +3,7 @@
 //! Demonstrates generating RSA keypairs and accessing them in
 //! PEM, DER, and JWK formats — without printing actual key material.
 //!
-//! Run with: cargo run -p uselesskey --example basic_rsa --features full
+//! Run with: cargo run -p uselesskey --example basic_rsa --features "rsa,jwk"
 
 #[cfg(all(feature = "rsa", feature = "jwk"))]
 fn main() {
@@ -74,5 +74,5 @@ fn main() {
 #[cfg(not(all(feature = "rsa", feature = "jwk")))]
 fn main() {
     eprintln!("Enable 'rsa' and 'jwk' features:");
-    eprintln!("  cargo run -p uselesskey --example basic_rsa --features full");
+    eprintln!("  cargo run -p uselesskey --example basic_rsa --features \"rsa,jwk\"");
 }

--- a/crates/uselesskey/examples/basic_usage.rs
+++ b/crates/uselesskey/examples/basic_usage.rs
@@ -3,7 +3,7 @@
 //! Shows how to create a deterministic factory and generate keypairs for
 //! all three asymmetric key types, accessing PEM, DER, and JWK outputs.
 //!
-//! Run with: cargo run -p uselesskey --example basic_usage --features full
+//! Run with: cargo run -p uselesskey --example basic_usage --features "ecdsa,ed25519,rsa,jwk"
 
 #[cfg(all(
     feature = "rsa",
@@ -169,5 +169,7 @@ fn main() {
 )))]
 fn main() {
     eprintln!("Enable required features:");
-    eprintln!("  cargo run -p uselesskey --example basic_usage --features full");
+    eprintln!(
+        "  cargo run -p uselesskey --example basic_usage --features \"ecdsa,ed25519,rsa,jwk\""
+    );
 }

--- a/crates/uselesskey/examples/deterministic.rs
+++ b/crates/uselesskey/examples/deterministic.rs
@@ -3,7 +3,7 @@
 //! Demonstrates how deterministic derivation works: same seed + same label +
 //! same spec always produces the same key, regardless of call order.
 //!
-//! Run with: cargo run -p uselesskey --example deterministic --features full
+//! Run with: cargo run -p uselesskey --example deterministic --features rsa
 
 #[cfg(feature = "rsa")]
 fn main() {
@@ -117,5 +117,5 @@ fn main() {
 #[cfg(not(feature = "rsa"))]
 fn main() {
     eprintln!("Enable 'rsa' feature:");
-    eprintln!("  cargo run -p uselesskey --example deterministic --features full");
+    eprintln!("  cargo run -p uselesskey --example deterministic --features rsa");
 }

--- a/crates/uselesskey/examples/deterministic_mode.rs
+++ b/crates/uselesskey/examples/deterministic_mode.rs
@@ -4,7 +4,7 @@
 //! label, and spec always produce the same key — regardless of the order in
 //! which fixtures are requested.
 //!
-//! Run with: cargo run -p uselesskey --example deterministic_mode --features full
+//! Run with: cargo run -p uselesskey --example deterministic_mode --features "ecdsa,ed25519,rsa"
 
 #[cfg(all(feature = "rsa", feature = "ecdsa", feature = "ed25519"))]
 fn main() {
@@ -138,5 +138,7 @@ fn main() {
 #[cfg(not(all(feature = "rsa", feature = "ecdsa", feature = "ed25519")))]
 fn main() {
     eprintln!("Enable required features:");
-    eprintln!("  cargo run -p uselesskey --example deterministic_mode --features full");
+    eprintln!(
+        "  cargo run -p uselesskey --example deterministic_mode --features \"ecdsa,ed25519,rsa\""
+    );
 }

--- a/crates/uselesskey/examples/jwk_generation.rs
+++ b/crates/uselesskey/examples/jwk_generation.rs
@@ -3,7 +3,7 @@
 //! Demonstrates building individual JWKs, combining them into a JWKS using
 //! `JwksBuilder`, and inspecting key metadata — without printing key material.
 //!
-//! Run with: cargo run -p uselesskey --example jwk_generation --features full
+//! Run with: cargo run -p uselesskey --example jwk_generation --features "ecdsa,ed25519,hmac,rsa,jwk"
 
 #[cfg(all(
     feature = "jwk",
@@ -152,5 +152,7 @@ fn main() {
 )))]
 fn main() {
     eprintln!("Enable required features:");
-    eprintln!("  cargo run -p uselesskey --example jwk_generation --features full");
+    eprintln!(
+        "  cargo run -p uselesskey --example jwk_generation --features \"ecdsa,ed25519,hmac,rsa,jwk\""
+    );
 }

--- a/crates/uselesskey/examples/jwk_jwks.rs
+++ b/crates/uselesskey/examples/jwk_jwks.rs
@@ -3,7 +3,7 @@
 //! Demonstrates building JWK Sets from multiple key types using JwksBuilder,
 //! and inspecting individual JWK metadata without printing key material.
 //!
-//! Run with: cargo run -p uselesskey --example jwk_jwks --features full
+//! Run with: cargo run -p uselesskey --example jwk_jwks --features "ecdsa,ed25519,hmac,rsa,jwk"
 
 #[cfg(all(
     feature = "jwk",
@@ -159,5 +159,7 @@ fn main() {
 )))]
 fn main() {
     eprintln!("Enable all key features + jwk:");
-    eprintln!("  cargo run -p uselesskey --example jwk_jwks --features full");
+    eprintln!(
+        "  cargo run -p uselesskey --example jwk_jwks --features \"ecdsa,ed25519,hmac,rsa,jwk\""
+    );
 }

--- a/crates/uselesskey/examples/jwks.rs
+++ b/crates/uselesskey/examples/jwks.rs
@@ -1,3 +1,10 @@
+//! Demonstrates building a JWKS from RSA and ECDSA public keys.
+//!
+//! Run with:
+//! ```sh
+//! cargo run -p uselesskey --example jwks --features "rsa,ecdsa,jwk"
+//! ```
+
 #[cfg(all(feature = "jwk", feature = "rsa", feature = "ecdsa"))]
 fn main() {
     use uselesskey::jwk::JwksBuilder;
@@ -17,5 +24,6 @@ fn main() {
 
 #[cfg(not(all(feature = "jwk", feature = "rsa", feature = "ecdsa")))]
 fn main() {
-    eprintln!("Enable 'jwk', 'rsa', and 'ecdsa' features to run this example.");
+    eprintln!("Enable 'jwk', 'rsa', and 'ecdsa' features to run this example:");
+    eprintln!("  cargo run -p uselesskey --example jwks --features \"rsa,ecdsa,jwk\"");
 }

--- a/crates/uselesskey/examples/jwks_server_mock.rs
+++ b/crates/uselesskey/examples/jwks_server_mock.rs
@@ -9,7 +9,7 @@
 //! - Simulate key rotation by building JWKS with old and new keys
 //! - Verify your code handles multi-algorithm JWKS correctly
 //!
-//! Run with: cargo run --example jwks_server_mock -p uselesskey --features "rsa,ecdsa,ed25519,jwk"
+//! Run with: cargo run -p uselesskey --example jwks_server_mock --features "rsa,ecdsa,ed25519,jwk"
 
 #[cfg(all(
     feature = "rsa",
@@ -218,6 +218,6 @@ fn main() {
 fn main() {
     eprintln!("Enable required features to run this example:");
     eprintln!(
-        "  cargo run --example jwks_server_mock -p uselesskey --features \"rsa,ecdsa,ed25519,jwk\""
+        "  cargo run -p uselesskey --example jwks_server_mock --features \"rsa,ecdsa,ed25519,jwk\""
     );
 }

--- a/crates/uselesskey/examples/jwt_rs256_jwks.rs
+++ b/crates/uselesskey/examples/jwt_rs256_jwks.rs
@@ -8,7 +8,7 @@
 //!
 //! Run with:
 //! ```sh
-//! cargo run --example jwt_rs256_jwks --features "rsa jwk"
+//! cargo run -p uselesskey --example jwt_rs256_jwks --features "rsa,jwk"
 //! ```
 
 use std::error::Error;
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     use uselesskey::{Factory, RsaFactoryExt, RsaSpec, Seed};
 
     // ==========================================================================
-    // Random mode: each run produces different keys (still cached per-process)
+    // Random mode: each run produces different keys (still cached per-factory)
     // ==========================================================================
     println!("=== Random Mode ===\n");
 
@@ -69,5 +69,5 @@ fn main() -> Result<(), Box<dyn Error>> {
 #[cfg(not(all(feature = "rsa", feature = "jwk")))]
 fn main() {
     eprintln!("Enable 'rsa' and 'jwk' features to run this example:");
-    eprintln!("  cargo run --example jwt_rs256_jwks --features \"rsa jwk\"");
+    eprintln!("  cargo run -p uselesskey --example jwt_rs256_jwks --features \"rsa,jwk\"");
 }

--- a/crates/uselesskey/examples/jwt_signing.rs
+++ b/crates/uselesskey/examples/jwt_signing.rs
@@ -5,7 +5,10 @@
 //! - Using JWK outputs for JWT verification
 //! - Creating a JWKS for multiple keys
 //!
-//! Run with: cargo run --example jwt_signing --features "rsa,ecdsa,hmac,jwk"
+//! Run with:
+//! ```sh
+//! cargo run -p uselesskey --example jwt_signing --features "rsa,jwk"
+//! ```
 
 use uselesskey::prelude::*;
 
@@ -54,7 +57,7 @@ fn main() {
 #[cfg(not(all(feature = "rsa", feature = "jwk")))]
 fn main() {
     eprintln!("Enable 'rsa' and 'jwk' features to run this example:");
-    eprintln!("  cargo run --example jwt_signing --features \"rsa,jwk\"");
-    eprintln!("\nFor full functionality with all key types:");
-    eprintln!("  cargo run --example jwt_signing --features \"rsa,ecdsa,hmac,jwk\"");
+    eprintln!("  cargo run -p uselesskey --example jwt_signing --features \"rsa,jwk\"");
+    eprintln!("\nFor optional ECDSA/HMAC variants:");
+    eprintln!("  cargo run -p uselesskey --example jwt_signing --features \"rsa,ecdsa,hmac,jwk\"");
 }

--- a/crates/uselesskey/examples/negative_fixtures.rs
+++ b/crates/uselesskey/examples/negative_fixtures.rs
@@ -6,7 +6,7 @@
 //! - Using corrupt PEM variants and truncated DER
 //! - Tempfile outputs for testing external tools
 //!
-//! Run with: cargo run --example negative_fixtures --features x509
+//! Run with: cargo run -p uselesskey --example negative_fixtures --features "x509"
 
 #[cfg(feature = "x509")]
 use std::io::Read;
@@ -107,5 +107,5 @@ fn main() {
 #[cfg(not(feature = "x509"))]
 fn main() {
     eprintln!("Enable required feature to run this example:");
-    eprintln!("  cargo run --example negative_fixtures --features \"x509\"");
+    eprintln!("  cargo run -p uselesskey --example negative_fixtures --features \"x509\"");
 }

--- a/crates/uselesskey/examples/tempfile_paths.rs
+++ b/crates/uselesskey/examples/tempfile_paths.rs
@@ -11,9 +11,9 @@
 //!
 //! # Running this example
 //!
-//! With RSA (default feature):
+//! With RSA:
 //! ```bash
-//! cargo run -p uselesskey --example tempfile_paths
+//! cargo run -p uselesskey --example tempfile_paths --features "rsa"
 //! ```
 //!
 //! With Ed25519:

--- a/crates/uselesskey/examples/tempfiles.rs
+++ b/crates/uselesskey/examples/tempfiles.rs
@@ -1,3 +1,10 @@
+//! X.509 file-writing example for cert, key, and identity tempfiles.
+//!
+//! Run with:
+//! ```sh
+//! cargo run -p uselesskey --example tempfiles --features "x509"
+//! ```
+
 #[cfg(feature = "x509")]
 fn main() {
     use uselesskey::{Factory, X509FactoryExt, X509Spec};
@@ -16,5 +23,6 @@ fn main() {
 
 #[cfg(not(feature = "x509"))]
 fn main() {
-    eprintln!("Enable the 'x509' feature to run this example.");
+    eprintln!("Enable the 'x509' feature to run this example:");
+    eprintln!("  cargo run -p uselesskey --example tempfiles --features \"x509\"");
 }

--- a/crates/uselesskey/examples/tls_server.rs
+++ b/crates/uselesskey/examples/tls_server.rs
@@ -5,7 +5,7 @@
 //! - Accessing certificates in PEM/DER formats
 //! - Creating self-signed certificates for testing
 //!
-//! Run with: cargo run --example tls_server --features "x509"
+//! Run with: cargo run -p uselesskey --example tls_server --features "x509"
 
 #[cfg(feature = "x509")]
 fn main() {
@@ -78,5 +78,5 @@ fn main() {
 #[cfg(not(feature = "x509"))]
 fn main() {
     eprintln!("Enable required feature to run this example:");
-    eprintln!("  cargo run --example tls_server --features \"x509\"");
+    eprintln!("  cargo run -p uselesskey --example tls_server --features \"x509\"");
 }

--- a/crates/uselesskey/examples/token_generation.rs
+++ b/crates/uselesskey/examples/token_generation.rs
@@ -3,7 +3,7 @@
 //! Demonstrates generating realistic test-token shapes that look like
 //! real secrets but are deterministic and safe for version control.
 //!
-//! Run with: cargo run -p uselesskey --example token_generation --features full
+//! Run with: cargo run -p uselesskey --example token_generation --features token
 
 #[cfg(feature = "token")]
 fn main() {
@@ -78,5 +78,5 @@ fn main() {
 #[cfg(not(feature = "token"))]
 fn main() {
     eprintln!("Enable 'token' feature:");
-    eprintln!("  cargo run -p uselesskey --example token_generation --features full");
+    eprintln!("  cargo run -p uselesskey --example token_generation --features token");
 }

--- a/crates/uselesskey/examples/x509_certificates.rs
+++ b/crates/uselesskey/examples/x509_certificates.rs
@@ -7,7 +7,7 @@
 //! - Chain negative fixtures (hostname mismatch, unknown CA, revoked leaf)
 //! - Writing certificates to tempfiles for external tools
 //!
-//! Run with: cargo run --example x509_certificates -p uselesskey --features x509
+//! Run with: cargo run -p uselesskey --example x509_certificates --features "x509"
 
 #[cfg(feature = "x509")]
 fn main() {
@@ -266,5 +266,5 @@ fn main() {
 #[cfg(not(feature = "x509"))]
 fn main() {
     eprintln!("Enable required feature to run this example:");
-    eprintln!("  cargo run --example x509_certificates -p uselesskey --features x509");
+    eprintln!("  cargo run -p uselesskey --example x509_certificates --features \"x509\"");
 }

--- a/crates/uselesskey/src/lib.rs
+++ b/crates/uselesskey/src/lib.rs
@@ -47,7 +47,7 @@
 //! # fn main() {
 //! use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
 //!
-//! // Random mode: each run produces different keys (still cached per-process)
+//! // Random mode: each run produces different keys (still cached per-factory)
 //! let fx = Factory::random();
 //! let keypair = fx.rsa("my-service", RsaSpec::rs256());
 //!

--- a/docs/adr/0005-cache-by-identity.md
+++ b/docs/adr/0005-cache-by-identity.md
@@ -7,12 +7,12 @@ Accepted
 RSA key generation is expensive (especially for 4096-bit keys). Without caching, tests that repeatedly request the same fixture would regenerate keys each time, making test suites slow.
 
 ## Decision
-Per-process cache keyed by `(domain, label, spec, variant)` using `DashMap` with `Arc<dyn Any + Send + Sync>` storage.
+Per-factory cache keyed by `(domain, label, spec, variant)` using `DashMap` with `Arc<dyn Any + Send + Sync>` storage.
 
 - Cache key is the full artifact identity tuple
 - Storage is thread-safe via DashMap
 - Values are Arc'd for cheap cloning
-- Cache lives for the process lifetime
+- Cache is tied to a `Factory` instance and shared across cloned `Factory`s
 
 ## Consequences
 
@@ -23,7 +23,7 @@ Per-process cache keyed by `(domain, label, spec, variant)` using `DashMap` with
 
 **Negative:**
 - Memory usage grows with unique fixtures (acceptable for test usage)
-- Cache invalidation is process-bound (acceptable for test usage)
+- Cache invalidation is factory-bound (acceptable for test usage)
 
 ## Alternatives Considered
 - **No cache:** Too slow for RSA-heavy tests

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -57,7 +57,7 @@ set of focused microcrates that each own a single concern:
 
 - `uselesskey-core-factory` — factory orchestration: mode
   (Random/Deterministic), derivation dispatch, artifact generation
-- `uselesskey-core-cache` — per-process artifact cache keyed by identity
+- `uselesskey-core-cache` — per-factory artifact cache keyed by identity
   (DashMap + `Arc<dyn Any>`)
 - `uselesskey-core-sink` — tempfile-backed artifact sinks for disk output
 


### PR DESCRIPTION
Docs/examples follow-up cleanup split from PR #267.