### PR TITLE
Fix core-factory tests to run without `std` (no-default-features)

### DIFF
--- a/crates/uselesskey-core-factory/tests/error_paths.rs
+++ b/crates/uselesskey-core-factory/tests/error_paths.rs
@@ -77,7 +77,9 @@ fn extremely_long_spec_bytes_does_not_panic() {
 
 #[test]
 fn type_mismatch_panics_not_silent() {
-    let fx = Factory::random();
+    // Use deterministic mode so this test also runs under `--no-default-features`
+    // where `Mode::Random` is intentionally unavailable.
+    let fx = Factory::deterministic(Seed::new([9u8; 32]));
     let _ = fx.get_or_init("domain:tm", "label", b"spec", "good", |_rng| 42u32);
 
     let result = catch_unwind(AssertUnwindSafe(|| {

--- a/crates/uselesskey-core-factory/tests/mutant_killers.rs
+++ b/crates/uselesskey-core-factory/tests/mutant_killers.rs
@@ -65,7 +65,8 @@ fn deterministic_different_variants_produce_different_values() {
 
 #[test]
 fn clear_cache_allows_regeneration() {
-    let fx = Factory::random();
+    // Deterministic mode keeps this behavior test valid under `--no-default-features`.
+    let fx = Factory::deterministic(Seed::new([7u8; 32]));
 
     let a: Arc<u32> = fx.get_or_init("d", "l", b"s", "v", |_| 1u32);
     assert_eq!(*a, 1);
@@ -98,7 +99,9 @@ fn debug_deterministic_mode() {
 
 #[test]
 fn clone_shares_cache() {
-    let fx = Factory::random();
+    // Deterministic mode keeps this cache-sharing invariant test independent
+    // from `std`-only random seeding.
+    let fx = Factory::deterministic(Seed::new([8u8; 32]));
     let a: Arc<u32> = fx.get_or_init("d", "l", b"s", "v", |_| 42u32);
 
     let fx2 = fx.clone();


### PR DESCRIPTION
### Motivation
- A handful of tests used `Factory::random()` in paths that call the crate's `random_seed()` which panics when the `std` feature is disabled, so tests were failing under `--no-default-features` and breaking CI for minimal builds.

### Description
- Replace `Factory::random()` with `Factory::deterministic(Seed::new(...))` in failing tests to preserve cache/type-mismatch semantics while avoiding `std`-only RNG paths in `crates/uselesskey-core-factory/tests/error_paths.rs` and `crates/uselesskey-core-factory/tests/mutant_killers.rs`.

### Testing
- Ran `cargo test -p uselesskey-core-factory --no-default-features` and the suite completed successfully with all tests passing.
- Ran `cargo test -p uselesskey-core-factory` and the suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e89563f0588333ab99b42d50001543)