### PR TITLE
Support uppercase `0X` seed prefix parsing

### DIFF
--- a/crates/uselesskey-core-seed/src/lib.rs
+++ b/crates/uselesskey-core-seed/src/lib.rs
@@ -52,7 +52,10 @@ impl Seed {
     /// - any other string (hashed with BLAKE3)
     pub fn from_env_value(value: &str) -> Result<Self, String> {
         let v = value.trim();
-        let hex = v.strip_prefix("0x").unwrap_or(v);
+        let hex = v
+            .strip_prefix("0x")
+            .or_else(|| v.strip_prefix("0X"))
+            .unwrap_or(v);
 
         if hex.len() == 64 {
             return parse_hex_32(hex).map(Self);
@@ -125,6 +128,14 @@ mod tests {
     fn seed_from_env_value_parses_hex_with_prefix_and_whitespace() {
         let hex = "0x0000000000000000000000000000000000000000000000000000000000000001";
         let seed = Seed::from_env_value(&format!("  {hex}  ")).unwrap();
+        assert_eq!(seed.bytes()[31], 1);
+        assert!(seed.bytes()[..31].iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn seed_from_env_value_parses_uppercase_0x_prefix() {
+        let hex = "0X0000000000000000000000000000000000000000000000000000000000000001";
+        let seed = Seed::from_env_value(hex).unwrap();
         assert_eq!(seed.bytes()[31], 1);
         assert!(seed.bytes()[..31].iter().all(|b| *b == 0));
     }

--- a/crates/uselesskey-core-seed/tests/seed_prop.rs
+++ b/crates/uselesskey-core-seed/tests/seed_prop.rs
@@ -15,7 +15,10 @@ proptest! {
     #[test]
     fn seed_from_env_value_non_64_lengths_are_ok(s in "[a-zA-Z0-9!@#$%^&*()]{0,63}|[a-zA-Z0-9!@#$%^&*()]{65,200}") {
         let trimmed = s.trim();
-        let after_prefix = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+        let after_prefix = trimmed
+            .strip_prefix("0x")
+            .or_else(|| trimmed.strip_prefix("0X"))
+            .unwrap_or(trimmed);
         prop_assume!(after_prefix.len() != 64);
         prop_assert!(Seed::from_env_value(&s).is_ok());
     }
@@ -33,6 +36,20 @@ proptest! {
     fn seed_from_env_value_valid_hex_with_prefix_roundtrips(hex_bytes in any::<[u8; 32]>()) {
         let hex = format!(
             "0x{}",
+            hex_bytes
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect::<String>()
+        );
+        let parsed = Seed::from_env_value(&hex).unwrap();
+        prop_assert_eq!(parsed.bytes(), &hex_bytes);
+    }
+
+    /// Optional uppercase 0X prefix remains valid.
+    #[test]
+    fn seed_from_env_value_valid_hex_with_uppercase_prefix_roundtrips(hex_bytes in any::<[u8; 32]>()) {
+        let hex = format!(
+            "0X{}",
             hex_bytes
                 .iter()
                 .map(|b| format!("{:02x}", b))

--- a/crates/uselesskey-core/tests/core_prop.rs
+++ b/crates/uselesskey-core/tests/core_prop.rs
@@ -83,7 +83,10 @@ proptest! {
     #[test]
     fn seed_from_env_value_non_64_byte_ascii_strings_always_ok(s in "[a-zA-Z0-9!@#$%^&*()]{0,63}|[a-zA-Z0-9!@#$%^&*()]{65,200}") {
         let trimmed = s.trim();
-        let after_prefix = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+        let after_prefix = trimmed
+            .strip_prefix("0x")
+            .or_else(|| trimmed.strip_prefix("0X"))
+            .unwrap_or(trimmed);
         // Only test if not 64 bytes after processing.
         prop_assume!(after_prefix.len() != 64);
 
@@ -109,6 +112,18 @@ proptest! {
     #[test]
     fn seed_from_env_value_valid_hex_with_prefix(hex_bytes in any::<[u8; 32]>()) {
         let hex: String = format!("0x{}", hex_bytes.iter().map(|b| format!("{:02x}", b)).collect::<String>());
+
+        let result = Seed::from_env_value(&hex);
+        prop_assert!(result.is_ok());
+
+        let seed = result.unwrap();
+        prop_assert_eq!(seed.bytes(), &hex_bytes);
+    }
+
+    /// Seed::from_env_value() with uppercase 0X prefix also works.
+    #[test]
+    fn seed_from_env_value_valid_hex_with_uppercase_prefix(hex_bytes in any::<[u8; 32]>()) {
+        let hex: String = format!("0X{}", hex_bytes.iter().map(|b| format!("{:02x}", b)).collect::<String>());
 
         let result = Seed::from_env_value(&hex);
         prop_assert!(result.is_ok());


### PR DESCRIPTION
### Motivation

- `Seed::from_env_value` only stripped a lowercase `0x` prefix, causing valid uppercase-prefixed (`0X`) 64-char hex seeds to be hashed as text instead of parsed as hex, producing surprising deterministic seeds.

### Description

- Update `Seed::from_env_value` to strip both `0x` and `0X` prefixes before deciding whether to parse a 64-char hex string. (`crates/uselesskey-core-seed/src/lib.rs`)
- Add a focused unit test to verify uppercase `0X` prefix parsing produces the expected 32-byte seed. (`crates/uselesskey-core-seed/src/lib.rs` tests)
- Extend property tests to account for the uppercase prefix in `crates/uselesskey-core-seed/tests/seed_prop.rs` and `crates/uselesskey-core/tests/core_prop.rs`, including a roundtrip property for `0X`-prefixed hex.

### Testing

- Ran `cargo test -p uselesskey-core-seed` and all tests passed (21 passed; 0 failed). 
- Ran `cargo test -p uselesskey-core` and relevant tests passed (all affected property and unit tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89563f0588333ab99b42d50001543)