### PR TITLE
docs(adr): define adapter and public surface criteria

### DIFF
--- a/docs/adr/0027-adapter-acceptance-criteria.md
+++ b/docs/adr/0027-adapter-acceptance-criteria.md
@@ -1,0 +1,72 @@
+# ADR-0027: Adapter Acceptance Criteria
+
+## Status
+
+Accepted
+
+## Context
+
+The workspace now tracks 43 publishable crates through `PUBLISH_CRATES`. Without guardrails, adapter ideas can quietly become permanent cargo-weight:
+
+- ecosystem demand can be satisfied by existing crates with the same native type family
+- small conversion helpers can be misclassified as adapters
+- release and review burden can grow faster than value
+
+This ADR defines a strict bar for adding new adapter crates so the line between core artifact generation and downstream compatibility adapters stays explicit.
+
+## Decision
+
+An **adapter crate** is a crate whose main purpose is to convert `uselesskey` artifacts into stable, ecosystem-native types for a specific dependency family (for example TLS credentials, JOSE signing keys, or native token/crypto types).
+
+An adapter crate **must** satisfy all of the following to be accepted:
+
+1. **Clear native-type return**
+   - The crate exposes helpers whose primary output is a type from the target ecosystem crate(s).
+   - The conversion target is not a format already covered by core (PEM/DER/JWK/artifacts only).
+2. **Existing surface check**
+   - If any existing adapter already provides the same native-type conversion, new work belongs in that adapter, not a new crate.
+3. **Ecosystem value**
+   - The adapter unlocks a non-trivial integration path that is currently difficult or fragile for test authors.
+   - The conversion path is used beyond a single internal consumer.
+4. **Crate-cost check**
+   - Expected ongoing maintenance is supported by at least one clear consumer need and a documented ownership plan.
+5. **Release-ready package boundary**
+   - It can be added to `PUBLISH_CRATES` with stable manifest metadata, docs, and release checklist updates.
+
+For each approved adapter crate, the following artifacts are required:
+
+- ADR-approved rationale and compatibility statement
+- crate README with dependency snippets and native type mapping
+- one runnable example with documented feature set
+- one smoke/integration test covering deterministic output path
+- `publish-check` / `publish-preflight` pass for the crate
+- feature-matrix or docs metadata entry for discoverability
+
+What does **not** qualify as a new adapter crate:
+
+- helper APIs that only format or rename existing core artifacts
+- wrappers that only compose existing adapter outputs without introducing new native mapping logic
+- one-off internal conversions for a single team/project
+- alternative APIs over the same conversion that duplicate another adapter
+
+## Consequences
+
+### Positive
+
+- Contributors get a deterministic decision rule for crate expansion.
+- Adapter set stays aligned with real ecosystem integration value, not accidental drift.
+- Release risk grows only when a crate has clear cross-consumer benefit.
+
+### Negative
+
+- Some useful but niche conversions will now stay as examples or downstream code instead of first-class crates.
+- Every new adapter requires explicit metadata and testing work before landing.
+
+## Alternatives Considered
+
+- **Keep adding adapters as existing adapters accrete more features**
+  - **Rejected:** increases coupling and makes compatibility promises less explicit.
+- **Put new adapters behind `uselesskey` feature flags**
+  - **Rejected:** does not solve version and dependency-graph pressure across the 43-crate publish set.
+- **Use issue labels only (no ADR)**
+  - **Rejected:** misses required release and maintenance requirements before crate creation.

--- a/docs/adr/0028-workspace-public-surface-policy.md
+++ b/docs/adr/0028-workspace-public-surface-policy.md
@@ -1,0 +1,74 @@
+# ADR-0028: Workspace Public Surface Policy
+
+## Status
+
+Accepted
+
+## Context
+
+`xtask` now publishes a long, explicit crate list (`PUBLISH_CRATES`) and release automation relies on that list as the only source of truth.
+
+Without explicit policy, publishable/crate-intent confusion creates two hazards:
+
+- accidental drift between manifests, release tooling, and public expectations
+- incremental expansion of publish surface without explicit cost review
+
+## Decision
+
+The workspace public surface is deliberately split into two categories:
+
+1. **Intentionally publishable**
+   - Crates explicitly listed in `PUBLISH_CRATES` in `xtask/src/main.rs`.
+   - Intended for external consumers and must remain semver-governed.
+   - Must have complete crates.io and docs.rs metadata and pass preflight checks.
+2. **Internal**
+   - Crates not in `PUBLISH_CRATES`, including helper/test tooling crates, build infra, and local adapters.
+   - Must set `publish = false` in `Cargo.toml`.
+
+Review bar before adding a new publishable crate:
+
+- submit a dedicated design rationale (e.g. ADR) and milestone/issue linkage
+- show upstream/native demand and expected consumer maintenance burden
+- place crate in a stable dependency slot in `PUBLISH_CRATES`
+- add or update:
+  - version policy in manifest
+  - dependency snippets in release-facing docs
+  - docs/metadata generated source
+  - smoke/integration coverage
+- run `cargo xtask publish-preflight` and `cargo xtask publish-check` in PR scope
+- add post-release verification for crates.io + docs.rs in the release checklist
+
+For removing or deprecating a public crate:
+
+- set `publish = false` when it should no longer be externally consumable
+- remove it from `PUBLISH_CRATES`
+- keep internal references updated so dependency edges remain valid
+- record rationale in changelog and ADR history
+
+Release risk control:
+
+- each additional publishable crate increases publish-set maintenance and release blast radius.
+- adding crate count requires explicit maintainer sign-off and a milestone with release governance checkpoints.
+- if a crate cannot be validated by release checks within current PR gates, it is rejected as publishable expansion.
+
+## Consequences
+
+### Positive
+
+- Public surface changes become explicit, reviewable, and tied directly to release tooling.
+- Release automation and dependency graphs stay aligned with documented intent.
+- Consumers can rely on a stable and documented crate set.
+
+### Negative
+
+- There is friction to publish surface changes, intentionally delaying low-value experiments.
+- Some potentially useful crates will remain internal until they pass formal review bar.
+
+## Alternatives Considered
+
+- **Maintain separate “publishable crates” docs and tooling lists**
+  - **Rejected:** drift risk rises as the list changes.
+- **Publish everything in workspace by default**
+  - **Rejected:** operational risk and maintenance burden increase with no corresponding consumer benefit.
+- **Rely on contributor discussion only**
+  - **Rejected:** insufficient control for deterministic release and preflight automation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,6 +67,8 @@ NNNN-short-title.md
 | [0024](0024-bias-free-base62.md) | Bias-Free Base62 Generation | Accepted | 2026-03-13 |
 | [0025](0025-pr-scoped-ci.md) | PR-Scoped CI | Accepted | 2026-03-13 |
 | [0026](0026-empty-default-features.md) | Empty Default Features | Accepted | 2026-03-13 |
+| [0027](0027-adapter-acceptance-criteria.md) | Adapter Acceptance Criteria | Accepted | 2026-03-22 |
+| [0028](0028-workspace-public-surface-policy.md) | Workspace Public Surface Policy | Accepted | 2026-03-22 |
 
 ## References
 


### PR DESCRIPTION
## Summary
- add ADR-0027 for adapter acceptance criteria
- add ADR-0028 for workspace public surface policy
- update ADR index with new records

## Why now
This sets explicit guardrails before adding more publishable adapters in the v0.5 cycle.

## Verification
- file-level review completed
- no code changes