### PR TITLE
docs: refresh hand-maintained README prose and add feature-choice how-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,88 +8,100 @@
 
 *Deterministic cryptographic test fixtures for Rust.*
 
-`uselesskey` is a test-fixture factory, not a crypto library. It generates key material,
-certificates, and token-shaped artifacts at runtime so tests do not need committed PEM/DER/JWK
-blobs.
+`uselesskey` is a **test-fixture factory**, not a crypto library. It generates key material, certificates, token-shaped fixtures, and negative artifacts at runtime so tests do not need committed PEM/DER/JWK blobs.
 
 ## Why this exists
 
-Fixture-heavy projects need realistic cryptographic artifacts without committing secret-shaped content:
+`uselesskey` is a **test-fixture layer**, not a runtime crypto service.
+
+Use it when you need realistic cryptographic fixtures without committing PEM/DER/JWK files.
+
+It exists to remove this test friction:
 
 - scanners inspect every commit in a PR, not just the final diff
-- push protection requires cleanup across commit history
-- path ignores and exceptions become maintenance debt
+- fake-looking keys still trigger policy, push protection, and review friction
 
-`uselesskey` replaces that workflow with one dev-dependency and runtime generation.
+`uselesskey` replaces security exceptions + path ignores + fixture directories with one dev-dependency and runtime generation.
 
-> Do not use this for production key or certificate work.
-> Deterministic fixtures are intentionally predictable. Random fixtures are test-only.
+> **Do not use this crate for production key generation or certificate management.**
+> Deterministic mode is intentionally predictable by design. Random mode is for tests only.
 
 ## What problem it solves
 
-Without this layer, teams commonly end up with:
+Without this layer, teams commonly end up with one of these:
 
 | Approach | Problem |
 |----------|----------|
-| Commit PEM/DER files | Triggers scanners and blocks pushes |
-| Generate keys ad-hoc in tests | No shared cache, slower RSA, ad-hoc shape handling |
-| Use raw crypto crates directly | You still assemble PEM/DER/JWK/TLS shapes manually |
-| Use rcgen directly | Useful for runtime generation, not fixture ergonomics |
+| Commit PEM/DER files | Triggers scanners and push protection |
+| Generate keys ad hoc in tests | Repeated boilerplate, slow RSA, no shared determinism |
+| Use raw crypto crates directly | You still have to assemble PEM/DER/JWK/X.509 shapes yourself |
+| Use `rcgen` or other runtime crates directly | Useful, but not centered on fixture ergonomics, determinism, or negative cases |
 
-`uselesskey` exists for test artifacts: shape-first outputs with stable fixture APIs.
+`uselesskey` is built specifically for **test artifacts**.
 
 ## What you get
+
+### Fixture families
 
 - RSA (2048, 3072, 4096)
 - ECDSA (P-256, P-384)
 - Ed25519
 - HMAC (HS256, HS384, HS512)
 - OpenPGP (RSA 2048/3072, Ed25519)
-- Token fixtures (API key, bearer, OAuth/JWT shape)
+- Token fixtures (API key, bearer, OAuth access-token / JWT shape)
 - X.509 self-signed certificates and certificate chains
 
 ### Output shapes
 
 - PKCS#8 PEM/DER
 - SPKI PEM/DER
+- OpenPGP armored and binary keyblocks
 - JWK / JWKS
-- Tempfiles
-- OpenPGP armored and binary blocks
-- Certificate leafs and chains
+- tempfiles for path-based APIs
+- X.509 leafs, chains, and negative variants
 
-### Negative fixtures
+### Negative artifacts
 
-- Corrupt PEM variants
-- Truncated DER
-- Mismatched keypairs
-- Expired/revoked/not-yet-valid certificates
-- Hostname and CA-chain mismatch families
+- corrupt PEM
+- truncated DER
+- mismatched keypairs
+- expired / revoked / hostname-mismatch / unknown-CA certificates
 
 ## Choose the smallest feature set
 
