### PR TITLE
feat(token): add negative fixture shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added scanner-safe JWK/JWKS and token-shape negative fixture helpers for
+  downstream parser and validator failure-path tests.
+
 ## [0.6.0] - 2026-04-08
 
 ### Added

--- a/crates/uselesskey-core-token-shape/README.md
+++ b/crates/uselesskey-core-token-shape/README.md
@@ -7,6 +7,7 @@ Low-level token shape primitives for `uselesskey`.
 - Generate deterministic and realistic API key shapes.
 - Generate opaque bearer token shapes.
 - Generate OAuth-like JWT-access-token shapes without signing.
+- Generate scanner-safe negative token shapes for downstream validator tests.
 
 This crate intentionally contains only token-shape construction and is used by
 `uselesskey-core-token` and higher-level token fixture crates.

--- a/crates/uselesskey-core-token-shape/src/lib.rs
+++ b/crates/uselesskey-core-token-shape/src/lib.rs
@@ -2,13 +2,15 @@
 
 //! Token shape generation primitives for test fixtures.
 //!
-//! Generates realistic-looking API keys, bearer tokens, and OAuth access
-//! tokens from deterministic seed material.
+//! Generates realistic-looking API keys, bearer tokens, OAuth access tokens,
+//! and scanner-safe negative token shapes from deterministic seed material.
 //!
 //! # Examples
 //!
 //! ```
-//! use uselesskey_core_token_shape::{generate_token, TokenKind, authorization_scheme};
+//! use uselesskey_core_token_shape::{
+//!     NegativeToken, authorization_scheme, generate_negative_token, generate_token, TokenKind,
+//! };
 //! use uselesskey_core_seed::Seed;
 //!
 //! let seed = Seed::new([42u8; 32]);
@@ -24,6 +26,15 @@
 //! // Generate an OAuth access token (JWT-shaped: header.payload.signature)
 //! let oauth = generate_token("my-service", TokenKind::OAuthAccessToken, seed);
 //! assert_eq!(oauth.matches('.').count(), 2);
+//!
+//! // Generate a scanner-safe negative token for validator error paths.
+//! let expired = generate_negative_token(
+//!     "my-service",
+//!     TokenKind::OAuthAccessToken,
+//!     seed,
+//!     NegativeToken::ExpiredClaims,
+//! );
+//! assert_eq!(expired.matches('.').count(), 2);
 //! ```
 
 use base64::Engine as _;
@@ -31,7 +42,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use rand_chacha10::ChaCha20Rng;
 use rand_core10::{Rng, SeedableRng};
 
-use serde_json::json;
+use serde_json::{Map, Value, json};
 pub use uselesskey_core_base62::random_base62;
 use uselesskey_core_seed::Seed;
 
@@ -50,8 +61,61 @@ pub const OAUTH_JTI_BYTES: usize = 16;
 /// Number of random bytes used for OAuth signature-like segment.
 pub const OAUTH_SIGNATURE_BYTES: usize = 32;
 
+const SCANNER_SAFE_INVALID_TOKEN_SEGMENT: &str = "not_base64url!*";
+
+const NEAR_MISS_API_KEY_PREFIX: &str = "uk_tset_";
+
 /// Token shape kind.
 pub use uselesskey_token_spec::TokenSpec as TokenKind;
