### PR TITLE
feat(jwk): add negative fixture shapes

### DIFF
--- a/crates/uselesskey-core-jwk-shape/README.md
+++ b/crates/uselesskey-core-jwk-shape/README.md
@@ -5,5 +5,6 @@ Core typed JWK and JWKS model definitions for `uselesskey` fixture crates.
 ## Purpose
 
 - Provide stable JWK shape structures (`PublicJwk`, `PrivateJwk`, `AnyJwk`, and `Jwks`).
+- Provide scanner-safe negative JWK/JWKS shapes for downstream parser tests.
 - Keep shape modeling separate from ordering/building behavior.
 - Re-exported through `uselesskey-core-jwk` for compatibility.

--- a/crates/uselesskey-core-jwk-shape/src/lib.rs
+++ b/crates/uselesskey-core-jwk-shape/src/lib.rs
@@ -34,8 +34,11 @@
 //! ```
 
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::fmt;
+
+const SCANNER_SAFE_INVALID_MATERIAL: &str = "not_base64url!*";
+const SCANNER_SAFE_MISMATCHED_MATERIAL: &str = "AAAA";
 
 /// A JSON Web Key Set containing zero or more JWK entries.
 #[derive(Clone, Serialize)]
@@ -49,6 +52,37 @@ impl Jwks {
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).expect("serialize JWKS")
     }
+
+    /// Serialize a shape-realistic negative JWKS fixture.
+    pub fn negative_value(&self, variant: NegativeJwks) -> Value {
+        let keys: Vec<Value> = self.keys.iter().map(AnyJwk::to_value).collect();
+        let negative_keys = match variant {
+            NegativeJwks::EmptyKeys => Vec::new(),
+            NegativeJwks::MissingKid => {
+                vec![negative_jwk_value(
+                    first_or_scanner_safe_key(&keys, "missing-kid"),
+                    NegativeJwk::MissingKid,
+                )]
+            }
+            NegativeJwks::DuplicateKid => {
+                let mut first = first_or_scanner_safe_key(&keys, "duplicate-kid");
+                set_string_field(&mut first, "kid", "duplicate-kid");
+                let mut second = first.clone();
+                set_first_material_field(
+                    &mut second,
+                    &["n", "x", "k", "d", "e", "y", "p", "q", "dp", "dq", "qi"],
+                    SCANNER_SAFE_MISMATCHED_MATERIAL,
+                );
+                vec![first, second]
+            }
+            NegativeJwks::DuplicateKey => {
+                let first = first_or_scanner_safe_key(&keys, "duplicate-key");
+                vec![first.clone(), first]
+            }
+        };
+
+        json!({ "keys": negative_keys })
+    }
 }
 
 impl fmt::Display for Jwks {
@@ -56,6 +90,34 @@ impl fmt::Display for Jwks {
         let s = serde_json::to_string(self).expect("serialize JWKS");
         f.write_str(&s)
     }
+}
+
+/// Negative JWK shape variants for downstream parser and validator tests.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NegativeJwk {
+    /// Remove the `kid` field from an otherwise realistic JWK.
+    MissingKid,
+    /// Replace one material field with scanner-safe invalid base64url text.
+    MalformedField,
+    /// Replace `kty` with a key type that does not match the material fields.
+    WrongKty,
+    /// Replace `alg` with an unsupported algorithm name.
+    UnsupportedAlg,
+    /// Change one material parameter while preserving the metadata shape.
+    MismatchedParameters,
+}
+
+/// Negative JWKS shape variants for downstream key-set tests.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NegativeJwks {
+    /// Emit an empty `keys` array.
+    EmptyKeys,
+    /// Remove `kid` from a key inside the set.
+    MissingKid,
+    /// Emit two distinct keys with the same `kid`.
+    DuplicateKid,
+    /// Emit the same key twice.
+    DuplicateKey,
 }
 
 /// RSA public key in JWK format (contains `n` and `e`).
@@ -265,6 +327,11 @@ impl PublicJwk {
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).expect("serialize JWK")
     }
+
+    /// Serialize a shape-realistic negative JWK fixture.
+    pub fn negative_value(&self, variant: NegativeJwk) -> Value {
+        negative_jwk_value(self.to_value(), variant)
+    }
 }
 
 impl fmt::Display for PublicJwk {
@@ -302,6 +369,11 @@ impl PrivateJwk {
     /// Serialize to a [`serde_json::Value`].
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).expect("serialize JWK")
+    }
+
+    /// Serialize a shape-realistic negative JWK fixture.
+    pub fn negative_value(&self, variant: NegativeJwk) -> Value {
+        negative_jwk_value(self.to_value(), variant)
     }
 }
 
