### PR TITLE
Fix PEM truncate to honor byte budget and UTF-8 boundaries

### DIFF
--- a/crates/uselesskey-core-negative-pem/src/lib.rs
+++ b/crates/uselesskey-core-negative-pem/src/lib.rs
@@ -51,9 +51,9 @@ pub enum CorruptPem {
     BadFooter,
     /// Inject a non-base64 line into the body so decoders reject the payload.
     BadBase64,
-    /// Keep only the first `bytes` characters of the PEM string.
+    /// Keep at most the first `bytes` bytes of the PEM string.
     Truncate {
-        /// Maximum number of characters to keep.
+        /// Maximum byte budget to keep without splitting a UTF-8 character.
         bytes: usize,
     },
     /// Insert a blank line after the header, breaking strict PEM parsers.
@@ -66,7 +66,7 @@ pub fn corrupt_pem(pem: &str, how: CorruptPem) -> String {
         CorruptPem::BadHeader => replace_first_line(pem, "-----BEGIN CORRUPTED KEY-----"),
         CorruptPem::BadFooter => replace_last_line(pem, "-----END CORRUPTED KEY-----"),
         CorruptPem::BadBase64 => inject_bad_base64_line(pem),
-        CorruptPem::Truncate { bytes } => pem.chars().take(bytes).collect(),
+        CorruptPem::Truncate { bytes } => truncate_utf8_at_byte_boundary(pem, bytes),
         CorruptPem::ExtraBlankLine => inject_blank_line(pem),
     }
 }
