### PR TITLE
Refresh advisory-blocked dependency floors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "serdect 0.4.2",
  "subtle",
  "zeroize",
@@ -855,7 +855,7 @@ checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -866,7 +866,7 @@ checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
 dependencies = [
  "crypto-bigint 0.7.3",
  "libm",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1336,7 +1336,7 @@ dependencies = [
  "once_cell",
  "pem-rfc7468 1.0.0",
  "pkcs8 0.11.0-rc.11",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1 0.8.0",
@@ -1594,7 +1594,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2977,7 +2977,7 @@ checksum = "c6543f5eec854fbf74ba5ef651fbdc9408919b47c3e1526623687135c16d12e9"
 dependencies = [
  "crypto-bigint 0.7.3",
  "crypto-common 0.2.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
  "zeroize",
@@ -3149,12 +3149,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3207,9 +3207,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3418,7 +3418,7 @@ dependencies = [
  "digest 0.11.2",
  "pkcs1 0.8.0-rc.4",
  "pkcs8 0.11.0-rc.11",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "sha2 0.11.0",
  "signature 3.0.0-rc.10",
  "spki 0.8.0-rc.4",
@@ -3475,7 +3475,7 @@ version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5db129183b2c139d7d87d08be57cba626c715789db17aec65c8866bfd767d1f"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -3485,7 +3485,7 @@ version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c4b1463f274a3ff6fb2f44da43e576cb9424367bd96f185ead87b52fe00523"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -3514,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3540,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3817,7 +3817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest 0.11.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4729,7 +4729,7 @@ dependencies = [
  "insta",
  "proptest",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rstest",
  "serde",
  "uselesskey-core-seed",
@@ -4754,7 +4754,7 @@ version = "0.6.0"
 dependencies = [
  "insta",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "uselesskey-core-cache",
  "uselesskey-core-id",
@@ -4923,7 +4923,7 @@ dependencies = [
  "insta",
  "proptest",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rstest",
  "serde",
 ]
@@ -4960,7 +4960,7 @@ dependencies = [
  "insta",
  "proptest",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "serde",
  "serde_json",
  "uselesskey-core-base62",
@@ -5000,7 +5000,7 @@ dependencies = [
  "insta",
  "proptest",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rcgen",
  "serde",
  "time",
@@ -5041,7 +5041,7 @@ dependencies = [
  "p384 0.14.0-rc.8",
  "proptest",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rstest",
  "serde",
  "serde_json",
@@ -5089,7 +5089,7 @@ dependencies = [
  "insta",
  "proptest",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "serde",
  "uselesskey-core",
  "uselesskey-core-hmac-spec",
@@ -5259,7 +5259,7 @@ dependencies = [
  "proptest",
  "rand_chacha 0.10.0",
  "rand_chacha 0.3.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rsa 0.10.0-rc.17",
  "rsa 0.9.10",
@@ -5400,7 +5400,7 @@ dependencies = [
  "hmac 0.13.0",
  "insta",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "sha2 0.11.0",
  "uselesskey-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,8 +127,8 @@ blake3 = "1.8.3"
 dashmap = "6.1.0"
 
 # RNG — workspace-wide line (all crates except rsa/pgp/x509 blocked islands)
-rand10 = { package = "rand", version = "0.10.0", default-features = false }
-rand_core10 = { package = "rand_core", version = "0.10.0", default-features = false }
+rand10 = { package = "rand", version = "0.10.1", default-features = false }
+rand_core10 = { package = "rand_core", version = "0.10.1", default-features = false }
 rand_chacha10 = { package = "rand_chacha", version = "0.10.0", default-features = false }
 
 # sinks
@@ -173,7 +173,7 @@ sha2 = "0.10.9"
 jsonwebtoken = { version = "10.3.0", features = ["use_pem", "rust_crypto"] }
 
 # TLS
-rustls = { version = "0.23.37", default-features = false, features = ["std", "tls12", "ring"] }
+rustls = { version = "0.23.40", default-features = false, features = ["std", "tls12", "ring"] }
 rustls-pki-types = "1.14.0"
 
 # Crypto backends

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "serdect 0.4.2",
  "subtle",
  "zeroize",
@@ -481,7 +481,7 @@ checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -492,7 +492,7 @@ checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
 dependencies = [
  "crypto-bigint 0.7.3",
  "libm",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -898,7 +898,7 @@ dependencies = [
  "once_cell",
  "pem-rfc7468 1.0.0",
  "pkcs8 0.11.0-rc.11",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "rustcrypto-group",
  "sec1 0.8.0",
@@ -1028,7 +1028,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1730,7 +1730,7 @@ checksum = "c6543f5eec854fbf74ba5ef651fbdc9408919b47c3e1526623687135c16d12e9"
 dependencies = [
  "crypto-bigint 0.7.3",
  "crypto-common 0.2.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
  "zeroize",
@@ -1812,12 +1812,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1837,7 +1837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1851,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rcgen"
@@ -1988,7 +1988,7 @@ dependencies = [
  "digest 0.11.2",
  "pkcs1 0.8.0-rc.4",
  "pkcs8 0.11.0-rc.11",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "sha2 0.11.0",
  "signature 3.0.0-rc.10",
  "spki 0.8.0-rc.4",
@@ -2010,7 +2010,7 @@ version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5db129183b2c139d7d87d08be57cba626c715789db17aec65c8866bfd767d1f"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2020,7 +2020,7 @@ version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c4b1463f274a3ff6fb2f44da43e576cb9424367bd96f185ead87b52fe00523"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -2253,7 +2253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest 0.11.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2518,7 +2518,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uselesskey"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core",
  "uselesskey-ecdsa",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "thiserror",
  "uselesskey-core-cache",
@@ -2544,16 +2544,16 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-base62"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "uselesskey-core-seed",
 ]
 
 [[package]]
 name = "uselesskey-core-cache"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "dashmap",
  "spin 0.10.0",
@@ -2562,27 +2562,27 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-factory"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
- "rand 0.10.0",
+ "rand 0.10.1",
  "uselesskey-core-cache",
  "uselesskey-core-id",
 ]
 
 [[package]]
 name = "uselesskey-core-hash"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "blake3",
 ]
 
 [[package]]
 name = "uselesskey-core-hmac-spec"
-version = "0.5.1"
+version = "0.6.0"
 
 [[package]]
 name = "uselesskey-core-id"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-hash",
  "uselesskey-core-seed",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwk"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-jwk-builder",
  "uselesskey-core-jwk-shape",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwk-builder"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "serde_json",
  "uselesskey-core-jwk-shape",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwk-shape"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2615,11 +2615,11 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwks-order"
-version = "0.5.1"
+version = "0.6.0"
 
 [[package]]
 name = "uselesskey-core-keypair-material"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core",
  "uselesskey-core-kid",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-kid"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64",
  "blake3",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-negative-der",
  "uselesskey-core-negative-pem",
@@ -2643,21 +2643,21 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative-der"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-hash",
 ]
 
 [[package]]
 name = "uselesskey-core-negative-pem"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-hash",
 ]
 
 [[package]]
 name = "uselesskey-core-rustls-pki"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "rustls-pki-types",
  "uselesskey-ecdsa",
@@ -2667,34 +2667,34 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-seed"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "blake3",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "uselesskey-core-sink"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "uselesskey-core-token"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-token-shape",
 ]
 
 [[package]]
 name = "uselesskey-core-token-shape"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "serde_json",
  "uselesskey-core-base62",
  "uselesskey-core-seed",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-x509-derive",
  "uselesskey-core-x509-negative",
@@ -2712,17 +2712,17 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-chain-negative"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-x509-spec",
 ]
 
 [[package]]
 name = "uselesskey-core-x509-derive"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rcgen",
  "time",
  "uselesskey-core-hash",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-negative"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-x509-chain-negative",
  "uselesskey-core-x509-spec",
@@ -2739,24 +2739,24 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-spec"
-version = "0.5.1"
+version = "0.6.0"
 
 [[package]]
 name = "uselesskey-ecdsa"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "elliptic-curve 0.14.0-rc.29",
  "p256 0.14.0-rc.8",
  "p384 0.14.0-rc.8",
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "uselesskey-core",
  "uselesskey-core-keypair-material",
 ]
 
 [[package]]
 name = "uselesskey-ed25519"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ed25519-dalek",
  "pkcs8 0.10.2",
@@ -2807,10 +2807,10 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-hmac"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "rand_chacha 0.10.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "uselesskey-core",
  "uselesskey-core-hmac-spec",
  "uselesskey-core-kid",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jsonwebtoken"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "jsonwebtoken",
  "uselesskey-ecdsa",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jwk"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-jwk",
  "uselesskey-core-jwk-builder",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pgp"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "pgp",
  "rand_chacha 0.3.1",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ring"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ring",
  "uselesskey-ecdsa",
@@ -2855,12 +2855,12 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rsa"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64",
  "rand_chacha 0.10.0",
  "rand_chacha 0.3.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rsa 0.10.0-rc.17",
  "rsa 0.9.10",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustcrypto"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ed25519-dalek",
  "hmac 0.13.0-rc.6",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustls"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core-rustls-pki",
  "uselesskey-ecdsa",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-token"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "uselesskey-core",
  "uselesskey-core-token",
@@ -2907,11 +2907,11 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-token-spec"
-version = "0.5.1"
+version = "0.6.0"
 
 [[package]]
 name = "uselesskey-x509"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64",
  "rand_chacha 0.3.1",


### PR DESCRIPTION
## Summary
- raise the workspace rand/rand_core floor to 0.10.1 for RUSTSEC-2026-0097
- raise rustls to 0.23.40 so rustls-webpki resolves to 0.103.13 for RUSTSEC-2026-0098/0099/0104
- refresh the workspace and fuzz lockfiles so CI and fuzz builds use the safe floors

## Review notes
- This is a queue-wide CI unblocker, not a feature PR.
- Existing PR failures in the `pr` job are currently failing at `cargo deny check advisories`; this branch addresses that shared blocker before reviewing and merging keeper PRs.

## Verification
- `cargo deny check advisories`
- `cargo xtask pr` (change detector only; skipped most lanes)
- `cargo check --workspace --all-features --exclude uselesskey-bdd`
- `cargo xtask dep-guard`
- `cargo check --manifest-path fuzz\Cargo.toml`
- `cargo xtask docs-sync --check`
- `git diff --check`