### PR TITLE
docs(roadmap): reset planning for v0.5.x

### DIFF
--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -1,0 +1,35 @@
+# Roadmap Follow-ups (v0.5.x)
+
+This plan decomposes `roadmap.md` into milestone-aligned execution items.
+
+## v0.5.0 adapter wave
+
+- [ ] Roadmap reset for v0.5.x
+- [ ] ADR: adapter acceptance criteria
+- [ ] ADR: workspace public-surface policy
+- [ ] Docs metadata source + docs-sync command
+- [ ] examples-smoke command
+- [ ] Adapter A
+- [ ] Adapter B
+- [ ] v0.5.0 release prep
+
+## v0.5.1 negative fixtures
+
+- [ ] X.509 negative wave 1
+- [ ] JWK/JWKS negative wave 1
+- [ ] token-shape negative wave 1
+- [ ] docs/examples coverage for negative fixtures
+
+## v0.5.2 benchmarks and governance
+
+- [ ] Criterion harness
+- [ ] Baseline performance report
+- [ ] Scheduled/manual perf workflow
+- [ ] CI threshold policy for benchmark trends
+- [ ] Release category notes + post-release audit
+
+## Governance
+
+- [ ] release governance milestone and labels
+- [ ] roadmap link to this follow-up from `roadmap.md`
+- [ ] one issue per checklist line (no unchecked line left without a tracked issue)

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -2,27 +2,31 @@
 
 This roadmap reflects the strategic direction for uselesskey as a **test-fixture layer** (not a crypto library).
 
-## Now (v0.4.1)
+## Now (v0.5.x)
 
-*Release polish and publish hygiene*
+*Post-release planning reset for the next cycle*
 
-- [x] Rust 1.92 / edition 2024 line is green on `main`
-- [x] Fixture families expose consistent `label()` / `spec()` accessors
-- [x] Publish preflight catches stale versioned dependency snippets in docs
-- [x] README and crate README dependency snippets track the current release line
+- [ ] [Roadmap reset for v0.5.x][roadmap-followups]
+- [ ] Create milestones and execution issues from the follow-up plan
+- [ ] ADR: adapter acceptance criteria
+- [ ] ADR: public surface policy
+- [ ] Add docs metadata source and sync enforcement
+- [ ] Add examples-smoke validation in the docs/examples path
 
-## Next (v0.5.0+)
+## Next (v0.5.0 adapter wave)
 
-*Planned - Next wave of improvements*
+*Planned - Next wave of work*
 
-- [ ] Additional adapter microcrates for ecosystem-specific test harnesses
+- [ ] Two adapter microcrates with complete per-adapter docs/tests/examples coverage
+- [ ] Release prep and release-note entries for v0.5.0
 
-## Later (Backlog)
+## Later (v0.5.1+)
 
-*Under evaluation - No commitment*
+*Under evaluation - Planned follow-up*
 
 - [ ] Additional negative fixture variants
 - [ ] Performance benchmarks for key generation paths
+- [ ] Release governance and post-release audit automation
 
 ## Shipped
 
@@ -136,3 +140,5 @@ These are explicitly out of scope:
 - **Derivation stability**: Changing the derivation algorithm requires bumping the derivation version field. Existing tests should not break.
 - **Semver**: Breaking API changes bump the minor version until 1.0, then major version.
 - **Feature flags**: New key types are opt-in via Cargo features to keep compile times reasonable.
+
+[roadmap-followups]: roadmap-followups-0251.md


### PR DESCRIPTION
## Summary
- Reset the roadmap `Now` section to v0.5.x to align planning with the post-release state.
- Add a v0.5 follow-up planning document with issue-sized items for v0.5.0, v0.5.1, v0.5.2, and governance.
- Keep all non-roadmap planning content unchanged; this is a planning-only PR.

## Scope guardrail
Only these files are modified:
- docs/explanation/roadmap.md
- docs/explanation/roadmap-followups-0251.md
