### PR TITLE
Handle oversized stable_bytes field lengths with backward-compatible u32 extension

### DIFF
--- a/crates/uselesskey-pkcs11-mock/src/lib.rs
+++ b/crates/uselesskey-pkcs11-mock/src/lib.rs
@@ -221,7 +221,13 @@ fn mock_certificate_der(
 fn write_field(out: &mut Vec<u8>, name: &str, value: &[u8]) {
     out.extend_from_slice(name.as_bytes());
     out.push(b'=');
-    out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    if value.len() <= u16::MAX as usize {
+        out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    } else {
+        // Backward-compatible extension for oversized values.
+        out.extend_from_slice(&u16::MAX.to_be_bytes());
+        out.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    }
     out.extend_from_slice(value);
     out.push(0);
 }
@@ -267,5 +273,15 @@ mod tests {
         let handle = provider.key_handles()[0];
         let der = provider.certificate_der(handle).expect("certificate");
         assert_eq!(&der[0..2], &[0x30, 0x82]);
+    }
+
+    #[test]
+    fn stable_bytes_distinguish_very_long_labels() {
+        let mut spec_a = Pkcs11MockSpec::basic("HSM-A");
+        let mut spec_b = Pkcs11MockSpec::basic("HSM-A");
+        spec_a.key_labels = vec!["a".repeat(65_536)];
+        spec_b.key_labels = vec!["b".repeat(65_536)];
+
+        assert_ne!(spec_a.stable_bytes(), spec_b.stable_bytes());
     }
 }

--- a/crates/uselesskey-webauthn/src/lib.rs
+++ b/crates/uselesskey-webauthn/src/lib.rs
@@ -323,7 +323,14 @@ fn sha256_arr(bytes: &[u8]) -> [u8; 32] {
 fn write_field(out: &mut Vec<u8>, name: &str, value: &[u8]) {
     out.extend_from_slice(name.as_bytes());
     out.push(0x1f);
-    out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    if value.len() <= u16::MAX as usize {
+        out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    } else {
+        // Backward-compatible extension: preserve existing encoding for short values,
+        // and only add an extended length marker for oversized fields.
+        out.extend_from_slice(&u16::MAX.to_be_bytes());
+        out.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    }
     out.extend_from_slice(value);
 }
 
@@ -383,5 +390,15 @@ mod tests {
             serde_json::from_slice(&reg.client_data_json).expect("parse clientDataJSON");
         assert_eq!(json["challenge"], base64url(challenge));
         assert_eq!(json["origin"], "https://example.com");
+    }
+
+    #[test]
+    fn stable_bytes_distinguish_very_long_challenges() {
+        let mut spec_a = WebAuthnSpec::packed("example.com", vec![b'a'; 65_536]);
+        let mut spec_b = WebAuthnSpec::packed("example.com", vec![b'b'; 65_536]);
+        spec_a.credential_id = b"cred-a".to_vec();
+        spec_b.credential_id = b"cred-a".to_vec();
+
+        assert_ne!(spec_a.stable_bytes(), spec_b.stable_bytes());
     }
 }


### PR DESCRIPTION
### Motivation
- `stable_bytes()` used a `u16` length for encoded fields which could truncate lengths and cause identity collisions for values >= 65,536 bytes, breaking deterministic derivation and cache-by-identity guarantees. 

### Description
- Update `write_field` in `crates/uselesskey-webauthn/src/lib.rs` to encode lengths using the existing `u16` form for short values and a backward-compatible extended form (`0xFFFF` marker followed by a `u32` length) for oversized fields. 
- Apply the same backward-compatible encoding change to `write_field` in `crates/uselesskey-pkcs11-mock/src/lib.rs`. 
- Add regression tests `stable_bytes_distinguish_very_long_challenges` in the WebAuthn crate and `stable_bytes_distinguish_very_long_labels` in the PKCS#11 mock crate to ensure distinct oversized inputs produce distinct `stable_bytes()` outputs. 
- Changes preserve existing encoding for normal-sized fields and only alter behavior for oversized inputs.

### Testing
- Ran `cargo test -p uselesskey-webauthn -p uselesskey-pkcs11-mock --all-features` and all tests passed. 
- The added unit tests in both crates passed when included in the test run and no other tests regressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8956435d4833397b172fef8ccc89d)