+
+/// Negative token shape variants for downstream parser and validator tests.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NegativeToken {
+    /// Emit a JWT-like value with the wrong number of dot-separated segments.
+    MalformedJwtSegmentCount,
+    /// Replace one JWT segment with scanner-safe invalid base64url text.
+    BadBase64UrlSegment,
+    /// Encode a JWT header that is JSON, but not a header object.
+    InvalidJwtHeaderShape,
+    /// Remove `alg` from the JWT header.
+    MissingAlg,
+    /// Set the JWT header algorithm to `none`.
+    AlgNone,
+    /// Emit different `kid` values in the header and payload.
+    MismatchedKid,
+    /// Set an already-expired `exp` claim.
+    ExpiredClaims,
+    /// Set a future `nbf` claim.
+    NotYetValidClaims,
+    /// Replace the expected issuer claim.
+    BadIssuer,
+    /// Replace the expected audience claim.
+    BadAudience,
+    /// Emit a bearer-like token that is not valid base64url.
+    MalformedBearer,
+    /// Emit an API-key near miss that is close to, but not, `uk_test_`.
+    NearMissApiKey,
+}
+
+impl NegativeToken {
+    /// Stable cache/disposition name for this negative token variant.
+    pub const fn variant_name(&self) -> &'static str {
+        match self {
+            Self::MalformedJwtSegmentCount => "malformed_jwt_segment_count",
+            Self::BadBase64UrlSegment => "bad_base64url_segment",
+            Self::InvalidJwtHeaderShape => "invalid_jwt_header_shape",
+            Self::MissingAlg => "missing_alg",
+            Self::AlgNone => "alg_none",
+            Self::MismatchedKid => "mismatched_kid",
+            Self::ExpiredClaims => "expired_claims",
+            Self::NotYetValidClaims => "not_yet_valid_claims",
+            Self::BadIssuer => "bad_issuer",
+            Self::BadAudience => "bad_audience",
+            Self::MalformedBearer => "malformed_bearer",
+            Self::NearMissApiKey => "near_miss_api_key",
+        }
+    }
+}
 
 /// Generate a token value for the provided shape kind.
 pub fn generate_token(label: &str, kind: TokenKind, seed: Seed) -> String {
@@ -59,6 +123,33 @@ pub fn generate_token(label: &str, kind: TokenKind, seed: Seed) -> String {
         TokenKind::ApiKey => generate_api_key(seed),
         TokenKind::Bearer => generate_bearer_token(seed),
         TokenKind::OAuthAccessToken => generate_oauth_access_token(label, seed),
+    }
+}
+
+/// Generate a scanner-safe negative token value for parser and validator tests.
+pub fn generate_negative_token(
+    label: &str,
+    kind: TokenKind,
+    seed: Seed,
+    variant: NegativeToken,
+) -> String {
+    match variant {
+        NegativeToken::MalformedJwtSegmentCount => malformed_jwt_segment_count(label, seed),
+        NegativeToken::BadBase64UrlSegment => bad_base64url_segment(label, seed),
+        NegativeToken::InvalidJwtHeaderShape => invalid_jwt_header_shape(label, seed),
+        NegativeToken::MissingAlg => missing_alg(label, seed),
+        NegativeToken::AlgNone => alg_none(label, seed),
+        NegativeToken::MismatchedKid => mismatched_kid(label, seed),
+        NegativeToken::ExpiredClaims => token_with_payload_claim(label, seed, "exp", json!(1u64)),
+        NegativeToken::NotYetValidClaims => not_yet_valid_claims(label, seed),
+        NegativeToken::BadIssuer => {
+            token_with_payload_claim(label, seed, "iss", json!("wrong-issuer"))
+        }
+        NegativeToken::BadAudience => {
+            token_with_payload_claim(label, seed, "aud", json!("wrong-audience"))
+        }
+        NegativeToken::MalformedBearer => malformed_bearer(seed),
+        NegativeToken::NearMissApiKey => near_miss_api_key(kind, seed),
     }
 }
 
@@ -108,6 +199,137 @@ pub fn generate_oauth_access_token(label: &str, seed: Seed) -> String {
     format!("{header}.{payload_segment}.{signature_segment}")
 }
 
