### PR TITLE
xtask: make `pr` resilient when configured base ref is unavailable

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1813,25 +1813,47 @@ fn resolve_base_ref() -> String {
 
 fn git_changed_files(base_ref: &str) -> Result<Vec<String>> {
     let revspec = format!("{base_ref}...HEAD");
-    let output = Command::new("git")
-        .args(["diff", "--name-only", &revspec])
-        .output()
-        .context("failed to run git diff")?;
-
-    if !output.status.success() {
-        bail!(
-            "git diff failed with status {}",
-            output.status.code().unwrap_or(-1)
-        );
+    if let Some(files) = git_diff_name_only(&["diff", "--name-only", &revspec])? {
+        return Ok(files);
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let files = stdout
+    eprintln!(
+        "warning: `git diff --name-only {revspec}` failed; falling back to local HEAD-based change detection"
+    );
+
+    if let Some(files) = git_diff_name_only(&["diff", "--name-only", "HEAD~1..HEAD"])? {
+        return Ok(files);
+    }
+
+    let mut files = git_diff_name_only(&["diff", "--name-only"])? // unstaged
+        .unwrap_or_default();
+    files.extend(
+        git_diff_name_only(&["diff", "--name-only", "--cached"])?.unwrap_or_default(), // staged
+    );
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn git_diff_name_only(args: &[&str]) -> Result<Option<Vec<String>>> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run git {}", args.join(" ")))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    Ok(Some(parse_name_only_output(&output.stdout)))
+}
+
+fn parse_name_only_output(stdout: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(stdout)
         .lines()
         .map(|line| line.trim().to_string())
         .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>();
-    Ok(files)
+        .collect::<Vec<_>>()
 }
 
 fn run_impacted_tests(
@@ -2821,6 +2843,19 @@ mod tests {
 
         restore_env("XTASK_BASE_REF", prev_xtask);
         restore_env("GITHUB_BASE_REF", prev_gh);
+    }
+
+    #[test]
+    fn parse_name_only_output_ignores_empty_lines_and_trims() {
+        let stdout = b"crates/uselesskey/src/lib.rs\n\n xtask/src/main.rs \n";
+        let files = parse_name_only_output(stdout);
+        assert_eq!(
+            files,
+            vec![
+                "crates/uselesskey/src/lib.rs".to_string(),
+                "xtask/src/main.rs".to_string()
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent `cargo xtask pr` from hard-failing in environments where the configured base ref (e.g. `origin/main`) is missing or inaccessible, which caused `git diff` to return non-zero and abort PR-scoped workflows.

### Description
- Replace the single `git diff --name-only <base>...HEAD` call with a tolerant helper `git_diff_name_only` that returns `None` on non-zero exit and centralizes error context handling.
- Add conservative fallback change-detection order: `git diff --name-only <base>...HEAD`, then `git diff --name-only HEAD~1..HEAD`, then the union of unstaged (`git diff --name-only`) and staged (`git diff --name-only --cached`) working-tree diffs.
- Introduce `parse_name_only_output` to trim and ignore empty lines from git output and add the unit test `parse_name_only_output_ignores_empty_lines_and_trims` to validate parsing.
- Keep behavior observable by emitting a clear warning when falling back from the configured base-ref diff to local detection.

### Testing
- Ran `cargo test -p xtask`, which passed (195 tests OK).
- Ran `cargo xtask fmt --fix` to apply formatting fixes and ensure `fmt` check passes afterward.
- Executed `cargo xtask pr` to validate the change-detection fallback; the run showed the fallback warning and proceeded past the original `git diff` failure point, confirming the regression is fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8956c7aac833399448462c2250f35)