### PR TITLE
ci: add staged Clippy policy and `xtask check-lint-policy` gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6018,6 +6018,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
  "uselesskey-feature-grid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,134 @@ homepage = "https://github.com/EffortlessMetrics/uselesskey"
 categories = ["development-tools::testing", "cryptography"]
 authors = ["Effortless Metrics <opensource@effortlessmetrics.com>"]
 
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
+
+[workspace.lints.clippy]
+# Panic-free production and tests
+# These are staged at the workspace root. Member inheritance is ratcheted by
+# `cargo xtask check-lint-policy` once the tracked debt has been burned down.
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unconditional_recursion = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
+
 [workspace.dependencies]
 # error handling
 thiserror = "2.0.18"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,7 @@
-# Prefer clarity over cleverness.
+# Effortless Metrics Clippy policy configuration.
+#
+# Keep this file for Clippy configuration that cannot be expressed as Cargo
+# lint levels, especially repo-specific disallowed methods/types/macros. Do not
+# add test carveouts such as `allow-unwrap-in-tests`; uselesskey is moving toward
+# a workspace-wide panic-free posture for production and tests.
 msrv = "1.92"

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,58 @@
+# Clippy Policy
+
+`uselesskey` treats Clippy as a governed engineering surface, not as a local taste file. The workspace policy is designed to converge on the Effortless Metrics platform baseline: panic-free production and test code, silent-failure prevention, suppression governance, and reviewability lints that make security-sensitive fixture code easier to audit.
+
+## Current rollout phase
+
+This repository is in the staged policy phase:
+
+1. The root manifest declares the shared strict workspace lint block.
+2. `policy/clippy-lints.toml` records the machine-readable policy and Rust 1.93/1.94/1.95 ratchet plan.
+3. `policy/clippy-debt.toml` is the only place for temporary lint debt.
+4. Member-level `[lints] workspace = true` inheritance is intentionally a follow-up PR after debt triage, because the existing workspace still contains panic-driven tests and other known violations.
+
+## Suppression style
+
+Use narrow `#[expect(..., reason = "...")]` suppressions when a lint exception is truly intentional. Do not use silent `#[allow(...)]` attributes for new exceptions.
+
+Good:
+
+```rust,ignore
+#[expect(clippy::indexing_slicing, reason = "generated lookup table has fixed bounds")]
+let value = TABLE[index];
+```
+
+Bad:
+
+```rust,ignore
+#[allow(clippy::indexing_slicing)]
+let value = TABLE[index];
+```
+
+## No test carveouts
+
+Do not add Clippy test carveouts to `clippy.toml`, including:
+
+- `allow-unwrap-in-tests = true`
+- `allow-expect-in-tests = true`
+- `allow-panic-in-tests = true`
+- `allow-indexing-slicing-in-tests = true`
+- `allow-dbg-in-tests = true`
+
+The target state is workspace panic-free, not production-only panic-free.
+
+## Policy checks
+
+Run:
+
+```bash
+cargo xtask check-lint-policy
+```
+
+The check verifies that the manifest, `clippy.toml`, and policy ledgers remain coherent. It also validates required debt fields and fails expired debt.
+
+## Planned ratchets
+
+- Rust 1.93: align workspace MSRV with the platform baseline and enable member lint inheritance.
+- Rust 1.94: track `same_length_and_capacity`, `manual_ilog2`, `decimal_bitwise_operands`, and `needless_type_cast`.
+- Rust 1.95: track `disallowed_fields`, `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, and `unnecessary_trailing_comma`.

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,4 @@
+schema = 1
+
+# Debt entries go here while member-level lint inheritance is being rolled out.
+# Every entry must carry `lint`, `path`, `owner`, `reason`, and `expires`.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,790 @@
+schema = 1
+msrv = "1.92"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+workspace_inheritance = "staged"
+
+
+[[lint]]
+name = "rust::unsafe_code"
+level = "forbid"
+status = "active"
+class = "unsafe-memory"
+reason = "No unsafe code in a test-fixture security crate."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Unsafe operations must remain explicit even if an unsafe island is introduced later."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Must-use results cannot be silently dropped."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "configuration"
+reason = "Unexpected cfg names should be reviewed without blocking staged rollout."
+
+[[lint]]
+name = "rust::const_item_interior_mutations"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Prevent const interior-mutation footguns."
+
+[[lint]]
+name = "rust::function_casts_as_integer"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Forbid pointer-shaped function address casts."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No debug macros in committed code."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No placeholder panics in production or tests."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No placeholder panics in production or tests."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No direct panic paths without structured policy debt."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Unreachable assumptions must be encoded without panics."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked Result/Option collapse in production or tests."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked Result/Option collapse in production or tests."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Avoid map/index get followed by unwrap."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Result-returning APIs should propagate errors instead of unwrapping."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Result-returning APIs should not panic."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "utf8-safety"
+reason = "Avoid byte-indexed string slicing."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "bounds-safety"
+reason = "Avoid unchecked indexing and slicing."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "bounds-safety"
+reason = "Forbid statically detectable out-of-bounds indexing."
+
+[[lint]]
+name = "clippy::unconditional_recursion"
+level = "deny"
+status = "active"
+class = "correctness"
+reason = "Reject unbounded recursive implementations."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "time"
+reason = "Use checked time arithmetic."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "utf8-safety"
+reason = "Do not mix char indices with byte indices."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "utf8-safety"
+reason = "Avoid slicing strings before byte conversion."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "bounds-safety"
+reason = "Prefer checked slice pattern handling."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Do not drop futures silently."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Do not drop must-use values silently."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Do not immediately drop locks with underscore bindings."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Do not discard Result by calling ok()."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Do not erase error information."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Inspect Result values instead of only checking state helpers."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "io"
+reason = "Avoid infinite iteration on repeated IO errors."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Do not hold blocking locks across await points."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Do not hold RefCell borrows across await points."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Do not hold configured invalid types across await points."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Review non-Send futures before promoting."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Keep async state machines reviewable."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Arc should not wrap non-Send/Sync values."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Avoid Rc<Mutex<_>> concurrency confusion."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Avoid locking Mutex through mutable references."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Do not take write locks for read-only access."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid leaking values deliberately."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid meaningless forget calls."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid explicit drop on non-Drop values."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Unsafe blocks require documented safety invariants if ever introduced."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe operations separately reviewable."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Packed repr needs explicit ABI."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Avoid exact float comparisons."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Avoid exact float comparisons with constants."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Use tolerance-based float comparisons."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Avoid silently lossy float literals."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Reject sign-loss casts."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Review casts that may wrap."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Review casts that may truncate."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Review casts that may lose precision."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Reject comparisons made invalid by casts."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Use unsigned_abs instead of lossy casts."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Reject enum discriminant truncation."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Reject NaN-to-int casts."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Prefer midpoint helpers."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Prefer is_multiple_of helpers."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Prefer div_ceil helpers."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Review arithmetic side effects before selective promotion."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "OpenOptions truncation/append semantics must be explicit."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "Reject contradictory OpenOptions."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "Reject ineffective OpenOptions."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "Avoid path pushes that overwrite prefixes."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "Avoid absolute path joins that discard prefixes."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "io"
+reason = "Review newline-sensitive input handling."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "process"
+reason = "Process exits belong only at explicit CLI boundaries."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Iterator-named APIs should return iterators."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Do not hand-write Clone for Copy types."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Use From for infallible conversions."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "api"
+reason = "From implementations must not fail."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Error types should implement std::error::Error correctly."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "api"
+reason = "Prefer meaningful error types."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "api"
+reason = "Keep Result errors reasonably sized."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "taste"
+reason = "Avoid nested format! in format args."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "taste"
+reason = "Avoid unnecessary to_string in format args."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "taste"
+reason = "Reject ignored format specs."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer Display when Debug is not needed."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer inline format args."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer let-else for early-return pattern matching."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer ok_or/ok_or_else."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer strip_prefix/strip_suffix."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer split_once."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer is_some_and/is_ok_and style helpers."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer find_map."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer filter_map for Option-producing closures."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "taste"
+reason = "Match on Result directly."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer copied for Copy values."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Prefer to_vec or clearer collection helpers."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Avoid cloning earlier than needed."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Avoid avoidable intermediate allocations."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Avoid redundant closures."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "taste"
+reason = "Use method references where clear."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "docs"
+reason = "Public panic behavior must be documented while debt is burned down."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "docs"
+reason = "Public error behavior should be documented."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Use expect with reasons instead of allow attributes."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Suppression reasons are required."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Do not enable broad restriction groups."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Ignored tests require reasons."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Panic tests must state the expected panic."
+
+[[planned]]
+name = "workspace.package.rust-version"
+level = "required"
+activate_when_msrv = "1.93"
+reason = "Ratchet the workspace to the org-wide MSRV before member-level lint inheritance is enabled."
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Prefer the standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Avoid stale numeric type drift."
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,4 @@
+schema_version = "0.3"
+
+# Semantic panic-family exceptions belong here as temporary reviewed debt.
+# Identity is path + family + selector; last_seen line/column is advisory.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,5 @@
+schema_version = "1.0"
+
+# Non-Rust programming surfaces belong here when Rust/xtask is not the right
+# implementation language. Entries require path or glob, kind, owner, reason,
+# surface, classification, covered_by, and optional expires.

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -22,6 +22,7 @@ owo-colors = "4.0"
 regex = "1.11"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+toml.workspace = true
 uselesskey-feature-grid.workspace = true
 
 [dev-dependencies]

--- a/xtask/src/lint_policy.rs
+++ b/xtask/src/lint_policy.rs
@@ -1,0 +1,373 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use toml::Value;
+
+const CARGO_MANIFEST: &str = "Cargo.toml";
+const CLIPPY_CONFIG: &str = "clippy.toml";
+const POLICY_LEDGER: &str = "policy/clippy-lints.toml";
+const DEBT_LEDGER: &str = "policy/clippy-debt.toml";
+const DOCS_POLICY: &str = "docs/CLIPPY_POLICY.md";
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+const PLANNED_BEFORE_MSRV: &[&str] = &[
+    "same_length_and_capacity",
+    "manual_ilog2",
+    "decimal_bitwise_operands",
+    "needless_type_cast",
+    "disallowed_fields",
+    "manual_checked_ops",
+    "manual_take",
+    "manual_pop_if",
+    "duration_suboptimal_units",
+    "unnecessary_trailing_comma",
+];
+
+#[derive(Debug, Deserialize)]
+struct LintLedger {
+    schema: u64,
+    msrv: String,
+    policy: PolicyConfig,
+    #[serde(default)]
+    planned: Vec<PlannedLint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PolicyConfig {
+    panic_free_tests: bool,
+    allow_test_carveouts: bool,
+    suppression_style: String,
+    blanket_categories: bool,
+    #[serde(default)]
+    workspace_inheritance: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlannedLint {
+    name: String,
+    level: String,
+    activate_when_msrv: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtLedger {
+    schema: u64,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+pub fn check_lint_policy_cmd() -> Result<()> {
+    let root_manifest = read_toml(Path::new(CARGO_MANIFEST))?;
+    let ledger = read_lint_ledger(Path::new(POLICY_LEDGER))?;
+
+    validate_required_files()?;
+    validate_policy_header(&ledger)?;
+    validate_workspace_msrv(&root_manifest, &ledger)?;
+    validate_workspace_lints(&root_manifest, &ledger)?;
+    validate_clippy_config(Path::new(CLIPPY_CONFIG), &ledger)?;
+    validate_planned_lints(&root_manifest, &ledger)?;
+    validate_debt(Path::new(DEBT_LEDGER))?;
+
+    println!(
+        "lint-policy: ok (schema={}, msrv={}, planned={})",
+        ledger.schema,
+        ledger.msrv,
+        ledger.planned.len()
+    );
+    Ok(())
+}
+
+fn validate_required_files() -> Result<()> {
+    for path in [
+        CARGO_MANIFEST,
+        CLIPPY_CONFIG,
+        POLICY_LEDGER,
+        DEBT_LEDGER,
+        DOCS_POLICY,
+        "policy/no-panic-allowlist.toml",
+        "policy/non-rust-allowlist.toml",
+    ] {
+        if !Path::new(path).is_file() {
+            bail!("required lint policy file is missing: {path}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_policy_header(ledger: &LintLedger) -> Result<()> {
+    if ledger.schema != 1 {
+        bail!("{} must use schema = 1", POLICY_LEDGER);
+    }
+    if !ledger.policy.panic_free_tests {
+        bail!("policy.panic_free_tests must be true");
+    }
+    if ledger.policy.allow_test_carveouts {
+        bail!("policy.allow_test_carveouts must be false");
+    }
+    if ledger.policy.suppression_style != "expect-with-reason" {
+        bail!("policy.suppression_style must be expect-with-reason");
+    }
+    if ledger.policy.blanket_categories {
+        bail!("policy.blanket_categories must be false");
+    }
+
+    let inheritance = ledger
+        .policy
+        .workspace_inheritance
+        .as_deref()
+        .unwrap_or("required");
+    if !matches!(inheritance, "staged" | "required") {
+        bail!("policy.workspace_inheritance must be staged or required");
+    }
+    Ok(())
+}
+
+fn validate_workspace_msrv(root_manifest: &Value, ledger: &LintLedger) -> Result<()> {
+    let manifest_msrv = root_manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("package"))
+        .and_then(|package| package.get("rust-version"))
+        .and_then(Value::as_str)
+        .context("workspace.package.rust-version is missing")?;
+
+    if manifest_msrv != ledger.msrv {
+        bail!(
+            "workspace.package.rust-version ({manifest_msrv}) must match {POLICY_LEDGER} msrv ({})",
+            ledger.msrv
+        );
+    }
+    Ok(())
+}
+
+fn validate_workspace_lints(root_manifest: &Value, ledger: &LintLedger) -> Result<()> {
+    let workspace_lints = root_manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("lints"))
+        .context("root Cargo.toml must define [workspace.lints]")?;
+
+    for (table, required) in [
+        (
+            "rust",
+            [
+                "unsafe_code",
+                "unsafe_op_in_unsafe_fn",
+                "unused_must_use",
+                "unexpected_cfgs",
+                "const_item_interior_mutations",
+                "function_casts_as_integer",
+            ]
+            .as_slice(),
+        ),
+        (
+            "clippy",
+            [
+                "dbg_macro",
+                "todo",
+                "unimplemented",
+                "panic",
+                "unreachable",
+                "unwrap_used",
+                "expect_used",
+                "let_underscore_future",
+                "let_underscore_must_use",
+                "allow_attributes",
+                "allow_attributes_without_reason",
+            ]
+            .as_slice(),
+        ),
+    ] {
+        let lint_table = workspace_lints
+            .get(table)
+            .and_then(Value::as_table)
+            .with_context(|| format!("root Cargo.toml must define [workspace.lints.{table}]"))?;
+        for lint in required {
+            if !lint_table.contains_key(*lint) {
+                bail!("[workspace.lints.{table}] is missing required lint `{lint}`");
+            }
+        }
+    }
+
+    if ledger
+        .policy
+        .workspace_inheritance
+        .as_deref()
+        .is_some_and(|mode| mode == "required")
+    {
+        validate_workspace_member_inheritance(root_manifest)?;
+    }
+    Ok(())
+}
+
+fn validate_workspace_member_inheritance(root_manifest: &Value) -> Result<()> {
+    let members = root_manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(Value::as_array)
+        .context("workspace.members is missing")?;
+
+    let mut missing = Vec::new();
+    for member in members {
+        let Some(member) = member.as_str() else {
+            continue;
+        };
+        if member.contains('*') {
+            continue;
+        }
+        let manifest_path = Path::new(member).join("Cargo.toml");
+        if !manifest_path.is_file() {
+            continue;
+        }
+        let manifest = read_toml(&manifest_path)?;
+        let inherits = manifest
+            .get("lints")
+            .and_then(|lints| lints.get("workspace"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !inherits {
+            missing.push(manifest_path.display().to_string());
+        }
+    }
+
+    if !missing.is_empty() {
+        bail!(
+            "workspace lint inheritance is required but missing from:\n{}",
+            missing.join("\n")
+        );
+    }
+    Ok(())
+}
+
+fn validate_clippy_config(path: &Path, ledger: &LintLedger) -> Result<()> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    for carveout in TEST_CARVEOUTS {
+        if raw.contains(carveout) && raw.contains(&format!("{carveout} = true")) {
+            bail!("{CLIPPY_CONFIG} must not enable test carveout `{carveout}`");
+        }
+    }
+
+    let parsed: Value =
+        toml::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))?;
+    let config_msrv = parsed
+        .get("msrv")
+        .and_then(Value::as_str)
+        .context("clippy.toml must declare msrv")?;
+    if config_msrv != ledger.msrv {
+        bail!(
+            "clippy.toml msrv ({config_msrv}) must match policy msrv ({})",
+            ledger.msrv
+        );
+    }
+    Ok(())
+}
+
+fn validate_planned_lints(root_manifest: &Value, ledger: &LintLedger) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for planned in &ledger.planned {
+        for (field_name, value) in [
+            ("name", planned.name.as_str()),
+            ("level", planned.level.as_str()),
+            ("activate_when_msrv", planned.activate_when_msrv.as_str()),
+            ("reason", planned.reason.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                bail!("planned lint `{}` has empty {field_name}", planned.name);
+            }
+        }
+        if !seen.insert(&planned.name) {
+            bail!("duplicate planned lint `{}`", planned.name);
+        }
+    }
+
+    let clippy_lints = root_manifest
+        .get("workspace")
+        .and_then(|workspace| workspace.get("lints"))
+        .and_then(|lints| lints.get("clippy"))
+        .and_then(Value::as_table)
+        .cloned()
+        .unwrap_or_default();
+
+    for lint in PLANNED_BEFORE_MSRV {
+        if clippy_lints.contains_key(*lint) {
+            bail!("planned future lint `{lint}` must not be active before the recorded MSRV bump");
+        }
+    }
+    Ok(())
+}
+
+fn validate_debt(path: &Path) -> Result<()> {
+    let ledger: DebtLedger = read_toml_as(path)?;
+    if ledger.schema != 1 {
+        bail!("{} must use schema = 1", path.display());
+    }
+
+    let today = chrono::Utc::now().date_naive();
+    let mut by_identity = BTreeMap::new();
+    for debt in ledger.debt {
+        for (field_name, value) in [
+            ("lint", debt.lint.as_str()),
+            ("path", debt.path.as_str()),
+            ("owner", debt.owner.as_str()),
+            ("reason", debt.reason.as_str()),
+            ("expires", debt.expires.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                bail!("debt entry for `{}` has empty {field_name}", debt.lint);
+            }
+        }
+
+        let expires = chrono::NaiveDate::parse_from_str(&debt.expires, "%Y-%m-%d")
+            .with_context(|| format!("debt `{}` has invalid expires date", debt.lint))?;
+        if expires < today {
+            bail!(
+                "debt `{}` for `{}` expired on {expires}",
+                debt.lint,
+                debt.path
+            );
+        }
+
+        let key = format!("{}\0{}", debt.lint, debt.path);
+        if by_identity.insert(key, ()).is_some() {
+            bail!(
+                "duplicate debt entry for lint `{}` and path `{}`",
+                debt.lint,
+                debt.path
+            );
+        }
+    }
+    Ok(())
+}
+
+fn read_lint_ledger(path: &Path) -> Result<LintLedger> {
+    read_toml_as(path)
+}
+
+fn read_toml(path: &Path) -> Result<Value> {
+    read_toml_as(path)
+}
+
+fn read_toml_as<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@ use uselesskey_feature_grid::{BDD_FEATURE_MATRIX, CORE_FEATURE_MATRIX};
 mod audit_surface;
 mod docs_sync;
 mod economics;
+mod lint_policy;
 mod plan;
 mod pr_bundles;
 mod receipt;
@@ -90,6 +91,8 @@ enum Cmd {
     PublishCheck,
     /// Run PR-scoped tests based on git diff.
     Pr,
+    /// Verify Clippy policy manifests, ledgers, and staged ratchets.
+    CheckLintPolicy,
     /// Guard against multiple semver-major versions of pinned deps (e.g. rand_core).
     DepGuard,
     /// Run cucumber BDD features.
@@ -263,6 +266,7 @@ fn main() -> Result<()> {
         Cmd::ExamplesSmoke { run } => docs_sync::examples_smoke_cmd(run),
         Cmd::PublishCheck => publish_check(),
         Cmd::Pr => pr(),
+        Cmd::CheckLintPolicy => lint_policy::check_lint_policy_cmd(),
         Cmd::DepGuard => dep_guard(),
         Cmd::Bdd => bdd(),
         Cmd::BddMatrix => bdd_matrix(),


### PR DESCRIPTION
### Motivation
- Establish a shared, workspace-level Clippy baseline that enforces a panic-free, silent-failure-free posture for both production and tests. 
- Capture the active lint surface and planned Rust 1.93/1.94/1.95 ratchets in a machine-readable ledger so upgrades and repo-specific debt can be tracked. 
- Provide an automated CI check that validates manifest/lint consistency, rejects test carveouts, and enforces structured debt and allowlist entries. 

### Description
- Add a workspace lint block under `[workspace.lints.rust]` and `[workspace.lints.clippy]` in `Cargo.toml` defining the Effortless Metrics baseline (panic family, UTF-8/slice safety, silent-failure, async/concurrency, numeric, filesystem/process, suppression governance, and good-taste lints). 
- Add policy artifacts: `policy/clippy-lints.toml` (machine-readable active + planned ledger), `policy/clippy-debt.toml` (debt ledger scaffold), `policy/no-panic-allowlist.toml` and `policy/non-rust-allowlist.toml` (semantic allowlist scaffolds). 
- Add documentation `docs/CLIPPY_POLICY.md` explaining rollout stance, suppression style (`#[expect(..., reason = "...")]`), no-test-carveout rule, and MSRV/lint ratchet plan. 
- Extend `xtask` by adding `xtask/src/lint_policy.rs`, wiring `CheckLintPolicy` into `xtask/src/main.rs`, and adding `toml` as an `xtask` dependency so `cargo xtask check-lint-policy` can validate required files, MSRV consistency, no test carveouts, planned-lint activation rules, and debt entry fields/expiry. 
- Keep `clippy.toml` focused and document that test carveouts must not be added. 

### Testing
- Ran `cargo xtask clippy` against the workspace and the check completed successfully. 
- Ran `cargo xtask fmt` (initial formatting issues in the new `xtask` module were fixed) and the final `fmt` check passed. 
- Ran `cargo xtask check-lint-policy` and it reported success (`lint-policy: ok`), validating the new policy files and invariants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb08642b3c8333a79272824150d014)