+fn malformed_jwt_segment_count(label: &str, seed: Seed) -> String {
+    let [header, payload, _signature] = oauth_parts(label, seed);
+    format!("{header}.{payload}")
+}
+
+fn bad_base64url_segment(label: &str, seed: Seed) -> String {
+    let [header, _payload, signature] = oauth_parts(label, seed);
+    format!("{header}.{SCANNER_SAFE_INVALID_TOKEN_SEGMENT}.{signature}")
+}
+
+fn invalid_jwt_header_shape(label: &str, seed: Seed) -> String {
+    let [_header, payload, signature] = oauth_parts(label, seed);
+    let header = encode_json(&json!(["not-a-header"]));
+    format!("{header}.{payload}.{signature}")
+}
+
+fn missing_alg(label: &str, seed: Seed) -> String {
+    let [_header, payload, signature] = oauth_parts(label, seed);
+    let header = encode_json(&json!({ "typ": "JWT" }));
+    format!("{header}.{payload}.{signature}")
+}
+
+fn alg_none(label: &str, seed: Seed) -> String {
+    token_with_header_claim(label, seed, "alg", json!("none"))
+}
+
+fn mismatched_kid(label: &str, seed: Seed) -> String {
+    let [_header, payload, signature] = oauth_parts(label, seed);
+    let mut header = jwt_header();
+    header.insert("kid".to_string(), json!("unknown-kid"));
+
+    let mut payload = decode_object(&payload);
+    payload.insert("kid".to_string(), json!("expected-kid"));
+
+    format!(
+        "{}.{}.{}",
+        encode_object(&header),
+        encode_object(&payload),
+        signature
+    )
+}
+
+fn not_yet_valid_claims(label: &str, seed: Seed) -> String {
+    let [_header, payload, signature] = oauth_parts(label, seed);
+    let mut claims = decode_object(&payload);
+    claims.insert("nbf".to_string(), json!(4_000_000_000u64));
+    claims.insert("exp".to_string(), json!(4_100_000_000u64));
+
+    format!(
+        "{}.{}.{}",
+        encode_object(&jwt_header()),
+        encode_object(&claims),
+        signature
+    )
+}
+
+fn token_with_header_claim(label: &str, seed: Seed, claim: &str, value: Value) -> String {
+    let [_header, payload, signature] = oauth_parts(label, seed);
+    let mut header = jwt_header();
+    header.insert(claim.to_string(), value);
+
+    format!("{}.{}.{}", encode_object(&header), payload, signature)
+}
+
+fn token_with_payload_claim(label: &str, seed: Seed, claim: &str, value: Value) -> String {
+    let [_header, payload, signature] = oauth_parts(label, seed);
+    let mut claims = decode_object(&payload);
+    claims.insert(claim.to_string(), value);
+
+    format!(
+        "{}.{}.{}",
+        encode_object(&jwt_header()),
+        encode_object(&claims),
+        signature
+    )
+}
+
+fn malformed_bearer(seed: Seed) -> String {
+    let mut value = generate_bearer_token(seed);
+    value.replace_range(0..1, "!");
+    value
+}
+
+fn near_miss_api_key(_kind: TokenKind, seed: Seed) -> String {
+    let valid = generate_api_key(seed);
+    let suffix = valid.strip_prefix(API_KEY_PREFIX).unwrap_or(&valid);
+
+    format!("{NEAR_MISS_API_KEY_PREFIX}{suffix}")
+}
+
+fn oauth_parts(label: &str, seed: Seed) -> [String; 3] {
+    let token = generate_oauth_access_token(label, seed);
+    let mut parts = token.split('.');
+    let header = parts.next().expect("JWT header segment").to_string();
+    let payload = parts.next().expect("JWT payload segment").to_string();
+    let signature = parts.next().expect("JWT signature segment").to_string();
+    assert!(
+        parts.next().is_none(),
+        "JWT should have exactly three segments"
+    );
+
+    [header, payload, signature]
+}
+
+fn jwt_header() -> Map<String, Value> {
+    Map::from_iter([
+        ("alg".to_string(), json!("RS256")),
+        ("typ".to_string(), json!("JWT")),
+    ])
+}
+
+fn decode_object(segment: &str) -> Map<String, Value> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(segment)
+        .expect("decode generated JWT JSON segment");
+    let value: Value = serde_json::from_slice(&bytes).expect("parse generated JWT JSON segment");
+    value
+        .as_object()
+        .expect("generated JWT JSON segment should be an object")
+        .clone()
+}
+
+fn encode_object(value: &Map<String, Value>) -> String {
+    encode_json(&Value::Object(value.clone()))
+}
+
+fn encode_json(value: &Value) -> String {
+    let json = serde_json::to_vec(value).expect("serialize token JSON");
+    URL_SAFE_NO_PAD.encode(json)
+}
+
 #[cfg(test)]
 mod tests {
     use base64::Engine as _;
@@ -116,8 +338,10 @@ mod tests {
     use uselesskey_core_seed::Seed;
 
     use super::{
-        API_KEY_PREFIX, API_KEY_RANDOM_LEN, BEARER_RANDOM_BYTES, TokenKind, authorization_scheme,
-        generate_api_key, generate_bearer_token, generate_oauth_access_token, generate_token,
+        API_KEY_PREFIX, API_KEY_RANDOM_LEN, BEARER_RANDOM_BYTES, NEAR_MISS_API_KEY_PREFIX,
+        NegativeToken, SCANNER_SAFE_INVALID_TOKEN_SEGMENT, TokenKind, authorization_scheme,
+        generate_api_key, generate_bearer_token, generate_negative_token,
+        generate_oauth_access_token, generate_token,
     };
     use uselesskey_core_base62::random_base62;
 
@@ -172,6 +396,78 @@ mod tests {
         assert_ne!(api, bearer);
         assert_ne!(api, oauth);
         assert_ne!(bearer, oauth);
+    }
+
+    #[test]
+    fn negative_token_variant_names_are_stable() {
+        assert_eq!(
+            NegativeToken::MalformedJwtSegmentCount.variant_name(),
+            "malformed_jwt_segment_count"
+        );
+        assert_eq!(
+            NegativeToken::BadBase64UrlSegment.variant_name(),
+            "bad_base64url_segment"
+        );
+        assert_eq!(
+            NegativeToken::InvalidJwtHeaderShape.variant_name(),
+            "invalid_jwt_header_shape"
+        );
+        assert_eq!(NegativeToken::MissingAlg.variant_name(), "missing_alg");
+        assert_eq!(NegativeToken::AlgNone.variant_name(), "alg_none");
+        assert_eq!(
+            NegativeToken::MismatchedKid.variant_name(),
+            "mismatched_kid"
+        );
+        assert_eq!(
+            NegativeToken::ExpiredClaims.variant_name(),
+            "expired_claims"
+        );
+        assert_eq!(
+            NegativeToken::NotYetValidClaims.variant_name(),
+            "not_yet_valid_claims"
+        );
+        assert_eq!(NegativeToken::BadIssuer.variant_name(), "bad_issuer");
+        assert_eq!(NegativeToken::BadAudience.variant_name(), "bad_audience");
+        assert_eq!(
+            NegativeToken::MalformedBearer.variant_name(),
+            "malformed_bearer"
+        );
+        assert_eq!(
+            NegativeToken::NearMissApiKey.variant_name(),
+            "near_miss_api_key"
+        );
+    }
+
+    #[test]
+    fn negative_api_key_near_miss_is_scanner_safe() {
+        let value = generate_negative_token(
+            "svc",
+            TokenKind::ApiKey,
+            Seed::new([19u8; 32]),
+            NegativeToken::NearMissApiKey,
+        );
+
+        assert!(value.starts_with(NEAR_MISS_API_KEY_PREFIX));
+        assert!(!value.starts_with(API_KEY_PREFIX));
+        assert_eq!(
+            value.len(),
+            NEAR_MISS_API_KEY_PREFIX.len() + API_KEY_RANDOM_LEN
+        );
+    }
+
+    #[test]
+    fn negative_malformed_bearer_is_not_base64url() {
+        let value = generate_negative_token(
+            "svc",
+            TokenKind::Bearer,
+            Seed::new([23u8; 32]),
+            NegativeToken::MalformedBearer,
+        );
+
+        assert_ne!(value, SCANNER_SAFE_INVALID_TOKEN_SEGMENT);
+        assert!(value.contains('!'));
+        assert_eq!(value.len(), 43);
+        assert!(URL_SAFE_NO_PAD.decode(value).is_err());
     }
 
     #[test]

--- a/crates/uselesskey-core-token-shape/tests/negative_fixtures.rs
+++ b/crates/uselesskey-core-token-shape/tests/negative_fixtures.rs
@@ -1,0 +1,194 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde_json::Value;
+use uselesskey_core_seed::Seed;
+use uselesskey_core_token_shape::{
+    API_KEY_PREFIX, API_KEY_RANDOM_LEN, NegativeToken, TokenKind, generate_negative_token,
+    generate_token,
+};
+
+const SCANNER_SAFE_INVALID_TOKEN_SEGMENT: &str = "not_base64url!*";
+const NEAR_MISS_API_KEY_PREFIX: &str = "uk_tset_";
+
+fn fixture(variant: NegativeToken) -> String {
+    generate_negative_token(
+        "issuer",
+        TokenKind::OAuthAccessToken,
+        Seed::new([31u8; 32]),
+        variant,
+    )
+}
+
+fn parts(token: &str) -> Vec<&str> {
+    token.split('.').collect()
+}
+
+fn decode_json(segment: &str) -> Value {
+    let bytes = URL_SAFE_NO_PAD.decode(segment).expect("decode JWT segment");
+    serde_json::from_slice(&bytes).expect("parse JWT JSON segment")
+}
+
+fn header(token: &str) -> Value {
+    decode_json(parts(token)[0])
+}
+
+fn payload(token: &str) -> Value {
+    decode_json(parts(token)[1])
+}
+
+#[test]
+fn malformed_jwt_segment_count_emits_two_segments() {
+    let value = fixture(NegativeToken::MalformedJwtSegmentCount);
+
+    assert_eq!(parts(&value).len(), 2);
+    assert_ne!(
+        value,
+        generate_token("issuer", TokenKind::OAuthAccessToken, Seed::new([31u8; 32]))
+    );
+}
+
+#[test]
+fn bad_base64url_segment_preserves_jwt_shape_but_breaks_payload_decode() {
+    let value = fixture(NegativeToken::BadBase64UrlSegment);
+    let parts = parts(&value);
+
+    assert_eq!(parts.len(), 3);
+    assert_eq!(parts[1], SCANNER_SAFE_INVALID_TOKEN_SEGMENT);
+    assert!(URL_SAFE_NO_PAD.decode(parts[1]).is_err());
+    assert!(decode_json(parts[0]).is_object());
+}
+
+#[test]
+fn invalid_header_shape_is_json_but_not_an_object() {
+    let value = fixture(NegativeToken::InvalidJwtHeaderShape);
+
+    assert_eq!(parts(&value).len(), 3);
+    assert!(header(&value).is_array());
+}
+
+#[test]
+fn missing_alg_removes_only_algorithm_header() {
+    let value = fixture(NegativeToken::MissingAlg);
+    let header = header(&value);
+
+    assert!(header.get("alg").is_none());
+    assert_eq!(header["typ"], "JWT");
+    assert_eq!(payload(&value)["iss"], "uselesskey");
+}
+
+#[test]
+fn alg_none_preserves_jwt_shape() {
+    let value = fixture(NegativeToken::AlgNone);
+    let header = header(&value);
+
+    assert_eq!(parts(&value).len(), 3);
+    assert_eq!(header["alg"], "none");
+    assert_eq!(header["typ"], "JWT");
+}
+
+#[test]
+fn mismatched_kid_uses_different_header_and_payload_values() {
+    let value = fixture(NegativeToken::MismatchedKid);
+
+    assert_eq!(header(&value)["kid"], "unknown-kid");
+    assert_eq!(payload(&value)["kid"], "expected-kid");
+    assert_ne!(header(&value)["kid"], payload(&value)["kid"]);
+}
+
+#[test]
+fn expired_claims_are_shape_realistic() {
+    let value = fixture(NegativeToken::ExpiredClaims);
+    let payload = payload(&value);
+
+    assert_eq!(parts(&value).len(), 3);
+    assert_eq!(payload["exp"], 1);
+    assert_eq!(payload["iss"], "uselesskey");
+}
+
+#[test]
+fn not_yet_valid_claims_keep_future_window() {
+    let value = fixture(NegativeToken::NotYetValidClaims);
+    let payload = payload(&value);
+
+    assert_eq!(payload["nbf"], 4_000_000_000u64);
+    assert_eq!(payload["exp"], 4_100_000_000u64);
+    assert!(payload["nbf"].as_u64().expect("nbf should be numeric") > 2_000_000_000u64);
+}
+
+#[test]
+fn bad_issuer_replaces_expected_claim_only() {
+    let value = fixture(NegativeToken::BadIssuer);
+    let payload = payload(&value);
+
+    assert_eq!(payload["iss"], "wrong-issuer");
+    assert_eq!(payload["aud"], "tests");
+}
+
+#[test]
+fn bad_audience_replaces_expected_claim_only() {
+    let value = fixture(NegativeToken::BadAudience);
+    let payload = payload(&value);
+
+    assert_eq!(payload["iss"], "uselesskey");
+    assert_eq!(payload["aud"], "wrong-audience");
+}
+
+#[test]
+fn malformed_bearer_is_scanner_safe_invalid_material() {
+    let value = generate_negative_token(
+        "gateway",
+        TokenKind::Bearer,
+        Seed::new([37u8; 32]),
+        NegativeToken::MalformedBearer,
+    );
+
+    assert_ne!(value, SCANNER_SAFE_INVALID_TOKEN_SEGMENT);
+    assert!(value.contains('!'));
+    assert_eq!(value.matches('.').count(), 0);
+    assert_eq!(value.len(), 43);
+    assert!(URL_SAFE_NO_PAD.decode(value).is_err());
+}
+
+#[test]
+fn near_miss_api_key_keeps_length_but_breaks_prefix() {
+    let value = generate_negative_token(
+        "billing",
+        TokenKind::ApiKey,
+        Seed::new([41u8; 32]),
+        NegativeToken::NearMissApiKey,
+    );
+
+    assert!(value.starts_with(NEAR_MISS_API_KEY_PREFIX));
+    assert!(!value.starts_with(API_KEY_PREFIX));
+    assert_eq!(
+        value.len(),
+        NEAR_MISS_API_KEY_PREFIX.len() + API_KEY_RANDOM_LEN
+    );
+    assert!(
+        value
+            .strip_prefix(NEAR_MISS_API_KEY_PREFIX)
+            .expect("near-miss prefix")
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric())
+    );
+}
+
+#[test]
+fn negative_generation_is_stable_for_same_identity() {
+    let a = generate_negative_token(
+        "stable",
+        TokenKind::OAuthAccessToken,
+        Seed::new([43u8; 32]),
+        NegativeToken::ExpiredClaims,
+    );
+    let b = generate_negative_token(
+        "stable",
+        TokenKind::OAuthAccessToken,
+        Seed::new([43u8; 32]),
+        NegativeToken::ExpiredClaims,
+    );
+    let good = generate_token("stable", TokenKind::OAuthAccessToken, Seed::new([43u8; 32]));
+
+    assert_eq!(a, b);
+    assert_ne!(a, good);
+}

--- a/crates/uselesskey-token/README.md
+++ b/crates/uselesskey-token/README.md
@@ -18,12 +18,13 @@ for minimal compile time.
 - API-key style tokens: `uk_test_<base62>`
 - Opaque bearer tokens: base64url data
 - OAuth access tokens in JWT shape: `header.payload.signature`
+- Scanner-safe negative token shapes for parser and validator error paths
 
 ## Usage
 
 ```rust
 use uselesskey_core::Factory;
-use uselesskey_token::{TokenFactoryExt, TokenSpec};
+use uselesskey_token::{NegativeToken, TokenFactoryExt, TokenSpec};
 
 let fx = Factory::random();
 
@@ -34,6 +35,13 @@ let oauth = fx.token("issuer", TokenSpec::oauth_access_token());
 assert!(api_key.value().starts_with("uk_test_"));
 assert!(bearer.authorization_header().starts_with("Bearer "));
 assert_eq!(oauth.value().split('.').count(), 3);
+
+let expired = oauth.negative_value(NegativeToken::ExpiredClaims);
+let near_miss_api_key = api_key.negative_value(NegativeToken::NearMissApiKey);
+
+assert_eq!(expired.split('.').count(), 3);
+assert!(near_miss_api_key.starts_with("uk_tset_"));
+assert!(!near_miss_api_key.starts_with("uk_test_"));
 ```
 
 ### Deterministic Mode

--- a/crates/uselesskey-token/src/lib.rs
+++ b/crates/uselesskey-token/src/lib.rs
@@ -12,17 +12,21 @@
 //! - API key style tokens (`uk_test_<base62>`)
 //! - Opaque bearer tokens (base64url)
 //! - OAuth-style JWT access tokens (`header.payload.signature`)
+//! - Scanner-safe negative token shapes for validator error paths
 //!
 //! # Examples
 //!
 //! ```
 //! use uselesskey_core::Factory;
-//! use uselesskey_token::{TokenFactoryExt, TokenSpec};
+//! use uselesskey_token::{NegativeToken, TokenFactoryExt, TokenSpec};
 //!
 //! let fx = Factory::random();
 //! let tok = fx.token("api-key", TokenSpec::api_key());
 //! let value = tok.value();
 //! assert!(!value.is_empty());
+//!
+//! let near_miss = tok.negative_value(NegativeToken::NearMissApiKey);
+//! assert!(!near_miss.starts_with("uk_test_"));
 //! ```
 //!
 //! # Deterministic Mode
@@ -49,4 +53,5 @@
 mod token;
 
 pub use token::{DOMAIN_TOKEN_FIXTURE, TokenFactoryExt, TokenFixture};
+pub use uselesskey_core_token::NegativeToken;
 pub use uselesskey_token_spec::TokenSpec;

--- a/crates/uselesskey-token/src/token.rs
+++ b/crates/uselesskey-token/src/token.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use uselesskey_core::Factory;
-use uselesskey_core_token::generate_token;
+use uselesskey_core_token::{NegativeToken, generate_negative_token, generate_token};
 
 use crate::TokenSpec;
 
@@ -194,6 +194,27 @@ impl TokenFixture {
         let scheme = self.spec.authorization_scheme();
         format!("{scheme} {}", self.value())
     }
+
+    /// Generate a scanner-safe negative token value for parser and validator tests.
+    ///
+    /// The generated value is cached by `(label, spec, variant)` and is stable in
+    /// deterministic mode without changing the positive token fixture.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use uselesskey_core::{Factory, Seed};
+    /// # use uselesskey_token::{NegativeToken, TokenFactoryExt, TokenSpec};
+    /// let fx = Factory::deterministic(Seed::from_env_value("test-seed").unwrap());
+    /// let oauth = fx.token("issuer", TokenSpec::oauth_access_token());
+    /// let expired = oauth.negative_value(NegativeToken::ExpiredClaims);
+    /// assert_eq!(expired.matches('.').count(), 2);
+    /// ```
+    pub fn negative_value(&self, variant: NegativeToken) -> String {
+        load_negative_inner(&self.factory, &self.label, self.spec, variant)
+            .value
+            .clone()
+    }
 }
 
 fn load_inner(factory: &Factory, label: &str, spec: TokenSpec, variant: &str) -> Arc<Inner> {
@@ -203,6 +224,27 @@ fn load_inner(factory: &Factory, label: &str, spec: TokenSpec, variant: &str) ->
         let value = generate_token(label, spec, seed);
         Inner { value }
     })