-The facade defaults to no features. Start with only what your test package needs.
+The `uselesskey` facade has an empty default feature set. Enable only the fixture families you need.
+
+Common starting points:
 
 ```toml
+# RSA fixtures
 [dev-dependencies]
 uselesskey = { version = "0.4.1", features = ["rsa"] }
 ```
 
 ```toml
+# Token-only fixtures, no RSA/X.509 pull-in
 [dev-dependencies]
 uselesskey = { version = "0.4.1", default-features = false, features = ["token"] }
 ```
 
 ```toml
+# RSA + JWK/JWKS
 [dev-dependencies]
 uselesskey = { version = "0.4.1", features = ["rsa", "jwk"] }
 ```
 
 ```toml
+# X.509 fixtures
 [dev-dependencies]
 uselesskey = { version = "0.4.1", features = ["x509"] }
 ```
 
-## Quick Start
+Use the facade for convenience. Depend on leaf crates only when compile-time minimization matters enough to justify the sharper API.
+
+If you are unsure which flags to start with, start from [docs/how-to/choose-features.md](docs/how-to/choose-features.md).
+
+## Quick start
 
 ```rust
 use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
@@ -109,6 +121,22 @@ let rsa = fx.rsa("issuer", RsaSpec::rs256());
 let pkcs8_pem = rsa.private_key_pkcs8_pem();
 let spki_der = rsa.public_key_spki_der();
 ```
+
+The core shape is always:
+
+```text
+(mode, domain, label, spec, variant) -> artifact
+```
+
+That keeps fixtures stable in deterministic mode and cacheable in both modes.
+
+## Feature reminders for common snippets
+
+- `rsa` for PEM/DER, tempfiles, and negative-key examples
+- `rsa` + `jwk` for `public_jwk()` / `public_jwks()`
+- `x509` for certificate, rustls, and tonic examples
+- `token` for token-shaped fixtures only
+- `pgp` for armored/binary OpenPGP fixtures
 
 ## Dependency Snippet Reminders
 
@@ -193,7 +221,7 @@ let cert_pem = cert.cert_pem();
 let key_pem = cert.private_key_pkcs8_pem();
 ```
 
-Three-level certificate chains (root CA → intermediate CA → leaf):
+Three-level chains (root  intermediate  leaf):
 
 ```rust
 use uselesskey::{Factory, X509FactoryExt, ChainSpec};
@@ -201,17 +229,17 @@ use uselesskey::{Factory, X509FactoryExt, ChainSpec};
 let fx = Factory::random();
 let chain = fx.x509_chain("my-service", ChainSpec::new("test.example.com"));
 
-// Standard TLS server chain (leaf + intermediate, no root)
+// Standard TLS server chain: leaf + intermediate, no root
 let chain_pem = chain.chain_pem();
 
-// Individual certs for custom setups
+// Individual artifacts for custom setups
 let root_pem = chain.root_cert_pem();
 let leaf_key = chain.leaf_private_key_pkcs8_pem();
 ```
 
-### X.509 Negative Fixtures
+### X.509 negative fixtures
 
-Generate intentionally invalid certificates for testing error-handling paths:
+These are for error-path tests, not validation logic.
 
 ```rust
 use uselesskey::{Factory, X509FactoryExt, ChainSpec};
@@ -233,7 +261,7 @@ let revoked = chain.revoked_leaf();
 let crl_pem = revoked.crl_pem().expect("CRL present for revoked variant");
 ```
 
-### Negative Fixtures (Keys)
+### Negative fixtures (keys)
 
 ```rust
 use uselesskey::{Factory, RsaSpec, RsaFactoryExt};