@@ -346,6 +418,11 @@ impl AnyJwk {
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).expect("serialize JWK")
     }
+
+    /// Serialize a shape-realistic negative JWK fixture.
+    pub fn negative_value(&self, variant: NegativeJwk) -> Value {
+        negative_jwk_value(self.to_value(), variant)
+    }
 }
 
 impl fmt::Display for AnyJwk {
@@ -364,6 +441,78 @@ impl From<PublicJwk> for AnyJwk {
 impl From<PrivateJwk> for AnyJwk {
     fn from(value: PrivateJwk) -> Self {
         AnyJwk::Private(value)
+    }
+}
+
+fn negative_jwk_value(mut value: Value, variant: NegativeJwk) -> Value {
+    match variant {
+        NegativeJwk::MissingKid => {
+            if let Some(obj) = value.as_object_mut() {
+                obj.remove("kid");
+            }
+        }
+        NegativeJwk::MalformedField => {
+            set_first_material_field(
+                &mut value,
+                &["n", "e", "x", "y", "k", "d", "p", "q", "dp", "dq", "qi"],
+                SCANNER_SAFE_INVALID_MATERIAL,
+            );
+        }
+        NegativeJwk::WrongKty => {
+            if let Some(obj) = value.as_object_mut() {
+                let wrong_kty = if obj.get("kty").and_then(Value::as_str) == Some("RSA") {
+                    "EC"
+                } else {
+                    "RSA"
+                };
+                obj.insert("kty".to_string(), Value::String(wrong_kty.to_string()));
+            }
+        }
+        NegativeJwk::UnsupportedAlg => {
+            set_string_field(&mut value, "alg", "UK-UNSUPPORTED");
+        }
+        NegativeJwk::MismatchedParameters => {
+            set_first_material_field(
+                &mut value,
+                &["d", "k", "n", "x", "y", "e", "p", "q", "dp", "dq", "qi"],
+                SCANNER_SAFE_MISMATCHED_MATERIAL,
+            );
+        }
+    }
+    value
+}
+
+fn first_or_scanner_safe_key(keys: &[Value], kid: &str) -> Value {
+    keys.first()
+        .cloned()
+        .unwrap_or_else(|| scanner_safe_rsa_public(kid))
+}
+
+fn scanner_safe_rsa_public(kid: &str) -> Value {
+    json!({
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": kid,
+        "n": "AAAA",
+        "e": "AQAB",
+    })
+}
+
+fn set_string_field(value: &mut Value, field: &str, replacement: &str) {
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(field.to_string(), Value::String(replacement.to_string()));
+    }
+}
+
+fn set_first_material_field(value: &mut Value, fields: &[&str], replacement: &str) {
+    if let Some(obj) = value.as_object_mut() {
+        let field = fields
+            .iter()
+            .find(|field| obj.contains_key(**field))
+            .copied()
+            .unwrap_or("x");
+        obj.insert(field.to_string(), Value::String(replacement.to_string()));
     }
 }
 

--- a/crates/uselesskey-core-jwk-shape/tests/negative_fixtures.rs
+++ b/crates/uselesskey-core-jwk-shape/tests/negative_fixtures.rs
@@ -1,0 +1,202 @@
+use serde_json::Value;
+use uselesskey_core_jwk_shape::{
+    AnyJwk, EcPublicJwk, Jwks, NegativeJwk, NegativeJwks, OctJwk, PrivateJwk, PublicJwk,
+    RsaPrivateJwk, RsaPublicJwk,
+};
+
+fn rsa_public(kid: &str) -> PublicJwk {
+    PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.to_string(),
+        n: "modulus".to_string(),
+        e: "AQAB".to_string(),
+    })
+}
+
+fn rsa_private(kid: &str) -> PrivateJwk {
+    PrivateJwk::Rsa(RsaPrivateJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.to_string(),
+        n: "modulus".to_string(),
+        e: "AQAB".to_string(),
+        d: "private-exponent".to_string(),
+        p: "p".to_string(),
+        q: "q".to_string(),
+        dp: "dp".to_string(),
+        dq: "dq".to_string(),
+        qi: "qi".to_string(),
+    })
+}
+
+fn ec_public(kid: &str) -> PublicJwk {
+    PublicJwk::Ec(EcPublicJwk {
+        kty: "EC",
+        use_: "sig",
+        alg: "ES256",
+        crv: "P-256",
+        kid: kid.to_string(),
+        x: "x-coordinate".to_string(),
+        y: "y-coordinate".to_string(),
+    })
+}
+
+fn oct_private(kid: &str) -> PrivateJwk {
+    PrivateJwk::Oct(OctJwk {
+        kty: "oct",
+        use_: "sig",
+        alg: "HS256",
+        kid: kid.to_string(),
+        k: "symmetric-key".to_string(),
+    })
+}
+
+fn keys(value: &Value) -> &[Value] {
+    value["keys"].as_array().expect("keys array").as_slice()
+}
+
+#[test]
+fn negative_jwk_missing_kid_removes_only_kid() {
+    let value = rsa_public("missing-kid").negative_value(NegativeJwk::MissingKid);
+
+    assert!(value.get("kid").is_none());
+    assert_eq!(value["kty"], "RSA");
+    assert_eq!(value["alg"], "RS256");
+    assert_eq!(value["n"], "modulus");
+}
+
+#[test]
+fn negative_jwk_malformed_field_is_scanner_safe_invalid_material() {
+    let value = rsa_public("bad-field").negative_value(NegativeJwk::MalformedField);
+
+    assert_eq!(value["kid"], "bad-field");
+    assert_eq!(value["kty"], "RSA");
+    assert_eq!(value["n"], "not_base64url!*");
+    assert_ne!(value["n"], "modulus");
+}
+
+#[test]
+fn negative_jwk_wrong_kty_preserves_metadata_and_material() {
+    let value = ec_public("wrong-kty").negative_value(NegativeJwk::WrongKty);
+
+    assert_eq!(value["kid"], "wrong-kty");
+    assert_eq!(value["alg"], "ES256");
+    assert_eq!(value["kty"], "RSA");
+    assert_eq!(value["crv"], "P-256");
+    assert_eq!(value["x"], "x-coordinate");
+}
+
+#[test]
+fn negative_jwk_wrong_kty_changes_rsa_to_ec() {
+    let value = rsa_public("wrong-rsa-kty").negative_value(NegativeJwk::WrongKty);
+
+    assert_eq!(value["kid"], "wrong-rsa-kty");
+    assert_eq!(value["alg"], "RS256");
+    assert_eq!(value["kty"], "EC");
+    assert_eq!(value["n"], "modulus");
+}
+
+#[test]
+fn negative_jwk_unsupported_alg_preserves_key_shape() {
+    let value = oct_private("unsupported-alg").negative_value(NegativeJwk::UnsupportedAlg);
+
+    assert_eq!(value["kid"], "unsupported-alg");
+    assert_eq!(value["kty"], "oct");
+    assert_eq!(value["alg"], "UK-UNSUPPORTED");
+    assert_eq!(value["k"], "symmetric-key");
+}
+
+#[test]
+fn negative_jwk_mismatched_parameters_changes_material_not_identity() {
+    let value = rsa_private("mismatch").negative_value(NegativeJwk::MismatchedParameters);
+
+    assert_eq!(value["kid"], "mismatch");
+    assert_eq!(value["kty"], "RSA");
+    assert_eq!(value["alg"], "RS256");
+    assert_eq!(value["n"], "modulus");
+    assert_eq!(value["d"], "AAAA");
+    assert_ne!(value["d"], "private-exponent");
+}
+
+#[test]
+fn negative_any_jwk_delegates_to_inner_shape() {
+    let jwk = AnyJwk::from(rsa_public("any-negative"));
+
+    let value = jwk.negative_value(NegativeJwk::UnsupportedAlg);
+
+    assert_eq!(value["kid"], "any-negative");
+    assert_eq!(value["kty"], "RSA");
+    assert_eq!(value["alg"], "UK-UNSUPPORTED");
+}
+
+#[test]
+fn negative_jwks_empty_keys_emits_empty_key_set() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(rsa_public("ignored"))],
+    };
+
+    let value = jwks.negative_value(NegativeJwks::EmptyKeys);
+
+    assert_eq!(keys(&value).len(), 0);
+}
+
+#[test]
+fn negative_jwks_missing_kid_removes_kid_from_key() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(rsa_public("missing"))],
+    };
+
+    let value = jwks.negative_value(NegativeJwks::MissingKid);
+    let keys = keys(&value);
+
+    assert_eq!(keys.len(), 1);
+    assert!(keys[0].get("kid").is_none());
+    assert_eq!(keys[0]["kty"], "RSA");
+}
+
+#[test]
+fn negative_jwks_duplicate_kid_uses_distinct_scanner_safe_material() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(rsa_public("dup"))],
+    };
+
+    let value = jwks.negative_value(NegativeJwks::DuplicateKid);
+    let keys = keys(&value);
+
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0]["kid"], "duplicate-kid");
+    assert_eq!(keys[1]["kid"], "duplicate-kid");
+    assert_eq!(keys[0]["kty"], keys[1]["kty"]);
+    assert_ne!(keys[0]["n"], keys[1]["n"]);
+    assert_eq!(keys[1]["n"], "AAAA");
+}
+
+#[test]
+fn negative_jwks_duplicate_key_repeats_exact_key() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(rsa_public("dup-key"))],
+    };
+
+    let value = jwks.negative_value(NegativeJwks::DuplicateKey);
+    let keys = keys(&value);
+
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0], keys[1]);
+    assert_eq!(keys[0]["kid"], "dup-key");
+}
+
+#[test]
+fn negative_jwks_empty_input_still_emits_shape_realistic_key_for_duplicate_cases() {
+    let jwks = Jwks { keys: vec![] };
+
+    let value = jwks.negative_value(NegativeJwks::DuplicateKey);
+    let keys = keys(&value);
+
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0]["kid"], "duplicate-key");
+    assert_eq!(keys[0]["n"], "AAAA");
+    assert_eq!(keys[0], keys[1]);
+}

