### PR TITLE
Fix WebAuthn stable bytes encoding for fields larger than u16::MAX

### DIFF
--- a/crates/uselesskey-webauthn/src/lib.rs
+++ b/crates/uselesskey-webauthn/src/lib.rs
@@ -290,26 +290,29 @@ fn mock_signature(seed: &[u8; 32], body: &[u8], context: &[u8]) -> Vec<u8> {
 fn base64url(input: &[u8]) -> String {
     const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
     let mut out = String::new();
-    let mut i = 0;
-    while i + 3 <= input.len() {
-        let chunk = &input[i..i + 3];
-        let n = ((chunk[0] as u32) << 16) | ((chunk[1] as u32) << 8) | chunk[2] as u32;
+    let mut chunks = input.chunks_exact(3);
+    for chunk in &mut chunks {
+        let n = ((chunk[0] as u32) << 16) + ((chunk[1] as u32) << 8) + chunk[2] as u32;
         out.push(TABLE[((n >> 18) & 0x3f) as usize] as char);
         out.push(TABLE[((n >> 12) & 0x3f) as usize] as char);
         out.push(TABLE[((n >> 6) & 0x3f) as usize] as char);
         out.push(TABLE[(n & 0x3f) as usize] as char);
-        i += 3;
     }
-    let rem = input.len() - i;
-    if rem == 1 {
-        let n = (input[i] as u32) << 16;
-        out.push(TABLE[((n >> 18) & 0x3f) as usize] as char);
-        out.push(TABLE[((n >> 12) & 0x3f) as usize] as char);
-    } else if rem == 2 {
-        let n = ((input[i] as u32) << 16) | ((input[i + 1] as u32) << 8);
-        out.push(TABLE[((n >> 18) & 0x3f) as usize] as char);
-        out.push(TABLE[((n >> 12) & 0x3f) as usize] as char);
-        out.push(TABLE[((n >> 6) & 0x3f) as usize] as char);
+
+    match chunks.remainder() {
+        [byte] => {
+            let n = (*byte as u32) << 16;
+            out.push(TABLE[((n >> 18) & 0x3f) as usize] as char);
+            out.push(TABLE[((n >> 12) & 0x3f) as usize] as char);
+        }
+        [first, second] => {
+            let n = ((*first as u32) << 16) + ((*second as u32) << 8);
+            out.push(TABLE[((n >> 18) & 0x3f) as usize] as char);
+            out.push(TABLE[((n >> 12) & 0x3f) as usize] as char);
+            out.push(TABLE[((n >> 6) & 0x3f) as usize] as char);
+        }
+        [] => {}
+        _ => unreachable!("chunks_exact remainder is shorter than the chunk size"),
     }
     out
 }
@@ -323,7 +326,17 @@ fn sha256_arr(bytes: &[u8]) -> [u8; 32] {
 fn write_field(out: &mut Vec<u8>, name: &str, value: &[u8]) {
     out.extend_from_slice(name.as_bytes());
     out.push(0x1f);
-    out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    if let Ok(short_len) = u16::try_from(value.len()) {
+        out.extend_from_slice(&short_len.to_be_bytes());
+    } else {
+        // Backward-compatible extension:
+        // - values <= u16::MAX keep the original encoding
+        // - longer values use 0xffff + u32 length, avoiding truncation collisions
+        let len32 = u32::try_from(value.len())
+            .expect("webauthn stable_bytes field length exceeds u32::MAX");
+        out.extend_from_slice(&u16::MAX.to_be_bytes());
+        out.extend_from_slice(&len32.to_be_bytes());
+    }
     out.extend_from_slice(value);
 }
 
@@ -383,5 +396,197 @@ mod tests {
             serde_json::from_slice(&reg.client_data_json).expect("parse clientDataJSON");
         assert_eq!(json["challenge"], base64url(challenge));
         assert_eq!(json["origin"], "https://example.com");
+    }
+
+    #[test]
+    fn attestation_mode_tags_are_stable() {
+        assert_eq!(AttestationMode::Packed.as_tag(), "packed");
+        assert_eq!(AttestationMode::SelfAttestation.as_tag(), "self");
+
+        let mut spec = WebAuthnSpec::packed("example.com", b"challenge-mode");
+        spec.attestation_mode = AttestationMode::SelfAttestation;
+        let stable = spec.stable_bytes();
+
+        assert_contains_bytes(&stable, b"attestation_mode");
+        assert_contains_bytes(&stable, b"self");
+    }
+
+    #[test]
+    fn authenticator_data_layout_matches_webauthn_shape() {
+        let rp_id_hash = [0x11; 32];
+        let sign_count = 0x0102_0304;
+        let aaguid = [0x22; 16];
+        let credential_id = b"cred";
+        let credential_public_key = b"public-key";
+
+        let reg = build_authenticator_data(
+            rp_id_hash,
+            sign_count,
+            Some((&aaguid, credential_id, credential_public_key)),
+        );
+
+        assert_eq!(&reg[..32], &rp_id_hash);
+        assert_eq!(reg[32], 0x41);
+        assert_eq!(&reg[33..37], &sign_count.to_be_bytes());
+        assert_eq!(&reg[37..53], &aaguid);
+        assert_eq!(u16::from_be_bytes(reg[53..55].try_into().unwrap()), 4);
+        assert_eq!(&reg[55..59], credential_id);
+        assert_eq!(&reg[59..], credential_public_key);
+
+        let assertion = build_authenticator_data(rp_id_hash, sign_count, None);
+        assert_eq!(assertion.len(), 37);
+        assert_eq!(&assertion[..32], &rp_id_hash);
+        assert_eq!(assertion[32], 0x01);
+        assert_eq!(&assertion[33..37], &sign_count.to_be_bytes());
+    }
+
+    #[test]
+    fn cbor_public_key_has_ec2_es256_shape() {
+        let encoded = cbor_public_key(&[4_u8; 32]);
+        let v: Value = from_reader(encoded.as_slice()).expect("parse public key cbor");
+        let entries = match v {
+            Value::Map(entries) => entries,
+            _ => panic!("public key must be cbor map"),
+        };
+
+        assert_eq!(
+            value_by_integer_key(&entries, 1),
+            Some(&Value::Integer(2.into()))
+        );
+        assert_eq!(
+            value_by_integer_key(&entries, 3),
+            Some(&Value::Integer((-7).into()))
+        );
+        assert_eq!(
+            value_by_integer_key(&entries, -1),
+            Some(&Value::Integer(1.into()))
+        );
+        let x = bytes_by_integer_key(&entries, -2).expect("x coordinate");
+        let y = bytes_by_integer_key(&entries, -3).expect("y coordinate");
+        assert_eq!(x.len(), 32);
+        assert_eq!(y.len(), 32);
+        assert_ne!(x, y);
+    }
+
+    #[test]
+    fn deterministic_values_are_sha256_derived() {
+        let seed = [3_u8; 32];
+        let mut spec = WebAuthnSpec::packed("example.com", b"challenge-derived");
+        spec.authenticator_model = "UK-MODEL-A".to_string();
+
+        let digest = Sha256::digest(spec.stable_bytes());
+        let expected_count = u32::from_be_bytes([digest[0], digest[1], digest[2], digest[3]]);
+        let mut aaguid_input = Vec::new();
+        aaguid_input.extend_from_slice(&seed);
+        aaguid_input.extend_from_slice(spec.authenticator_model.as_bytes());
+        let digest = Sha256::digest(aaguid_input);
+        let mut expected_aaguid = [0_u8; 16];
+        expected_aaguid.copy_from_slice(&digest[..16]);
+
+        let reg = build_registration(spec.clone(), seed);
+        assert_eq!(reg.rp_id_hash, sha256_arr(spec.rp_id.as_bytes()));
+        assert_eq!(reg.sign_count, expected_count);
+        assert_eq!(reg.aaguid, expected_aaguid);
+
+        let assertion = build_assertion(spec, seed);
+        assert_eq!(assertion.sign_count, expected_count.saturating_add(1));
+        assert_eq!(assertion.rp_id_hash, reg.rp_id_hash);
+    }
+
+    #[test]
+    fn mock_signature_hashes_seed_context_and_body() {
+        let seed = [5_u8; 32];
+        let body = b"auth-data-and-client-data";
+        let context = b"assertion";
+        let mut h = Sha256::new();
+        h.update(seed);
+        h.update(context);
+        h.update(body);
+
+        assert_eq!(mock_signature(&seed, body, context), h.finalize().to_vec());
+    }
+
+    #[test]
+    fn base64url_matches_known_no_padding_vectors() {
+        let cases: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"f", "Zg"),
+            (b"fo", "Zm8"),
+            (b"foo", "Zm9v"),
+            (b"foob", "Zm9vYg"),
+            (b"fooba", "Zm9vYmE"),
+            (b"foobar", "Zm9vYmFy"),
+            (&[0xfb, 0xff], "-_8"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(base64url(input), *expected);
+        }
+    }
+
+    #[test]
+    fn sha256_arr_matches_known_digest() {
+        assert_eq!(
+            sha256_arr(b"abc"),
+            [
+                0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae,
+                0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61,
+                0xf2, 0x00, 0x15, 0xad,
+            ]
+        );
+    }
+
+    #[test]
+    fn stable_bytes_keeps_legacy_short_length_encoding() {
+        let spec = WebAuthnSpec::packed("example.com", b"short-challenge");
+        let bytes = spec.stable_bytes();
+        let marker = b"challenge\x1f";
+        let at = bytes
+            .windows(marker.len())
+            .position(|window| window == marker)
+            .expect("challenge marker present");
+        let len_offset = at + marker.len();
+        assert_eq!(&bytes[len_offset..len_offset + 2], &[0, 15]);
+    }
+
+    #[test]
+    fn stable_bytes_long_challenge_uses_extended_length_prefix() {
+        let long = vec![0xAB; 70_000];
+        let spec = WebAuthnSpec::packed("example.com", &long);
+        let bytes = spec.stable_bytes();
+        let marker = b"challenge\x1f";
+        let at = bytes
+            .windows(marker.len())
+            .position(|window| window == marker)
+            .expect("challenge marker present");
+        let len_offset = at + marker.len();
+        assert_eq!(&bytes[len_offset..len_offset + 2], &[0xFF, 0xFF]);
+        assert_eq!(
+            &bytes[len_offset + 2..len_offset + 6],
+            &(70_000u32).to_be_bytes()
+        );
+    }
+
+    fn assert_contains_bytes(haystack: &[u8], needle: &[u8]) {
+        assert!(
+            haystack
+                .windows(needle.len())
+                .any(|window| window == needle),
+            "expected bytes to contain {:?}",
+            String::from_utf8_lossy(needle)
+        );
+    }
+
+    fn value_by_integer_key(entries: &[(Value, Value)], key: i64) -> Option<&Value> {
+        entries
+            .iter()
+            .find_map(|(k, v)| (*k == Value::Integer(key.into())).then_some(v))
+    }
+
+    fn bytes_by_integer_key(entries: &[(Value, Value)], key: i64) -> Option<&[u8]> {
+        match value_by_integer_key(entries, key)? {
+            Value::Bytes(bytes) => Some(bytes.as_slice()),
+            _ => None,
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- `WebAuthnSpec::stable_bytes` encoded field lengths as a `u16`, which truncated values > `u16::MAX` and risked collisions in deterministic derivation and cache keys.
- Deterministic fixture stability is critical to avoid accidental changes in test inputs and cache identity when fields grow large.

### Description

- Update `write_field` in `crates/uselesskey-webauthn/src/lib.rs` to preserve legacy 2-byte length encoding for short values and use a backward-compatible extended format for long values: write `0xffff` as a sentinel followed by a 4-byte big-endian `u32` length for values > `u16::MAX`.
- Add unit tests `stable_bytes_keeps_legacy_short_length_encoding` and `stable_bytes_long_challenge_uses_extended_length_prefix` validating the legacy behavior and the new extended-length path respectively.
- No public API changes; behavior is compatible for existing fixtures while preventing truncation for oversized fields.

### Testing

- Ran `cargo test -p uselesskey-webauthn` and all tests passed, including the two new regressions (`stable_bytes_keeps_legacy_short_length_encoding` and `stable_bytes_long_challenge_uses_extended_length_prefix`).
- Local unit test run for the crate completed successfully with zero failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8956547e88333a0e0ca4247e15724)