@@ -247,12 +275,9 @@ let truncated = rsa.private_key_pkcs8_der_truncated(32);
 let mismatched_pub = rsa.mismatched_public_key_spki_der();
 ```
 
-### Token Fixtures
+### Token fixtures
 
-Token fixtures are fixture artifacts by shape, not a signing engine.
-Use them for realistic token-shaped payloads in tests; not for authorization policy or signature verification.
-
-Generate realistic token-shaped fixtures without committing token blobs:
+Token fixtures are **artifact shapes**, not an auth framework. They exist so tests can use realistic-looking token values without committing blobs.
 
 ```rust
 use uselesskey::{Factory, TokenFactoryExt, TokenSpec};
@@ -267,13 +292,15 @@ assert!(bearer.authorization_header().starts_with("Bearer "));
 assert_eq!(oauth.value().split('.').count(), 3);
 ```
 
-## Adapter Examples
+## Adapter crates
 
-Adapter crates bridge uselesskey fixtures to third-party library types. They are separate crates (not features) to avoid coupling versioning. See the [Workspace Crates](#workspace-crates) section below for the public crates and adapter overview.
+Adapter crates are separate packages, not facade features. That keeps integration versioning explicit and avoids coupling the facade to every downstream ecosystem type.
 
-### TLS Config Builders (uselesskey-rustls)
+Use them when you want **native third-party library types** returned directly from fixture artifacts.
 
-With the `tls-config` feature, build rustls configs in one line:
+### TLS config builders (`uselesskey-rustls`)
+
+With the `tls-config` feature, build rustls configs in one step:
 
 ```toml
 [dev-dependencies]
@@ -288,11 +315,11 @@ use uselesskey_rustls::{RustlsServerConfigExt, RustlsClientConfigExt};
 let fx = Factory::random();
 let chain = fx.x509_chain("my-service", ChainSpec::new("test.example.com"));
 
-let server_config = chain.server_config_rustls();   // ServerConfig (no client auth)
-let client_config = chain.client_config_rustls();    // ClientConfig (trusts root CA)
+let server_config = chain.server_config_rustls();
+let client_config = chain.client_config_rustls();
 ```
 
-### ring Signing Keys (uselesskey-ring)
+### ring signing keys (`uselesskey-ring`)
 
 ```toml
 [dev-dependencies]
@@ -306,10 +333,10 @@ use uselesskey_ring::RingRsaKeyPairExt;
 
 let fx = Factory::random();
 let rsa = fx.rsa("signer", RsaSpec::rs256());
-let ring_kp = rsa.rsa_key_pair_ring();  // ring::rsa::KeyPair
+let ring_kp = rsa.rsa_key_pair_ring();
 ```
 
-### RustCrypto Types (uselesskey-rustcrypto)
+### RustCrypto types (`uselesskey-rustcrypto`)
 
 ```toml
 [dev-dependencies]
@@ -323,10 +350,10 @@ use uselesskey_rustcrypto::RustCryptoRsaExt;
 
 let fx = Factory::random();
 let rsa = fx.rsa("signer", RsaSpec::rs256());
-let rsa_pk = rsa.rsa_private_key(); // rsa::RsaPrivateKey
+let rsa_pk = rsa.rsa_private_key();
 ```
 
-### aws-lc-rs Types (uselesskey-aws-lc-rs)
+### aws-lc-rs types (`uselesskey-aws-lc-rs`)
 
 ```toml
 [dev-dependencies]
@@ -340,10 +367,10 @@ use uselesskey_aws_lc_rs::AwsLcRsRsaKeyPairExt;
 
 let fx = Factory::random();
 let rsa = fx.rsa("signer", RsaSpec::rs256());
-let lc_kp = rsa.rsa_key_pair_aws_lc_rs();  // aws_lc_rs::rsa::KeyPair
+let lc_kp = rsa.rsa_key_pair_aws_lc_rs();
 ```
 
-### gRPC TLS (uselesskey-tonic)
+### gRPC TLS (`uselesskey-tonic`)
 
 ```toml
 [dev-dependencies]
