### PR TITLE
chore(deps): bump proptest to 1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ tempfile = "3.27.0"
 uselesskey-core-sink = { path = "crates/uselesskey-core-sink", version = "0.4.1" }
 
 # testing
-proptest = "1.10.0"
+proptest = "1.11.0"
 rstest = "0.26.1"
 insta = { version = "1.46.3", features = ["yaml", "redactions"] }
 criterion = { version = "0.8.2", default-features = false, features = ["html_reports", "cargo_bench_support"] }


### PR DESCRIPTION
Bump the workspace proptest dependency from 1.10.0 to 1.11.0 and refresh Cargo.lock.

Validation: cargo xtask gate --check