### PR TITLE
Harden BDD feature-grid consistency and facade coverage

### DIFF
--- a/crates/uselesskey-feature-grid/src/lib.rs
+++ b/crates/uselesskey-feature-grid/src/lib.rs
@@ -148,30 +148,28 @@ pub const CORE_FEATURE_MATRIX: &[FeatureSet] = &[
 ];
 
 /// BDD matrix consumed by automation and CI receipt generation.
-pub const BDD_FEATURE_MATRIX: &[FeatureSet] = &[
-    FeatureSet::new("all-features", &["--features", UK_FEATURE_ALL]),
-    FeatureSet::new("all-features+rustls", &["--features", "uk-all,uk-rustls"]),
-    FeatureSet::new("all-features+tonic", &["--features", "uk-all,uk-tonic"]),
-    FeatureSet::new("all-features+ring", &["--features", "uk-all,uk-ring"]),
-    FeatureSet::new(
-        "all-features+rustcrypto",
-        &["--features", "uk-all,uk-rustcrypto"],
-    ),
-    FeatureSet::new(
-        "all-features+aws-lc-rs",
-        &["--features", "uk-all,uk-aws-lc-rs"],
-    ),
-];
+macro_rules! define_bdd_feature_grid {
+    ($(($name:literal, [$($arg:expr),* $(,)?])),+ $(,)?) => {
+        /// BDD matrix consumed by automation and CI receipt generation.
+        pub const BDD_FEATURE_MATRIX: &[FeatureSet] = &[
+            $(FeatureSet::new($name, &[$($arg),*]),)+
+        ];
 
-/// All entries in `BDD_FEATURE_MATRIX`, for simple iteration in tooling.
-pub const BDD_FEATURE_SETS: &[&str] = &[
-    "all-features",
-    "all-features+rustls",
-    "all-features+tonic",
-    "all-features+ring",
-    "all-features+rustcrypto",
-    "all-features+aws-lc-rs",
-];
+        /// All entries in `BDD_FEATURE_MATRIX`, for simple iteration in tooling.
+        pub const BDD_FEATURE_SETS: &[&str] = &[
+            $($name,)+
+        ];
+    };
+}
+
+define_bdd_feature_grid!(
+    ("all-features", ["--features", UK_FEATURE_ALL]),
+    ("all-features+rustls", ["--features", "uk-all,uk-rustls"]),
+    ("all-features+tonic", ["--features", "uk-all,uk-tonic"]),
+    ("all-features+ring", ["--features", "uk-all,uk-ring"]),
+    ("all-features+rustcrypto", ["--features", "uk-all,uk-rustcrypto"]),
+    ("all-features+aws-lc-rs", ["--features", "uk-all,uk-aws-lc-rs"]),
+);
 
 #[cfg(test)]
 mod tests {
@@ -587,6 +585,13 @@ mod tests {
             for prev in BDD_FEATURE_SETS.iter().take(i) {
                 assert_ne!(name, prev, "duplicate in BDD_FEATURE_SETS");
             }
+        }
+    }
+
+    #[test]
+    fn bdd_feature_sets_preserve_matrix_order() {
+        for (name, matrix_entry) in BDD_FEATURE_SETS.iter().zip(BDD_FEATURE_MATRIX.iter()) {
+            assert_eq!(name, &matrix_entry.name);
         }
     }
 

--- a/crates/uselesskey-test-grid/tests/reexport_tests.rs
+++ b/crates/uselesskey-test-grid/tests/reexport_tests.rs
@@ -10,7 +10,7 @@ use uselesskey_test_grid::{
     UK_FEATURE_CORE_TOKEN_SHAPE, UK_FEATURE_ECDSA, UK_FEATURE_ED25519, UK_FEATURE_HMAC,
     UK_FEATURE_JWK, UK_FEATURE_JWT, UK_FEATURE_PGP, UK_FEATURE_RING, UK_FEATURE_RSA,
     UK_FEATURE_RUSTCRYPTO, UK_FEATURE_RUSTLS, UK_FEATURE_SETS, UK_FEATURE_TOKEN, UK_FEATURE_TONIC,
-    UK_FEATURE_X509,
+    UK_FEATURE_SSH, UK_FEATURE_X509,
 };
 
 // ---------------------------------------------------------------------------
@@ -68,6 +68,7 @@ fn all_feature_constants_are_non_empty() {
         UK_FEATURE_ED25519,
         UK_FEATURE_HMAC,
         UK_FEATURE_PGP,
+        UK_FEATURE_SSH,
         UK_FEATURE_X509,
         UK_FEATURE_JWK,
         UK_FEATURE_TOKEN,
@@ -100,6 +101,7 @@ fn all_feature_constants_start_with_uk_prefix() {
         UK_FEATURE_ED25519,
         UK_FEATURE_HMAC,
         UK_FEATURE_PGP,
+        UK_FEATURE_SSH,
         UK_FEATURE_X509,
         UK_FEATURE_JWK,
         UK_FEATURE_TOKEN,


### PR DESCRIPTION
### Motivation
- Prevent drift between the BDD matrix and the exported list of BDD feature set names by eliminating the duplicate, hand-maintained definitions.
- Make the BDD ordering contract explicit so tooling and receipts that iterate `BDD_FEATURE_SETS` remain stable.
- Improve facade test coverage to ensure the `uselesskey-test-grid` re-export continues to include all canonical feature constants.

### Description
- Introduced a macro `define_bdd_feature_grid!` in `crates/uselesskey-feature-grid/src/lib.rs` which emits both `BDD_FEATURE_MATRIX` and `BDD_FEATURE_SETS` from a single source of truth.
- Added the unit test `bdd_feature_sets_preserve_matrix_order` in `crates/uselesskey-feature-grid/src/lib.rs` to assert that `BDD_FEATURE_SETS` preserves the exact order and names from `BDD_FEATURE_MATRIX`.
- Extended `crates/uselesskey-test-grid/tests/reexport_tests.rs` to include `UK_FEATURE_SSH` in the exported-constant checks so the façade tests cover the SSH tag.

### Testing
- Ran `cargo test -p uselesskey-feature-grid -p uselesskey-test-grid` and all tests passed. 
- The new test `bdd_feature_sets_preserve_matrix_order` executed and passed as part of the `uselesskey-feature-grid` test suite.
- The façade re-export tests in `uselesskey-test-grid` also ran and passed, validating the additional `UK_FEATURE_SSH` coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957ae3d2c83338a9fb04caa1251f1)