@@ -430,22 +457,7 @@ Depend on the facade for convenience, or on individual crates to minimize compil
 
 ## Feature Flags
 
-Use this list for quick feature-to-trait selection. For output-family coverage and dependency impact, use the matrix below.
-
-| Feature | Description |
-|---------|-------------|
-| `rsa` | RSA keypairs |
-| `ecdsa` | ECDSA P-256/P-384 keypairs |
-| `ed25519` | Ed25519 keypairs |
-| `hmac` | HMAC secrets |
-| `pgp` | OpenPGP keypairs (armored + binary keyblocks) |
-| `token` | API key, bearer token, and OAuth access token fixtures |
-| `x509` | X.509 certificate generation (implies `rsa`) |
-| `jwk` | JWK/JWKS output for enabled key types |
-| `all-keys` | All key algorithms (`rsa` + `ecdsa` + `ed25519` + `hmac` + `pgp`) |
-| `full` | Everything (`all-keys` + `token` + `x509` + `jwk`) |
-
-The `uselesskey` facade default feature set is empty.
+The `uselesskey` facade defaults to no features.
 
 Extension traits by feature:
 - `rsa`: `RsaFactoryExt`
@@ -456,7 +468,9 @@ Extension traits by feature:
 - `token`: `TokenFactoryExt`
 - `x509`: `X509FactoryExt`
 
-## Feature Matrix
+For output-family coverage and dependency implications, use the matrix below.
+
+## Feature matrix
 
 ### Facade features (`uselesskey` crate)
 