+}
+
+fn load_negative_inner(
+    factory: &Factory,
+    label: &str,
+    spec: TokenSpec,
+    variant: NegativeToken,
+) -> Arc<Inner> {
+    let spec_bytes = spec.stable_bytes();
+    let cache_variant = format!("negative:{}", variant.variant_name());
+
+    factory.get_or_init(
+        DOMAIN_TOKEN_FIXTURE,
+        label,
+        &spec_bytes,
+        &cache_variant,
+        |seed| {
+            let value = generate_negative_token(label, spec, seed, variant);
+            Inner { value }
+        },
+    )
 }
 
 #[cfg(test)]
@@ -298,6 +340,32 @@ mod tests {
         let custom = fx.token_with_variant("svc", TokenSpec::api_key(), "custom");
 
         assert_ne!(good.value(), custom.value());
+    }
+
+    #[test]
+    fn negative_value_is_cached_and_stable() {
+        let fx = Factory::deterministic(Seed::from_env_value("token-negative").unwrap());
+        let token = fx.token("issuer", TokenSpec::oauth_access_token());
+
+        let a = token.negative_value(NegativeToken::ExpiredClaims);
+        let b = token.negative_value(NegativeToken::ExpiredClaims);
+
+        assert_eq!(a, b);
+        assert_ne!(a, token.value());
+        assert_eq!(a.matches('.').count(), 2);
+    }
+
+    #[test]
+    fn negative_api_key_near_miss_keeps_positive_fixture_unchanged() {
+        let fx = Factory::deterministic(Seed::from_env_value("token-negative-api").unwrap());
+        let token = fx.token("billing", TokenSpec::api_key());
+
+        let near_miss = token.negative_value(NegativeToken::NearMissApiKey);
+
+        assert!(token.value().starts_with("uk_test_"));
+        assert!(near_miss.starts_with("uk_tset_"));
+        assert!(!near_miss.starts_with("uk_test_"));
+        assert_ne!(near_miss, token.value());
     }
 
     #[test]

