### PR TITLE
chore: add governed Clippy policy, policy ledgers, and xtask checks (MSRV → 1.93)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6018,6 +6018,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
  "uselesskey-feature-grid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,11 +70,135 @@ exclude = ["fuzz"]
 [workspace.package]
 edition = "2024"
 license = "MIT OR Apache-2.0"
-rust-version = "1.92"
+rust-version = "1.93"
 repository = "https://github.com/EffortlessMetrics/uselesskey"
 homepage = "https://github.com/EffortlessMetrics/uselesskey"
 categories = ["development-tools::testing", "cryptography"]
 authors = ["Effortless Metrics <opensource@effortlessmetrics.com>"]
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
+
+[workspace.lints.clippy]
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 
 [workspace.dependencies]
 # error handling

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
 # Prefer clarity over cleverness.
-msrv = "1.92"
+msrv = "1.93"

--- a/crates/materialize-buildrs-example/Cargo.toml
+++ b/crates/materialize-buildrs-example/Cargo.toml
@@ -12,3 +12,6 @@ description = "Build-time materialization example for uselesskey fixtures."
 
 [build-dependencies]
 uselesskey-cli = { path = "../uselesskey-cli", version = "0.6.0", default-features = false, features = ["rsa-materialize"] }
+
+[lints]
+workspace = true

--- a/crates/materialize-shape-buildrs-example/Cargo.toml
+++ b/crates/materialize-shape-buildrs-example/Cargo.toml
@@ -13,3 +13,6 @@ description = "Build-time shape-only materialization example for uselesskey fixt
 [build-dependencies]
 uselesskey-cli = { path = "../uselesskey-cli", version = "0.6.0", default-features = false }
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-aws-lc-rs/Cargo.toml
+++ b/crates/uselesskey-aws-lc-rs/Cargo.toml
@@ -48,3 +48,6 @@ serde.workspace = true
 insta.workspace = true
 proptest.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-axum/Cargo.toml
+++ b/crates/uselesskey-axum/Cargo.toml
@@ -26,3 +26,6 @@ uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", features = ["j
 
 [dev-dependencies]
 tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-bdd-steps/Cargo.toml
+++ b/crates/uselesskey-bdd-steps/Cargo.toml
@@ -74,3 +74,6 @@ uk-rustls = ["dep:uselesskey-rustls", "dep:rustls-pki-types", "uk-bdd-keys"]
 uk-tonic = ["dep:uselesskey-tonic"]
 uk-ring = ["dep:uselesskey-ring", "dep:ring", "uk-bdd-keys"]
 uk-rustcrypto = ["dep:uselesskey-rustcrypto", "dep:hmac", "uk-bdd-keys"]
+
+[lints]
+workspace = true

--- a/crates/uselesskey-bdd/Cargo.toml
+++ b/crates/uselesskey-bdd/Cargo.toml
@@ -50,3 +50,6 @@ uk-rustcrypto = ["uselesskey-bdd-steps/uk-rustcrypto"]
 [[test]]
 name = "bdd"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/uselesskey-bench/Cargo.toml