@@ -494,7 +508,11 @@ Each adapter crate has per-algorithm feature flags (`rsa`, `ecdsa`, `ed25519`, `
 
 ### Order-independent determinism
 
-`seed + (domain, label, spec, variant) -> derived seed -> artifact`
+Fixtures derive from stable identity components:
+
+```text
+seed + (domain, label, spec, variant) -> derived seed -> artifact
+```
 
 Adding new fixtures doesn't perturb existing ones. Test order doesn't matter.
 
@@ -505,21 +523,32 @@ RSA keygen is expensive. Per-factory caching by `(domain, label, spec, variant)`
 ### Shape-first outputs
 
 Ask for shapes first: PKCS#8, SPKI, PEM, DER, JWK, JWKS, or tempfiles.
-The crate should not force consumers to reason about lower-level algorithm internals.
+Consumers ask for artifact shapes; low-level crypto primitives are intentionally not the default output.
 
-### Negative fixtures first-class
+### Negative artifacts as first-class
 
-Corrupt PEM, truncated DER, mismatched keys, expired certs, revoked leaves with CRLs. These are annoying to produce manually, which is why teams commit them. This crate makes them cheap and ephemeral.
+Corrupt PEM, truncated DER, mismatched keys, expired certs, revoked leaves with CRLs: these are exactly the artifacts teams otherwise handcraft and commit.
+`uselesskey` makes them deterministic, cheap, and disposable.
 
-### When NOT to use this crate
+## When not to use this crate
 
-- Production key generation or certificate management
-- Runtime validation or policy logic (use `rustls`, `x509-parser` in production paths)
-- Certificate authority operations and operational PKI workflows (use `rcgen` directly)
+- production key generation
+- runtime certificate authority behavior
+- certificate validation logic
+- HSM / TPM / hardware-backed keys
+- signing or verification APIs as the primary abstraction
+
+For runtime certificate generation, reach for `rcgen` directly. For validation, use `rustls`, `x509-parser`, or the library actually responsible for verification.
 
 ## Ecosystem
 
-Use uselesskey when you need **test fixtures that don't trip secret scanners**. If you need runtime certificate generation for production (e.g., an internal CA), reach for [`rcgen`](https://docs.rs/rcgen) directly. If you need certificate validation logic, see [`rustls`](https://docs.rs/rustls) or [`x509-parser`](https://docs.rs/x509-parser).
+Use `uselesskey` when you need **realistic test fixtures that should not live in git history**.
+
+Reach for:
+
+- `rcgen` when you need runtime certificate generation outside a fixture-centric workflow
+- `rustls` when you need TLS runtime integration and validation
+- `x509-parser` when you need parsing/inspection/validation work
 
 ## Community
 
@@ -529,11 +558,17 @@ Use uselesskey when you need **test fixtures that don't trip secret scanners**. 
 - [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) — Contributor Covenant
 - [SUPPORT](SUPPORT.md) — how to get help
 
-## Stability & Versioning
+## Stability and versioning
 
-**Derivation stability:** Artifacts generated with a given `(seed, domain, label, spec, variant)` tuple are stable within the same `DerivationVersion`. We will never change `V1` output; if derivation logic changes, a new version (e.g., `V2`) will be introduced.
+**Derivation stability**
+Artifacts for a given `(seed, domain, label, spec, variant)` tuple are stable within the same `DerivationVersion`.
+If derivation logic changes, a new derivation version is introduced instead of mutating the old one.
 
-**MSRV:** The minimum supported Rust version is **1.92** (edition 2024).
+**Semver**
+Breaking API changes bump the minor version until `1.0`, then the major version.
+
+**MSRV**
+The minimum supported Rust version is **1.92** (edition 2024).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Task-oriented instructions for common workflows.
 - [migration.md](how-to/migration.md) — Migrating between uselesskey versions
 - [publishing.md](how-to/publishing.md) — Publishing crates to crates.io
 - [release.md](how-to/release.md) — Cutting a release
+- [choose-features.md](how-to/choose-features.md) — Choosing feature sets by need
 
 ## Explanation
 

--- a/docs/how-to/choose-features.md
+++ b/docs/how-to/choose-features.md
@@ -1,0 +1,56 @@
+# Choosing `uselesskey` feature sets
+
+Use this page when you are deciding which feature flags to enable first.
+
+`uselesskey` is a facade crate with an empty default feature set. Start from one goal and add only what tests need.
+
+## I need keys
+
+- Use `rsa` for RSA fixtures (2048/3072/4096).
+- Add `ecdsa` for P-256 / P-384.
+- Add `ed25519` for Ed25519 keypairs.
+- Add `hmac` for HS256/HS384/HS512 fixtures.
+- Add `pgp` for OpenPGP armored/binary artifacts.
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.4.1", features = ["rsa", "ecdsa", "ed25519", "hmac", "pgp"] }
+```
+
+If you need every key family, use `all-keys`.
+
+## I need JWK / JWKS
+
+- Add `jwk` plus the key families you want represented in the JWK outputs.
+- Keep `jwk` off when all you need is PEM/DER/private-key text.
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.4.1", features = ["rsa", "jwk"] }
+```
+
+## I need X.509 / TLS
+
+- Add `x509` for self-signed certs and certificate chains.
+- Add `uselesskey-rustls` (with `tls-config`) when you need rustls-native config builders.
+- Add `uselesskey-tonic` when you need gRPC TLS examples.
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.4.1", features = ["x509"] }
+uselesskey-rustls = { version = "0.4.1", features = ["tls-config", "rustls-ring"] }
+```
+
+## I need token shapes only
+
+- Add `token` (and disable default features if you only want token fixtures).
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.4.1", default-features = false, features = ["token"] }
+```
+
+## When you want fewer dependencies
+
+- Prefer the facade for speed and convenience.
+- Prefer direct leaf crates when dependency shape is more important than convenience.


### PR DESCRIPTION
## Summary
- Rewrite the hand-maintained README copy in `README.md` and `docs/README.md` while leaving docs-sync generated sections untouched.
- Add a new how-to for picking smallest feature sets: `docs/how-to/choose-features.md`.
- Keep all generated tables/blocks out of manual edits (compatible with `docs-sync`).

## Validation
- `cargo xtask docs-sync --check`
