### PR TITLE
pkcs11-mock: fail fast on oversized u16 fixture encodings

### DIFF
--- a/crates/uselesskey-pkcs11-mock/src/lib.rs
+++ b/crates/uselesskey-pkcs11-mock/src/lib.rs
@@ -221,7 +221,7 @@ fn mock_certificate_der(
     write_field(&mut out, "mfr", manufacturer_id.as_bytes());
     write_field(&mut out, "model", model.as_bytes());
     write_field(&mut out, "fingerprint", &Sha256::digest(secret));
-    let body_len = (out.len() - 4) as u16;
+    let body_len = u16_len("certificate_der_body", out.len() - 4);
     out[2..4].copy_from_slice(&body_len.to_be_bytes());
     out
 }
@@ -229,9 +229,18 @@ fn mock_certificate_der(
 fn write_field(out: &mut Vec<u8>, name: &str, value: &[u8]) {
     out.extend_from_slice(name.as_bytes());
     out.push(b'=');
-    out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    out.extend_from_slice(&u16_len(name, value.len()).to_be_bytes());
     out.extend_from_slice(value);
     out.push(0);
+}
+
+fn u16_len(field_name: &str, len: usize) -> u16 {
+    u16::try_from(len).unwrap_or_else(|_| {
+        panic!(
+            "{field_name} length {len} exceeds u16::MAX; fixture encoding requires <= {} bytes",
+            u16::MAX
+        )
+    })
 }
 
 fn hex8(bytes: &[u8]) -> String {
@@ -369,5 +378,25 @@ mod tests {
             "expected stable identity to contain {}",
             String::from_utf8_lossy(needle)
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "token_label length")]
+    fn rejects_oversized_field_length() {
+        let fx = Factory::random();
+        let spec = Pkcs11MockSpec::basic("a".repeat((u16::MAX as usize) + 1));
+        let _ = fx.pkcs11_mock("oversized-field", spec);
+    }
+
+    #[test]
+    #[should_panic(expected = "certificate_der_body length")]
+    fn rejects_oversized_der_body() {
+        let fx = Factory::random();
+        let mut spec = Pkcs11MockSpec::basic("token");
+        let long = "z".repeat(22_000);
+        spec.manufacturer_id = long.clone();
+        spec.model = long;
+        spec.key_labels = vec!["k".repeat(22_000)];
+        let _ = fx.pkcs11_mock("oversized-der", spec);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent silent truncation when encoding lengths into u16 fields in the PKCS#11 mock; the prior `as u16` casts could produce malformed DER-like blobs for very large inputs. 
- Make fixture encoding failures explicit so callers get immediate, clear errors instead of subtle data corruption.

### Description
- Added a shared helper `u16_len(field_name: &str, len: usize) -> u16` that checks and converts `usize` lengths to `u16`, panicking with a descriptive message on overflow. 
- Replaced direct `as u16` casts with `u16_len(...)` for per-field length encoding in `write_field` and for the DER-body length in `mock_certificate_der` in `crates/uselesskey-pkcs11-mock/src/lib.rs`.
- Added two regression tests that assert the new panic behavior for an oversized individual field and for an oversized DER-like body to prevent regressions.

### Testing
- Ran `cargo test -p uselesskey-pkcs11-mock`, which passed all tests (5 passed, 0 failed). 
- Ran `cargo clippy -p uselesskey-pkcs11-mock --all-targets -- -D warnings`, which completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8956c33188333936d3684d9efea32)