### PR TITLE
ci: extend main workflow timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
   main:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- extend the main push workflow timeout from 75 to 120 minutes
- leave PR timeout unchanged

## Rationale
The post-#445 main run passed cargo xtask ci and publish-preflight, then hit the 75-minute job timeout during cargo xtask economics. This is a workflow budget issue, not a Rust/test failure.

## Validation
- git diff --check