--- a/crates/uselesskey-token/tests/negative_fixtures.rs
+++ b/crates/uselesskey-token/tests/negative_fixtures.rs
@@ -1,0 +1,46 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde_json::Value;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_token::{NegativeToken, TokenFactoryExt, TokenSpec};
+
+fn decode_payload(token: &str) -> Value {
+    let payload = token.split('.').nth(1).expect("JWT payload segment");
+    let bytes = URL_SAFE_NO_PAD.decode(payload).expect("decode payload");
+    serde_json::from_slice(&bytes).expect("parse payload")
+}
+
+#[test]
+fn token_fixture_emits_expired_oauth_negative_value() {
+    let fx = Factory::deterministic(Seed::from_env_value("token-negative-it").unwrap());
+    let token = fx.token("issuer", TokenSpec::oauth_access_token());
+
+    let expired = token.negative_value(NegativeToken::ExpiredClaims);
+
+    assert_eq!(expired.matches('.').count(), 2);
+    assert_eq!(decode_payload(&expired)["exp"], 1);
+    assert_ne!(expired, token.value());
+}
+
+#[test]
+fn token_fixture_emits_malformed_bearer_negative_value() {
+    let fx = Factory::deterministic(Seed::from_env_value("token-negative-bearer").unwrap());
+    let token = fx.token("gateway", TokenSpec::bearer());
+
+    let malformed = token.negative_value(NegativeToken::MalformedBearer);
+
+    assert!(URL_SAFE_NO_PAD.decode(&malformed).is_err());
+    assert_ne!(malformed, token.value());
+}
+
+#[test]
+fn token_fixture_emits_api_key_near_miss_negative_value() {
+    let fx = Factory::deterministic(Seed::from_env_value("token-negative-api").unwrap());
+    let token = fx.token("billing", TokenSpec::api_key());
+
+    let near_miss = token.negative_value(NegativeToken::NearMissApiKey);
+
+    assert!(near_miss.starts_with("uk_tset_"));
+    assert!(!near_miss.starts_with("uk_test_"));
+    assert_ne!(near_miss, token.value());
+}