@@ -91,13 +91,27 @@ pub fn corrupt_pem_deterministic(pem: &str, variant: &str) -> String {
 }
 
 fn derived_truncate_len(pem: &str, digest: &[u8; 32]) -> usize {
-    let chars = pem.chars().count();
-    if chars <= 1 {
+    let total_bytes = pem.len();
+    if total_bytes <= 1 {
         return 0;
     }
 
-    let span = chars - 1;
+    let span = total_bytes - 1;
     1 + (u16::from_be_bytes([digest[1], digest[2]]) as usize % span)
+}
+
+fn truncate_utf8_at_byte_boundary(input: &str, max_bytes: usize) -> String {
+    if max_bytes >= input.len() {
+        return input.to_string();
+    }
+
+    let end = input
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .take_while(|idx| *idx <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    input[..end].to_string()
 }
 
 fn replace_first_line(pem: &str, replacement: &str) -> String {
@@ -205,6 +219,28 @@ mod tests {
         let pem = "-----BEGIN TEST-----\nAAA=\n-----END TEST-----\n";
         let out = corrupt_pem(pem, CorruptPem::Truncate { bytes: 10 });
         assert_eq!(out.len(), 10);
+    }
+
+    #[test]
+    fn truncate_variant_uses_byte_budget_without_breaking_utf8() {
+        let pem = "🔐KEY";
+        let out = corrupt_pem(pem, CorruptPem::Truncate { bytes: 3 });
+        assert_eq!(out, "");
+
+        let out = corrupt_pem(pem, CorruptPem::Truncate { bytes: 4 });
+        assert_eq!(out, "🔐");
+    }
+
+    #[test]
+    fn deterministic_truncate_never_exceeds_input_byte_length() {
+        let pem = "🔐A";
+        let variant = (0..256)
+            .map(|i| alloc::format!("corrupt:truncate:{i}"))
+            .find(|candidate| hash32(candidate.as_bytes()).as_bytes()[0] % 5 == 4)
+            .expect("a truncate variant should exist");
+        let out = corrupt_pem_deterministic(pem, &variant);
+        assert!(out.len() <= pem.len());
+        assert!(pem.starts_with(&out));
     }
 
     #[test]
@@ -319,7 +355,7 @@ mod tests {
         let mut digest = [0u8; 32];
         digest[1] = 0x0A;
         digest[2] = 0x0B;
-        // chars=10, span=9, u16=0x0A0B=2571, 2571%9=6, result=1+6=7
+        // bytes=10, span=9, u16=0x0A0B=2571, 2571%9=6, result=1+6=7
         assert_eq!(derived_truncate_len("0123456789", &digest), 7);
     }
 

--- a/crates/uselesskey-core-negative/tests/corruption_validity.rs
+++ b/crates/uselesskey-core-negative/tests/corruption_validity.rs
@@ -6,7 +6,7 @@
 //! - flip_byte is involutory (applying twice restores original)
 //! - Corruption of every common PEM label type
 //! - Deterministic corruption is isolated per-variant (no cross-talk)
-//! - CorruptPem::Truncate operates on *chars*, not bytes (Unicode safety)
+//! - CorruptPem::Truncate uses a byte budget without splitting UTF-8 characters
 //! - Edge-case interactions (empty + corrupt, single-byte DER, etc.)
 
 use std::collections::HashSet;
@@ -249,16 +249,20 @@ fn deterministic_der_stable_across_1000_calls() {
     }
 }
 
-// ── 7. CorruptPem::Truncate operates on chars, not bytes ─────────────
+// ── 7. CorruptPem::Truncate uses a byte budget safely ────────────────
 
 #[test]
-fn truncate_operates_on_chars_not_bytes() {
+fn truncate_uses_byte_budget_without_breaking_utf8() {
     // Multi-byte chars: each '€' is 3 bytes in UTF-8
     let pem_with_unicode = "-----BEGIN X-----\n€€€€€\n-----END X-----\n";
     let out = corrupt_pem(pem_with_unicode, CorruptPem::Truncate { bytes: 20 });
-    assert_eq!(out.chars().count(), 20, "Truncate counts chars, not bytes");
-    // The byte length will be >= 20 because of multi-byte chars
-    assert!(out.len() >= 20);
+    assert!(out.len() <= 20, "Truncate honors the byte budget");
+    assert!(pem_with_unicode.starts_with(&out));
+    assert_eq!(
+        out.len(),
+        "-----BEGIN X-----\n".len(),
+        "Truncate backs up to the previous UTF-8 boundary"
+    );
 }
 
 // ── 8. BadHeader preserves body, BadFooter preserves body ────────────
@@ -350,20 +354,21 @@ fn pem_truncate_to_zero_is_empty() {
 
 #[test]
 fn pem_truncate_beyond_length_returns_full() {
-    let char_count = VALID_PEM.chars().count();
+    let byte_len = VALID_PEM.len();
     let out = corrupt_pem(
         VALID_PEM,
         CorruptPem::Truncate {
-            bytes: char_count + 100,
+            bytes: byte_len + 100,
         },
     );
-    assert_eq!(out.chars().count(), char_count);
+    assert_eq!(out, VALID_PEM);
+    assert_eq!(out.len(), byte_len);
 }
 
 #[test]
 fn pem_truncate_at_exact_length_returns_full() {
-    let char_count = VALID_PEM.chars().count();
-    let out = corrupt_pem(VALID_PEM, CorruptPem::Truncate { bytes: char_count });
+    let byte_len = VALID_PEM.len();
+    let out = corrupt_pem(VALID_PEM, CorruptPem::Truncate { bytes: byte_len });
     assert_eq!(out, VALID_PEM);
 }
 


### PR DESCRIPTION
### Motivation
- `CorruptPem::Truncate { bytes }` used `chars().take(bytes)`, which counted Unicode scalar values rather than bytes and could produce outputs larger than the requested byte budget or cut a codepoint in half for non-ASCII PEM-like inputs.
- The deterministic truncate length derivation used character counts, which made deterministic behavior inconsistent with the `bytes` semantics.

### Description
- Implemented byte-budgeted truncation by replacing the `Truncate` arm with a call to a new helper `truncate_utf8_at_byte_boundary(input, max_bytes)` that enforces the byte limit and preserves UTF-8 boundaries.
- Updated `derived_truncate_len` to use `pem.len()` (bytes) instead of `pem.chars().count()` so deterministic truncation matches byte-based semantics.
- Added regression tests `truncate_variant_uses_byte_budget_without_breaking_utf8` and `deterministic_truncate_never_exceeds_input_byte_length` to cover Unicode truncation and deterministic truncate behavior.
- No public API changes; behavior is now consistent with the `bytes` field and returns valid UTF-8.

### Testing
- Ran `cargo test -p uselesskey-core-negative-pem` and all tests for the crate passed.
- Also ran `cargo test -p uselesskey-core --all-features` and `cargo test -p uselesskey-webauthn`, both of which passed in this environment.
- The new unit tests exercise both byte-boundary truncation and the deterministic truncate branch and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8956c7aac833399448462c2250f35)