### PR TITLE
test(pgp): avoid platform-dependent all-spec lengths

### DIFF
--- a/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__all_specs_snapshots__pgp_all_specs_comparison.snap
+++ b/crates/uselesskey-pgp/tests/snapshots/snapshots_pgp__all_specs_snapshots__pgp_all_specs_comparison.snap
@@ -4,14 +4,14 @@ assertion_line: 313
 expression: cases
 ---
 - spec_name: ed25519
-  private_binary_len: 268
-  public_binary_len: 233
+  private_binary_present: true
+  public_binary_present: true
   fingerprint_len: 40
 - spec_name: rsa2048
-  private_binary_len: 1311
-  public_binary_len: 660
+  private_binary_present: true
+  public_binary_present: true
   fingerprint_len: 40
 - spec_name: rsa3072
-  private_binary_len: 1887
-  public_binary_len: 916
+  private_binary_present: true
+  public_binary_present: true
   fingerprint_len: 40

--- a/crates/uselesskey-pgp/tests/snapshots_pgp.rs
+++ b/crates/uselesskey-pgp/tests/snapshots_pgp.rs
@@ -289,8 +289,8 @@ mod all_specs_snapshots {
         #[derive(Serialize)]
         struct SpecInfo {
             spec_name: &'static str,
-            private_binary_len: usize,
-            public_binary_len: usize,
+            private_binary_present: bool,
+            public_binary_present: bool,
             fingerprint_len: usize,
         }
 
@@ -304,8 +304,8 @@ mod all_specs_snapshots {
             let key = fx.pgp(format!("snapshot-all-{name}"), spec);
             SpecInfo {
                 spec_name: name,
-                private_binary_len: key.private_key_binary().len(),
-                public_binary_len: key.public_key_binary().len(),
+                private_binary_present: !key.private_key_binary().is_empty(),
+                public_binary_present: !key.public_key_binary().is_empty(),
                 fingerprint_len: key.fingerprint().len(),
             }
         })


### PR DESCRIPTION
## Summary
- repair post-merge main CI failure in `uselesskey-pgp` all-specs snapshot
- stop pinning exact PGP binary lengths in the aggregate snapshot; individual RSA snapshots already mark those lengths as platform dependent
- keep spec ordering, material presence, and fingerprint-length coverage in the all-specs comparison

## Main failure being fixed
- main run `25434296090` failed in `xtask ci`
- failing test: `cargo test -p uselesskey-pgp --test snapshots_pgp`
- failing snapshot: `all_specs_snapshots::snapshot_pgp_all_specs_comparison`
- observed Linux drift: RSA-2048 private/public binary lengths changed by one byte (`1311/660` -> `1310/659`)

## Validation
- `cargo fmt -p uselesskey-pgp -- --check`
- `cargo test -p uselesskey-pgp --test snapshots_pgp --all-features`
- `cargo test -p uselesskey-pgp --all-features`