### PR TITLE
Accept uppercase `0X` prefixes in `Seed::from_env_value`

### DIFF
--- a/crates/uselesskey-core-seed/src/lib.rs
+++ b/crates/uselesskey-core-seed/src/lib.rs
@@ -52,7 +52,10 @@ impl Seed {
     /// - any other string (hashed with BLAKE3)
     pub fn from_env_value(value: &str) -> Result<Self, String> {
         let v = value.trim();
-        let hex = v.strip_prefix("0x").unwrap_or(v);
+        let hex = v
+            .strip_prefix("0x")
+            .or_else(|| v.strip_prefix("0X"))
+            .unwrap_or(v);
 
         if hex.len() == 64 {
             return parse_hex_32(hex).map(Self);
@@ -134,6 +137,13 @@ mod tests {
         let hex = "F".repeat(64);
         let seed = Seed::from_env_value(&hex).unwrap();
         assert!(seed.bytes().iter().all(|b| *b == 0xFF));
+    }
+
+    #[test]
+    fn seed_from_env_value_parses_hex_with_uppercase_prefix() {
+        let hex = format!("0X{}", "ab".repeat(32));
+        let seed = Seed::from_env_value(&hex).unwrap();
+        assert!(seed.bytes().iter().all(|b| *b == 0xAB));
     }
 
     #[test]

--- a/crates/uselesskey-core-seed/tests/seed_prop.rs
+++ b/crates/uselesskey-core-seed/tests/seed_prop.rs
@@ -15,7 +15,10 @@ proptest! {
     #[test]
     fn seed_from_env_value_non_64_lengths_are_ok(s in "[a-zA-Z0-9!@#$%^&*()]{0,63}|[a-zA-Z0-9!@#$%^&*()]{65,200}") {
         let trimmed = s.trim();
-        let after_prefix = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+        let after_prefix = trimmed
+            .strip_prefix("0x")
+            .or_else(|| trimmed.strip_prefix("0X"))
+            .unwrap_or(trimmed);
         prop_assume!(after_prefix.len() != 64);
         prop_assert!(Seed::from_env_value(&s).is_ok());
     }
@@ -33,6 +36,20 @@ proptest! {
     fn seed_from_env_value_valid_hex_with_prefix_roundtrips(hex_bytes in any::<[u8; 32]>()) {
         let hex = format!(
             "0x{}",
+            hex_bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        );
+        let parsed = Seed::from_env_value(&hex).unwrap();
+        prop_assert_eq!(parsed.bytes(), &hex_bytes);
+    }
+
+    /// Optional uppercase 0X prefix also remains valid.
+    #[test]
+    fn seed_from_env_value_valid_hex_with_uppercase_prefix_roundtrips(hex_bytes in any::<[u8; 32]>()) {
+        let hex = format!(
+            "0X{}",
             hex_bytes
                 .iter()
                 .map(|b| format!("{:02x}", b))

--- a/crates/uselesskey-core/tests/core_prop.rs
+++ b/crates/uselesskey-core/tests/core_prop.rs
@@ -83,7 +83,10 @@ proptest! {
     #[test]
     fn seed_from_env_value_non_64_byte_ascii_strings_always_ok(s in "[a-zA-Z0-9!@#$%^&*()]{0,63}|[a-zA-Z0-9!@#$%^&*()]{65,200}") {
         let trimmed = s.trim();
-        let after_prefix = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+        let after_prefix = trimmed
+            .strip_prefix("0x")
+            .or_else(|| trimmed.strip_prefix("0X"))
+            .unwrap_or(trimmed);
         // Only test if not 64 bytes after processing.
         prop_assume!(after_prefix.len() != 64);
 
@@ -109,6 +112,18 @@ proptest! {
     #[test]
     fn seed_from_env_value_valid_hex_with_prefix(hex_bytes in any::<[u8; 32]>()) {
         let hex: String = format!("0x{}", hex_bytes.iter().map(|b| format!("{:02x}", b)).collect::<String>());
+
+        let result = Seed::from_env_value(&hex);
+        prop_assert!(result.is_ok());
+
+        let seed = result.unwrap();
+        prop_assert_eq!(seed.bytes(), &hex_bytes);
+    }
+
+    /// Seed::from_env_value() with 0X prefix also works.
+    #[test]
+    fn seed_from_env_value_valid_hex_with_uppercase_prefix(hex_bytes in any::<[u8; 32]>()) {
+        let hex: String = format!("0X{}", hex_bytes.iter().map(|b| format!("{:02x}", b)).collect::<String>());
 
         let result = Seed::from_env_value(&hex);
         prop_assert!(result.is_ok());


### PR DESCRIPTION
### Motivation
- Some environments emit an uppercase `0X` hex prefix; `Seed::from_env_value` previously only recognized lowercase `0x`, causing uppercase-prefixed 64-char hex seeds to be treated as text and hashed instead of parsed as explicit seed bytes.

### Description
- Update `Seed::from_env_value` to accept either `0x` or `0X` prefixes and add unit/property test coverage to `crates/uselesskey-core-seed/src/lib.rs`, `crates/uselesskey-core-seed/tests/seed_prop.rs`, and `crates/uselesskey-core/tests/core_prop.rs` to validate uppercase-prefixed hex roundtrips.

### Testing
- Ran `cargo test -p uselesskey-core-seed --all-features` and `cargo test -p uselesskey-core --test core_prop`, and the relevant test suites passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89563f0588333ab99b42d50001543)