--- a/crates/uselesskey/src/lib.rs
+++ b/crates/uselesskey/src/lib.rs
@@ -313,7 +313,9 @@ pub use uselesskey_ed25519::{
 pub use uselesskey_hmac::{DOMAIN_HMAC_SECRET, HmacFactoryExt, HmacSecret, HmacSpec};
 
 #[cfg(feature = "token")]
-pub use uselesskey_token::{DOMAIN_TOKEN_FIXTURE, TokenFactoryExt, TokenFixture, TokenSpec};
+pub use uselesskey_token::{
+    DOMAIN_TOKEN_FIXTURE, NegativeToken, TokenFactoryExt, TokenFixture, TokenSpec,
+};
 
 #[cfg(feature = "ssh")]
 pub use uselesskey_ssh::{
@@ -364,7 +366,7 @@ pub mod prelude {
     pub use crate::{HmacFactoryExt, HmacSecret, HmacSpec};
 
     #[cfg(feature = "token")]
-    pub use crate::{TokenFactoryExt, TokenFixture, TokenSpec};
+    pub use crate::{NegativeToken, TokenFactoryExt, TokenFixture, TokenSpec};
 
     #[cfg(feature = "ssh")]
     pub use crate::{

--- a/crates/uselesskey/tests/facade.rs
+++ b/crates/uselesskey/tests/facade.rs
@@ -63,12 +63,17 @@ fn hmac_reexport_works() {
 #[test]
 #[cfg(feature = "token")]
 fn token_reexport_works() {
+    use uselesskey::NegativeToken;
     use uselesskey::TokenFactoryExt;
     use uselesskey::TokenSpec;
 
     let fx = testutil::fx();
     let token = fx.token("issuer", TokenSpec::api_key());
     assert!(token.value().starts_with("uk_test_"));
+
+    let near_miss = token.negative_value(NegativeToken::NearMissApiKey);
+    assert!(near_miss.starts_with("uk_tset_"));
+    assert!(!near_miss.starts_with("uk_test_"));
 }
 
 #[test]

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -23,8 +23,8 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 
 ## v0.6.1 follow-on negatives
 
-- [ ] JWK/JWKS negative wave 1
-- [ ] token-shape negative wave 1
+- [x] JWK/JWKS negative wave 1
+- [x] token-shape negative wave 1
 - [ ] docs/examples coverage for negative fixtures
 
 ## v0.6.1 benchmarks and governance

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -16,7 +16,7 @@ This roadmap reflects the strategic direction for uselesskey as a **test-fixture
 
 *Planned follow-up*
 
-- [ ] JWK/JWKS and token-shape negative fixture follow-ons.
+- [x] JWK/JWKS and token-shape negative fixture follow-ons.
 - [ ] Docs/examples coverage for the remaining negative-fixture surface.
 - [ ] Performance benchmarks for key generation and materialization paths.
 - [ ] Release governance and post-release audit automation.


### PR DESCRIPTION
## Summary

- add scanner-safe `NegativeToken` variants for JWT, bearer, and API-key validator failure paths
- expose `TokenFixture::negative_value(...)` through `uselesskey-token` and the main facade
- add mutation-focused tests for malformed JWT segments, bad base64url, header/claim failures, mismatched kid, malformed bearer, and near-miss API keys
- update README, roadmap follow-up, and changelog release evidence

## Validation

- `cargo test -p uselesskey-core-token-shape --all-features`
- `cargo test -p uselesskey-token --all-features`
- `cargo test -p uselesskey --all-features`
- `cargo xtask clippy`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask no-blob`
- `cargo xtask bdd`
- `cargo mutants -p uselesskey-core-token-shape -f crates/uselesskey-core-token-shape/src/lib.rs -F "NegativeToken|generate_negative_token|malformed_jwt|bad_base64url|invalid_jwt|missing_alg|alg_none|mismatched_kid|not_yet_valid|token_with_|malformed_bearer|near_miss_api_key|oauth_parts|jwt_header|decode_object|encode_object|encode_json" --baseline skip -j 4 --timeout 120` (`34 mutants tested: 32 caught, 2 unviable`)