### PR TITLE
Add governed Clippy policy baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6018,6 +6018,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
  "uselesskey-feature-grid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ exclude = ["fuzz"]
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-rust-version = "1.92"
+rust-version = "1.93"
 repository = "https://github.com/EffortlessMetrics/uselesskey"
 homepage = "https://github.com/EffortlessMetrics/uselesskey"
 categories = ["development-tools::testing", "cryptography"]
@@ -179,6 +179,128 @@ rustls-pki-types = "1.14.0"
 # Crypto backends
 aws-lc-rs = { version = "1.16.3", default-features = false, features = ["alloc", "non-fips"] }
 ring = { version = "0.17.14", default-features = false, features = ["std"] }
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+
+[workspace.lints.clippy]
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 
 [profile.dev]
 # RSA keygen can be slow in debug; opt-level 2 keeps BDD/RSA tests from looking hung.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
 # Prefer clarity over cleverness.
-msrv = "1.92"
+msrv = "1.93"

--- a/crates/materialize-buildrs-example/Cargo.toml
+++ b/crates/materialize-buildrs-example/Cargo.toml
@@ -12,3 +12,6 @@ description = "Build-time materialization example for uselesskey fixtures."
 
 [build-dependencies]
 uselesskey-cli = { path = "../uselesskey-cli", version = "0.6.0", default-features = false, features = ["rsa-materialize"] }
+
+[lints]
+workspace = true

--- a/crates/materialize-shape-buildrs-example/Cargo.toml
+++ b/crates/materialize-shape-buildrs-example/Cargo.toml
@@ -13,3 +13,5 @@ description = "Build-time shape-only materialization example for uselesskey fixt
 [build-dependencies]
 uselesskey-cli = { path = "../uselesskey-cli", version = "0.6.0", default-features = false }
 
+[lints]
+workspace = true

--- a/crates/uselesskey-aws-lc-rs/Cargo.toml
+++ b/crates/uselesskey-aws-lc-rs/Cargo.toml
@@ -48,3 +48,5 @@ serde.workspace = true
 insta.workspace = true
 proptest.workspace = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-axum/Cargo.toml
+++ b/crates/uselesskey-axum/Cargo.toml
@@ -26,3 +26,6 @@ uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", features = ["j
 
 [dev-dependencies]
 tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-bdd-steps/Cargo.toml
+++ b/crates/uselesskey-bdd-steps/Cargo.toml
@@ -74,3 +74,6 @@ uk-rustls = ["dep:uselesskey-rustls", "dep:rustls-pki-types", "uk-bdd-keys"]
 uk-tonic = ["dep:uselesskey-tonic"]
 uk-ring = ["dep:uselesskey-ring", "dep:ring", "uk-bdd-keys"]
 uk-rustcrypto = ["dep:uselesskey-rustcrypto", "dep:hmac", "uk-bdd-keys"]
+
+[lints]
+workspace = true

--- a/crates/uselesskey-bdd/Cargo.toml
+++ b/crates/uselesskey-bdd/Cargo.toml
@@ -50,3 +50,6 @@ uk-rustcrypto = ["uselesskey-bdd-steps/uk-rustcrypto"]
 [[test]]
 name = "bdd"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/uselesskey-bench/Cargo.toml
