### PR TITLE
release: prepare v0.5.0 cleanup artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-03-25
+
+### Added
+
+- Added a reusable adapter template with a scoped checklist for public-surface
+  additions and release-readiness requirements.
+- Added the `uselesskey-jose-openid` adapter crate for JOSE/OpenID-oriented
+  native key conversion flows and example coverage.
+- Added the `uselesskey-pgp-native` adapter crate for native OpenPGP key handling
+  and example coverage.
+
+### Changed
+
+- Added `docs-sync` and metadata-driven docs checks to PR validation, including
+  release-facing example/snippet verification.
+- Moved README, adapter matrix, and workspace documentation to the cleaner
+  adapter-wave wording and boundary-focused guidance.
+
 ## [0.4.1] - 2026-03-17
 
 ### Added

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -4,14 +4,14 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 
 ## v0.5.0 adapter wave
 
-- [ ] Roadmap reset for v0.5.x
-- [ ] ADR: adapter acceptance criteria
-- [ ] ADR: workspace public-surface policy
-- [ ] Docs metadata source + docs-sync command
-- [ ] examples-smoke command
-- [ ] Adapter A
-- [ ] Adapter B
-- [ ] v0.5.0 release prep
+- [x] Roadmap reset for v0.5.x
+- [x] ADR: adapter acceptance criteria
+- [x] ADR: workspace public-surface policy
+- [x] Docs metadata source + docs-sync command
+- [x] examples-smoke command
+- [x] Adapter A
+- [x] Adapter B
+- [x] v0.5.0 release prep
 
 ## v0.5.1 negative fixtures
 

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -6,21 +6,14 @@ This roadmap reflects the strategic direction for uselesskey as a **test-fixture
 
 *Post-release planning reset for the next cycle*
 
-- [ ] [Roadmap reset for v0.5.x][roadmap-followups]
-- [ ] Create milestones and execution issues from the follow-up plan
-- [ ] ADR: adapter acceptance criteria
-- [ ] ADR: public surface policy
-- [ ] Add docs metadata source and sync enforcement
-- [ ] Add examples-smoke validation in the docs/examples path
+- [x] [Roadmap reset for v0.5.x][roadmap-followups]
+- [x] Create milestones and execution issues from the follow-up plan
+- [x] ADR: adapter acceptance criteria
+- [x] ADR: public surface policy
+- [x] Add docs metadata source and sync enforcement
+- [x] Add examples-smoke validation in the docs/examples path
 
-## Next (v0.5.0 adapter wave)
-
-*Planned - Next wave of work*
-
-- [ ] Two adapter microcrates with complete per-adapter docs/tests/examples coverage
-- [ ] Release prep and release-note entries for v0.5.0
-
-## Later (v0.5.1+)
+## Next (v0.5.1+)
 
 *Under evaluation - Planned follow-up*
 
@@ -29,6 +22,17 @@ This roadmap reflects the strategic direction for uselesskey as a **test-fixture
 - [ ] Release governance and post-release audit automation
 
 ## Shipped
+
+### v0.5.0 (2026-03-25)
+
+*Adapter-wave release and docs/infrastructure alignment*
+
+- Added a reusable adapter-scaffold template and established adapter acceptance
+  requirements.
+- Added `uselesskey-jose-openid` and `uselesskey-pgp-native` adapter
+  microcrates with runtime examples and smoke/integration coverage.
+- Added docs metadata source, `docs-sync`, and examples-smoke coverage to PR
+  checks, and aligned release-facing docs to avoid drift.
 
 ### v0.4.0 (2026-03)
 


### PR DESCRIPTION
Closes #278.\n\nAdds release-prep artifacts after adapter wave:\n\n- Marks v0.5.0 follow-up execution items complete in roadmap docs\n- Moves adapter-wave completion into shipped roadmap history\n- Adds 