### PR TITLE
Fix WebAuthn stable-bytes collisions for large fields

### DIFF
--- a/crates/uselesskey-webauthn/src/lib.rs
+++ b/crates/uselesskey-webauthn/src/lib.rs
@@ -323,7 +323,16 @@ fn sha256_arr(bytes: &[u8]) -> [u8; 32] {
 fn write_field(out: &mut Vec<u8>, name: &str, value: &[u8]) {
     out.extend_from_slice(name.as_bytes());
     out.push(0x1f);
-    out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    let len = value.len();
+    if len <= u16::MAX as usize {
+        out.extend_from_slice(&(len as u16).to_be_bytes());
+    } else {
+        // Backward-compatible extension:
+        // - lengths up to u16::MAX keep the original encoding.
+        // - larger values use an escape length followed by u32 length bytes.
+        out.extend_from_slice(&u16::MAX.to_be_bytes());
+        out.extend_from_slice(&(len as u32).to_be_bytes());
+    }
     out.extend_from_slice(value);
 }
 
@@ -383,5 +392,16 @@ mod tests {
             serde_json::from_slice(&reg.client_data_json).expect("parse clientDataJSON");
         assert_eq!(json["challenge"], base64url(challenge));
         assert_eq!(json["origin"], "https://example.com");
+    }
+
+    #[test]
+    fn stable_bytes_distinguish_long_field_lengths_after_u16_boundary() {
+        let mut a = WebAuthnSpec::packed("example.com", b"challenge");
+        let mut b = a.clone();
+
+        a.challenge = vec![0x41; u16::MAX as usize + 1];
+        b.challenge = vec![0x41; u16::MAX as usize + 2];
+
+        assert_ne!(a.stable_bytes(), b.stable_bytes());
     }
 }


### PR DESCRIPTION
### Motivation
- `WebAuthnSpec::stable_bytes` previously encoded field lengths as a `u16`, which truncated lengths above `65535` and could make different specs serialize to identical bytes and therefore collide in deterministic fixture derivation.
- Preserve backward compatibility with existing fixtures while ensuring derivation stability for arbitrarily large fields.

### Description
- Changed `write_field` to emit the original 2-byte length for lengths `<= 65535` and to use an escape (`0xFFFF`) followed by a `u32` length for larger values to avoid truncation when serializing field lengths.
- Kept the rest of the stable serialization format unchanged so existing fixtures remain stable.
- Added a regression test `stable_bytes_distinguish_long_field_lengths_after_u16_boundary` that verifies two `WebAuthnSpec` instances with lengths just above the `u16` boundary produce different `stable_bytes()` outputs.
- Modified file: `crates/uselesskey-webauthn/src/lib.rs` (implementation and tests).

### Testing
- Ran `cargo test -p uselesskey-webauthn` and all tests passed, including the new `stable_bytes_distinguish_long_field_lengths_after_u16_boundary` regression test.
- Verified existing unit tests in the crate continued to pass with the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8956435d4833397b172fef8ccc89d)