+++ b/crates/uselesskey-bench/Cargo.toml
@@ -19,3 +19,6 @@ uselesskey = { path = "../uselesskey", features = ["full"] }
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-cli/Cargo.toml
+++ b/crates/uselesskey-cli/Cargo.toml
@@ -54,3 +54,6 @@ tempfile.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-base62/Cargo.toml
+++ b/crates/uselesskey-core-base62/Cargo.toml
@@ -28,3 +28,5 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-cache/Cargo.toml
+++ b/crates/uselesskey-core-cache/Cargo.toml
@@ -32,3 +32,5 @@ std = ["dep:dashmap", "uselesskey-core-id/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-factory/Cargo.toml
+++ b/crates/uselesskey-core-factory/Cargo.toml
@@ -36,3 +36,5 @@ std = [
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-hash/Cargo.toml
+++ b/crates/uselesskey-core-hash/Cargo.toml
@@ -29,3 +29,5 @@ std = ["blake3/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-hmac-spec/Cargo.toml
+++ b/crates/uselesskey-core-hmac-spec/Cargo.toml
@@ -22,3 +22,5 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-id/Cargo.toml
+++ b/crates/uselesskey-core-id/Cargo.toml
@@ -31,3 +31,5 @@ std = ["uselesskey-core-hash/std", "uselesskey-core-seed/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwk-builder/Cargo.toml
+++ b/crates/uselesskey-core-jwk-builder/Cargo.toml
@@ -28,3 +28,5 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwk-shape/Cargo.toml
+++ b/crates/uselesskey-core-jwk-shape/Cargo.toml
@@ -27,3 +27,5 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwk/Cargo.toml
+++ b/crates/uselesskey-core-jwk/Cargo.toml
@@ -27,3 +27,5 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwks-order/Cargo.toml
+++ b/crates/uselesskey-core-jwks-order/Cargo.toml
@@ -24,3 +24,5 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-keypair-material/Cargo.toml
+++ b/crates/uselesskey-core-keypair-material/Cargo.toml
@@ -26,3 +26,5 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-keypair/Cargo.toml
+++ b/crates/uselesskey-core-keypair/Cargo.toml
@@ -26,3 +26,5 @@ uselesskey-core-negative.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-kid/Cargo.toml
+++ b/crates/uselesskey-core-kid/Cargo.toml
@@ -27,3 +27,5 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-negative-der/Cargo.toml
+++ b/crates/uselesskey-core-negative-der/Cargo.toml
@@ -30,3 +30,5 @@ std = ["uselesskey-core-hash/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-negative-pem/Cargo.toml
+++ b/crates/uselesskey-core-negative-pem/Cargo.toml
@@ -30,3 +30,5 @@ std = ["uselesskey-core-hash/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-negative/Cargo.toml
+++ b/crates/uselesskey-core-negative/Cargo.toml
@@ -31,3 +31,5 @@ std = ["uselesskey-core-negative-der/std", "uselesskey-core-negative-pem/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-rustls-pki/Cargo.toml
+++ b/crates/uselesskey-core-rustls-pki/Cargo.toml
@@ -43,3 +43,5 @@ uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
 [package.metadata.docs.rs]
 features = ["all"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-seed/Cargo.toml
+++ b/crates/uselesskey-core-seed/Cargo.toml
@@ -32,3 +32,5 @@ std = ["blake3/std", "rand_chacha10/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-sink/Cargo.toml
+++ b/crates/uselesskey-core-sink/Cargo.toml
@@ -26,3 +26,5 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-token-shape/Cargo.toml
+++ b/crates/uselesskey-core-token-shape/Cargo.toml
@@ -31,3 +31,5 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-token/Cargo.toml
+++ b/crates/uselesskey-core-token/Cargo.toml
@@ -28,3 +28,5 @@ uselesskey-core-seed.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-chain-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-chain-negative/Cargo.toml
@@ -30,3 +30,5 @@ std = []
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-derive/Cargo.toml
+++ b/crates/uselesskey-core-x509-derive/Cargo.toml
@@ -31,3 +31,5 @@ uselesskey-core-hash = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-negative/Cargo.toml
@@ -31,4 +31,5 @@ std = []
 [package.metadata.docs.rs]
 features = ["std"]
 
-
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-spec/Cargo.toml
+++ b/crates/uselesskey-core-x509-spec/Cargo.toml
@@ -25,3 +25,5 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509/Cargo.toml
+++ b/crates/uselesskey-core-x509/Cargo.toml
@@ -29,3 +29,5 @@ uselesskey-core-seed.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-core/Cargo.toml
+++ b/crates/uselesskey-core/Cargo.toml
@@ -43,3 +43,5 @@ serde = { workspace = true }
 [package.metadata.docs.rs]
 features = ["std"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-ecdsa/Cargo.toml
+++ b/crates/uselesskey-ecdsa/Cargo.toml
@@ -44,3 +44,5 @@ rstest.workspace = true
 serde.workspace = true
 uselesskey-core-kid.workspace = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-ed25519/Cargo.toml
+++ b/crates/uselesskey-ed25519/Cargo.toml
@@ -39,3 +39,5 @@ rstest.workspace = true
 serde.workspace = true
 uselesskey-core-kid.workspace = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-entropy/Cargo.toml
+++ b/crates/uselesskey-entropy/Cargo.toml
@@ -22,3 +22,6 @@ proptest.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-feature-grid/Cargo.toml
+++ b/crates/uselesskey-feature-grid/Cargo.toml
@@ -18,4 +18,5 @@ documentation = "https://docs.rs/uselesskey-feature-grid"
 
 [dev-dependencies]
 
-
+[lints]
+workspace = true

--- a/crates/uselesskey-hmac/Cargo.toml
+++ b/crates/uselesskey-hmac/Cargo.toml
@@ -38,3 +38,5 @@ serde.workspace = true
 default = []
 jwk = ["dep:uselesskey-jwk", "dep:base64"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-interop-tests/Cargo.toml
+++ b/crates/uselesskey-interop-tests/Cargo.toml
@@ -53,3 +53,6 @@ cross-tls = ["dep:uselesskey-x509", "dep:uselesskey-rustls"]
 jwt-interop = ["dep:uselesskey-jsonwebtoken"]
 aws-lc-rs-interop = ["dep:uselesskey-aws-lc-rs", "dep:aws-lc-rs", "uselesskey-rustls?/rustls-aws-lc-rs"]
 all = ["cross-signing", "cross-tls", "jwt-interop", "aws-lc-rs-interop"]
+
+[lints]
+workspace = true

--- a/crates/uselesskey-jose-openid/Cargo.toml
+++ b/crates/uselesskey-jose-openid/Cargo.toml
@@ -43,3 +43,5 @@ uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0" }
 uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
 uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0" }
 
+[lints]
+workspace = true

--- a/crates/uselesskey-jsonwebtoken/Cargo.toml
+++ b/crates/uselesskey-jsonwebtoken/Cargo.toml
@@ -51,3 +51,5 @@ proptest.workspace = true
 version = "10"
 features = ["use_pem", "rust_crypto"]
 
+[lints]
+workspace = true

--- a/crates/uselesskey-jwk/Cargo.toml
+++ b/crates/uselesskey-jwk/Cargo.toml
@@ -26,3 +26,5 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-pgp-native/Cargo.toml
+++ b/crates/uselesskey-pgp-native/Cargo.toml
@@ -29,3 +29,5 @@ pgp-native = ["dep:uselesskey-pgp"]
 uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.6.0" }
 uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
 
+[lints]
+workspace = true

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -28,3 +28,5 @@ insta.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-pkcs11-mock/Cargo.toml
+++ b/crates/uselesskey-pkcs11-mock/Cargo.toml
@@ -20,3 +20,6 @@ sha2.workspace = true
 
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+
+[lints]
+workspace = true

--- a/crates/uselesskey-ring/Cargo.toml
+++ b/crates/uselesskey-ring/Cargo.toml
@@ -39,3 +39,5 @@ serde.workspace = true
 insta.workspace = true
 proptest.workspace = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-rsa/Cargo.toml
+++ b/crates/uselesskey-rsa/Cargo.toml
@@ -43,3 +43,5 @@ proptest.workspace = true
 rstest.workspace = true
 serde.workspace = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-rustcrypto/Cargo.toml
+++ b/crates/uselesskey-rustcrypto/Cargo.toml
@@ -51,3 +51,6 @@ rsa = { workspace = true, features = ["sha2"] }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -53,3 +53,5 @@ serde.workspace = true
 insta.workspace = true
 proptest.workspace = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-ssh/Cargo.toml
+++ b/crates/uselesskey-ssh/Cargo.toml
@@ -24,3 +24,6 @@ proptest.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-test-grid/Cargo.toml
+++ b/crates/uselesskey-test-grid/Cargo.toml
@@ -20,3 +20,5 @@ uselesskey-feature-grid.workspace = true
 [dev-dependencies]
 uselesskey-feature-grid.workspace = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-test-server/Cargo.toml
+++ b/crates/uselesskey-test-server/Cargo.toml
@@ -31,3 +31,6 @@ uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", features = ["j
 
 [dev-dependencies]
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
+
+[lints]
+workspace = true

--- a/crates/uselesskey-token-spec/Cargo.toml
+++ b/crates/uselesskey-token-spec/Cargo.toml
@@ -21,3 +21,5 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -29,3 +29,5 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-tonic/Cargo.toml
+++ b/crates/uselesskey-tonic/Cargo.toml
@@ -32,3 +32,5 @@ proptest.workspace = true
 serde.workspace = true
 insta.workspace = true
 
+[lints]
+workspace = true

--- a/crates/uselesskey-webauthn/Cargo.toml
+++ b/crates/uselesskey-webauthn/Cargo.toml
@@ -23,3 +23,6 @@ sha2.workspace = true
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-webhook/Cargo.toml
+++ b/crates/uselesskey-webhook/Cargo.toml
@@ -29,3 +29,6 @@ insta.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-x509/Cargo.toml
+++ b/crates/uselesskey-x509/Cargo.toml
@@ -40,3 +40,5 @@ rstest.workspace = true
 insta.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
+[lints]
+workspace = true

--- a/crates/uselesskey/Cargo.toml
+++ b/crates/uselesskey/Cargo.toml
@@ -85,3 +85,6 @@ rustls-pki-types.workspace = true
 name = "keygen"
 harness = false
 required-features = ["full"]
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,42 @@
+# Clippy Policy
+
+`uselesskey` treats Clippy as a governed engineering surface, not a local preference file. The workspace uses the Effortless Metrics strict Rust baseline: panic-free production and test code, silent-failure prevention, explicit suppression governance, and reviewability lints that keep fixture code readable.
+
+## Active baseline
+
+The active baseline lives in the root `Cargo.toml` under `[workspace.lints.rust]` and `[workspace.lints.clippy]`. Every workspace package must inherit it with:
+
+```toml
+[lints]
+workspace = true
+```
+
+The policy ledger in `policy/clippy-lints.toml` records the MSRV and the planned Rust 1.94 / 1.95 lint flips that should become active when the workspace MSRV advances.
+
+## No test carveouts
+
+The standard is workspace panic-free, not just production panic-free. Do not add Clippy test carveouts such as `allow-unwrap-in-tests`, `allow-expect-in-tests`, `allow-panic-in-tests`, `allow-indexing-slicing-in-tests`, or `allow-dbg-in-tests`.
+
+Tests should prefer `Result`-returning helpers and explicit assertion helpers over `unwrap`, `expect`, or panic-driven setup.
+
+## Suppression style
+
+Local suppressions must use `#[expect(..., reason = "...")]` with a narrow scope and a human-readable reason. Broad `#[allow(...)]` attributes are policy debt and should be replaced by either:
+
+1. a small code change that satisfies the lint;
+2. a narrow `#[expect(..., reason = "...")]`; or
+3. a temporary entry in `policy/clippy-debt.toml` with owner, reason, path, lint, and expiry.
+
+## Crypto/security overlay
+
+`uselesskey` is a test-fixture crate, but it deliberately emits secret-shaped cryptographic artifacts. The workspace therefore keeps the stricter crypto/security posture from the shared baseline: no unsafe code, no silent result loss, no unchecked panic-family collapse, and staged numeric correctness lints.
+
+## Policy gate
+
+Run the policy gate with:
+
+```bash
+cargo xtask check-lint-policy
+```
+
+The gate verifies MSRV alignment, workspace lint inheritance, planned lint consistency, lack of test carveouts, and required debt metadata.

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,4 @@
+schema = 1
+
+# Temporary repo-local exceptions belong here, never in broad clippy.toml test carveouts.
+# Each entry must include lint, path, owner, reason, and expires.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,70 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+# Rust 1.94 planned flips. These stay out of Cargo.toml until the MSRV bump.
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Prefer the standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Avoid stale numeric type drift."
+
+# Rust 1.95 planned flips. These stay out of Cargo.toml until the MSRV bump.
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,4 @@
+schema_version = "0.3"
+
+# Semantic panic-family exceptions use identity = path + family + selector.
+# last_seen is advisory only and may drift during refactors.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,3 @@
+schema_version = "1.0"
+
+# Non-Rust programming files must be reviewed policy exceptions with ownership and CI coverage.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -313,3 +313,6 @@ required-features = ["api-surface"]
 name = "security_invariants"
 path = "security_invariants.rs"
 required-features = ["security-invariants"]
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -22,7 +22,11 @@ owo-colors = "4.0"
 regex = "1.11"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+toml.workspace = true
 uselesskey-feature-grid.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -68,6 +68,8 @@ enum Cmd {
     Ci,
     /// Run the feature matrix checks.
     FeatureMatrix,
+    /// Verify workspace lint policy files and inheritance.
+    CheckLintPolicy,
     /// Enforce no secret-shaped blobs in test/fixture paths.
     NoBlob {
         /// Subcommand: scan (default) or migrate (show replacement recipe).
@@ -255,6 +257,7 @@ fn main() -> Result<()> {
         Cmd::Typos { fix } => typos(fix),
         Cmd::Ci => ci(),
         Cmd::FeatureMatrix => feature_matrix_cmd(),
+        Cmd::CheckLintPolicy => check_lint_policy(),
         Cmd::NoBlob { subcmd } => match subcmd.as_ref().unwrap_or(&NoBlobCmd::Scan) {
             NoBlobCmd::Scan => no_blob_gate(),
             NoBlobCmd::Migrate => no_blob_migrate(),
@@ -641,6 +644,7 @@ fn ci() -> Result<()> {
 fn run_ci_plan(runner: &mut receipt::Runner) -> Result<()> {
     runner.step("fmt", None, || fmt(false))?;
     runner.step("clippy", None, clippy)?;
+    runner.step("lint-policy", None, check_lint_policy)?;
     runner.step("typos", None, || typos(false))?;
     runner.step("deny", None, deny)?;
     runner.step("tests", None, test)?;
@@ -669,6 +673,355 @@ fn run_ci_plan(runner: &mut receipt::Runner) -> Result<()> {
 
     run_publish_preflight(runner, false)?;
 
+    Ok(())
+}
+
+fn check_lint_policy() -> Result<()> {
+    let root = workspace_root_path();
+    let cargo_toml = root.join("Cargo.toml");
+    let cargo_raw = read_text(&cargo_toml)?;
+    let cargo_doc: toml::Value = toml::from_str(&cargo_raw)
+        .with_context(|| format!("failed to parse {}", cargo_toml.display()))?;
+
+    let policy_path = root.join("policy/clippy-lints.toml");
+    let policy_raw = read_text(&policy_path)?;
+    let policy_doc: toml::Value = toml::from_str(&policy_raw)
+        .with_context(|| format!("failed to parse {}", policy_path.display()))?;
+
+    let workspace = table(&cargo_doc, "workspace")?;
+    let workspace_package = table_value(workspace, "package")?;
+    let rust_version = string_value(workspace_package, "rust-version")?;
+    let policy_msrv = string_field(&policy_doc, "msrv")?;
+    if rust_version != policy_msrv {
+        bail!(
+            "workspace.package.rust-version ({rust_version}) must match policy/clippy-lints.toml msrv ({policy_msrv})"
+        );
+    }
+
+    let clippy_toml = read_text(&root.join("clippy.toml"))?;
+    if !clippy_toml.contains(&format!("msrv = \"{policy_msrv}\"")) {
+        bail!("clippy.toml msrv must match policy MSRV {policy_msrv}");
+    }
+    ensure_no_test_carveouts(&clippy_toml)?;
+
+    let workspace_lints = table_value(workspace, "lints")?;
+    ensure_table_has_keys(
+        table_value(workspace_lints, "rust")?,
+        REQUIRED_RUST_LINTS,
+        "workspace.lints.rust",
+    )?;
+    ensure_table_has_keys(
+        table_value(workspace_lints, "clippy")?,
+        REQUIRED_CLIPPY_LINTS,
+        "workspace.lints.clippy",
+    )?;
+
+    let planned = policy_doc
+        .get("planned")
+        .and_then(toml::Value::as_array)
+        .context("policy/clippy-lints.toml must contain planned lint entries")?;
+    ensure_planned_lints(planned, table_value(workspace_lints, "clippy")?)?;
+
+    ensure_workspace_members_inherit_lints(&root, workspace)?;
+    ensure_debt_entries(&root.join("policy/clippy-debt.toml"))?;
+
+    println!(
+        "lint policy OK: MSRV {policy_msrv}, {} active Clippy lints, {} planned flips",
+        table_value(workspace_lints, "clippy")?.len(),
+        planned.len()
+    );
+    Ok(())
+}
+
+const REQUIRED_RUST_LINTS: &[&str] = &[
+    "unsafe_code",
+    "unsafe_op_in_unsafe_fn",
+    "unused_must_use",
+    "unexpected_cfgs",
+];
+
+const REQUIRED_CLIPPY_LINTS: &[&str] = &[
+    "dbg_macro",
+    "todo",
+    "unimplemented",
+    "panic",
+    "unreachable",
+    "unwrap_used",
+    "expect_used",
+    "get_unwrap",
+    "unwrap_in_result",
+    "panic_in_result_fn",
+    "string_slice",
+    "indexing_slicing",
+    "out_of_bounds_indexing",
+    "unchecked_time_subtraction",
+    "char_indices_as_byte_indices",
+    "sliced_string_as_bytes",
+    "index_refutable_slice",
+    "let_underscore_future",
+    "let_underscore_must_use",
+    "let_underscore_lock",
+    "unused_result_ok",
+    "map_err_ignore",
+    "assertions_on_result_states",
+    "lines_filter_map_ok",
+    "await_holding_lock",
+    "await_holding_refcell_ref",
+    "await_holding_invalid_type",
+    "future_not_send",
+    "large_futures",
+    "arc_with_non_send_sync",
+    "rc_mutex",
+    "mut_mutex_lock",
+    "readonly_write_lock",
+    "mem_forget",
+    "forget_non_drop",
+    "drop_non_drop",
+    "undocumented_unsafe_blocks",
+    "multiple_unsafe_ops_per_block",
+    "repr_packed_without_abi",
+    "float_cmp",
+    "float_cmp_const",
+    "float_equality_without_abs",
+    "lossy_float_literal",
+    "cast_sign_loss",
+    "cast_possible_wrap",
+    "cast_possible_truncation",
+    "cast_precision_loss",
+    "invalid_upcast_comparisons",
+    "cast_abs_to_unsigned",
+    "cast_enum_truncation",
+    "cast_nan_to_int",
+    "manual_midpoint",
+    "manual_is_multiple_of",
+    "manual_div_ceil",
+    "arithmetic_side_effects",
+    "suspicious_open_options",
+    "nonsensical_open_options",
+    "ineffective_open_options",
+    "path_buf_push_overwrite",
+    "join_absolute_paths",
+    "read_line_without_trim",
+    "exit",
+    "iter_not_returning_iterator",
+    "expl_impl_clone_on_copy",
+    "infallible_try_from",
+    "fallible_impl_from",
+    "error_impl_error",
+    "result_unit_err",
+    "result_large_err",
+    "format_in_format_args",
+    "to_string_in_format_args",
+    "unused_format_specs",
+    "unnecessary_debug_formatting",
+    "uninlined_format_args",
+    "manual_let_else",
+    "manual_ok_or",
+    "manual_strip",
+    "manual_split_once",
+    "manual_is_variant_and",
+    "filter_map_next",
+    "flat_map_option",
+    "match_result_ok",
+    "cloned_instead_of_copied",
+    "iter_cloned_collect",
+    "iter_overeager_cloned",
+    "needless_collect",
+    "redundant_closure",
+    "redundant_closure_for_method_calls",
+    "missing_panics_doc",
+    "missing_errors_doc",
+    "allow_attributes",
+    "allow_attributes_without_reason",
+    "blanket_clippy_restriction_lints",
+    "ignore_without_reason",
+    "should_panic_without_expect",
+];
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+const PLANNED_LINTS: &[&str] = &[
+    "clippy::same_length_and_capacity",
+    "clippy::manual_ilog2",
+    "clippy::decimal_bitwise_operands",
+    "clippy::needless_type_cast",
+    "clippy::disallowed_fields",
+    "clippy::manual_checked_ops",
+    "clippy::manual_take",
+    "clippy::manual_pop_if",
+    "clippy::duration_suboptimal_units",
+    "clippy::unnecessary_trailing_comma",
+];
+
+fn read_text(path: &Path) -> Result<String> {
+    fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))
+}
+
+fn table<'a>(
+    value: &'a toml::Value,
+    name: &str,
+) -> Result<&'a toml::map::Map<String, toml::Value>> {
+    value
+        .get(name)
+        .and_then(toml::Value::as_table)
+        .with_context(|| format!("missing [{name}] table"))
+}
+
+fn table_value<'a>(
+    table: &'a toml::map::Map<String, toml::Value>,
+    key: &str,
+) -> Result<&'a toml::map::Map<String, toml::Value>> {
+    table
+        .get(key)
+        .and_then(toml::Value::as_table)
+        .with_context(|| format!("missing table `{key}`"))
+}
+
+fn string_value<'a>(table: &'a toml::map::Map<String, toml::Value>, key: &str) -> Result<&'a str> {
+    table
+        .get(key)
+        .and_then(toml::Value::as_str)
+        .with_context(|| format!("missing string `{key}`"))
+}
+
+fn string_field<'a>(value: &'a toml::Value, key: &str) -> Result<&'a str> {
+    value
+        .get(key)
+        .and_then(toml::Value::as_str)
+        .with_context(|| format!("missing string `{key}`"))
+}
+
+fn ensure_no_test_carveouts(clippy_toml: &str) -> Result<()> {
+    for carveout in TEST_CARVEOUTS {
+        if clippy_toml.contains(carveout) {
+            bail!("clippy.toml contains forbidden test carveout `{carveout}`");
+        }
+    }
+    Ok(())
+}
+
+fn ensure_table_has_keys(
+    table: &toml::map::Map<String, toml::Value>,
+    required: &[&str],
+    label: &str,
+) -> Result<()> {
+    let missing = required
+        .iter()
+        .filter(|key| !table.contains_key(**key))
+        .copied()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        bail!("{label} is missing required lints: {}", missing.join(", "));
+    }
+    Ok(())
+}
+
+fn ensure_planned_lints(
+    planned: &[toml::Value],
+    active_clippy: &toml::map::Map<String, toml::Value>,
+) -> Result<()> {
+    for expected in PLANNED_LINTS {
+        let planned_entry = planned.iter().find(|entry| {
+            entry
+                .get("name")
+                .and_then(toml::Value::as_str)
+                .is_some_and(|name| name == *expected)
+        });
+        let Some(entry) = planned_entry else {
+            bail!("policy/clippy-lints.toml missing planned lint `{expected}`");
+        };
+        for required in ["level", "activate_when_msrv", "reason"] {
+            if entry.get(required).and_then(toml::Value::as_str).is_none() {
+                bail!("planned lint `{expected}` missing `{required}`");
+            }
+        }
+        let active_key = expected.strip_prefix("clippy::").unwrap_or(expected);
+        if active_clippy.contains_key(active_key) {
+            bail!("planned lint `{expected}` is already active before its MSRV flip");
+        }
+    }
+    Ok(())
+}
+
+fn ensure_workspace_members_inherit_lints(
+    root: &Path,
+    workspace: &toml::map::Map<String, toml::Value>,
+) -> Result<()> {
+    let members = workspace
+        .get("members")
+        .and_then(toml::Value::as_array)
+        .context("workspace.members must be an array")?;
+    let mut missing = Vec::new();
+    for member in members {
+        let Some(member_path) = member.as_str() else {
+            bail!("workspace.members entries must be strings");
+        };
+        let manifest = root.join(member_path).join("Cargo.toml");
+        if !manifest.exists() {
+            continue;
+        }
+        let raw = read_text(&manifest)?;
+        let doc: toml::Value = toml::from_str(&raw)
+            .with_context(|| format!("failed to parse {}", manifest.display()))?;
+        let inherits = doc
+            .get("lints")
+            .and_then(toml::Value::as_table)
+            .and_then(|lints| lints.get("workspace"))
+            .and_then(toml::Value::as_bool)
+            .unwrap_or(false);
+        if !inherits {
+            missing.push(member_path.to_string());
+        }
+    }
+    if !missing.is_empty() {
+        bail!(
+            "workspace members missing `[lints] workspace = true`: {}",
+            missing.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn ensure_debt_entries(path: &Path) -> Result<()> {
+    let raw = read_text(path)?;
+    let doc: toml::Value =
+        toml::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))?;
+    let schema = doc
+        .get("schema")
+        .and_then(toml::Value::as_integer)
+        .context("policy/clippy-debt.toml must set integer schema")?;
+    if schema != 1 {
+        bail!("unsupported clippy debt schema {schema}");
+    }
+    let Some(debt) = doc.get("debt") else {
+        return Ok(());
+    };
+    let entries = debt
+        .as_array()
+        .context("policy/clippy-debt.toml debt must be an array")?;
+    let today = chrono::Utc::now().date_naive();
+    for (idx, entry) in entries.iter().enumerate() {
+        for required in ["lint", "path", "owner", "reason", "expires"] {
+            if entry.get(required).and_then(toml::Value::as_str).is_none() {
+                bail!("clippy debt entry #{idx} missing `{required}`");
+            }
+        }
+        let expires = entry
+            .get("expires")
+            .and_then(toml::Value::as_str)
+            .expect("checked above");
+        let expires = chrono::NaiveDate::parse_from_str(expires, "%Y-%m-%d")
+            .with_context(|| format!("clippy debt entry #{idx} has invalid expires date"))?;
+        if expires < today {
+            bail!("clippy debt entry #{idx} expired on {expires}");
+        }
+    }
     Ok(())
 }
 
@@ -2663,6 +3016,7 @@ fn gate() -> Result<()> {
 fn run_gate(runner: &mut receipt::Runner) -> Result<()> {
     runner.step("fmt", None, || fmt(false))?;
     runner.step("docs-sync", None, || docs_sync::docs_sync_cmd(true))?;
+    runner.step("lint-policy", None, check_lint_policy)?;
     runner.step("check", None, || {
         run(Command::new("cargo").args(["check", "--workspace", "--all-targets", "--all-features"]))
     })?;


### PR DESCRIPTION
### Motivation
- Establish a governed, workspace-level Clippy/Rust lint baseline (MSRV 1.93) to enforce panic-free tests, no silent failures, and suppression governance rather than ad-hoc per-crate rules. 
- Provide machine-readable policy ledgers and allowlists so exceptions are tracked as explicit, expiring debt and so CI can verify policy inheritance and planned future flips. 
- Make `xtask` the policy gate so lint policy, debt, and allowlist checks are part of the normal CI automation rather than scattered manual checks. 

### Description
- Ratcheted the workspace MSRV to `1.93` and added a shared lint baseline under `[workspace.lints.rust]` and `[workspace.lints.clippy]` in the root `Cargo.toml` with deny/warn settings for panic-family, AST/indexing safety, async/concurrency, numeric correctness, file/path footguns, and suppression governance. 
- Updated `clippy.toml` `msrv` to `1.93` and added `toml` as an xtask dependency (and workspace wiring) so `xtask` can parse policy files. 
- Added machine-readable policy files: `policy/clippy-lints.toml` (active MSRV + planned 1.94/1.95 flips), `policy/clippy-debt.toml` (debt ledger template), `policy/no-panic-allowlist.toml` (semantic panic-family allowlist schema), and `policy/non-rust-allowlist.toml` (non-Rust file allowlist schema). 
- Added `docs/CLIPPY_POLICY.md` documenting the baseline, suppression style (`#[expect(..., reason = "...")]`), no-test-carveout rule, crypto overlay, and the `cargo xtask check-lint-policy` gate. 
- Implemented `check_lint_policy()` in `xtask/src/main.rs`, wired a new `CheckLintPolicy` xtask command and integrated the check into CI/gate flows to verify MSRV alignment, `clippy.toml` MSRV, absence of test carveouts, required active lints, planned flips not prematurely active, workspace inheritance (`[lints] workspace = true`), and debt entries with expiry. 
- Propagated `[lints] workspace = true` to workspace members' `Cargo.toml` manifests (crates, tests, and `xtask`) so the root block is inherited by each package. 

### Testing
- Ran `cargo fmt --all -- --check` which succeeded. 
- Ran `cargo check --ignore-rust-version -p xtask` which succeeded for the modified `xtask` binary. 
- Ran `cargo run --ignore-rust-version -p xtask -- check-lint-policy` which parsed the new policy and printed `lint policy OK: MSRV 1.93, 95 active Clippy lints, 10 planned flips`. 
- Ran `cargo clippy --ignore-rust-version -p xtask --all-targets --all-features -- -D warnings` which surfaced existing strict-policy debt inside `xtask` (numerous `#[allow]` attributes without reasons, `expect`/`unwrap` uses, string/indexing/format issues, and other lints) and therefore failed as expected to highlight work to remediate. 
- Note: the local toolchain in the runtime was `rustc 1.92.0`, and CI should run with Rust `1.93` to fully validate the planned flips and active lint surface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb08642b3c8333a79272824150d014)