### PR TITLE
xtask: finalize no-blob hints and closed donor matching

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2151,14 +2151,17 @@ fn classify_by_content(
             {
                 return Some((
                     "SSH public key",
-                    "fx.token(\"ssh-key\", TokenSpec::opaque()) or uselesskey-ssh (planned)",
+                    "fx.ssh_key(\"key\", SshSpec::ed25519()).authorized_key_line()",
                 ));
             }
         }
     }
 
     if find_jwt_candidate(&text).is_some() {
-        return Some(("JWT token", "fx.token(\"auth\", TokenSpec::jwt_shape())"));
+        return Some((
+            "JWT token",
+            "fx.token(\"auth\", TokenSpec::oauth_access_token())",
+        ));
     }
 
     None
@@ -2205,7 +2208,7 @@ fn classify_pem_label(label: &str) -> (&'static str, &'static str) {
         ),
         "OPENSSH PRIVATE KEY" => (
             "OpenSSH private key",
-            "fx.token(\"ssh-key\", TokenSpec::opaque()) or uselesskey-ssh (planned)",
+            "fx.ssh_key(\"key\", SshSpec::ed25519()).private_key_openssh()",
         ),
         "PGP PUBLIC KEY BLOCK" | "PGP PRIVATE KEY BLOCK" => {
             ("PGP key block", "fx.pgp(\"key\", PgpSpec::rsa()).armored()")
@@ -2297,7 +2300,7 @@ fn classify_by_extension(path: &Path) -> (&'static str, &'static str) {
         ),
         "p12" | "pfx" => (
             "PKCS#12 bundle",
-            "fx.x509_self_signed(\"ca\", X509Spec::default()) -- PKCS#12 not yet supported; use PEM/DER",
+            "fx.x509_self_signed(\"ca\", X509Spec::default()) for cert/key material, then build PKCS#12 at runtime",
         ),
         "pub" => (
             "Public key file",
@@ -2860,8 +2863,12 @@ mod tests {
         // SSH key on a non-first line should still be classified as SSH, not fall
         // through to extension-based classification.
         let bytes = b"# authorized keys\nssh-rsa AAAAB3NzaC1yc2EAAA... user@host\n";
-        let result = classify_by_content(bytes, true);
-        assert_eq!(result.unwrap().0, "SSH public key");
+        let (kind, suggestion) = classify_by_content(bytes, true).expect("classify by content");
+        assert_eq!(kind, "SSH public key");
+        assert_eq!(
+            suggestion,
+            "fx.ssh_key(\"key\", SshSpec::ed25519()).authorized_key_line()"
+        );
     }
 
     #[test]
@@ -2905,8 +2912,13 @@ mod tests {
     #[test]
     fn test_classify_by_content_finds_embedded_jwt() {
         let bytes = format!(r#"{{"authorization":"Bearer {}"}}"#, sample_jwt());
-        let result = classify_by_content(bytes.as_bytes(), false);
-        assert_eq!(result.unwrap().0, "JWT token");
+        let (kind, suggestion) =
+            classify_by_content(bytes.as_bytes(), false).expect("should classify jwt content");
+        assert_eq!(kind, "JWT token");
+        assert_eq!(
+            suggestion,
+            "fx.token(\"auth\", TokenSpec::oauth_access_token())"
+        );
     }
 
     #[test]
@@ -2924,6 +2936,14 @@ mod tests {
         assert_eq!(
             classify_pem_label("OPENSSH PRIVATE KEY").0,
             "OpenSSH private key"
+        );
+        assert_eq!(
+            classify_pem_label("OPENSSH PRIVATE KEY").1,
+            "fx.ssh_key(\"key\", SshSpec::ed25519()).private_key_openssh()"
+        );
+        assert_eq!(
+            classify_pem_label("RSA PRIVATE KEY").1,
+            "fx.rsa(\"key\", RsaSpec::rs256()).private_key_pkcs1_pem()"
         );
         assert_eq!(
             classify_pem_label("PGP PUBLIC KEY BLOCK").0,
@@ -3071,6 +3091,11 @@ mod tests {
 
     #[test]
     fn perf_baseline_schema_is_valid() {
+        let _cwd_lock = CWD_LOCK.lock().unwrap();
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap_or(Path::new(env!("CARGO_MANIFEST_DIR")));
+        let _cwd = CwdGuard::new(workspace_root);
         let json =
             fs::read_to_string(workspace_path(PERF_BASELINE_PATH)).expect("read perf baseline");
         let parsed: PerfBaselineFile = serde_json::from_str(&json).expect("parse perf baseline");

--- a/xtask/src/pr_bundles.rs
+++ b/xtask/src/pr_bundles.rs
@@ -543,19 +543,18 @@ pub fn analyze_snapshot(snapshot: &BundleSnapshot) -> BundleAnalysis {
     }
 
     let mut unmatched_closed = snapshot.closed_pull_requests.clone();
-    for bundle in &mut bundles {
-        let profile = bundle_profile(bundle);
-        let mut matched = Vec::new();
-        let mut rest = Vec::new();
-        for donor in unmatched_closed.into_iter() {
-            if closed_similarity(&donor.pr, &profile) >= DONOR_THRESHOLD {
-                matched.push(donor);
-            } else {
-                rest.push(donor);
-            }
+    let bundle_profiles: Vec<BundleProfile> = bundles.iter().map(bundle_profile).collect();
+    let mut assigned = vec![Vec::new(); bundles.len()];
+    let mut unmatched = Vec::new();
+    for donor in unmatched_closed.into_iter() {
+        match pick_best_bundle_for_closed_donor(&donor.pr, &bundle_profiles) {
+            Some((idx, _)) => assigned[idx].push(donor),
+            None => unmatched.push(donor),
         }
+    }
+    unmatched_closed = unmatched;
+    for (bundle, matched) in bundles.iter_mut().zip(assigned.into_iter()) {
         bundle.closed_donor_pull_requests = matched;
-        unmatched_closed = rest;
     }
 
     for bundle in &mut bundles {
@@ -1001,6 +1000,41 @@ fn closed_similarity(donor: &PullRequestSnapshot, bundle: &BundleProfile) -> f64
             0.0
         };
     (base + stem_prefix_boost).min(1.0)
+}
+
+fn pick_best_bundle_for_closed_donor(
+    donor: &PullRequestSnapshot,
+    bundle_profiles: &[BundleProfile],
+) -> Option<(usize, f64)> {
+    let donor_stem = canonical_head_ref_stem(&donor.head_ref);
+    let mut best: Option<(usize, f64, bool)> = None;
+
+    for (idx, profile) in bundle_profiles.iter().enumerate() {
+        let score = closed_similarity(donor, profile);
+        if score < DONOR_THRESHOLD {
+            continue;
+        }
+
+        let is_exact = profile
+            .canonical_stem
+            .as_deref()
+            .is_some_and(|stem| stem == donor_stem.as_str());
+        match best {
+            None => {
+                best = Some((idx, score, is_exact));
+            }
+            Some((best_idx, best_score, best_is_exact))
+                if score > best_score
+                    || (score == best_score && is_exact && !best_is_exact)
+                    || (score == best_score && is_exact == best_is_exact && idx < best_idx) =>
+            {
+                best = Some((idx, score, is_exact));
+            }
+            Some(_) => {}
+        }
+    }
+
+    best.map(|(idx, score, _)| (idx, score))
 }
 
 fn bundle_profile(bundle: &BundleCluster) -> BundleProfile {
@@ -2155,6 +2189,156 @@ mod tests {
             analysis.bundles[0].closed_donor_pull_requests[0].pr.number,
             5
         );
+        assert!(analysis.unmatched_closed_donors.is_empty());
+    }
+
+    #[test]
+    fn closed_donor_uses_best_scoring_bundle_for_prefix_stems() {
+        let snapshot = BundleSnapshot {
+            captured_at: "2026-04-05T00:00:00Z".into(),
+            repository: "owner/repo".into(),
+            open_pull_requests: vec![
+                open_pr(
+                    10,
+                    "Add RSA fixtures",
+                    "codex/add-rsa-aaa111",
+                    &["crates/uselesskey-rsa/src/lib.rs"],
+                    1,
+                    0,
+                    Some(true),
+                    3,
+                    80,
+                    10,
+                    1,
+                ),
+                open_pr(
+                    11,
+                    "Add RSA docs",
+                    "codex/add-rsa-bbb222",
+                    &["crates/uselesskey-rsa/src/lib.rs"],
+                    1,
+                    0,
+                    Some(true),
+                    2,
+                    60,
+                    5,
+                    1,
+                ),
+                open_pr(
+                    12,
+                    "RSA fixtures cleanup",
+                    "codex/add-rsa-ccc333",
+                    &["crates/uselesskey-rsa/src/lib.rs"],
+                    1,
+                    0,
+                    Some(true),
+                    2,
+                    90,
+                    8,
+                    1,
+                ),
+                open_pr(
+                    13,
+                    "RSA fixture docs",
+                    "codex/add-rsa-ddd444",
+                    &["crates/uselesskey-rsa/src/lib.rs"],
+                    1,
+                    0,
+                    Some(true),
+                    4,
+                    40,
+                    12,
+                    1,
+                ),
+                open_pr(
+                    20,
+                    "Add RSA adapter",
+                    "codex/add-rsa-adapter-eee555",
+                    &["crates/uselesskey-rsa-adapter/src/lib.rs"],
+                    1,
+                    0,
+                    Some(true),
+                    3,
+                    80,
+                    10,
+                    1,
+                ),
+                open_pr(
+                    21,
+                    "Adjust RSA adapter API",
+                    "codex/add-rsa-adapter-fff666",
+                    &["crates/uselesskey-rsa-adapter/src/api.rs"],
+                    1,
+                    0,
+                    Some(true),
+                    2,
+                    55,
+                    6,
+                    1,
+                ),
+                open_pr(
+                    22,
+                    "Add RSA adapter coverage",
+                    "codex/add-rsa-adapter-ggg777",
+                    &["crates/uselesskey-rsa-adapter/src/tests.rs"],
+                    1,
+                    0,
+                    Some(true),
+                    2,
+                    70,
+                    7,
+                    1,
+                ),
+                open_pr(
+                    23,
+                    "Fix RSA adapter bug",
+                    "codex/add-rsa-adapter-hhh888",
+                    &["crates/uselesskey-rsa-adapter/src/lib.rs"],
+                    1,
+                    0,
+                    Some(true),
+                    4,
+                    75,
+                    9,
+                    1,
+                ),
+            ],
+            closed_pull_requests: vec![ClosedPullRequestSnapshot {
+                pr: open_pr(
+                    99,
+                    "Add RSA fixture set",
+                    "codex/add-rsa-zzz999",
+                    &["crates/uselesskey-rsa/src/lib.rs"],
+                    1,
+                    0,
+                    Some(true),
+                    3,
+                    80,
+                    10,
+                    1,
+                )
+                .pr,
+            }],
+        };
+
+        let analysis = analyze_snapshot(&snapshot);
+        let exact_match_bundle = analysis
+            .bundles
+            .iter()
+            .find(|bundle| bundle.canonical_stem.as_deref() == Some("codex/add-rsa"))
+            .expect("bundle for codex/add-rsa should exist");
+        let adapter_bundle = analysis
+            .bundles
+            .iter()
+            .find(|bundle| bundle.canonical_stem.as_deref() == Some("codex/add-rsa-adapter"))
+            .expect("bundle for codex/add-rsa-adapter should exist");
+
+        assert_eq!(exact_match_bundle.closed_donor_pull_requests.len(), 1);
+        assert_eq!(
+            exact_match_bundle.closed_donor_pull_requests[0].pr.number,
+            99
+        );
+        assert!(adapter_bundle.closed_donor_pull_requests.is_empty());
         assert!(analysis.unmatched_closed_donors.is_empty());
     }
 


### PR DESCRIPTION
Finalizing xtask cleanup: fixed closed donor best-match bundle assignment (and added prefix-stem regression), made no-blob migration suggestions actionable for SSH/JWT/PKCS#12, and stabilized perf baseline schema test. Validation: cargo test -p xtask; cargo xtask no-blob; cargo xtask no-blob migrate.