### PR TITLE
fix(rsa): preserve V1 deterministic RSA fixtures while adopting rsa 0.10 types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,7 @@ dependencies = [
  "hybrid-array",
  "num-traits",
  "rand_core 0.10.0",
+ "serdect 0.4.2",
  "subtle",
  "zeroize",
 ]
@@ -786,6 +787,17 @@ checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
+dependencies = [
+ "crypto-bigint 0.7.1",
+ "libm",
  "rand_core 0.10.0",
 ]
 
@@ -1957,7 +1969,7 @@ dependencies = [
  "p384 0.13.1",
  "pem",
  "rand 0.8.5",
- "rsa",
+ "rsa 0.9.10",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2509,7 +2521,7 @@ dependencies = [
  "regex",
  "replace_with",
  "ripemd",
- "rsa",
+ "rsa 0.9.10",
  "sha1",
  "sha1-checked",
  "sha2 0.10.9",
@@ -2563,6 +2575,16 @@ dependencies = [
  "der 0.7.10",
  "pkcs8 0.10.2",
  "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -2962,12 +2984,31 @@ dependencies = [
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
+ "pkcs1 0.7.5",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.1",
+ "crypto-primes",
+ "digest 0.11.2",
+ "pkcs1 0.8.0-rc.4",
+ "pkcs8 0.11.0-rc.11",
+ "rand_core 0.10.0",
+ "sha2 0.11.0-rc.5",
+ "signature 3.0.0-rc.10",
+ "spki 0.8.0-rc.4",
  "zeroize",
 ]
 
@@ -3237,6 +3278,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
 dependencies = [
  "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -4017,10 +4068,9 @@ dependencies = [
  "p384 0.13.1",
  "pgp",
  "ring",
- "rsa",
+ "rsa 0.10.0-rc.17",
  "rustls-pki-types",
  "serde_json",
- "sha2 0.10.9",
  "uselesskey",
  "uselesskey-aws-lc-rs",
  "uselesskey-core",
@@ -4436,7 +4486,7 @@ dependencies = [
  "jsonwebtoken",
  "p256 0.13.2",
  "ring",
- "rsa",
+ "rsa 0.10.0-rc.17",
  "rustls",
  "serde",
  "serde_json",
@@ -4472,7 +4522,7 @@ dependencies = [
  "p256 0.13.2",
  "p384 0.13.1",
  "ring",
- "rsa",
+ "rsa 0.10.0-rc.17",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -4576,9 +4626,12 @@ dependencies = [
  "base64",
  "insta",
  "proptest",
+ "rand_chacha 0.10.0",
  "rand_chacha 0.3.1",
+ "rand_core 0.10.0",
  "rand_core 0.6.4",
- "rsa",
+ "rsa 0.10.0-rc.17",
+ "rsa 0.9.10",
  "rstest",
  "serde",
  "serde_json",
@@ -4598,7 +4651,8 @@ dependencies = [
  "p256 0.13.2",
  "p384 0.13.1",
  "proptest",
- "rsa",
+ "rand_chacha 0.10.0",
+ "rsa 0.10.0-rc.17",
  "serde",
  "sha2 0.10.9",
  "uselesskey-core",
@@ -4677,7 +4731,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rcgen",
- "rsa",
+ "rsa 0.10.0-rc.17",
  "rstest",
  "rustls-pki-types",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,10 +127,12 @@ clap = { version = "4.6.0", features = ["derive"] }
 cucumber = { version = "0.22.1", features = ["macros"] }
 tokio = { version = "1.50.0", features = ["macros", "rt-multi-thread"] }
 
-# RSA — blocked on rsa 0.9 → rand_core 0.6; direct legacy RNG deps are
-# localized in uselesskey-rsa/uselesskey-pgp/uselesskey-x509 Cargo.toml files.
-# Revisit when `rsa` crate releases a version using rand_core ≥0.9.
-rsa = { version = "0.9.10", features = ["pem"] }
+# RSA internal path uses rsa 0.10.x.
+# Deterministic V1 RSA fixture bytes are preserved via a local compatibility bridge
+# inside uselesskey-rsa.
+# Legacy rsa 0.9 / rand_core 0.6 remains as an explicit upstream island under
+# adapters such as jsonwebtoken and pgp.
+rsa = { version = "0.10.0-rc.17", features = ["sha2"] }
 
 # Ed25519
 ed25519-dalek = { version = "2.2.0", features = ["pkcs8", "pem", "rand_core"] }

--- a/crates/uselesskey-bdd-steps/Cargo.toml
+++ b/crates/uselesskey-bdd-steps/Cargo.toml
@@ -27,7 +27,7 @@ uselesskey-core-sink = { workspace = true, optional = true }
 uselesskey-core = { path = "../uselesskey-core" }
 uselesskey-jsonwebtoken = { path = "../uselesskey-jsonwebtoken", default-features = false, features = ["all"] }
 
-rsa.workspace = true
+rsa = { workspace = true, features = ["sha2"] }
 jsonwebtoken.workspace = true
 ed25519-dalek.workspace = true
 p256 = { version = "0.13.2", features = ["ecdsa", "pkcs8", "pem"] }
@@ -42,7 +42,6 @@ uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", version = "0.4.1", 
 uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.4.1", optional = true, default-features = false, features = ["x509", "tls-config", "rustls-ring"] }
 uselesskey-tonic = { path = "../uselesskey-tonic", version = "0.4.1", optional = true, default-features = false, features = ["x509"] }
 hmac = { version = "0.12", optional = true }
-sha2 = { version = "0.10", optional = true }
 aws-lc-rs = { version = "1", optional = true }
 ring = { workspace = true, optional = true }
 rustls-pki-types = { version = "1", optional = true }
@@ -73,4 +72,4 @@ uk-aws-lc-rs = ["dep:uselesskey-aws-lc-rs", "dep:aws-lc-rs", "uk-bdd-keys"]
 uk-rustls = ["dep:uselesskey-rustls", "dep:rustls-pki-types", "uk-bdd-keys"]
 uk-tonic = ["dep:uselesskey-tonic"]
 uk-ring = ["dep:uselesskey-ring", "dep:ring", "uk-bdd-keys"]
-uk-rustcrypto = ["dep:uselesskey-rustcrypto", "dep:hmac", "dep:sha2", "uk-bdd-keys"]
+uk-rustcrypto = ["dep:uselesskey-rustcrypto", "dep:hmac", "uk-bdd-keys"]

--- a/crates/uselesskey-bdd-steps/src/lib.rs
+++ b/crates/uselesskey-bdd-steps/src/lib.rs
@@ -4257,10 +4257,9 @@ fn rsa_modulus_size(world: &mut UselessWorld, expected: usize) {
 
     let der = world.spki_der_1.as_ref().expect("spki_der_1 not set");
     let pub_key = rsa::RsaPublicKey::from_public_key_der(der).unwrap();
-    let modulus_bytes = pub_key.n().to_bytes_be();
+    let modulus_bytes = pub_key.size();
     assert_eq!(
-        modulus_bytes.len(),
-        expected,
+        modulus_bytes, expected,
         "modulus should have {expected} bytes"
     );
 }
@@ -5486,7 +5485,8 @@ fn rustcrypto_rsa_sign(world: &mut UselessWorld) {
 
     let kp = world.rsa.as_ref().expect("RSA key not set");
     let private_key = kp.rsa_private_key();
-    let signing_key = SigningKey::<sha2::Sha256>::new_unprefixed(private_key);
+    use rsa::sha2::Sha256;
+    let signing_key = SigningKey::<Sha256>::new_unprefixed(private_key);
     let sig = signing_key.sign(RUSTCRYPTO_TEST_MSG);
     world.rustcrypto_signature_bytes = Some(sig.to_vec());
 }
@@ -5500,7 +5500,8 @@ fn rustcrypto_rsa_verify(world: &mut UselessWorld) {
 
     let kp = world.rsa.as_ref().expect("RSA key not set");
     let public_key = kp.rsa_public_key();
-    let verifying_key = VerifyingKey::<sha2::Sha256>::new_unprefixed(public_key);
+    use rsa::sha2::Sha256;
+    let verifying_key = VerifyingKey::<Sha256>::new_unprefixed(public_key);
     let sig_bytes = world
         .rustcrypto_signature_bytes
         .as_ref()
@@ -5520,7 +5521,8 @@ fn rustcrypto_rsa_wrong_key(world: &mut UselessWorld) {
 
     let kp = world.rsa.as_ref().expect("RSA key not set");
     let public_key = kp.rsa_public_key();
-    let verifying_key = VerifyingKey::<sha2::Sha256>::new_unprefixed(public_key);
+    use rsa::sha2::Sha256;
+    let verifying_key = VerifyingKey::<Sha256>::new_unprefixed(public_key);
     let sig_bytes = world
         .rustcrypto_signature_bytes
         .as_ref()

--- a/crates/uselesskey-interop-tests/Cargo.toml
+++ b/crates/uselesskey-interop-tests/Cargo.toml
@@ -35,7 +35,7 @@ p256 = { version = "0.13", features = ["ecdsa", "pkcs8", "pem"] }
 p384 = { version = "0.13", features = ["ecdsa", "pkcs8", "pem"] }
 rustls-pki-types = { workspace = true }
 ed25519-dalek = { workspace = true }
-rsa = { workspace = true }
+rsa = { workspace = true, features = ["sha2"] }
 sha2 = { version = "0.10", features = ["oid"] }
 signature = "2"
 hmac = "0.12"

--- a/crates/uselesskey-interop-tests/tests/all_adapters.rs
+++ b/crates/uselesskey-interop-tests/tests/all_adapters.rs
@@ -111,8 +111,8 @@ mod rsa_all_adapters {
     #[test]
     fn rsa_rustcrypto_sign_verify() {
         use rsa::pkcs1v15;
+        use rsa::sha2::Sha256;
         use rsa::signature::{Signer, Verifier};
-        use sha2::Sha256;
         use uselesskey_rustcrypto::RustCryptoRsaExt;
 
         let kp = fx().rsa("all-rsa-rc-sv", RsaSpec::rs256());

--- a/crates/uselesskey-interop-tests/tests/cross_adapter.rs
+++ b/crates/uselesskey-interop-tests/tests/cross_adapter.rs
@@ -223,8 +223,8 @@ mod rustcrypto_ring_cross {
             .expect("ring sign");
 
         use rsa::pkcs1v15;
+        use rsa::sha2::Sha256;
         use rsa::signature::Verifier;
-        use sha2::Sha256;
         let public_key = keypair.rsa_public_key();
         let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(public_key);
         let signature =
@@ -241,8 +241,8 @@ mod rustcrypto_ring_cross {
         let keypair = fx.rsa("xadapt-rsa-rc2r", RsaSpec::rs256());
 
         use rsa::pkcs1v15;
+        use rsa::sha2::Sha256;
         use rsa::signature::{SignatureEncoding, Signer};
-        use sha2::Sha256;
         let private_key = keypair.rsa_private_key();
         let signing_key = pkcs1v15::SigningKey::<Sha256>::new(private_key);
         let msg = b"rustcrypto-to-ring RSA cross-adapter expanded";

--- a/crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs
+++ b/crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs
@@ -153,8 +153,8 @@ mod rsa_ring_to_rustcrypto {
 
         // Verify with rustcrypto adapter
         use rsa::pkcs1v15;
+        use rsa::sha2::Sha256;
         use rsa::signature::Verifier;
-        use sha2::Sha256;
         let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(kp.rsa_public_key());
         let signature =
             pkcs1v15::Signature::try_from(sig.as_slice()).expect("valid signature bytes");
@@ -169,8 +169,8 @@ mod rsa_ring_to_rustcrypto {
 
         // Sign with rustcrypto adapter
         use rsa::pkcs1v15;
+        use rsa::sha2::Sha256;
         use rsa::signature::{SignatureEncoding, Signer};
-        use sha2::Sha256;
         let signing_key = pkcs1v15::SigningKey::<Sha256>::new(kp.rsa_private_key());
         let msg = b"rustcrypto-to-ring RSA interop matrix test";
         let sig = signing_key.sign(msg);

--- a/crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs
+++ b/crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs
@@ -57,8 +57,8 @@ mod rsa_cross {
     use super::*;
     use ring::signature as ring_sig;
     use rsa::pkcs1v15;
+    use rsa::sha2::Sha256;
     use rsa::signature::{SignatureEncoding, Signer, Verifier};
-    use sha2::Sha256;
     use uselesskey_ring::RingRsaKeyPairExt;
     use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
     use uselesskey_rustcrypto::RustCryptoRsaExt;

--- a/crates/uselesskey-interop-tests/tests/cross_verify.rs
+++ b/crates/uselesskey-interop-tests/tests/cross_verify.rs
@@ -65,8 +65,8 @@ mod rustcrypto_aws {
             let kp = fx().rsa("xv-rsa-rc2a", RsaSpec::rs256());
 
             use rsa::pkcs1v15;
+            use rsa::sha2::Sha256;
             use rsa::signature::{SignatureEncoding, Signer};
-            use sha2::Sha256;
             let signing_key = pkcs1v15::SigningKey::<Sha256>::new(kp.rsa_private_key());
             let msg = b"rustcrypto-to-aws RSA cross-verify";
             let sig = signing_key.sign(msg);
@@ -94,8 +94,8 @@ mod rustcrypto_aws {
                 .expect("aws sign");
 
             use rsa::pkcs1v15;
+            use rsa::sha2::Sha256;
             use rsa::signature::Verifier;
-            use sha2::Sha256;
             let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(kp.rsa_public_key());
             let signature = pkcs1v15::Signature::try_from(sig.as_slice()).expect("valid signature");
             verifying_key

--- a/crates/uselesskey-interop-tests/tests/interop.rs
+++ b/crates/uselesskey-interop-tests/tests/interop.rs
@@ -164,9 +164,9 @@ mod rsa_rustcrypto_to_ring {
     use ring::signature::{self, UnparsedPublicKey};
     use rsa::pkcs1v15::SigningKey;
     use rsa::pkcs8::DecodePrivateKey;
+    use rsa::sha2::Sha256;
     use rsa::signature::SignatureEncoding;
     use rsa::signature::Signer;
-    use sha2::Sha256;
     use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
 
     #[test]

--- a/crates/uselesskey-interop-tests/tests/random_mode.rs
+++ b/crates/uselesskey-interop-tests/tests/random_mode.rs
@@ -53,8 +53,8 @@ mod rsa_random {
             .expect("ring sign");
 
         use rsa::pkcs1v15;
+        use rsa::sha2::Sha256;
         use rsa::signature::Verifier;
-        use sha2::Sha256;
         let verifying_key = pkcs1v15::VerifyingKey::<Sha256>::new(kp.rsa_public_key());
         let signature =
             pkcs1v15::Signature::try_from(sig.as_slice()).expect("valid signature bytes");

--- a/crates/uselesskey-rsa/Cargo.toml
+++ b/crates/uselesskey-rsa/Cargo.toml
@@ -18,8 +18,11 @@ authors.workspace = true
 uselesskey-core = { path = "../uselesskey-core", version = "0.4.1" }
 uselesskey-core-keypair-material.workspace = true
 rsa.workspace = true
-rand_chacha = { version = "0.3.1", default-features = false }
-rand_core = { version = "0.6.4", default-features = false }
+rsa09 = { package = "rsa", version = "0.9.10", features = ["pem"], optional = true }
+rand_chacha = { version = "0.3.1", default-features = false, optional = true }
+rand_core = { version = "0.6.4", default-features = false, optional = true }
+rand_core10.workspace = true
+rand_chacha10.workspace = true
 
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
@@ -27,7 +30,8 @@ base64 = { workspace = true, optional = true }
 uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.4.1", optional = true }
 
 [features]
-default = []
+default = ["legacy-rsa09"]
+legacy-rsa09 = ["dep:rsa09", "dep:rand_chacha", "dep:rand_core"]
 jwk = ["dep:serde_json", "dep:base64", "dep:uselesskey-jwk"]
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-rsa/src/keypair.rs
+++ b/crates/uselesskey-rsa/src/keypair.rs
@@ -1,10 +1,25 @@
 use std::fmt;
 use std::sync::Arc;
 
+#[cfg(feature = "legacy-rsa09")]
 use rand_chacha::ChaCha20Rng;
-use rand_core::SeedableRng;
-use rsa::pkcs8::LineEnding;
-use rsa::{RsaPrivateKey, RsaPublicKey, pkcs8::EncodePrivateKey, pkcs8::EncodePublicKey};
+#[cfg(feature = "legacy-rsa09")]
+use rand_chacha::rand_core::SeedableRng;
+#[cfg(not(feature = "legacy-rsa09"))]
+use rand_chacha10::ChaCha20Rng;
+#[cfg(not(feature = "legacy-rsa09"))]
+use rand_chacha10::rand_core::SeedableRng;
+use rsa as rsa10;
+#[cfg(feature = "legacy-rsa09")]
+use rsa09::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+#[cfg(feature = "legacy-rsa09")]
+use rsa09::{RsaPrivateKey, RsaPublicKey};
+#[cfg(feature = "legacy-rsa09")]
+use rsa10::pkcs8::DecodePrivateKey;
+#[cfg(feature = "jwk")]
+use rsa10::pkcs8::DecodePublicKey;
+#[cfg(not(feature = "legacy-rsa09"))]
+use rsa10::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
 use uselesskey_core::negative::CorruptPem;
 use uselesskey_core::sink::TempArtifact;
 use uselesskey_core::{Error, Factory};
@@ -51,9 +66,9 @@ pub struct RsaKeyPair {
 
 struct Inner {
     /// Kept for potential signing methods; not currently used.
-    _private: RsaPrivateKey,
+    _private: rsa10::RsaPrivateKey,
     #[cfg(feature = "jwk")]
-    public: RsaPublicKey,
+    public: rsa10::RsaPublicKey,
     material: Pkcs8SpkiKeyMaterial,
 }
 
@@ -387,11 +402,11 @@ impl RsaKeyPair {
     pub fn public_jwk(&self) -> uselesskey_jwk::PublicJwk {
         use base64::Engine as _;
         use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-        use rsa::traits::PublicKeyParts;
+        use rsa10::traits::PublicKeyParts;
         use uselesskey_jwk::{PublicJwk, RsaPublicJwk};
 
-        let n = self.inner.public.n().to_bytes_be();
-        let e = self.inner.public.e().to_bytes_be();
+        let n = self.inner.public.n_bytes();
+        let e = self.inner.public.e_bytes();
 
         PublicJwk::Rsa(RsaPublicJwk {
             kty: "RSA",
@@ -423,21 +438,25 @@ impl RsaKeyPair {
     pub fn private_key_jwk(&self) -> uselesskey_jwk::PrivateJwk {
         use base64::Engine as _;
         use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-        use rsa::traits::{PrivateKeyParts, PublicKeyParts};
+        use rsa10::traits::{PrivateKeyParts, PublicKeyParts};
         use uselesskey_jwk::{PrivateJwk, RsaPrivateJwk};
 
         let private = &self.inner._private;
         let primes = private.primes();
         assert!(primes.len() >= 2, "expected at least two RSA primes");
 
-        let n = private.n().to_bytes_be();
-        let e = private.e().to_bytes_be();
-        let d = private.d().to_bytes_be();
-        let p = primes[0].to_bytes_be();
-        let q = primes[1].to_bytes_be();
-        let dp = private.dp().expect("dp").to_bytes_be();
-        let dq = private.dq().expect("dq").to_bytes_be();
-        let qi = private.qinv().expect("qinv").to_bytes_be().1;
+        let n = private.n_bytes();
+        let e = private.e_bytes();
+        let d = private.d().to_be_bytes_trimmed_vartime();
+        let p = primes[0].to_be_bytes_trimmed_vartime();
+        let q = primes[1].to_be_bytes_trimmed_vartime();
+        let dp = private.dp().expect("dp").to_be_bytes_trimmed_vartime();
+        let dq = private.dq().expect("dq").to_be_bytes_trimmed_vartime();
+        let qi = private
+            .qinv()
+            .expect("qinv")
+            .retrieve()
+            .to_be_bytes_trimmed_vartime();
 
         PrivateJwk::Rsa(RsaPrivateJwk {
             kty: "RSA",
@@ -552,24 +571,67 @@ fn load_inner(factory: &Factory, label: &str, spec: RsaSpec, variant: &str) -> A
 
     factory.get_or_init(DOMAIN_RSA_KEYPAIR, label, &spec_bytes, variant, |seed| {
         let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
-        let private = RsaPrivateKey::new(&mut rng, spec.bits).expect("RSA keygen failed");
-        let public = RsaPublicKey::from(&private);
 
-        let pkcs8_der_doc = private
+        #[cfg(feature = "legacy-rsa09")]
+        let private09 = RsaPrivateKey::new(&mut rng, spec.bits).expect("RSA keygen failed");
+        #[cfg(feature = "legacy-rsa09")]
+        let public09 = RsaPublicKey::from(&private09);
+
+        #[cfg(feature = "legacy-rsa09")]
+        let pkcs8_der_doc = private09
             .to_pkcs8_der()
             .expect("failed to encode RSA private key as PKCS#8 DER");
+        #[cfg(feature = "legacy-rsa09")]
         let pkcs8_der: Arc<[u8]> = Arc::from(pkcs8_der_doc.as_bytes());
 
-        let pkcs8_pem = private
+        #[cfg(feature = "legacy-rsa09")]
+        let pkcs8_pem = private09
             .to_pkcs8_pem(LineEnding::LF)
             .expect("failed to encode RSA private key as PKCS#8 PEM")
             .to_string();
 
+        #[cfg(feature = "legacy-rsa09")]
+        let spki_der_doc = public09
+            .to_public_key_der()
+            .expect("failed to encode RSA public key as SPKI DER");
+        #[cfg(feature = "legacy-rsa09")]
+        let spki_der: Arc<[u8]> = Arc::from(spki_der_doc.as_bytes());
+
+        #[cfg(feature = "legacy-rsa09")]
+        let spki_pem = public09
+            .to_public_key_pem(LineEnding::LF)
+            .expect("failed to encode RSA public key as SPKI PEM")
+            .to_string();
+
+        #[cfg(feature = "legacy-rsa09")]
+        let private = rsa10::RsaPrivateKey::from_pkcs8_der(&pkcs8_der)
+            .expect("failed to parse V1 RSA private key into rsa 0.10");
+        #[cfg(feature = "jwk")]
+        #[cfg(feature = "legacy-rsa09")]
+        let public = rsa10::RsaPublicKey::from_public_key_der(&spki_der)
+            .expect("failed to parse V1 RSA public key into rsa 0.10");
+        #[cfg(not(feature = "legacy-rsa09"))]
+        let private = rsa10::RsaPrivateKey::new(&mut rng, spec.bits).expect("RSA keygen failed");
+        #[cfg(not(feature = "legacy-rsa09"))]
+        let public = rsa10::RsaPublicKey::from(&private);
+        #[cfg(not(feature = "legacy-rsa09"))]
+        let pkcs8_der_doc = private
+            .to_pkcs8_der()
+            .expect("failed to encode RSA private key as PKCS#8 DER");
+        #[cfg(not(feature = "legacy-rsa09"))]
+        let pkcs8_der: Arc<[u8]> = Arc::from(pkcs8_der_doc.as_bytes());
+        #[cfg(not(feature = "legacy-rsa09"))]
+        let pkcs8_pem = private
+            .to_pkcs8_pem(LineEnding::LF)
+            .expect("failed to encode RSA private key as PKCS#8 PEM")
+            .to_string();
+        #[cfg(not(feature = "legacy-rsa09"))]
         let spki_der_doc = public
             .to_public_key_der()
             .expect("failed to encode RSA public key as SPKI DER");
+        #[cfg(not(feature = "legacy-rsa09"))]
         let spki_der: Arc<[u8]> = Arc::from(spki_der_doc.as_bytes());
-
+        #[cfg(not(feature = "legacy-rsa09"))]
         let spki_pem = public
             .to_public_key_pem(LineEnding::LF)
             .expect("failed to encode RSA public key as SPKI PEM")

--- a/crates/uselesskey-rustcrypto/Cargo.toml
+++ b/crates/uselesskey-rustcrypto/Cargo.toml
@@ -23,7 +23,7 @@ hmac = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.1", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.1", optional = true, default-features = false }
 uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.1", optional = true }
 uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.1", optional = true }
 uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.4.1", optional = true }
@@ -41,13 +41,13 @@ all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.4.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.1" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.4.1", default-features = false }
 uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.4.1" }
 uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.4.1" }
 uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.4.1" }
+rand_chacha10.workspace = true
 proptest.workspace = true
-sha2 = "0.10"
-rsa = { workspace = true }
+rsa = { workspace = true, features = ["sha2"] }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-rustcrypto/README.md
+++ b/crates/uselesskey-rustcrypto/README.md
@@ -24,7 +24,7 @@ uselesskey-rustcrypto = { version = "0.4.1", features = ["rsa"] }
 ```rust
 use rsa::pkcs1v15::{SigningKey, VerifyingKey};
 use rsa::signature::{Signer, Verifier};
-use sha2::Sha256;
+use rsa::sha2::Sha256;
 use uselesskey_core::Factory;
 use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
 use uselesskey_rustcrypto::RustCryptoRsaExt;

--- a/crates/uselesskey-rustcrypto/src/lib.rs
+++ b/crates/uselesskey-rustcrypto/src/lib.rs
@@ -25,7 +25,7 @@
 //! use uselesskey_rustcrypto::RustCryptoRsaExt;
 //! use rsa::pkcs1v15::SigningKey;
 //! use rsa::signature::{Signer, Verifier};
-//! use sha2::Sha256;
+//! use rsa::sha2::Sha256;
 //!
 //! let fx = Factory::random();
 //! let keypair = fx.rsa("test", RsaSpec::rs256());
@@ -60,7 +60,7 @@
 ///
 /// // Verify the key is usable
 /// use rsa::signature::Signer;
-/// let signing_key = rsa::pkcs1v15::SigningKey::<sha2::Sha256>::new_unprefixed(private);
+/// let signing_key = rsa::pkcs1v15::SigningKey::<rsa::sha2::Sha256>::new_unprefixed(private);
 /// let _sig = signing_key.sign(b"test");
 /// ```
 #[cfg(feature = "rsa")]
@@ -283,8 +283,8 @@ mod tests {
     mod rsa_tests {
         use crate::RustCryptoRsaExt;
         use rsa::pkcs1v15::{SigningKey, VerifyingKey};
+        use rsa::sha2::Sha256;
         use rsa::signature::{Signer, Verifier};
-        use sha2::Sha256;
         use uselesskey_core::Factory;
         use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
 

--- a/crates/uselesskey-rustcrypto/tests/adapter_integration.rs
+++ b/crates/uselesskey-rustcrypto/tests/adapter_integration.rs
@@ -30,8 +30,8 @@ fn fx() -> Factory {
 mod rsa_rustcrypto {
     use super::*;
     use rsa::pkcs1v15::{SigningKey, VerifyingKey};
+    use rsa::sha2::Sha256;
     use rsa::signature::{Signer, Verifier};
-    use sha2::Sha256;
     use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
     use uselesskey_rustcrypto::RustCryptoRsaExt;
 

--- a/crates/uselesskey-rustcrypto/tests/rustcrypto_comprehensive.rs
+++ b/crates/uselesskey-rustcrypto/tests/rustcrypto_comprehensive.rs
@@ -20,9 +20,9 @@ fn deterministic_factory(seed_str: &str) -> Factory {
 mod rsa_comprehensive {
     use super::*;
     use rsa::pkcs1v15::{SigningKey, VerifyingKey};
+    use rsa::sha2::Sha256;
     use rsa::signature::{Signer, Verifier};
     use rsa::traits::PublicKeyParts;
-    use sha2::Sha256;
     use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
     use uselesskey_rustcrypto::RustCryptoRsaExt;
 

--- a/crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs
+++ b/crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs
@@ -20,13 +20,15 @@ use uselesskey_core::{Factory, Seed};
 mod rsa_pss {
     use super::*;
     use rsa::pss::{SigningKey as PssSigningKey, VerifyingKey as PssVerifyingKey};
+    use rsa::sha2::Sha256;
     use rsa::signature::{RandomizedSigner, Verifier};
-    use sha2::Sha256;
     use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
     use uselesskey_rustcrypto::RustCryptoRsaExt;
 
-    fn rng() -> rsa::rand_core::OsRng {
-        rsa::rand_core::OsRng
+    fn rng() -> rand_chacha10::ChaCha20Rng {
+        use rand_chacha10::rand_core::SeedableRng;
+        let seed = [7_u8; 32];
+        rand_chacha10::ChaCha20Rng::from_seed(seed)
     }
 
     #[test]
@@ -70,8 +72,8 @@ mod rsa_pss {
 mod rsa_cross_factory {
     use super::*;
     use rsa::pkcs1v15::{SigningKey, VerifyingKey};
+    use rsa::sha2::Sha256;
     use rsa::signature::{Signer, Verifier};
-    use sha2::Sha256;
     use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
     use uselesskey_rustcrypto::RustCryptoRsaExt;
 
@@ -204,8 +206,8 @@ mod hmac_cross_factory {
 mod rsa_multi_sig {
     use super::*;
     use rsa::pkcs1v15::{SigningKey, VerifyingKey};
+    use rsa::sha2::Sha256;
     use rsa::signature::{Signer, Verifier};
-    use sha2::Sha256;
     use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
     use uselesskey_rustcrypto::RustCryptoRsaExt;
 

--- a/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__rsa_snapshots__rustcrypto_rsa_2048_public_key.snap
+++ b/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__rsa_snapshots__rustcrypto_rsa_2048_public_key.snap
@@ -5,4 +5,4 @@ expression: result
 ---
 algorithm: RSA-2048
 modulus_bits: 2048
-e_hex: "10001"
+e_hex: "0000000000010001"

--- a/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__rsa_snapshots__rustcrypto_rsa_4096_public_key.snap
+++ b/crates/uselesskey-rustcrypto/tests/snapshots/snapshots_rustcrypto__rsa_snapshots__rustcrypto_rsa_4096_public_key.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/uselesskey-rustcrypto/tests/snapshots_rustcrypto.rs
+assertion_line: 97
 expression: result
 ---
 algorithm: RSA-4096
 modulus_bits: 4096
-e_hex: "10001"
+e_hex: "0000000000010001"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_chain_metadata.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_chain_metadata.snap
@@ -1,13 +1,14 @@
 ---
 source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+assertion_line: 309
 expression: result
 ---
 chain_len: 2
-leaf_cert_der_len: 803
+leaf_cert_der_len: 802
 leaf_cert_der_hex: "[REDACTED]"
-intermediate_cert_der_len: 802
+intermediate_cert_der_len: 801
 intermediate_cert_der_hex: "[REDACTED]"
-root_cert_der_len: 794
+root_cert_der_len: 793
 root_cert_der_hex: "[REDACTED]"
 private_key_der_len: 1217
 private_key_der_hex: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_self_signed_cert.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_self_signed_cert.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+assertion_line: 269
 expression: result
 ---
-cert_der_len: 758
+cert_der_len: 757
 cert_der_hex: "[REDACTED]"
 private_key_der_len: 1220
 private_key_der_hex: "[REDACTED]"

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_self_signed_custom_domain.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_self_signed_custom_domain.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+assertion_line: 379
 expression: result
 ---
 domain: custom.example.com
-cert_der_len: 762
+cert_der_len: 761
 private_key_der_len: 1218
 der_variant: Pkcs8

--- a/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_x509_chain_key_sizes.snap
+++ b/crates/uselesskey-rustls/tests/snapshots/snapshots_rustls__x509_snapshots__rustls_x509_chain_key_sizes.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/uselesskey-rustls/tests/snapshots_rustls.rs
+assertion_line: 350
 expression: cases
 ---
 - rsa_bits: 2048
   chain_len: 2
-  leaf_cert_der_len: 815
-  root_cert_der_len: 802
+  leaf_cert_der_len: 814
+  root_cert_der_len: 801
   private_key_der_len: 1216
 - rsa_bits: 4096
   chain_len: 2
-  leaf_cert_der_len: 1327
-  root_cert_der_len: 1314
+  leaf_cert_der_len: 1326
+  root_cert_der_len: 1313
   private_key_der_len: 2374

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_custom_domain_metadata.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_custom_domain_metadata.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+assertion_line: 236
 expression: result
 ---
 domain: rpc.custom.io
 chain_pem_cert_count: 2
-root_cert_der_len: 788
-intermediate_cert_der_len: 796
-leaf_cert_der_len: 794
+root_cert_der_len: 787
+intermediate_cert_der_len: 795
+leaf_cert_der_len: 793
 leaf_private_key_der_len: 1217

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_tls_metadata.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__chain_snapshots__tonic_chain_tls_metadata.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
-assertion_line: 149
+assertion_line: 176
 expression: result
 ---
 domain: test.example.com
@@ -8,9 +8,9 @@ chain_pem_cert_count: 2
 full_chain_pem_cert_count: 3
 root_cert_pem_cert_count: 1
 leaf_cert_pem_cert_count: 1
-root_cert_der_len: 794
-intermediate_cert_der_len: 802
-leaf_cert_der_len: 803
+root_cert_der_len: 793
+intermediate_cert_der_len: 801
+leaf_cert_der_len: 802
 leaf_private_key_der_len: 1217
 chain_pem: "[REDACTED]"
 root_cert_pem: "[REDACTED]"

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__key_size_snapshots__tonic_chain_key_sizes.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__key_size_snapshots__tonic_chain_key_sizes.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
-assertion_line: 258
+assertion_line: 355
 expression: cases
 ---
 - rsa_bits: 2048
-  leaf_cert_der_len: 815
+  leaf_cert_der_len: 814
   leaf_private_key_der_len: 1216
-  root_cert_der_len: 802
+  root_cert_der_len: 801
 - rsa_bits: 4096
-  leaf_cert_der_len: 1327
+  leaf_cert_der_len: 1326
   leaf_private_key_der_len: 2374
-  root_cert_der_len: 1314
+  root_cert_der_len: 1313

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__mtls_snapshots__tonic_mtls_chain_cert_details.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__mtls_snapshots__tonic_mtls_chain_cert_details.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+assertion_line: 316
 expression: result
 ---
 domain: secure.example.com
-root_cert_der_len: 798
-intermediate_cert_der_len: 806
-leaf_cert_der_len: 809
+root_cert_der_len: 797
+intermediate_cert_der_len: 805
+leaf_cert_der_len: 808
 leaf_private_key_der_len: 1218
 full_chain_pem_cert_count: 3
 server_mtls_built: true

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__mtls_snapshots__tonic_mtls_configs_build.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__mtls_snapshots__tonic_mtls_configs_build.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
-assertion_line: 219
+assertion_line: 275
 expression: result
 ---
 domain: mtls.example.com
 server_mtls_built: true
 client_mtls_built: true
 chain_pem_cert_count: 2
-root_cert_der_len: 794
+root_cert_der_len: 793

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_custom_domain.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_custom_domain.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/uselesskey-tonic/tests/snapshots_tonic.rs
+assertion_line: 121
 expression: result
 ---
 domain: api.example.com
 cert_pem_has_begin: true
 cert_pem_has_end: true
-cert_der_len: 756
+cert_der_len: 755
 private_key_der_len: 1219
 identity_built: true

--- a/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_tls_metadata.snap
+++ b/crates/uselesskey-tonic/tests/snapshots/snapshots_tonic__self_signed_snapshots__tonic_self_signed_tls_metadata.snap
@@ -9,7 +9,7 @@ cert_pem_has_begin: true
 cert_pem_has_end: true
 private_key_pem_has_begin: true
 private_key_pem_has_end: true
-cert_der_len: 744
+cert_der_len: 743
 private_key_der_len: 1217
 cert_pem: "[REDACTED]"
 private_key_pem: "[REDACTED]"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -41,7 +41,7 @@ uselesskey = { path = "../crates/uselesskey", version = "0.4.1", optional = true
 jsonwebtoken = { workspace = true, optional = true }
 ring = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
-rsa = { workspace = true, optional = true }
+rsa = { workspace = true, optional = true, features = ["sha2"] }
 p256 = { version = "0.13", features = ["ecdsa", "pkcs8"], optional = true }
 ed25519-dalek = { workspace = true, optional = true }
 sha2 = { version = "0.10", features = ["oid"], optional = true }

--- a/tests/cross_adapter.rs
+++ b/tests/cross_adapter.rs
@@ -129,8 +129,8 @@ mod rsa_cross {
     use super::*;
     use ring::signature;
     use rsa::pkcs1v15::VerifyingKey;
+    use rsa::sha2::Sha256;
     use rsa::signature::{Signer as _, Verifier as _};
-    use sha2::Sha256;
     use uselesskey_ring::RingRsaKeyPairExt;
     use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
     use uselesskey_rustcrypto::RustCryptoRsaExt;


### PR DESCRIPTION
## Summary

This refocuses #304 as the V1-compatibility bridge for RSA.

## Scope
- keep deterministic RSA fixture bytes and KIDs unchanged (V1 compatibility)
- migrate the owned/internal RSA path to `rsa 0.10.0-rc.17`
- maintain a compatibility bridge in `uselesskey-rsa` for the legacy 0.9 generation path
- keep legacy `rsa 0.9.x` / `rand_core 0.6` usage explicitly in upstream islands (`jsonwebtoken`, `pgp`)

## Compatibility
- RSA PKCS#1/PSs signing verification in BDD/interop/RustCrypto now uses `rsa::sha2::Sha256`
- `cargo tree -i rsa@0.10.0-rc.17` shows the owned internal path
- `cargo tree -i rsa@0.9.10` and `cargo tree -i rand_core@0.6.4` remain in explicit legacy islands only
