### PR TITLE
fix(xtask): make `cargo xtask pr` resilient when `origin/main` is missing

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1812,20 +1812,80 @@ fn resolve_base_ref() -> String {
 }
 
 fn git_changed_files(base_ref: &str) -> Result<Vec<String>> {
-    let revspec = format!("{base_ref}...HEAD");
-    let output = Command::new("git")
-        .args(["diff", "--name-only", &revspec])
-        .output()
-        .context("failed to run git diff")?;
+    let mut attempts = Vec::new();
 
-    if !output.status.success() {
-        bail!(
-            "git diff failed with status {}",
+    for candidate in base_ref_candidates(base_ref) {
+        let revspec = format!("{candidate}...HEAD");
+        let output = Command::new("git")
+            .args(["diff", "--name-only", &revspec])
+            .output()
+            .context("failed to run git diff")?;
+
+        if output.status.success() {
+            return parse_changed_files(&output.stdout);
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        attempts.push(format!(
+            "{revspec} (status {}): {stderr}",
             output.status.code().unwrap_or(-1)
-        );
+        ));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    if git_commit_exists("HEAD~1")? {
+        let output = Command::new("git")
+            .args(["diff", "--name-only", "HEAD~1..HEAD"])
+            .output()
+            .context("failed to run git diff HEAD~1..HEAD")?;
+        if output.status.success() {
+            eprintln!("xtask pr: base ref '{base_ref}' unavailable, falling back to HEAD~1..HEAD");
+            return parse_changed_files(&output.stdout);
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        attempts.push(format!(
+            "HEAD~1..HEAD (status {}): {stderr}",
+            output.status.code().unwrap_or(-1)
+        ));
+    } else {
+        eprintln!(
+            "xtask pr: base ref '{base_ref}' and HEAD~1 unavailable, treating repository as unchanged"
+        );
+        return Ok(Vec::new());
+    }
+
+    bail!(
+        "git diff failed for all attempted base refs: {}",
+        attempts.join(" | ")
+    )
+}
+
+fn base_ref_candidates(base_ref: &str) -> Vec<String> {
+    let mut refs = vec![base_ref.to_string()];
+    if let Some(local) = base_ref.strip_prefix("origin/")
+        && !local.is_empty()
+    {
+        refs.push(local.to_string());
+    }
+    refs
+}
+
+fn git_commit_exists(rev: &str) -> Result<bool> {
+    Ok(Command::new("git")
+        .args([
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{rev}^{{commit}}"),
+        ])
+        .status()
+        .with_context(|| format!("failed to run git rev-parse --verify for {rev}"))?
+        .success())
+}
+
+fn parse_changed_files(stdout: &[u8]) -> Result<Vec<String>> {
+    let stdout =
+        String::from_utf8(stdout.to_vec()).context("git diff output was not valid UTF-8")?;
     let files = stdout
         .lines()
         .map(|line| line.trim().to_string())
@@ -2751,6 +2811,14 @@ mod tests {
         }
     }
 
+    fn run_git<const N: usize>(args: [&str; N]) {
+        let status = Command::new("git")
+            .args(args)
+            .status()
+            .unwrap_or_else(|err| panic!("failed to run git {}: {err}", args.join(" ")));
+        assert!(status.success(), "git {} failed", args.join(" "));
+    }
+
     fn restore_env(key: &str, prev: Option<String>) {
         match prev {
             Some(val) => unsafe { env::set_var(key, val) },
@@ -2821,6 +2889,71 @@ mod tests {
 
         restore_env("XTASK_BASE_REF", prev_xtask);
         restore_env("GITHUB_BASE_REF", prev_gh);
+    }
+
+    #[test]
+    fn base_ref_candidates_include_local_branch_for_origin_ref() {
+        assert_eq!(
+            base_ref_candidates("origin/main"),
+            vec!["origin/main".to_string(), "main".to_string()]
+        );
+    }
+
+    #[test]
+    fn base_ref_candidates_keep_non_origin_ref_as_is() {
+        assert_eq!(
+            base_ref_candidates("upstream/trunk"),
+            vec!["upstream/trunk".to_string()]
+        );
+    }
+
+    #[test]
+    fn git_changed_files_uses_local_branch_when_origin_ref_missing() {
+        let _cwd_lock = CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _cwd = CwdGuard::new(dir.path());
+
+        run_git(["init"]);
+        run_git(["config", "user.email", "agent@example.com"]);
+        run_git(["config", "user.name", "Agent"]);
+
+        fs::write("tracked.txt", "base\n").expect("write base");
+        run_git(["add", "tracked.txt"]);
+        run_git(["commit", "-m", "initial"]);
+        run_git(["branch", "-M", "main"]);
+        run_git(["checkout", "-b", "feature"]);
+
+        fs::write("first.txt", "one\n").expect("write first");
+        run_git(["add", "first.txt"]);
+        run_git(["commit", "-m", "first"]);
+        fs::write("second.txt", "two\n").expect("write second");
+        run_git(["add", "second.txt"]);
+        run_git(["commit", "-m", "second"]);
+
+        let mut changed =
+            git_changed_files("origin/main").expect("local main fallback should succeed");
+        changed.sort();
+        assert_eq!(
+            changed,
+            vec!["first.txt".to_string(), "second.txt".to_string()]
+        );
+    }
+
+    #[test]
+    fn git_changed_files_returns_empty_without_base_ref_or_parent() {
+        let _cwd_lock = CWD_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let _cwd = CwdGuard::new(dir.path());
+
+        run_git(["init"]);
+        run_git(["config", "user.email", "agent@example.com"]);
+        run_git(["config", "user.name", "Agent"]);
+        fs::write("tracked.txt", "v1\n").expect("write tracked");
+        run_git(["add", "tracked.txt"]);
+        run_git(["commit", "-m", "initial"]);
+
+        let changed = git_changed_files("origin/main").expect("missing refs should not fail");
+        assert!(changed.is_empty(), "expected no changes, got {changed:?}");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- `cargo xtask pr` could fail early with `git diff` status 128 in ephemeral or local-only clones where `origin/main` does not exist. 
- The PR-scoped flow must work in sandboxed developer environments without requiring remote tracking refs. 
- Improve diagnostics so failures to compute diffs show which revspecs were attempted.

### Description

- Update `git_changed_files` to try multiple base refs produced by a new `base_ref_candidates` helper and return on the first successful `git diff` result. 
- Add a final fallback to run `git diff --name-only HEAD~1..HEAD` and emit a clear fallback message when the configured base ref is unavailable. 
- Introduce `parse_changed_files` to centralize stdout parsing and aggregate failed revspec attempts for improved error messages. 
- Add unit tests covering `base_ref_candidates` behavior to ensure `origin/*` base refs also include the local branch name and non-origin refs are preserved.

### Testing

- Ran the new unit tests with `cargo test -p xtask base_ref_candidates`, which passed. 
- Ran `cargo xtask lint-fix --no-clippy` to ensure formatting, which completed successfully. 
- Executed `cargo xtask pr` in a local sandbox where `origin/main` was missing and observed the fallback message (`falling back to HEAD~1..HEAD`) and that the pipeline advanced past detect-changes and `fmt` stages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8956547e88333a0e0ca4247e15724)