--- a/crates/uselesskey-jwk/README.md
+++ b/crates/uselesskey-jwk/README.md
@@ -21,6 +21,9 @@ builder.push_private(PrivateJwk::Oct(OctJwk {
 
 let jwks = builder.build();
 assert_eq!(jwks.keys.len(), 1);
+
+let duplicate = jwks.negative_value(uselesskey_jwk::NegativeJwks::DuplicateKey);
+assert_eq!(duplicate["keys"].as_array().unwrap().len(), 2);
 ```
 
 ## License

--- a/crates/uselesskey-jwk/tests/negative_reexports.rs
+++ b/crates/uselesskey-jwk/tests/negative_reexports.rs
@@ -1,0 +1,34 @@
+use uselesskey_jwk::{AnyJwk, Jwks, NegativeJwk, NegativeJwks, PublicJwk, RsaPublicJwk};
+
+fn rsa_public(kid: &str) -> PublicJwk {
+    PublicJwk::Rsa(RsaPublicJwk {
+        kty: "RSA",
+        use_: "sig",
+        alg: "RS256",
+        kid: kid.to_string(),
+        n: "modulus".to_string(),
+        e: "AQAB".to_string(),
+    })
+}
+
+#[test]
+fn facade_reexports_negative_jwk_variants() {
+    let value = rsa_public("facade").negative_value(NegativeJwk::UnsupportedAlg);
+
+    assert_eq!(value["kid"], "facade");
+    assert_eq!(value["alg"], "UK-UNSUPPORTED");
+}
+
+#[test]
+fn facade_reexports_negative_jwks_variants() {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(rsa_public("facade-jwks"))],
+    };
+
+    let value = jwks.negative_value(NegativeJwks::DuplicateKey);
+    let keys = value["keys"].as_array().expect("keys array");
+
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0], keys[1]);
+    assert_eq!(keys[0]["kid"], "facade-jwks");
+}


### PR DESCRIPTION
## Summary
- add `NegativeJwk` and `NegativeJwks` JSON value helpers for scanner-safe JWK/JWKS negative fixture shapes
- cover missing kid, malformed material, wrong kty, unsupported alg, mismatched parameters, empty JWKS, duplicate kid, and duplicate key cases
- re-export the negative fixture API through `uselesskey-jwk` and document the facade path

## Validation
- `cargo fmt -p uselesskey-core-jwk-shape -p uselesskey-jwk -- --check`
- `cargo test -p uselesskey-core-jwk-shape --all-features`
- `cargo test -p uselesskey-jwk --all-features`
- `cargo test -p uselesskey-core-token-shape --all-features`
- `cargo test -p uselesskey --all-features`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask bdd` (523 scenarios: 517 passed, 6 skipped)
- `cargo mutants -p uselesskey-core-jwk-shape --file crates/uselesskey-core-jwk-shape/src/lib.rs --all-features -F "negative|scanner_safe|set_string_field|set_first_material_field|first_or_scanner_safe_key" --baseline skip --timeout 120 -j 4 -v` (10/10 relevant mutants caught)