+++ b/crates/uselesskey-bench/Cargo.toml
@@ -19,3 +19,6 @@ uselesskey = { path = "../uselesskey", features = ["full"] }
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-cli/Cargo.toml
+++ b/crates/uselesskey-cli/Cargo.toml
@@ -54,3 +54,6 @@ tempfile.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-base62/Cargo.toml
+++ b/crates/uselesskey-core-base62/Cargo.toml
@@ -28,3 +28,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-cache/Cargo.toml
+++ b/crates/uselesskey-core-cache/Cargo.toml
@@ -32,3 +32,6 @@ std = ["dep:dashmap", "uselesskey-core-id/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-factory/Cargo.toml
+++ b/crates/uselesskey-core-factory/Cargo.toml
@@ -36,3 +36,6 @@ std = [
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-hash/Cargo.toml
+++ b/crates/uselesskey-core-hash/Cargo.toml
@@ -29,3 +29,6 @@ std = ["blake3/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-hmac-spec/Cargo.toml
+++ b/crates/uselesskey-core-hmac-spec/Cargo.toml
@@ -22,3 +22,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-id/Cargo.toml
+++ b/crates/uselesskey-core-id/Cargo.toml
@@ -31,3 +31,6 @@ std = ["uselesskey-core-hash/std", "uselesskey-core-seed/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwk-builder/Cargo.toml
+++ b/crates/uselesskey-core-jwk-builder/Cargo.toml
@@ -28,3 +28,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwk-shape/Cargo.toml
+++ b/crates/uselesskey-core-jwk-shape/Cargo.toml
@@ -27,3 +27,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwk/Cargo.toml
+++ b/crates/uselesskey-core-jwk/Cargo.toml
@@ -27,3 +27,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwks-order/Cargo.toml
+++ b/crates/uselesskey-core-jwks-order/Cargo.toml
@@ -24,3 +24,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-keypair-material/Cargo.toml
+++ b/crates/uselesskey-core-keypair-material/Cargo.toml
@@ -26,3 +26,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-keypair/Cargo.toml
+++ b/crates/uselesskey-core-keypair/Cargo.toml
@@ -26,3 +26,6 @@ uselesskey-core-negative.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-kid/Cargo.toml
+++ b/crates/uselesskey-core-kid/Cargo.toml
@@ -27,3 +27,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-negative-der/Cargo.toml
+++ b/crates/uselesskey-core-negative-der/Cargo.toml
@@ -30,3 +30,6 @@ std = ["uselesskey-core-hash/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-negative-pem/Cargo.toml
+++ b/crates/uselesskey-core-negative-pem/Cargo.toml
@@ -30,3 +30,6 @@ std = ["uselesskey-core-hash/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-negative/Cargo.toml
+++ b/crates/uselesskey-core-negative/Cargo.toml
@@ -31,3 +31,6 @@ std = ["uselesskey-core-negative-der/std", "uselesskey-core-negative-pem/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-rustls-pki/Cargo.toml
+++ b/crates/uselesskey-core-rustls-pki/Cargo.toml
@@ -43,3 +43,6 @@ uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
 [package.metadata.docs.rs]
 features = ["all"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-seed/Cargo.toml
+++ b/crates/uselesskey-core-seed/Cargo.toml
@@ -32,3 +32,6 @@ std = ["blake3/std", "rand_chacha10/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-sink/Cargo.toml
+++ b/crates/uselesskey-core-sink/Cargo.toml
@@ -26,3 +26,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-token-shape/Cargo.toml
+++ b/crates/uselesskey-core-token-shape/Cargo.toml
@@ -31,3 +31,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-token/Cargo.toml
+++ b/crates/uselesskey-core-token/Cargo.toml
@@ -28,3 +28,6 @@ uselesskey-core-seed.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-chain-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-chain-negative/Cargo.toml
@@ -30,3 +30,6 @@ std = []
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-derive/Cargo.toml
+++ b/crates/uselesskey-core-x509-derive/Cargo.toml
@@ -31,3 +31,6 @@ uselesskey-core-hash = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-negative/Cargo.toml
@@ -32,3 +32,6 @@ std = []
 features = ["std"]
 
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-spec/Cargo.toml
+++ b/crates/uselesskey-core-x509-spec/Cargo.toml
@@ -25,3 +25,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509/Cargo.toml
+++ b/crates/uselesskey-core-x509/Cargo.toml
@@ -29,3 +29,6 @@ uselesskey-core-seed.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core/Cargo.toml
+++ b/crates/uselesskey-core/Cargo.toml
@@ -43,3 +43,6 @@ serde = { workspace = true }
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-ecdsa/Cargo.toml
+++ b/crates/uselesskey-ecdsa/Cargo.toml
@@ -44,3 +44,6 @@ rstest.workspace = true
 serde.workspace = true
 uselesskey-core-kid.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-ed25519/Cargo.toml
+++ b/crates/uselesskey-ed25519/Cargo.toml
@@ -39,3 +39,6 @@ rstest.workspace = true
 serde.workspace = true
 uselesskey-core-kid.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-entropy/Cargo.toml
+++ b/crates/uselesskey-entropy/Cargo.toml
@@ -22,3 +22,6 @@ proptest.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-feature-grid/Cargo.toml
+++ b/crates/uselesskey-feature-grid/Cargo.toml
@@ -19,3 +19,6 @@ documentation = "https://docs.rs/uselesskey-feature-grid"
 [dev-dependencies]
 
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-hmac/Cargo.toml
+++ b/crates/uselesskey-hmac/Cargo.toml
@@ -38,3 +38,6 @@ serde.workspace = true
 default = []
 jwk = ["dep:uselesskey-jwk", "dep:base64"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-interop-tests/Cargo.toml
+++ b/crates/uselesskey-interop-tests/Cargo.toml
@@ -53,3 +53,6 @@ cross-tls = ["dep:uselesskey-x509", "dep:uselesskey-rustls"]
 jwt-interop = ["dep:uselesskey-jsonwebtoken"]
 aws-lc-rs-interop = ["dep:uselesskey-aws-lc-rs", "dep:aws-lc-rs", "uselesskey-rustls?/rustls-aws-lc-rs"]
 all = ["cross-signing", "cross-tls", "jwt-interop", "aws-lc-rs-interop"]
+
+[lints]
+workspace = true

--- a/crates/uselesskey-jose-openid/Cargo.toml
+++ b/crates/uselesskey-jose-openid/Cargo.toml
@@ -43,3 +43,6 @@ uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0" }
 uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
 uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0" }
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-jsonwebtoken/Cargo.toml
+++ b/crates/uselesskey-jsonwebtoken/Cargo.toml
@@ -51,3 +51,6 @@ proptest.workspace = true
 version = "10"
 features = ["use_pem", "rust_crypto"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-jwk/Cargo.toml
+++ b/crates/uselesskey-jwk/Cargo.toml
@@ -26,3 +26,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-pgp-native/Cargo.toml
+++ b/crates/uselesskey-pgp-native/Cargo.toml
@@ -29,3 +29,6 @@ pgp-native = ["dep:uselesskey-pgp"]
 uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.6.0" }
 uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -28,3 +28,6 @@ insta.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-pkcs11-mock/Cargo.toml
+++ b/crates/uselesskey-pkcs11-mock/Cargo.toml
@@ -20,3 +20,6 @@ sha2.workspace = true
 
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+
+[lints]
+workspace = true

--- a/crates/uselesskey-ring/Cargo.toml
+++ b/crates/uselesskey-ring/Cargo.toml
@@ -39,3 +39,6 @@ serde.workspace = true
 insta.workspace = true
 proptest.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-rsa/Cargo.toml
+++ b/crates/uselesskey-rsa/Cargo.toml
@@ -43,3 +43,6 @@ proptest.workspace = true
 rstest.workspace = true
 serde.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-rustcrypto/Cargo.toml
+++ b/crates/uselesskey-rustcrypto/Cargo.toml
@@ -51,3 +51,6 @@ rsa = { workspace = true, features = ["sha2"] }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -53,3 +53,6 @@ serde.workspace = true
 insta.workspace = true
 proptest.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-ssh/Cargo.toml
+++ b/crates/uselesskey-ssh/Cargo.toml
@@ -24,3 +24,6 @@ proptest.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-test-grid/Cargo.toml
+++ b/crates/uselesskey-test-grid/Cargo.toml
@@ -20,3 +20,6 @@ uselesskey-feature-grid.workspace = true
 [dev-dependencies]
 uselesskey-feature-grid.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-test-server/Cargo.toml
+++ b/crates/uselesskey-test-server/Cargo.toml
@@ -31,3 +31,6 @@ uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", features = ["j
 
 [dev-dependencies]
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
+
+[lints]
+workspace = true

--- a/crates/uselesskey-token-spec/Cargo.toml
+++ b/crates/uselesskey-token-spec/Cargo.toml
@@ -21,3 +21,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -29,3 +29,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-tonic/Cargo.toml
+++ b/crates/uselesskey-tonic/Cargo.toml
@@ -32,3 +32,6 @@ proptest.workspace = true
 serde.workspace = true
 insta.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-webauthn/Cargo.toml
+++ b/crates/uselesskey-webauthn/Cargo.toml
@@ -23,3 +23,6 @@ sha2.workspace = true
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-webhook/Cargo.toml
+++ b/crates/uselesskey-webhook/Cargo.toml
@@ -29,3 +29,6 @@ insta.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-x509/Cargo.toml
+++ b/crates/uselesskey-x509/Cargo.toml
@@ -40,3 +40,6 @@ rstest.workspace = true
 insta.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey/Cargo.toml
+++ b/crates/uselesskey/Cargo.toml
@@ -85,3 +85,6 @@ rustls-pki-types.workspace = true
 name = "keygen"
 harness = false
 required-features = ["full"]
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,59 @@
+# Clippy policy
+
+`uselesskey` treats Clippy as a governed engineering surface. The workspace policy is shared with the broader Effortless Metrics Rust platform: strict defaults, explicit suppressions, and expiring debt rather than silent carveouts.
+
+## Baseline
+
+The root `Cargo.toml` owns the active lint baseline in `[workspace.lints.rust]` and `[workspace.lints.clippy]`. Every workspace member inherits it with:
+
+```toml
+[lints]
+workspace = true
+```
+
+The active baseline covers:
+
+- panic-free production and test code (`unwrap`, `expect`, `panic!`, `todo!`, `unimplemented!`, `unreachable!`);
+- silent-failure prevention (`let _` on important results, ignored `Result::ok`, ignored `map_err`);
+- AST, UTF-8, string, slice, file, path, async, unsafe, memory, numeric, and trait-correctness footguns;
+- good-taste reviewability lints that reduce allocation noise and make public contracts easier to audit;
+- suppression governance.
+
+## No test carveouts
+
+Tests follow the same panic-free posture as production code. Do not add these `clippy.toml` carveouts:
+
+```toml
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-indexing-slicing-in-tests = true
+allow-dbg-in-tests = true
+```
+
+Prefer fallible tests that return `Result` and propagate fixture setup errors with `?`.
+
+## Suppression style
+
+Use narrow `#[expect(..., reason = "...")]` suppressions when a lint exception is intentional and local. Do not use broad `#[allow(...)]` suppression unless a policy check has a dedicated exception for generated code or a similarly reviewed surface.
+
+Example:
+
+```rust
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "test vector arithmetic intentionally exercises wrapping behavior"
+)]
+fn wrapping_vector_case() {
+    // ...
+}
+```
+
+## Policy ledgers
+
+- `policy/clippy-lints.toml` records the active platform posture and planned Rust 1.94/1.95 lint flips.
+- `policy/clippy-debt.toml` records temporary repo-local debt with lint, path, owner, reason, and expiry.
+- `policy/no-panic-allowlist.toml` is reserved for semantic panic-family exceptions using path + family + selector identity.
+- `policy/non-rust-allowlist.toml` records reviewed non-Rust surfaces with owner, reason, classification, and CI coverage.
+
+Run `cargo xtask check-lint-policy` before review to verify the policy files and workspace inheritance stay coherent.

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,11 @@
+schema = 1
+
+# Temporary lint exceptions belong here, not in clippy.toml carveouts or broad crate-level allows.
+#
+# Example:
+# [[debt]]
+# lint = "clippy::indexing_slicing"
+# path = "crates/example/src/parser/table.rs"
+# owner = "parser"
+# reason = "Generated table access; replace with checked table abstraction."
+# expires = "2026-07-01"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,68 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Prefer the standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Avoid stale numeric type drift."
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,4 @@
+schema_version = "0.3"
+
+# Semantic panic-family exceptions use path + family + selector as identity.
+# last_seen is advisory and should only help humans repair drift.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,28 @@
+schema_version = "1.0"
+
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+surface = "ci"
+classification = "config"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "docs/**/*.md"
+kind = "documentation"
+owner = "docs"
+reason = "Repository user guides, design records, and policy documentation are Markdown by design."
+surface = "docs"
+classification = "config"
+covered_by = ["cargo xtask docs-sync --check"]
+
+[[allow]]
+glob = "tests/fixtures/**"
+kind = "fixture_input"
+owner = "test-infra"
+reason = "Fixture workspaces intentionally contain source and metadata files consumed by integration tests."
+surface = "fixtures"
+classification = "test"
+covered_by = ["cargo xtask test"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92"
+channel = "1.93"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -313,3 +313,6 @@ required-features = ["api-surface"]
 name = "security_invariants"
 path = "security_invariants.rs"
 required-features = ["security-invariants"]
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -22,7 +22,11 @@ owo-colors = "4.0"
 regex = "1.11"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+toml.workspace = true
 uselesskey-feature-grid.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/xtask/src/lint_policy.rs
+++ b/xtask/src/lint_policy.rs
@@ -1,0 +1,470 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use chrono::{NaiveDate, Utc};
+use toml::Value;
+
+const ROOT_MANIFEST: &str = "Cargo.toml";
+const CLIPPY_TOML: &str = "clippy.toml";
+const CLIPPY_POLICY: &str = "policy/clippy-lints.toml";
+const CLIPPY_DEBT: &str = "policy/clippy-debt.toml";
+const NO_PANIC_ALLOWLIST: &str = "policy/no-panic-allowlist.toml";
+const NON_RUST_ALLOWLIST: &str = "policy/non-rust-allowlist.toml";
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+const REQUIRED_RUST_LINTS: &[(&str, &str)] = &[
+    ("unsafe_code", "forbid"),
+    ("unsafe_op_in_unsafe_fn", "deny"),
+    ("unused_must_use", "deny"),
+    ("unexpected_cfgs", "warn"),
+    ("const_item_interior_mutations", "deny"),
+    ("function_casts_as_integer", "deny"),
+];
+
+const REQUIRED_CLIPPY_LINTS: &[(&str, &str)] = &[
+    ("dbg_macro", "deny"),
+    ("todo", "deny"),
+    ("unimplemented", "deny"),
+    ("panic", "deny"),
+    ("unreachable", "deny"),
+    ("unwrap_used", "deny"),
+    ("expect_used", "deny"),
+    ("get_unwrap", "deny"),
+    ("unwrap_in_result", "deny"),
+    ("panic_in_result_fn", "deny"),
+    ("string_slice", "deny"),
+    ("indexing_slicing", "deny"),
+    ("out_of_bounds_indexing", "deny"),
+    ("unchecked_time_subtraction", "deny"),
+    ("char_indices_as_byte_indices", "deny"),
+    ("sliced_string_as_bytes", "deny"),
+    ("index_refutable_slice", "deny"),
+    ("let_underscore_future", "deny"),
+    ("let_underscore_must_use", "deny"),
+    ("let_underscore_lock", "deny"),
+    ("unused_result_ok", "deny"),
+    ("map_err_ignore", "deny"),
+    ("assertions_on_result_states", "deny"),
+    ("lines_filter_map_ok", "deny"),
+    ("await_holding_lock", "deny"),
+    ("await_holding_refcell_ref", "deny"),
+    ("await_holding_invalid_type", "deny"),
+    ("future_not_send", "warn"),
+    ("large_futures", "warn"),
+    ("arc_with_non_send_sync", "deny"),
+    ("rc_mutex", "deny"),
+    ("mut_mutex_lock", "deny"),
+    ("readonly_write_lock", "deny"),
+    ("mem_forget", "deny"),
+    ("forget_non_drop", "deny"),
+    ("drop_non_drop", "deny"),
+    ("undocumented_unsafe_blocks", "deny"),
+    ("multiple_unsafe_ops_per_block", "deny"),
+    ("repr_packed_without_abi", "deny"),
+    ("float_cmp", "deny"),
+    ("float_cmp_const", "deny"),
+    ("float_equality_without_abs", "deny"),
+    ("lossy_float_literal", "deny"),
+    ("cast_sign_loss", "deny"),
+    ("cast_possible_wrap", "warn"),
+    ("cast_possible_truncation", "warn"),
+    ("cast_precision_loss", "warn"),
+    ("invalid_upcast_comparisons", "deny"),
+    ("cast_abs_to_unsigned", "deny"),
+    ("cast_enum_truncation", "deny"),
+    ("cast_nan_to_int", "deny"),
+    ("manual_midpoint", "warn"),
+    ("manual_is_multiple_of", "warn"),
+    ("manual_div_ceil", "warn"),
+    ("arithmetic_side_effects", "warn"),
+    ("suspicious_open_options", "deny"),
+    ("nonsensical_open_options", "deny"),
+    ("ineffective_open_options", "deny"),
+    ("path_buf_push_overwrite", "deny"),
+    ("join_absolute_paths", "deny"),
+    ("read_line_without_trim", "warn"),
+    ("exit", "deny"),
+    ("iter_not_returning_iterator", "deny"),
+    ("expl_impl_clone_on_copy", "deny"),
+    ("infallible_try_from", "deny"),
+    ("fallible_impl_from", "deny"),
+    ("error_impl_error", "deny"),
+    ("result_unit_err", "warn"),
+    ("result_large_err", "warn"),
+    ("format_in_format_args", "deny"),
+    ("to_string_in_format_args", "deny"),
+    ("unused_format_specs", "deny"),
+    ("unnecessary_debug_formatting", "warn"),
+    ("uninlined_format_args", "warn"),
+    ("manual_let_else", "warn"),
+    ("manual_ok_or", "warn"),
+    ("manual_strip", "warn"),
+    ("manual_split_once", "warn"),
+    ("manual_is_variant_and", "warn"),
+    ("filter_map_next", "warn"),
+    ("flat_map_option", "warn"),
+    ("match_result_ok", "deny"),
+    ("cloned_instead_of_copied", "warn"),
+    ("iter_cloned_collect", "warn"),
+    ("iter_overeager_cloned", "warn"),
+    ("needless_collect", "warn"),
+    ("redundant_closure", "warn"),
+    ("redundant_closure_for_method_calls", "warn"),
+    ("missing_panics_doc", "deny"),
+    ("missing_errors_doc", "warn"),
+    ("allow_attributes", "deny"),
+    ("allow_attributes_without_reason", "deny"),
+    ("blanket_clippy_restriction_lints", "deny"),
+    ("ignore_without_reason", "deny"),
+    ("should_panic_without_expect", "deny"),
+];
+
+const EXPECTED_PLANNED: &[(&str, &str, &str)] = &[
+    ("clippy::same_length_and_capacity", "deny", "1.94"),
+    ("clippy::manual_ilog2", "warn", "1.94"),
+    ("clippy::decimal_bitwise_operands", "warn", "1.94"),
+    ("clippy::needless_type_cast", "warn", "1.94"),
+    ("clippy::disallowed_fields", "deny", "1.95"),
+    ("clippy::manual_checked_ops", "warn", "1.95"),
+    ("clippy::manual_take", "warn", "1.95"),
+    ("clippy::manual_pop_if", "warn", "1.95"),
+    ("clippy::duration_suboptimal_units", "warn", "1.95"),
+    ("clippy::unnecessary_trailing_comma", "warn", "1.95"),
+];
+
+pub fn check_lint_policy() -> Result<()> {
+    let root = read_toml(ROOT_MANIFEST)?;
+    let policy = read_toml(CLIPPY_POLICY)?;
+
+    check_msrv(&root, &policy)?;
+    check_workspace_lints(&root)?;
+    check_member_lint_inheritance(&root)?;
+    check_no_test_carveouts()?;
+    check_planned_lints(&root, &policy)?;
+    check_debt_file()?;
+    check_allowlist_schema(NO_PANIC_ALLOWLIST, AllowlistKind::NoPanic)?;
+    check_allowlist_schema(NON_RUST_ALLOWLIST, AllowlistKind::NonRust)?;
+
+    println!("lint policy: ok");
+    Ok(())
+}
+
+pub fn check_no_panic_family() -> Result<()> {
+    check_allowlist_schema(NO_PANIC_ALLOWLIST, AllowlistKind::NoPanic)?;
+    println!("no-panic allowlist schema: ok");
+    Ok(())
+}
+
+pub fn check_file_policy() -> Result<()> {
+    check_allowlist_schema(NON_RUST_ALLOWLIST, AllowlistKind::NonRust)?;
+    println!("non-rust file policy schema: ok");
+    Ok(())
+}
+
+pub fn policy_report() -> Result<()> {
+    let policy = read_toml(CLIPPY_POLICY)?;
+    let planned = policy
+        .get("planned")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let debt = read_toml(CLIPPY_DEBT)?
+        .get("debt")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let no_panic = read_toml(NO_PANIC_ALLOWLIST)?
+        .get("allow")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let non_rust = read_toml(NON_RUST_ALLOWLIST)?
+        .get("allow")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+
+    println!("policy report");
+    println!("  clippy planned flips: {planned}");
+    println!("  clippy debt entries: {debt}");
+    println!("  panic exceptions: {no_panic}");
+    println!("  non-rust exceptions: {non_rust}");
+    Ok(())
+}
+
+fn check_msrv(root: &Value, policy: &Value) -> Result<()> {
+    let manifest_msrv = root
+        .get("workspace")
+        .and_then(|v| v.get("package"))
+        .and_then(|v| v.get("rust-version"))
+        .and_then(Value::as_str)
+        .context("missing workspace.package.rust-version")?;
+    let policy_msrv = policy
+        .get("msrv")
+        .and_then(Value::as_str)
+        .context("missing policy/clippy-lints.toml msrv")?;
+    if manifest_msrv != policy_msrv {
+        bail!("workspace MSRV {manifest_msrv} does not match clippy policy MSRV {policy_msrv}");
+    }
+
+    let clippy = fs::read_to_string(CLIPPY_TOML).context("failed to read clippy.toml")?;
+    if !clippy.contains(&format!("msrv = \"{policy_msrv}\"")) {
+        bail!("clippy.toml msrv must match policy MSRV {policy_msrv}");
+    }
+    Ok(())
+}
+
+fn check_workspace_lints(root: &Value) -> Result<()> {
+    let rust_lints = root
+        .get("workspace")
+        .and_then(|v| v.get("lints"))
+        .and_then(|v| v.get("rust"))
+        .and_then(Value::as_table)
+        .context("missing [workspace.lints.rust]")?;
+    for (lint, level) in REQUIRED_RUST_LINTS {
+        require_lint_level(rust_lints, lint, level, "workspace.lints.rust")?;
+    }
+
+    let clippy_lints = root
+        .get("workspace")
+        .and_then(|v| v.get("lints"))
+        .and_then(|v| v.get("clippy"))
+        .and_then(Value::as_table)
+        .context("missing [workspace.lints.clippy]")?;
+    for (lint, level) in REQUIRED_CLIPPY_LINTS {
+        require_lint_level(clippy_lints, lint, level, "workspace.lints.clippy")?;
+    }
+    Ok(())
+}
+
+fn check_member_lint_inheritance(root: &Value) -> Result<()> {
+    let members = root
+        .get("workspace")
+        .and_then(|v| v.get("members"))
+        .and_then(Value::as_array)
+        .context("missing workspace.members")?;
+
+    let mut missing = Vec::new();
+    for member in members {
+        let member = member
+            .as_str()
+            .context("workspace.members must contain strings")?;
+        let manifest_path = Path::new(member).join("Cargo.toml");
+        let manifest = read_toml(&manifest_path)?;
+        let inherits = manifest
+            .get("lints")
+            .and_then(|v| v.get("workspace"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !inherits {
+            missing.push(manifest_path.display().to_string());
+        }
+    }
+
+    if !missing.is_empty() {
+        bail!(
+            "workspace members missing `[lints] workspace = true`: {}",
+            missing.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn check_no_test_carveouts() -> Result<()> {
+    let clippy = fs::read_to_string(CLIPPY_TOML).context("failed to read clippy.toml")?;
+    for carveout in TEST_CARVEOUTS {
+        if clippy.contains(carveout) {
+            bail!("clippy.toml must not configure test carveout `{carveout}`");
+        }
+    }
+    Ok(())
+}
+
+fn check_planned_lints(root: &Value, policy: &Value) -> Result<()> {
+    let planned = policy
+        .get("planned")
+        .and_then(Value::as_array)
+        .context("policy/clippy-lints.toml must contain [[planned]] entries")?;
+
+    for (name, level, msrv) in EXPECTED_PLANNED {
+        let found = planned.iter().any(|entry| {
+            entry.get("name").and_then(Value::as_str) == Some(*name)
+                && entry.get("level").and_then(Value::as_str) == Some(*level)
+                && entry.get("activate_when_msrv").and_then(Value::as_str) == Some(*msrv)
+                && entry
+                    .get("reason")
+                    .and_then(Value::as_str)
+                    .is_some_and(non_empty)
+        });
+        if !found {
+            bail!("missing planned lint `{name}` at {level} for MSRV {msrv}");
+        }
+    }
+
+    let clippy_lints = root
+        .get("workspace")
+        .and_then(|v| v.get("lints"))
+        .and_then(|v| v.get("clippy"))
+        .and_then(Value::as_table)
+        .context("missing [workspace.lints.clippy]")?;
+    for entry in planned {
+        let name = required_str(entry, "name")?;
+        let short_name = name.strip_prefix("clippy::").unwrap_or(name);
+        if clippy_lints.contains_key(short_name) {
+            bail!("planned lint `{name}` is active before its MSRV flip");
+        }
+    }
+    Ok(())
+}
+
+fn check_debt_file() -> Result<()> {
+    let debt = read_toml(CLIPPY_DEBT)?;
+    if let Some(entries) = debt.get("debt").and_then(Value::as_array) {
+        for entry in entries {
+            for field in ["lint", "path", "owner", "reason", "expires"] {
+                required_str(entry, field)
+                    .with_context(|| format!("invalid clippy debt entry: missing {field}"))?;
+            }
+            check_not_expired(required_str(entry, "expires")?, "clippy debt")?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum AllowlistKind {
+    NoPanic,
+    NonRust,
+}
+
+fn check_allowlist_schema(path: impl AsRef<Path>, kind: AllowlistKind) -> Result<()> {
+    let value = read_toml(path.as_ref())?;
+    let entries = value
+        .get("allow")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    for entry in &entries {
+        match kind {
+            AllowlistKind::NoPanic => check_no_panic_entry(entry)?,
+            AllowlistKind::NonRust => check_non_rust_entry(entry)?,
+        }
+    }
+    Ok(())
+}
+
+fn check_no_panic_entry(entry: &Value) -> Result<()> {
+    for field in ["path", "family", "classification", "owner", "explanation"] {
+        required_str(entry, field)
+            .with_context(|| format!("invalid no-panic allow entry: missing {field}"))?;
+    }
+    let selector = entry
+        .get("selector")
+        .and_then(Value::as_table)
+        .context("invalid no-panic allow entry: missing selector")?;
+    for field in ["kind", "container"] {
+        require_table_str(selector, field)
+            .with_context(|| format!("invalid no-panic selector: missing {field}"))?;
+    }
+    if let Some(expires) = entry.get("expires").and_then(Value::as_str) {
+        check_not_expired(expires, "no-panic allow entry")?;
+    }
+    Ok(())
+}
+
+fn check_non_rust_entry(entry: &Value) -> Result<()> {
+    let has_path = entry
+        .get("path")
+        .and_then(Value::as_str)
+        .is_some_and(non_empty);
+    let has_glob = entry
+        .get("glob")
+        .and_then(Value::as_str)
+        .is_some_and(non_empty);
+    if has_path == has_glob {
+        bail!("non-rust allow entry must set exactly one of path or glob");
+    }
+    for field in ["kind", "owner", "reason", "surface", "classification"] {
+        required_str(entry, field)
+            .with_context(|| format!("invalid non-rust allow entry: missing {field}"))?;
+    }
+    let covered_by = entry
+        .get("covered_by")
+        .and_then(Value::as_array)
+        .context("invalid non-rust allow entry: missing covered_by")?;
+    if covered_by
+        .iter()
+        .filter_map(Value::as_str)
+        .all(|item| item.trim().is_empty())
+    {
+        bail!("non-rust allow entry must have at least one non-empty covered_by command");
+    }
+    if let Some(expires) = entry.get("expires").and_then(Value::as_str) {
+        check_not_expired(expires, "non-rust allow entry")?;
+    }
+    Ok(())
+}
+
+fn check_not_expired(expires: &str, label: &str) -> Result<()> {
+    let expires = NaiveDate::parse_from_str(expires, "%Y-%m-%d")
+        .with_context(|| format!("invalid {label} expiry date `{expires}`"))?;
+    let today = Utc::now().date_naive();
+    if expires < today {
+        bail!("expired {label} entry with expiry {expires}");
+    }
+    Ok(())
+}
+
+fn require_lint_level(
+    table: &toml::map::Map<String, Value>,
+    lint: &str,
+    expected: &str,
+    table_name: &str,
+) -> Result<()> {
+    let actual = table
+        .get(lint)
+        .and_then(Value::as_str)
+        .with_context(|| format!("missing lint `{lint}` in {table_name}"))?;
+    if actual != expected {
+        bail!("lint `{lint}` in {table_name} must be `{expected}`, found `{actual}`");
+    }
+    Ok(())
+}
+
+fn required_str<'a>(value: &'a Value, field: &str) -> Result<&'a str> {
+    let value = value
+        .get(field)
+        .and_then(Value::as_str)
+        .with_context(|| format!("missing string field `{field}`"))?;
+    if value.trim().is_empty() {
+        bail!("field `{field}` must not be empty");
+    }
+    Ok(value)
+}
+
+fn require_table_str<'a>(table: &'a toml::map::Map<String, Value>, field: &str) -> Result<&'a str> {
+    let value = table
+        .get(field)
+        .and_then(Value::as_str)
+        .with_context(|| format!("missing string field `{field}`"))?;
+    if value.trim().is_empty() {
+        bail!("field `{field}` must not be empty");
+    }
+    Ok(value)
+}
+
+fn read_toml(path: impl AsRef<Path>) -> Result<Value> {
+    let path = path.as_ref();
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    toml::from_str::<Value>(&raw).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn non_empty(value: &str) -> bool {
+    !value.trim().is_empty()
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@ use uselesskey_feature_grid::{BDD_FEATURE_MATRIX, CORE_FEATURE_MATRIX};
 mod audit_surface;
 mod docs_sync;
 mod economics;
+mod lint_policy;
 mod plan;
 mod pr_bundles;
 mod receipt;
@@ -139,6 +140,14 @@ enum Cmd {
         #[arg(long)]
         check: bool,
     },
+    /// Verify the governed Clippy lint policy and ledgers.
+    CheckLintPolicy,
+    /// Validate the semantic no-panic allowlist schema.
+    CheckNoPanicFamily,
+    /// Validate the non-Rust file policy allowlist schema.
+    CheckFilePolicy,
+    /// Print a concise policy ledger summary.
+    PolicyReport,
     /// Configure git hooks (sets core.hooksPath to .githooks).
     Setup,
     /// Lint commit message (used by git hooks).
@@ -273,6 +282,10 @@ fn main() -> Result<()> {
         Cmd::Fuzz { target, args } => fuzz(target.as_deref(), &args),
         Cmd::LintFix { check, no_clippy } => lint_fix(check, no_clippy),
         Cmd::Gate { check: _ } => gate(),
+        Cmd::CheckLintPolicy => lint_policy::check_lint_policy(),
+        Cmd::CheckNoPanicFamily => lint_policy::check_no_panic_family(),
+        Cmd::CheckFilePolicy => lint_policy::check_file_policy(),
+        Cmd::PolicyReport => lint_policy::policy_report(),
         Cmd::Setup => setup(),
         Cmd::CommitLint { message_file } => commit_lint(&message_file),
         Cmd::Hook { hook } => match hook {


### PR DESCRIPTION
### Motivation

- Establish a single, governed Clippy baseline for the workspace (MSRV 1.93) enforcing panic-free code, no silent failures, AST/string/index safety, and suppression governance. 
- Provide machine-readable policy ledgers and programmatic checks so exceptions are tracked as expiring debt and non-Rust surfaces are reviewed instead of silently allowed.
- Make policy verification part of repo automation (`xtask`) so CI can validate MSRV/lint inheritance/no-test-carveouts/planned flips and allowlist schemas.

### Description

- Bumped workspace MSRV to `1.93` and updated `rust-toolchain.toml` and `clippy.toml` accordingly.
- Added an explicit workspace lint baseline under `[workspace.lints.rust]` and `[workspace.lints.clippy]` in `Cargo.toml` and added `[lints] workspace = true` to workspace member manifests so crates inherit the policy.
- Added policy ledgers and allowlists: `policy/clippy-lints.toml`, `policy/clippy-debt.toml`, `policy/no-panic-allowlist.toml`, and `policy/non-rust-allowlist.toml`, plus `docs/CLIPPY_POLICY.md` documenting the posture and suppression style.
- Added an `xtask` policy checker: `xtask/src/lint_policy.rs` and wired new CLI commands (`CheckLintPolicy`, `CheckNoPanicFamily`, `CheckFilePolicy`, `PolicyReport`) into `xtask/src/main.rs`, and added `toml` as an `xtask` dependency to parse the ledgers.
- Implemented policy checks for MSRV alignment, workspace lint presence, member inheritance (`[lints] workspace = true`), ban on test-carveouts in `clippy.toml`, planned 1.94/1.95 flip ledger presence, debt schema validation, and allowlist schema validation for panic and non-Rust entries.

### Testing

- Ran `cargo xtask fmt` and formatting checks succeeded.
- Ran `cargo xtask check-lint-policy`, `cargo xtask check-no-panic-family`, `cargo xtask check-file-policy`, and `cargo xtask policy-report`; all policy/check commands succeeded and reported the new ledger counts.
- Ran `cargo check -p xtask` and the `xtask` binary builds OK; `cargo xtask no-blob` completed successfully and `git diff --check` reported no whitespace errors.
- Ran `cargo clippy -p xtask -- -D warnings` to validate the stricter Clippy posture; it fails on existing lint debt (multiple `#[allow]` usages without `#[expect(..., reason = "...")]`, `expect`/`unwrap`/`unwrap_used`, indexing/string-slicing, arithmetic-side-effect/precision casts, and other reviewability lints) and will be addressed in follow-up cleanup PR(s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb08642b3c8333a79272824150d014)