### PR TITLE
seed: accept uppercase 0X hex prefixes in deterministic seed parsing

### DIFF
--- a/crates/uselesskey-core-seed/src/lib.rs
+++ b/crates/uselesskey-core-seed/src/lib.rs
@@ -52,7 +52,10 @@ impl Seed {
     /// - any other string (hashed with BLAKE3)
     pub fn from_env_value(value: &str) -> Result<Self, String> {
         let v = value.trim();
-        let hex = v.strip_prefix("0x").unwrap_or(v);
+        let hex = v
+            .strip_prefix("0x")
+            .or_else(|| v.strip_prefix("0X"))
+            .unwrap_or(v);
 
         if hex.len() == 64 {
             return parse_hex_32(hex).map(Self);
@@ -125,6 +128,14 @@ mod tests {
     fn seed_from_env_value_parses_hex_with_prefix_and_whitespace() {
         let hex = "0x0000000000000000000000000000000000000000000000000000000000000001";
         let seed = Seed::from_env_value(&format!("  {hex}  ")).unwrap();
+        assert_eq!(seed.bytes()[31], 1);
+        assert!(seed.bytes()[..31].iter().all(|b| *b == 0));
+    }
+
+    #[test]
+    fn seed_from_env_value_parses_uppercase_hex_prefix() {
+        let hex = "0X0000000000000000000000000000000000000000000000000000000000000001";
+        let seed = Seed::from_env_value(hex).unwrap();
         assert_eq!(seed.bytes()[31], 1);
         assert!(seed.bytes()[..31].iter().all(|b| *b == 0));
     }


### PR DESCRIPTION
### Motivation
- Ensure `Seed::from_env_value` recognizes both `0x` and `0X` hex prefixes so uppercase-prefixed 64-char hex seeds are parsed as raw 32-byte seeds instead of being hashed, preventing surprising determinism mismatches.

### Description
- Update `from_env_value` to strip either `"0x"` or `"0X"` before 64-char hex parsing and add unit test `seed_from_env_value_parses_uppercase_hex_prefix` to lock in the behavior.

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/ukey-target2 cargo test -p uselesskey-core-seed` and all unit tests in the crate passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8956435d4833397b172fef8ccc89d)