### PR TITLE
ci: enforce docs-sync and examples-smoke in PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
       - name: xtask pr
         run: cargo xtask pr
 
+      - name: docs-sync check
+        run: cargo xtask docs-sync --check
+
+      - name: examples smoke check
+        run: cargo xtask examples-smoke
+
       - name: Upload receipt
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Implements CI coverage for docs/examples enforcement by running cargo xtask docs-sync --check and cargo xtask examples-smoke in the PR workflow. xamples-smoke --run remains available for manual or scheduled execution.

Fixes #292