### PR TITLE
feat(policy): add panic-safety policy stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,11 @@ cargo xtask typos --fix     # Auto-fix typos
 cargo xtask bdd-matrix      # BDD matrix with feature sets
 cargo xtask publish         # Publish all crates in dependency order
 cargo xtask setup           # Configure git hooks (sets core.hooksPath to .githooks)
+cargo xtask check-no-panic-family  # Semantic panic-family ledger (advisory in Stage A)
+cargo xtask no-panic propose       # Emit candidate no-panic allowlist under target/policy-proposed/
+cargo xtask check-file-policy      # Validate non-Rust file allowlist
+cargo xtask check-lint-policy      # Validate MSRV / [lints] inheritance / debt expiry
+cargo xtask policy-report          # Aggregate report across no-panic + file + lint policy
 ```
 
 Run a single test:
@@ -160,6 +165,22 @@ Adapter crates (e.g. `uselesskey-jsonwebtoken`) are separate crates, not feature
 - `clippy.toml` - MSRV 1.92
 - `deny.toml` - Allowed licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, CC0-1.0
 - `mutants.toml` - Mutation testing exclusions
+
+## Policy stack
+
+Lint, panic-family, and non-Rust file policy is encoded under `policy/` and
+documented under `docs/`:
+
+- `policy/clippy-lints.toml` — MSRV, planned lint flips, suppression rules.
+- `policy/clippy-debt.toml` — receipted Clippy warn-stage debt with expiry.
+- `policy/no-panic-allowlist.toml` — semantic panic-family allowlist
+  (path + family + selector identity); enforced by
+  `cargo xtask check-no-panic-family` (advisory in Stage A).
+- `policy/non-rust-allowlist.toml` — owner/surface/classification ledger for
+  every tracked non-Rust file; enforced by `cargo xtask check-file-policy`.
+
+See `docs/CLIPPY_POLICY.md`, `docs/NO_PANIC_POLICY.md`, `docs/FILE_POLICY.md`,
+and `docs/POLICY_ALLOWLISTS.md` for the design.
 
 ## Git Hooks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6018,6 +6018,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
  "uselesskey-feature-grid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,3 +186,33 @@ opt-level = 2
 
 [profile.test]
 opt-level = 2
+
+# =============================================================================
+# Lint policy — Stage A enforcement floor
+# =============================================================================
+#
+# See: docs/CLIPPY_POLICY.md, docs/NO_PANIC_POLICY.md, policy/clippy-lints.toml.
+#
+# `cargo xtask clippy` uses `-D warnings`, so any lint at `warn` is effectively
+# a hard error in CI. Stage A therefore enforces ONLY rules the workspace is
+# already clean against:
+#
+#   - panic-family debt is tracked by `cargo xtask check-no-panic-family`
+#     (advisory in Stage A, blocking in Stage B, promoted to clippy `deny`
+#     in Stage C). The semantic checker is the authoritative ledger.
+#   - the warn-stage posture for the rest of the strict block lives in
+#     `policy/clippy-lints.toml` and is staged in as the codebase converges.
+#
+# Member crates inherit via `[lints]\nworkspace = true`.
+
+[workspace.lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+
+[workspace.lints.clippy]
+# Panic-family hard bans (zero-debt today; the semantic checker carries the
+# warn-stage families).
+todo = "deny"
+unimplemented = "deny"
+dbg_macro = "deny"

--- a/crates/materialize-buildrs-example/Cargo.toml
+++ b/crates/materialize-buildrs-example/Cargo.toml
@@ -12,3 +12,6 @@ description = "Build-time materialization example for uselesskey fixtures."
 
 [build-dependencies]
 uselesskey-cli = { path = "../uselesskey-cli", version = "0.6.0", default-features = false, features = ["rsa-materialize"] }
+
+[lints]
+workspace = true

--- a/crates/materialize-shape-buildrs-example/Cargo.toml
+++ b/crates/materialize-shape-buildrs-example/Cargo.toml
@@ -13,3 +13,6 @@ description = "Build-time shape-only materialization example for uselesskey fixt
 [build-dependencies]
 uselesskey-cli = { path = "../uselesskey-cli", version = "0.6.0", default-features = false }
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-aws-lc-rs/Cargo.toml
+++ b/crates/uselesskey-aws-lc-rs/Cargo.toml
@@ -48,3 +48,6 @@ serde.workspace = true
 insta.workspace = true
 proptest.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-axum/Cargo.toml
+++ b/crates/uselesskey-axum/Cargo.toml
@@ -26,3 +26,6 @@ uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", features = ["j
 
 [dev-dependencies]
 tokio.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-bdd-steps/Cargo.toml
+++ b/crates/uselesskey-bdd-steps/Cargo.toml
@@ -74,3 +74,6 @@ uk-rustls = ["dep:uselesskey-rustls", "dep:rustls-pki-types", "uk-bdd-keys"]
 uk-tonic = ["dep:uselesskey-tonic"]
 uk-ring = ["dep:uselesskey-ring", "dep:ring", "uk-bdd-keys"]
 uk-rustcrypto = ["dep:uselesskey-rustcrypto", "dep:hmac", "uk-bdd-keys"]
+
+[lints]
+workspace = true

--- a/crates/uselesskey-bdd/Cargo.toml
+++ b/crates/uselesskey-bdd/Cargo.toml
@@ -50,3 +50,6 @@ uk-rustcrypto = ["uselesskey-bdd-steps/uk-rustcrypto"]
 [[test]]
 name = "bdd"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/uselesskey-bench/Cargo.toml
+++ b/crates/uselesskey-bench/Cargo.toml
@@ -19,3 +19,6 @@ uselesskey = { path = "../uselesskey", features = ["full"] }
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-cli/Cargo.toml
+++ b/crates/uselesskey-cli/Cargo.toml
@@ -54,3 +54,6 @@ tempfile.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-base62/Cargo.toml
+++ b/crates/uselesskey-core-base62/Cargo.toml
@@ -28,3 +28,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-cache/Cargo.toml
+++ b/crates/uselesskey-core-cache/Cargo.toml
@@ -32,3 +32,6 @@ std = ["dep:dashmap", "uselesskey-core-id/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-factory/Cargo.toml
+++ b/crates/uselesskey-core-factory/Cargo.toml
@@ -36,3 +36,6 @@ std = [
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-hash/Cargo.toml
+++ b/crates/uselesskey-core-hash/Cargo.toml
@@ -29,3 +29,6 @@ std = ["blake3/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-hmac-spec/Cargo.toml
+++ b/crates/uselesskey-core-hmac-spec/Cargo.toml
@@ -22,3 +22,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-id/Cargo.toml
+++ b/crates/uselesskey-core-id/Cargo.toml
@@ -31,3 +31,6 @@ std = ["uselesskey-core-hash/std", "uselesskey-core-seed/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwk-builder/Cargo.toml
+++ b/crates/uselesskey-core-jwk-builder/Cargo.toml
@@ -28,3 +28,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwk-shape/Cargo.toml
+++ b/crates/uselesskey-core-jwk-shape/Cargo.toml
@@ -27,3 +27,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwk/Cargo.toml
+++ b/crates/uselesskey-core-jwk/Cargo.toml
@@ -27,3 +27,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-jwks-order/Cargo.toml
+++ b/crates/uselesskey-core-jwks-order/Cargo.toml
@@ -24,3 +24,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-keypair-material/Cargo.toml
+++ b/crates/uselesskey-core-keypair-material/Cargo.toml
@@ -26,3 +26,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-keypair/Cargo.toml
+++ b/crates/uselesskey-core-keypair/Cargo.toml
@@ -26,3 +26,6 @@ uselesskey-core-negative.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-kid/Cargo.toml
+++ b/crates/uselesskey-core-kid/Cargo.toml
@@ -27,3 +27,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-negative-der/Cargo.toml
+++ b/crates/uselesskey-core-negative-der/Cargo.toml
@@ -30,3 +30,6 @@ std = ["uselesskey-core-hash/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-negative-pem/Cargo.toml
+++ b/crates/uselesskey-core-negative-pem/Cargo.toml
@@ -30,3 +30,6 @@ std = ["uselesskey-core-hash/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-negative/Cargo.toml
+++ b/crates/uselesskey-core-negative/Cargo.toml
@@ -31,3 +31,6 @@ std = ["uselesskey-core-negative-der/std", "uselesskey-core-negative-pem/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-rustls-pki/Cargo.toml
+++ b/crates/uselesskey-core-rustls-pki/Cargo.toml
@@ -43,3 +43,6 @@ uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
 [package.metadata.docs.rs]
 features = ["all"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-seed/Cargo.toml
+++ b/crates/uselesskey-core-seed/Cargo.toml
@@ -32,3 +32,6 @@ std = ["blake3/std", "rand_chacha10/std"]
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-sink/Cargo.toml
+++ b/crates/uselesskey-core-sink/Cargo.toml
@@ -26,3 +26,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-token-shape/Cargo.toml
+++ b/crates/uselesskey-core-token-shape/Cargo.toml
@@ -31,3 +31,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-token/Cargo.toml
+++ b/crates/uselesskey-core-token/Cargo.toml
@@ -28,3 +28,6 @@ uselesskey-core-seed.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-chain-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-chain-negative/Cargo.toml
@@ -30,3 +30,6 @@ std = []
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-derive/Cargo.toml
+++ b/crates/uselesskey-core-x509-derive/Cargo.toml
@@ -31,3 +31,6 @@ uselesskey-core-hash = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-negative/Cargo.toml
@@ -32,3 +32,6 @@ std = []
 features = ["std"]
 
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509-spec/Cargo.toml
+++ b/crates/uselesskey-core-x509-spec/Cargo.toml
@@ -25,3 +25,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core-x509/Cargo.toml
+++ b/crates/uselesskey-core-x509/Cargo.toml
@@ -29,3 +29,6 @@ uselesskey-core-seed.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-core/Cargo.toml
+++ b/crates/uselesskey-core/Cargo.toml
@@ -43,3 +43,6 @@ serde = { workspace = true }
 [package.metadata.docs.rs]
 features = ["std"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-ecdsa/Cargo.toml
+++ b/crates/uselesskey-ecdsa/Cargo.toml
@@ -44,3 +44,6 @@ rstest.workspace = true
 serde.workspace = true
 uselesskey-core-kid.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-ed25519/Cargo.toml
+++ b/crates/uselesskey-ed25519/Cargo.toml
@@ -39,3 +39,6 @@ rstest.workspace = true
 serde.workspace = true
 uselesskey-core-kid.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-entropy/Cargo.toml
+++ b/crates/uselesskey-entropy/Cargo.toml
@@ -22,3 +22,6 @@ proptest.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-feature-grid/Cargo.toml
+++ b/crates/uselesskey-feature-grid/Cargo.toml
@@ -19,3 +19,6 @@ documentation = "https://docs.rs/uselesskey-feature-grid"
 [dev-dependencies]
 
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-hmac/Cargo.toml
+++ b/crates/uselesskey-hmac/Cargo.toml
@@ -38,3 +38,6 @@ serde.workspace = true
 default = []
 jwk = ["dep:uselesskey-jwk", "dep:base64"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-interop-tests/Cargo.toml
+++ b/crates/uselesskey-interop-tests/Cargo.toml
@@ -53,3 +53,6 @@ cross-tls = ["dep:uselesskey-x509", "dep:uselesskey-rustls"]
 jwt-interop = ["dep:uselesskey-jsonwebtoken"]
 aws-lc-rs-interop = ["dep:uselesskey-aws-lc-rs", "dep:aws-lc-rs", "uselesskey-rustls?/rustls-aws-lc-rs"]
 all = ["cross-signing", "cross-tls", "jwt-interop", "aws-lc-rs-interop"]
+
+[lints]
+workspace = true

--- a/crates/uselesskey-jose-openid/Cargo.toml
+++ b/crates/uselesskey-jose-openid/Cargo.toml
@@ -43,3 +43,6 @@ uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0" }
 uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
 uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0" }
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-jsonwebtoken/Cargo.toml
+++ b/crates/uselesskey-jsonwebtoken/Cargo.toml
@@ -51,3 +51,6 @@ proptest.workspace = true
 version = "10"
 features = ["use_pem", "rust_crypto"]
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-jwk/Cargo.toml
+++ b/crates/uselesskey-jwk/Cargo.toml
@@ -26,3 +26,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-pgp-native/Cargo.toml
+++ b/crates/uselesskey-pgp-native/Cargo.toml
@@ -29,3 +29,6 @@ pgp-native = ["dep:uselesskey-pgp"]
 uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.6.0" }
 uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -28,3 +28,6 @@ insta.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-pkcs11-mock/Cargo.toml
+++ b/crates/uselesskey-pkcs11-mock/Cargo.toml
@@ -20,3 +20,6 @@ sha2.workspace = true
 
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+
+[lints]
+workspace = true

--- a/crates/uselesskey-ring/Cargo.toml
+++ b/crates/uselesskey-ring/Cargo.toml
@@ -39,3 +39,6 @@ serde.workspace = true
 insta.workspace = true
 proptest.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-rsa/Cargo.toml
+++ b/crates/uselesskey-rsa/Cargo.toml
@@ -43,3 +43,6 @@ proptest.workspace = true
 rstest.workspace = true
 serde.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-rustcrypto/Cargo.toml
+++ b/crates/uselesskey-rustcrypto/Cargo.toml
@@ -51,3 +51,6 @@ rsa = { workspace = true, features = ["sha2"] }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -53,3 +53,6 @@ serde.workspace = true
 insta.workspace = true
 proptest.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-ssh/Cargo.toml
+++ b/crates/uselesskey-ssh/Cargo.toml
@@ -24,3 +24,6 @@ proptest.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-test-grid/Cargo.toml
+++ b/crates/uselesskey-test-grid/Cargo.toml
@@ -20,3 +20,6 @@ uselesskey-feature-grid.workspace = true
 [dev-dependencies]
 uselesskey-feature-grid.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-test-server/Cargo.toml
+++ b/crates/uselesskey-test-server/Cargo.toml
@@ -31,3 +31,6 @@ uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", features = ["j
 
 [dev-dependencies]
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
+
+[lints]
+workspace = true

--- a/crates/uselesskey-token-spec/Cargo.toml
+++ b/crates/uselesskey-token-spec/Cargo.toml
@@ -21,3 +21,6 @@ serde.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -29,3 +29,6 @@ serde_json.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-tonic/Cargo.toml
+++ b/crates/uselesskey-tonic/Cargo.toml
@@ -32,3 +32,6 @@ proptest.workspace = true
 serde.workspace = true
 insta.workspace = true
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey-webauthn/Cargo.toml
+++ b/crates/uselesskey-webauthn/Cargo.toml
@@ -23,3 +23,6 @@ sha2.workspace = true
 [dev-dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-webhook/Cargo.toml
+++ b/crates/uselesskey-webhook/Cargo.toml
@@ -29,3 +29,6 @@ insta.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/crates/uselesskey-x509/Cargo.toml
+++ b/crates/uselesskey-x509/Cargo.toml
@@ -40,3 +40,6 @@ rstest.workspace = true
 insta.workspace = true
 serde = { workspace = true, features = ["derive"] }
 
+
+[lints]
+workspace = true

--- a/crates/uselesskey/Cargo.toml
+++ b/crates/uselesskey/Cargo.toml
@@ -85,3 +85,6 @@ rustls-pki-types.workspace = true
 name = "keygen"
 harness = false
 required-features = ["full"]
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,61 @@
+# Clippy / Rust lint policy
+
+> Authoritative file: `policy/clippy-lints.toml`. Lints are configured in
+> `[workspace.lints]` in the root `Cargo.toml`. Crate `Cargo.toml` files opt
+> in via `[lints]\nworkspace = true`. The xtask `check-lint-policy` enforces
+> consistency.
+
+## Why
+
+`uselesskey` is a crypto/security workspace whose users embed our fixtures in
+their tests. Surprising panics, silent result loss, byte-boundary indexing
+mistakes, or `dbg!()` left in adapters are all unacceptable. Clippy catches
+these *shapes* close to the code; the [no-panic policy](NO_PANIC_POLICY.md)
+owns the *exception ledger*.
+
+## The dual-rail design
+
+```
+Clippy lints           ← fast, IDE-visible, catches local bad shapes
+no-panic checker       ← owns the exception ledger (path + family + selector)
+file-policy checker    ← owns non-Rust surface allowlist
+lint-policy checker    ← verifies every crate inherits the shared rules
+```
+
+Clippy is the immediate detector. The no-panic checker (`cargo xtask
+check-no-panic-family`) is the *authoritative* exception mechanism: it carries
+owner, classification, reason, expiry, and selector identity — none of which
+fit in `#[expect(...)]` attributes alone.
+
+## Stage A (current)
+
+- Panic-family Clippy lints are at **`warn`** while debt is being mapped.
+- `cargo xtask check-no-panic-family` runs in **advisory** mode (reports but
+  does not block CI).
+- `cargo xtask no-panic propose` writes a candidate baseline allowlist.
+- The strict baseline (Stage C) flips panic-family lints to `deny` once the
+  allowlist is the authoritative ledger.
+
+## Suppression style
+
+- **No bare `#[allow(...)]`.** Use `#[expect(..., reason = "...")]` only.
+- **No `clippy.toml` test carveouts** (`allow-unwrap-in-tests` etc.).
+- Receipted panic-family exceptions live in
+  `policy/no-panic-allowlist.toml` (see [NO_PANIC_POLICY.md](NO_PANIC_POLICY.md)).
+- Clippy-debt entries live in `policy/clippy-debt.toml` with owner, reason,
+  and expiry.
+
+## Planned MSRV-staged flips
+
+`policy/clippy-lints.toml` lists lints planned to flip on at MSRV 1.94 and
+1.95. `cargo xtask check-lint-policy` verifies they are NOT activated before
+their target MSRV.
+
+## What `check-lint-policy` enforces
+
+- Workspace MSRV matches `policy/clippy-lints.toml`.
+- Every member crate has `[lints]\nworkspace = true`.
+- No `clippy.toml` test carveouts.
+- No bare `#[allow(...)]` in crate sources (use `#[expect(..., reason = ...)]`).
+- All `clippy-debt.toml` entries have owner, reason, and a non-expired date.
+- Planned MSRV-staged lints are not activated too early.

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -1,0 +1,68 @@
+# Non-Rust file policy
+
+> Authoritative file: `policy/non-rust-allowlist.toml`. Enforced by `cargo
+> xtask check-file-policy`. See also [POLICY_ALLOWLISTS.md](POLICY_ALLOWLISTS.md).
+
+## Why
+
+`uselesskey` is a Rust workspace. The default implementation surface is Rust
+plus `xtask`. Every other tracked file represents a deliberate non-Rust
+surface — CI declarations, BDD features, generated metadata, golden fixtures.
+Each non-Rust surface needs an explicit owner, reason, classification, and a
+test/CI command that exercises it.
+
+This is not aesthetics. It prevents:
+
+- silent introduction of shell scripts that bypass `cargo xtask`
+- generated artifacts checked in without a regenerator command
+- vendored config that nobody owns
+
+## Default-allowed defaults
+
+The checker treats the following as default-allowed (still classified for the
+report):
+
+- `*.rs`, `Cargo.toml`, `Cargo.lock`, `*.md`
+- `LICENSE-APACHE`, `LICENSE-MIT`, `CODEOWNERS`,
+  `.gitignore`, `.gitattributes`, `.editorconfig`
+
+## Required schema
+
+```toml
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+surface = "ci"
+classification = "config"  # config | test | tooling | generated | production
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+covered_by = ["cargo xtask ci"]
+# generated entries also include:
+# generated_by = "cargo xtask docs-sync"
+# optional:
+# expires = "2026-09-01"
+# retired = false
+```
+
+### Classifications
+
+| Classification | Meaning                                                                    |
+|----------------|----------------------------------------------------------------------------|
+| `config`       | Declarative configuration consumed by an external tool.                    |
+| `test`         | Test fixture, golden file, BDD feature, snapshot, regression seed.         |
+| `tooling`      | Repo-managed tooling/automation (hooks, helper scripts).                   |
+| `generated`    | Generated artifact; must specify `generated_by`.                           |
+| `production`   | Production non-Rust surface (none currently in `uselesskey`).              |
+
+## What `check-file-policy` enforces
+
+- Enumerate git-tracked files.
+- Classify each file. Default-allowed defaults pass automatically.
+- Match the rest against `policy/non-rust-allowlist.toml`.
+- Fail on:
+  - tracked files with no matching entry,
+  - entries missing `owner`/`reason`/`surface`/`classification`,
+  - `production`/`test`/`tooling` entries missing `covered_by`,
+  - entries past their `expires` date,
+  - entries with no matching tracked file (unless `retired = true`).
+- Write `target/file-policy.md` and `target/file-policy.json` reports.

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -1,0 +1,101 @@
+# No-panic policy
+
+> Authoritative file: `policy/no-panic-allowlist.toml`. Enforced by `cargo
+> xtask check-no-panic-family`. See also [CLIPPY_POLICY.md](CLIPPY_POLICY.md).
+
+## Definition
+
+> *Panic-free* in `uselesskey` means **no unreceipted panic-family behavior in
+> production or tests**.
+
+The panic family includes:
+
+- `unwrap`
+- `expect`
+- `panic!`
+- `todo!`
+- `unimplemented!`
+- `unreachable!`
+- unchecked indexing/slicing (`a[i]`, `&s[i..]`)
+- `get(...).unwrap()`
+- unchecked time subtraction (`Instant::duration_since`, etc. that can panic)
+- `Result`-returning bodies that `unwrap()` internally
+
+Test assertion macros (`assert!`, `assert_eq!`, `assert_ne!`) are still test
+oracles and are NOT panic-family. A future migration may introduce fallible
+assertion helpers (`ensure_eq`, `require_some`); that is a separate policy
+decision.
+
+## Identity
+
+The no-panic checker matches by **`path + family + selector`** — never by
+line/column. `last_seen.line` and `last_seen.column` are advisory hints used
+to surface drift.
+
+```toml
+[[allow]]
+id = "panic-0001"
+path = "crates/uselesskey-core/src/sink/mod.rs"
+family = "expect"
+classification = "test_helper"
+owner = "core"
+explanation = "Sink test helper; will move to fallible assertion helper."
+expires = "2026-09-01"
+
+[allow.selector]
+kind = "method_call"
+container = "tempfile_text_roundtrip"
+callee = "expect"
+receiver_fingerprint = "TempArtifact::new(...)"
+
+[allow.last_seen]
+line = 50
+column = 14
+```
+
+### Classifications
+
+| Classification           | Meaning                                                |
+|--------------------------|--------------------------------------------------------|
+| `production`             | Live runtime path; should be near-zero, hard to renew. |
+| `test_helper`            | Pure test scaffolding; migrate to fallible API.        |
+| `fixture`                | Fixture builder where panic equals "test bug".         |
+| `infallible_invariant`   | Compiler/data-driven invariants; document the proof.   |
+| `build_script`           | `build.rs` setup.                                      |
+
+## Stages
+
+- **Stage A (current)** — Clippy panic-family at `warn`. `cargo xtask
+  check-no-panic-family` runs advisory-only, reporting findings.
+- **Stage B** — debt is moved into `policy/no-panic-allowlist.toml` with
+  owner/reason/expiry; the checker becomes blocking; new findings outside the
+  allowlist fail CI.
+- **Stage C** — Clippy panic-family lints flip to `deny`. The allowlist is the
+  only legitimate route to a panic-family call site.
+
+## Workflow
+
+```bash
+# 1. Find new findings.
+cargo xtask check-no-panic-family
+
+# 2. Generate a candidate allowlist file (stays under target/).
+cargo xtask no-panic propose
+
+# 3. Review proposed entries; copy reviewed ones into
+#    policy/no-panic-allowlist.toml with owner, reason, classification,
+#    and expiry. Re-run.
+
+cargo xtask check-no-panic-family
+```
+
+## What `check-no-panic-family` enforces
+
+- Detect panic-family calls in workspace Rust sources.
+- Match each finding to an allowlist entry by `path + family + selector`.
+- In `mode = "blocking"`, fail on unallowlisted findings.
+- Fail on **expired** allowlist entries.
+- Fail on **stale** entries (entry exists but no matching finding).
+- Warn on `last_seen` drift (line/column moved more than the configured
+  tolerance).
+- Write `target/no-panic.md` and `target/no-panic.json` reports.

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -1,0 +1,56 @@
+# Policy allowlists overview
+
+This document describes the shared structure of every policy allowlist used
+in `uselesskey`. The principle is constant:
+
+> **Deny by default. Allow by receipt. Expire exceptions. Measure drift.**
+
+## Files
+
+| File                                  | Purpose                                            | Checker                                |
+|---------------------------------------|----------------------------------------------------|----------------------------------------|
+| `policy/clippy-lints.toml`            | Lint posture, MSRV, planned 1.94/1.95 flips        | `cargo xtask check-lint-policy`        |
+| `policy/clippy-debt.toml`             | Receipted Clippy warn-stage debt with expiry       | `cargo xtask check-lint-policy`        |
+| `policy/no-panic-allowlist.toml`      | Receipted panic-family call sites                  | `cargo xtask check-no-panic-family`    |
+| `policy/non-rust-allowlist.toml`      | Receipted non-Rust tracked files                   | `cargo xtask check-file-policy`        |
+
+## Common rules
+
+- **Identity, not coordinates.** Allowlist entries match by *what* (path +
+  family + selector, or path-glob + kind), never by line/column.
+- **Owner + reason + classification are required.** Every entry has a human
+  owner and a written justification.
+- **Expiry.** `expires` is an ISO-8601 date. Past entries are rejected.
+- **Drift.** `last_seen` (no-panic) and unmatched-entry detection
+  (file-policy) surface drift.
+- **`covered_by`.** Every non-Rust file class with `production`, `test`, or
+  `tooling` classification must point to a CI/xtask command that exercises it.
+
+## Reports
+
+Each checker writes both human-readable and machine-readable artifacts:
+
+```
+target/no-panic.md       target/no-panic.json
+target/file-policy.md    target/file-policy.json
+target/lint-policy.md    target/lint-policy.json
+target/policy-report.md  target/policy-report.json
+```
+
+`cargo xtask policy-report` aggregates all four into a single review surface.
+
+## Process
+
+```
+1. Run `cargo xtask check-no-panic-family` and `check-file-policy`.
+2. If new findings exist:
+   a. Run `cargo xtask no-panic propose` to write a candidate allowlist
+      under target/policy-proposed/.
+   b. Review proposed entries; add owner, reason, classification, and
+      expiry; copy into policy/.
+3. Re-run the checkers.
+4. Commit policy changes alongside the code changes that triggered them.
+```
+
+The checkers never mutate `policy/`. Proposals are emitted under `target/` so
+that human review is required.

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,24 @@
+# Effortless Metrics — Clippy debt ledger
+#
+# Use this file to receipt intentional warn-stage Clippy debt that is currently
+# being tolerated but tracked. Only entries that survive `cargo xtask
+# check-lint-policy` are valid.
+#
+# Owner: repo-policy
+# See: docs/CLIPPY_POLICY.md
+schema_version = "1.0"
+
+# Each entry must specify owner, reason, and an expiry date. After the expiry,
+# the entry is rejected unless extended.
+#
+# Example:
+#
+# [[debt]]
+# id = "clippy-0001"
+# lint = "clippy::missing_panics_doc"
+# scope = "crates/uselesskey-core"
+# owner = "core"
+# reason = "Doc-coverage backfill scheduled with public-surface review."
+# expires = "2026-09-01"
+#
+# (No active debt entries at this time.)

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,111 @@
+# Effortless Metrics — Clippy / Rust lint policy for uselesskey
+#
+# This file is the authoritative description of the lint posture. The actual
+# lints are configured in the workspace `[workspace.lints]` block in the root
+# `Cargo.toml`; this file documents intent, MSRV-staged plans, and the rules
+# that `cargo xtask check-lint-policy` enforces.
+#
+# Owner: repo-policy
+# See: docs/CLIPPY_POLICY.md, docs/POLICY_ALLOWLISTS.md
+schema_version = "1.0"
+msrv = "1.92"
+
+[policy]
+# uselesskey is a crypto/security workspace; no production runtime panics.
+panic_free_tests = true
+# No `clippy.toml` test carveouts (`allow-unwrap-in-tests` etc.).
+allow_test_carveouts = false
+# `#[expect(..., reason = "...")]` only — no bare `#[allow(...)]`.
+suppression_style = "expect-with-reason"
+# Do not use `clippy::all`/`pedantic`/`nursery` blanket categories.
+blanket_categories = false
+# Promote panic-family clippy lints to `deny` only when the no-panic
+# allowlist is the authoritative ledger. Currently warn-stage.
+panic_family_level = "warn"
+# `cargo xtask check-no-panic-family` is the authoritative ledger for
+# panic-family exceptions. Clippy is the immediate code-shape detector.
+no_panic_authoritative = "xtask"
+
+# Lints that are planned to flip on once MSRV reaches the indicated version.
+# `cargo xtask check-lint-policy` verifies these are NOT active too early.
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+reason = "Catch raw-parts reconstruction mistakes in low-level adapters."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Prefer standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Avoid stale numeric type drift."
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+reason = "Ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use collection APIs that encode predicate-and-pop intent."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Keep format macro calls clean."
+
+# Forbidden carveouts — `cargo xtask check-lint-policy` fails if any of these
+# appear in `clippy.toml` or in `[workspace.lints.*]`.
+[forbidden_carveouts]
+keys = [
+  "allow-unwrap-in-tests",
+  "allow-expect-in-tests",
+  "allow-panic-in-tests",
+  "allow-indexing-slicing-in-tests",
+  "allow-dbg-in-tests",
+]
+
+# Stage tracking for the panic-family rollout.
+#
+# Stage A (current): warn-level panic-family lints, advisory no-panic checker.
+# Stage B: burn down debt, every remaining exception receipted in
+#          policy/no-panic-allowlist.toml with owner/reason/expiry.
+# Stage C: flip panic-family lints to deny.
+[stage]
+current = "A"
+description = "Warn-stage panic-family lints; semantic no-panic checker advisory."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,54 @@
+# Effortless Metrics — semantic no-panic allowlist
+#
+# Authoritative ledger of receipted panic-family debt. Each `[[allow]]` entry
+# is identified by `path + family + selector`; line/column are advisory
+# `last_seen` hints only.
+#
+# Owner: repo-policy
+# See: docs/NO_PANIC_POLICY.md, docs/POLICY_ALLOWLISTS.md
+#
+# This baseline file starts empty. Stage A keeps the no-panic checker advisory
+# (it reports findings but does not block CI). Once a baseline is generated
+# via `cargo xtask no-panic propose` and reviewed, entries are moved into this
+# file with owner/reason/expiry, and the checker is promoted to blocking.
+schema_version = "0.3"
+
+[policy]
+# Families enforced by `cargo xtask check-no-panic-family`.
+families = [
+  "unwrap",
+  "expect",
+  "panic_macro",
+  "todo",
+  "unimplemented",
+  "unreachable",
+  "indexing",
+  "string_slice",
+  "get_unwrap",
+  "unchecked_time_subtraction",
+]
+# Stage A: advisory only. The checker reports but does not fail.
+mode = "advisory"
+
+# Each [[allow]] looks like:
+#
+# [[allow]]
+# id = "panic-0001"
+# path = "crates/example/src/parser.rs"
+# family = "unwrap"
+# classification = "test_helper"   # one of: production, test_helper, fixture, infallible_invariant, build_script
+# owner = "core"
+# explanation = "Fixture builder; migrate to fallible API in next minor."
+# expires = "2026-09-01"
+#
+# [allow.selector]
+# kind = "method_call"
+# container = "load_fixture"
+# callee = "unwrap"
+# receiver_fingerprint = "std::fs::read_to_string(path)"
+#
+# [allow.last_seen]
+# line = 42
+# column = 17
+#
+# (No receipted entries yet.)

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,233 @@
+# Effortless Metrics — non-Rust file policy allowlist
+#
+# Rust and `xtask` are the default implementation surface. Any tracked file
+# that is not Rust source, a `Cargo.toml`/`Cargo.lock`, or a `.md` doc requires
+# an approved entry in this file with owner, surface, classification, reason,
+# and `covered_by` evidence.
+#
+# Owner: repo-policy
+# See: docs/FILE_POLICY.md, docs/POLICY_ALLOWLISTS.md
+schema_version = "1.0"
+
+[policy]
+# Files are matched in order; the first match wins.
+# Globs use forward-slash repo-relative paths.
+# Default-allowed extensions (no entry required) are listed here for
+# transparency only — they are still classified by the checker.
+default_allowed_extensions = ["rs", "toml", "md"]
+# Default-allowed top-level filenames that have no extension.
+default_allowed_filenames = [
+  "LICENSE-APACHE",
+  "LICENSE-MIT",
+  "CODEOWNERS",
+  ".gitignore",
+  ".gitattributes",
+  ".editorconfig",
+]
+
+# === CI / declarative configuration ==========================================
+
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+covered_by = ["cargo xtask ci"]
+
+[[allow]]
+glob = ".github/*.yml"
+kind = "github_meta"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "GitHub repo metadata: settings, dependabot, funding, release notes."
+covered_by = ["GitHub schema validation"]
+
+[[allow]]
+glob = "lefthook.yml"
+kind = "git_hooks_config"
+owner = "repo-policy"
+surface = "tooling"
+classification = "config"
+reason = "Lefthook git-hook configuration."
+covered_by = ["lefthook run pre-commit"]
+
+# === Repo automation / hooks ================================================
+
+[[allow]]
+glob = ".githooks/pre-commit"
+kind = "git_hook"
+owner = "repo-policy"
+surface = "tooling"
+classification = "tooling"
+reason = "Repo-managed pre-commit hook script."
+covered_by = ["cargo xtask setup"]
+
+[[allow]]
+glob = ".githooks/pre-push"
+kind = "git_hook"
+owner = "repo-policy"
+surface = "tooling"
+classification = "tooling"
+reason = "Repo-managed pre-push hook script."
+covered_by = ["cargo xtask gate"]
+
+[[allow]]
+glob = ".claude/agent-swarm-workflow/*.sh"
+kind = "automation_script"
+owner = "repo-policy"
+surface = "tooling"
+classification = "tooling"
+reason = "Internal Claude agent automation helpers."
+covered_by = ["manual review"]
+
+# === Cargo / lock / manifests ==============================================
+
+[[allow]]
+glob = "Cargo.lock"
+kind = "cargo_lockfile"
+owner = "repo-policy"
+surface = "build"
+classification = "generated"
+reason = "Cargo lockfile."
+generated_by = "cargo build"
+covered_by = ["cargo xtask dep-guard"]
+
+[[allow]]
+glob = "fuzz/Cargo.lock"
+kind = "cargo_lockfile"
+owner = "fuzz"
+surface = "build"
+classification = "generated"
+reason = "Fuzz workspace lockfile."
+generated_by = "cargo fuzz build"
+covered_by = ["cargo xtask fuzz"]
+
+[[allow]]
+glob = "fuzz/.gitignore"
+kind = "vcs_meta"
+owner = "fuzz"
+surface = "build"
+classification = "config"
+reason = "Fuzz workspace gitignore."
+covered_by = ["manual review"]
+
+[[allow]]
+glob = ".cargo/*.toml"
+kind = "cargo_config"
+owner = "repo-policy"
+surface = "build"
+classification = "config"
+reason = "Cargo build configuration (workspace + mutants tuning)."
+covered_by = ["cargo xtask ci"]
+
+[[allow]]
+glob = "**/uselesskey-fixtures.toml"
+kind = "fixture_manifest"
+owner = "core/buildrs"
+surface = "fixtures"
+classification = "test"
+reason = "Materialize build.rs example fixture manifest."
+covered_by = ["cargo xtask test"]
+
+[[allow]]
+glob = ".typos.toml"
+kind = "tooling_config"
+owner = "repo-policy"
+surface = "tooling"
+classification = "config"
+reason = "typos spell-check configuration."
+covered_by = ["cargo xtask typos"]
+
+# === BDD feature files ======================================================
+
+[[allow]]
+glob = "crates/uselesskey-bdd/features/*.feature"
+kind = "bdd_feature"
+owner = "bdd"
+surface = "tests"
+classification = "test"
+reason = "Cucumber feature files for BDD tests."
+covered_by = ["cargo xtask bdd"]
+
+# === Test fixtures (golden, snapshots, regressions) ========================
+
+[[allow]]
+glob = "crates/uselesskey-cli/tests/golden/*.json"
+kind = "fixture_input"
+owner = "cli"
+surface = "fixtures"
+classification = "test"
+reason = "CLI golden fixture inputs."
+covered_by = ["cargo test -p uselesskey-cli"]
+
+[[allow]]
+glob = "crates/uselesskey-cli/tests/golden/*.yaml"
+kind = "fixture_input"
+owner = "cli"
+surface = "fixtures"
+classification = "test"
+reason = "CLI golden fixture inputs (k8s/sops shape)."
+covered_by = ["cargo test -p uselesskey-cli"]
+
+[[allow]]
+glob = "crates/uselesskey-cli/tests/golden/*.env"
+kind = "fixture_input"
+owner = "cli"
+surface = "fixtures"
+classification = "test"
+reason = "CLI golden fixture .env file."
+covered_by = ["cargo test -p uselesskey-cli"]
+
+[[allow]]
+glob = "tests/fixtures/**/.gitignore"
+kind = "vcs_meta"
+owner = "tests"
+surface = "fixtures"
+classification = "config"
+reason = "Per-fixture gitignore."
+covered_by = ["manual review"]
+
+[[allow]]
+glob = "**/snapshots/**/*.snap"
+kind = "snapshot"
+owner = "tests"
+surface = "tests"
+classification = "test"
+reason = "insta snapshot files (per-crate and workspace-level)."
+generated_by = "cargo insta accept"
+covered_by = ["cargo test"]
+
+[[allow]]
+glob = "**/*.proptest-regressions"
+kind = "proptest_regressions"
+owner = "tests"
+surface = "tests"
+classification = "test"
+reason = "proptest regression seeds."
+generated_by = "proptest persistence"
+covered_by = ["cargo test"]
+
+[[allow]]
+glob = "tests/compile_fail/*.stderr"
+kind = "trybuild_stderr"
+owner = "tests"
+surface = "tests"
+classification = "test"
+reason = "trybuild compile-fail expected stderr output."
+generated_by = "TRYBUILD=overwrite cargo test"
+covered_by = ["cargo test --test compile_fail"]
+
+# === Generated metadata =====================================================
+
+[[allow]]
+glob = "docs/metadata/*.json"
+kind = "generated_metadata"
+owner = "docs/metadata"
+surface = "docs"
+classification = "generated"
+reason = "Generated workspace docs / perf-baseline metadata."
+generated_by = "cargo xtask docs-sync"
+covered_by = ["cargo xtask docs-sync --check"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -313,3 +313,6 @@ required-features = ["api-surface"]
 name = "security_invariants"
 path = "security_invariants.rs"
 required-features = ["security-invariants"]
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -22,7 +22,11 @@ owo-colors = "4.0"
 regex = "1.11"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+toml.workspace = true
 uselesskey-feature-grid.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -18,6 +18,7 @@ mod audit_surface;
 mod docs_sync;
 mod economics;
 mod plan;
+mod policy;
 mod pr_bundles;
 mod receipt;
 
@@ -158,6 +159,19 @@ enum Cmd {
         #[command(subcommand)]
         command: PrBundlesCmd,
     },
+    /// Check the semantic no-panic allowlist (panic-family ledger).
+    CheckNoPanicFamily,
+    /// Emit a proposed no-panic allowlist under target/policy-proposed/.
+    NoPanic {
+        #[command(subcommand)]
+        action: NoPanicCmd,
+    },
+    /// Check the non-Rust file allowlist.
+    CheckFilePolicy,
+    /// Check the lint-policy invariants (MSRV, [lints] inheritance, debt expiry).
+    CheckLintPolicy,
+    /// Aggregate policy report across no-panic, file-policy, and lint-policy.
+    PolicyReport,
 }
 
 #[derive(Subcommand)]
@@ -166,6 +180,12 @@ enum NoBlobCmd {
     Scan,
     /// Scan and emit a migration recipe for each detected blob (read-only).
     Migrate,
+}
+
+#[derive(Subcommand)]
+enum NoPanicCmd {
+    /// Generate a candidate allowlist file under target/policy-proposed/.
+    Propose,
 }
 
 #[derive(Subcommand)]
@@ -279,6 +299,13 @@ fn main() -> Result<()> {
             HookCmd::PreCommit => hook_pre_commit(),
             HookCmd::PrePush => hook_pre_push(),
         },
+        Cmd::CheckNoPanicFamily => policy::check_no_panic_family(),
+        Cmd::NoPanic { action } => match action {
+            NoPanicCmd::Propose => policy::no_panic_propose(),
+        },
+        Cmd::CheckFilePolicy => policy::check_file_policy(),
+        Cmd::CheckLintPolicy => policy::check_lint_policy(),
+        Cmd::PolicyReport => policy::policy_report(),
         Cmd::PrBundles { command } => match command {
             PrBundlesCmd::Snapshot {
                 repo,

--- a/xtask/src/policy.rs
+++ b/xtask/src/policy.rs
@@ -1,0 +1,1261 @@
+//! Effortless Metrics policy stack: no-panic, file-policy, lint-policy.
+//!
+//! See `docs/CLIPPY_POLICY.md`, `docs/NO_PANIC_POLICY.md`, `docs/FILE_POLICY.md`,
+//! and `docs/POLICY_ALLOWLISTS.md`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use chrono::NaiveDate;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+const NO_PANIC_TOML: &str = "policy/no-panic-allowlist.toml";
+const NON_RUST_TOML: &str = "policy/non-rust-allowlist.toml";
+const CLIPPY_LINTS_TOML: &str = "policy/clippy-lints.toml";
+const CLIPPY_DEBT_TOML: &str = "policy/clippy-debt.toml";
+
+const TARGET_DIR: &str = "target";
+const PROPOSED_DIR: &str = "target/policy-proposed";
+
+// =============================================================================
+// Glob matching (forward-slash, supports **, *, ?)
+// =============================================================================
+
+fn glob_to_regex(glob: &str) -> Regex {
+    let mut re = String::from("^");
+    let mut chars = glob.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '*' => {
+                if chars.peek() == Some(&'*') {
+                    chars.next();
+                    // consume optional trailing '/'
+                    if chars.peek() == Some(&'/') {
+                        chars.next();
+                        re.push_str("(?:.*/)?");
+                    } else {
+                        re.push_str(".*");
+                    }
+                } else {
+                    re.push_str("[^/]*");
+                }
+            }
+            '?' => re.push_str("[^/]"),
+            '.' | '+' | '(' | ')' | '|' | '^' | '$' | '{' | '}' | '[' | ']' | '\\' => {
+                re.push('\\');
+                re.push(c);
+            }
+            _ => re.push(c),
+        }
+    }
+    re.push('$');
+    Regex::new(&re).expect("valid generated regex")
+}
+
+fn glob_match(glob: &str, path: &str) -> bool {
+    glob_to_regex(glob).is_match(path)
+}
+
+// =============================================================================
+// Common helpers
+// =============================================================================
+
+fn read_toml<T: for<'de> Deserialize<'de>>(path: &str) -> Result<T> {
+    let raw = fs::read_to_string(path).with_context(|| format!("read {path}"))?;
+    toml::from_str(&raw).with_context(|| format!("parse {path}"))
+}
+
+fn git_ls_files() -> Result<Vec<String>> {
+    let out = Command::new("git")
+        .args(["ls-files"])
+        .output()
+        .context("git ls-files")?;
+    if !out.status.success() {
+        bail!("git ls-files exited with {:?}", out.status);
+    }
+    let s = String::from_utf8(out.stdout).context("git ls-files: utf-8")?;
+    Ok(s.lines()
+        .filter(|l| !l.is_empty())
+        .map(String::from)
+        .collect())
+}
+
+fn write_outputs(name: &str, json: &serde_json::Value, markdown: &str) -> Result<()> {
+    fs::create_dir_all(TARGET_DIR).ok();
+    let json_path = format!("{TARGET_DIR}/{name}.json");
+    let md_path = format!("{TARGET_DIR}/{name}.md");
+    fs::write(&json_path, serde_json::to_string_pretty(json)?)
+        .with_context(|| format!("write {json_path}"))?;
+    fs::write(&md_path, markdown).with_context(|| format!("write {md_path}"))?;
+    Ok(())
+}
+
+fn today() -> NaiveDate {
+    chrono::Utc::now().date_naive()
+}
+
+// =============================================================================
+// no-panic allowlist
+// =============================================================================
+
+#[derive(Debug, Deserialize)]
+struct NoPanicConfig {
+    #[expect(
+        dead_code,
+        reason = "schema validation; surfaced in policy reports later"
+    )]
+    #[serde(default)]
+    schema_version: Option<String>,
+    #[serde(default)]
+    policy: NoPanicPolicy,
+    #[serde(default)]
+    allow: Vec<NoPanicAllow>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct NoPanicPolicy {
+    // `families` is part of the schema and parsed for validation; the scanner
+    // currently scans all known families.
+    #[expect(
+        dead_code,
+        reason = "schema validation; consumed once families become tunable"
+    )]
+    #[serde(default)]
+    families: Vec<String>,
+    #[serde(default = "default_no_panic_mode")]
+    mode: String,
+}
+
+fn default_no_panic_mode() -> String {
+    "advisory".into()
+}
+
+#[derive(Debug, Deserialize)]
+#[expect(dead_code, reason = "schema fields preserved for surfacing in reports")]
+struct NoPanicAllow {
+    id: String,
+    path: String,
+    family: String,
+    classification: String,
+    owner: String,
+    #[serde(default)]
+    explanation: Option<String>,
+    expires: String,
+    selector: NoPanicSelector,
+    #[serde(default)]
+    last_seen: Option<NoPanicLastSeen>,
+}
+
+#[derive(Debug, Deserialize)]
+#[expect(dead_code, reason = "schema fields used by the matching reducer")]
+struct NoPanicSelector {
+    kind: String,
+    #[serde(default)]
+    container: Option<String>,
+    callee: String,
+    #[serde(default)]
+    receiver_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[expect(dead_code, reason = "advisory `last_seen` hints surface drift later")]
+struct NoPanicLastSeen {
+    #[serde(default)]
+    line: Option<u32>,
+    #[serde(default)]
+    column: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PanicFinding {
+    pub path: String,
+    pub family: String,
+    pub line: u32,
+    pub column: u32,
+    pub selector_kind: String,
+    pub selector_callee: String,
+    pub snippet: String,
+}
+
+pub fn check_no_panic_family() -> Result<()> {
+    let config: NoPanicConfig = if Path::new(NO_PANIC_TOML).exists() {
+        read_toml(NO_PANIC_TOML)?
+    } else {
+        bail!("missing {NO_PANIC_TOML}");
+    };
+
+    let findings = scan_panic_findings()?;
+    let mut report = NoPanicReport::default();
+    let mut matched = vec![false; config.allow.len()];
+    let mut unallowlisted: Vec<&PanicFinding> = Vec::new();
+
+    for finding in &findings {
+        let mut matched_one = false;
+        for (idx, entry) in config.allow.iter().enumerate() {
+            if entry_matches(entry, finding) {
+                matched[idx] = true;
+                matched_one = true;
+                break;
+            }
+        }
+        if !matched_one {
+            unallowlisted.push(finding);
+        }
+    }
+
+    let mut stale: Vec<&NoPanicAllow> = Vec::new();
+    let mut expired: Vec<&NoPanicAllow> = Vec::new();
+    let now = today();
+    for (idx, entry) in config.allow.iter().enumerate() {
+        if !matched[idx] {
+            stale.push(entry);
+        }
+        if let Ok(d) = NaiveDate::parse_from_str(&entry.expires, "%Y-%m-%d") {
+            if d < now {
+                expired.push(entry);
+            }
+        } else {
+            bail!(
+                "no-panic allowlist entry `{}`: invalid expires date `{}` (expected YYYY-MM-DD)",
+                entry.id,
+                entry.expires
+            );
+        }
+    }
+
+    report.total_findings = findings.len();
+    report.allowlisted = findings.len().saturating_sub(unallowlisted.len());
+    report.unallowlisted = unallowlisted.len();
+    report.stale_entries = stale.len();
+    report.expired_entries = expired.len();
+    report.mode = config.policy.mode.clone();
+    report.by_family = group_by_family(&findings);
+    report.by_crate = group_by_crate(&findings);
+
+    let markdown = render_no_panic_md(&report, &unallowlisted, &stale, &expired);
+    write_outputs("no-panic", &serde_json::to_value(&report)?, &markdown)?;
+
+    eprintln!(
+        "no-panic: {} finding(s); {} unallowlisted; {} stale; {} expired (mode={})",
+        report.total_findings,
+        report.unallowlisted,
+        report.stale_entries,
+        report.expired_entries,
+        report.mode
+    );
+
+    let blocking = config.policy.mode == "blocking";
+    if blocking
+        && (report.unallowlisted > 0 || report.stale_entries > 0 || report.expired_entries > 0)
+    {
+        bail!(
+            "no-panic policy is blocking and there are {} unallowlisted, {} stale, {} expired",
+            report.unallowlisted,
+            report.stale_entries,
+            report.expired_entries
+        );
+    }
+    Ok(())
+}
+
+pub fn no_panic_propose() -> Result<()> {
+    let findings = scan_panic_findings()?;
+    fs::create_dir_all(PROPOSED_DIR).ok();
+    let path = format!("{PROPOSED_DIR}/no-panic-proposed-allowlist.toml");
+
+    let mut buf = String::new();
+    buf.push_str("# Proposed no-panic allowlist (review before copying into\n");
+    buf.push_str("# policy/no-panic-allowlist.toml). Add owner/reason/expiry per entry.\n");
+    buf.push_str("schema_version = \"0.3\"\n\n");
+
+    let stub_expires = stub_expiry();
+    for (idx, f) in findings.iter().enumerate() {
+        let id = format!("panic-proposed-{idx:05}");
+        buf.push_str("[[allow]]\n");
+        buf.push_str(&format!("id = \"{id}\"\n"));
+        buf.push_str(&format!("path = \"{}\"\n", f.path));
+        buf.push_str(&format!("family = \"{}\"\n", f.family));
+        buf.push_str("classification = \"test_helper\"  # FIXME: classify\n");
+        buf.push_str("owner = \"FIXME\"\n");
+        buf.push_str(&format!(
+            "explanation = \"FIXME: explain or migrate. Snippet: {}\"\n",
+            escape_toml(&f.snippet)
+        ));
+        buf.push_str(&format!("expires = \"{stub_expires}\"\n"));
+        buf.push_str("\n[allow.selector]\n");
+        buf.push_str(&format!("kind = \"{}\"\n", f.selector_kind));
+        buf.push_str(&format!("callee = \"{}\"\n", f.selector_callee));
+        buf.push_str("\n[allow.last_seen]\n");
+        buf.push_str(&format!("line = {}\n", f.line));
+        buf.push_str(&format!("column = {}\n", f.column));
+        buf.push('\n');
+    }
+
+    fs::write(&path, buf).with_context(|| format!("write {path}"))?;
+    eprintln!(
+        "no-panic propose: wrote {} ({} candidate entries)",
+        path,
+        findings.len()
+    );
+    Ok(())
+}
+
+fn stub_expiry() -> String {
+    let d = today() + chrono::Duration::days(180);
+    d.format("%Y-%m-%d").to_string()
+}
+
+fn escape_toml(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn entry_matches(entry: &NoPanicAllow, finding: &PanicFinding) -> bool {
+    entry.path == finding.path
+        && entry.family == finding.family
+        && entry.selector.kind == finding.selector_kind
+        && entry.selector.callee == finding.selector_callee
+}
+
+#[derive(Debug, Default, Serialize)]
+struct NoPanicReport {
+    total_findings: usize,
+    allowlisted: usize,
+    unallowlisted: usize,
+    stale_entries: usize,
+    expired_entries: usize,
+    mode: String,
+    by_family: BTreeMap<String, usize>,
+    by_crate: BTreeMap<String, usize>,
+}
+
+fn group_by_family(findings: &[PanicFinding]) -> BTreeMap<String, usize> {
+    let mut map = BTreeMap::new();
+    for f in findings {
+        *map.entry(f.family.clone()).or_default() += 1;
+    }
+    map
+}
+
+fn group_by_crate(findings: &[PanicFinding]) -> BTreeMap<String, usize> {
+    let mut map = BTreeMap::new();
+    for f in findings {
+        let krate = f.path.split('/').take(2).collect::<Vec<_>>().join("/");
+        *map.entry(krate).or_default() += 1;
+    }
+    map
+}
+
+fn render_no_panic_md(
+    report: &NoPanicReport,
+    unallowlisted: &[&PanicFinding],
+    stale: &[&NoPanicAllow],
+    expired: &[&NoPanicAllow],
+) -> String {
+    let mut s = String::new();
+    s.push_str("# No-panic policy report\n\n");
+    s.push_str(&format!("- Mode: `{}`\n", report.mode));
+    s.push_str(&format!(
+        "- Total findings: **{}**\n",
+        report.total_findings
+    ));
+    s.push_str(&format!("- Allowlisted: {}\n", report.allowlisted));
+    s.push_str(&format!("- Unallowlisted: **{}**\n", report.unallowlisted));
+    s.push_str(&format!("- Stale entries: {}\n", report.stale_entries));
+    s.push_str(&format!(
+        "- Expired entries: {}\n\n",
+        report.expired_entries
+    ));
+
+    s.push_str("## By family\n\n");
+    for (k, v) in &report.by_family {
+        s.push_str(&format!("- `{}`: {}\n", k, v));
+    }
+    s.push('\n');
+
+    s.push_str("## By crate (top 20)\n\n");
+    let mut by_crate: Vec<_> = report.by_crate.iter().collect();
+    by_crate.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+    for (k, v) in by_crate.iter().take(20) {
+        s.push_str(&format!("- `{}`: {}\n", k, v));
+    }
+    s.push('\n');
+
+    if !unallowlisted.is_empty() {
+        s.push_str(&format!(
+            "## Unallowlisted findings ({})\n\n",
+            unallowlisted.len()
+        ));
+        s.push_str("First 50 shown.\n\n");
+        for f in unallowlisted.iter().take(50) {
+            s.push_str(&format!(
+                "- `{}:{}:{}` — `{}` ({})\n",
+                f.path, f.line, f.column, f.family, f.selector_callee
+            ));
+        }
+        s.push('\n');
+    }
+
+    if !stale.is_empty() {
+        s.push_str(&format!("## Stale allowlist entries ({})\n\n", stale.len()));
+        for e in stale {
+            s.push_str(&format!("- `{}` ({}, {})\n", e.id, e.path, e.family));
+        }
+        s.push('\n');
+    }
+
+    if !expired.is_empty() {
+        s.push_str(&format!(
+            "## Expired allowlist entries ({})\n\n",
+            expired.len()
+        ));
+        for e in expired {
+            s.push_str(&format!(
+                "- `{}` expired {} ({}, {})\n",
+                e.id, e.expires, e.path, e.family
+            ));
+        }
+        s.push('\n');
+    }
+
+    s
+}
+
+// =============================================================================
+// panic-family scanning (regex-based)
+// =============================================================================
+
+fn scan_panic_findings() -> Result<Vec<PanicFinding>> {
+    let files = git_ls_files()?;
+    let rust_files: Vec<&str> = files
+        .iter()
+        .filter(|p| p.ends_with(".rs"))
+        .map(String::as_str)
+        .collect();
+
+    // Skip tests/build helpers under target, and ignore generated files.
+    let unwrap_re = Regex::new(r"\.unwrap\s*\(\s*\)").expect("valid regex");
+    let expect_re = Regex::new(r"\.expect\s*\(").expect("valid regex");
+    let get_unwrap_re =
+        Regex::new(r"\.get(?:_mut)?\s*\([^)]*\)\s*\.\s*unwrap\s*\(").expect("valid regex");
+    let panic_macro_re = Regex::new(r"\bpanic!\s*\(").expect("valid regex");
+    let todo_re = Regex::new(r"\btodo!\s*\(").expect("valid regex");
+    let unimplemented_re = Regex::new(r"\bunimplemented!\s*\(").expect("valid regex");
+    let unreachable_re = Regex::new(r"\bunreachable!\s*\(").expect("valid regex");
+
+    let mut out = Vec::new();
+    for file in &rust_files {
+        let content = match fs::read_to_string(file) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        for (idx, line) in content.lines().enumerate() {
+            // Skip pure-comment / doc lines as a fast first pass; this is not perfect
+            // (block comments slip through) but is a reasonable signal-to-noise.
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || trimmed.starts_with("///") {
+                continue;
+            }
+
+            // get_unwrap takes precedence over plain unwrap so we don't double-count.
+            if let Some(m) = get_unwrap_re.find(line) {
+                out.push(PanicFinding {
+                    path: file.to_string(),
+                    family: "get_unwrap".into(),
+                    line: (idx + 1) as u32,
+                    column: (m.start() + 1) as u32,
+                    selector_kind: "method_call".into(),
+                    selector_callee: "unwrap".into(),
+                    snippet: line.trim().to_string(),
+                });
+                continue;
+            }
+            if let Some(m) = unwrap_re.find(line) {
+                out.push(PanicFinding {
+                    path: file.to_string(),
+                    family: "unwrap".into(),
+                    line: (idx + 1) as u32,
+                    column: (m.start() + 1) as u32,
+                    selector_kind: "method_call".into(),
+                    selector_callee: "unwrap".into(),
+                    snippet: line.trim().to_string(),
+                });
+            }
+            if let Some(m) = expect_re.find(line) {
+                out.push(PanicFinding {
+                    path: file.to_string(),
+                    family: "expect".into(),
+                    line: (idx + 1) as u32,
+                    column: (m.start() + 1) as u32,
+                    selector_kind: "method_call".into(),
+                    selector_callee: "expect".into(),
+                    snippet: line.trim().to_string(),
+                });
+            }
+            if let Some(m) = panic_macro_re.find(line) {
+                out.push(PanicFinding {
+                    path: file.to_string(),
+                    family: "panic_macro".into(),
+                    line: (idx + 1) as u32,
+                    column: (m.start() + 1) as u32,
+                    selector_kind: "macro".into(),
+                    selector_callee: "panic".into(),
+                    snippet: line.trim().to_string(),
+                });
+            }
+            if let Some(m) = todo_re.find(line) {
+                out.push(PanicFinding {
+                    path: file.to_string(),
+                    family: "todo".into(),
+                    line: (idx + 1) as u32,
+                    column: (m.start() + 1) as u32,
+                    selector_kind: "macro".into(),
+                    selector_callee: "todo".into(),
+                    snippet: line.trim().to_string(),
+                });
+            }
+            if let Some(m) = unimplemented_re.find(line) {
+                out.push(PanicFinding {
+                    path: file.to_string(),
+                    family: "unimplemented".into(),
+                    line: (idx + 1) as u32,
+                    column: (m.start() + 1) as u32,
+                    selector_kind: "macro".into(),
+                    selector_callee: "unimplemented".into(),
+                    snippet: line.trim().to_string(),
+                });
+            }
+            if let Some(m) = unreachable_re.find(line) {
+                out.push(PanicFinding {
+                    path: file.to_string(),
+                    family: "unreachable".into(),
+                    line: (idx + 1) as u32,
+                    column: (m.start() + 1) as u32,
+                    selector_kind: "macro".into(),
+                    selector_callee: "unreachable".into(),
+                    snippet: line.trim().to_string(),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+// =============================================================================
+// non-rust file policy
+// =============================================================================
+
+#[derive(Debug, Deserialize)]
+struct FilePolicyConfig {
+    #[expect(
+        dead_code,
+        reason = "schema validation; surfaced in policy reports later"
+    )]
+    #[serde(default)]
+    schema_version: Option<String>,
+    #[serde(default)]
+    policy: FilePolicySettings,
+    #[serde(default)]
+    allow: Vec<FilePolicyAllow>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct FilePolicySettings {
+    #[serde(default = "default_allowed_extensions")]
+    default_allowed_extensions: Vec<String>,
+    #[serde(default = "default_allowed_filenames")]
+    default_allowed_filenames: Vec<String>,
+}
+
+fn default_allowed_extensions() -> Vec<String> {
+    vec!["rs".into(), "toml".into(), "md".into()]
+}
+
+fn default_allowed_filenames() -> Vec<String> {
+    vec![
+        "LICENSE-APACHE".into(),
+        "LICENSE-MIT".into(),
+        "CODEOWNERS".into(),
+        ".gitignore".into(),
+        ".gitattributes".into(),
+        ".editorconfig".into(),
+    ]
+}
+
+#[derive(Debug, Deserialize)]
+struct FilePolicyAllow {
+    #[serde(default)]
+    glob: Option<String>,
+    #[serde(default)]
+    path: Option<String>,
+    kind: String,
+    owner: String,
+    surface: String,
+    classification: String,
+    #[expect(dead_code, reason = "human-readable, surfaced in reports later")]
+    reason: String,
+    #[serde(default)]
+    covered_by: Vec<String>,
+    #[expect(
+        dead_code,
+        reason = "documents regeneration command for `generated` entries"
+    )]
+    #[serde(default)]
+    generated_by: Option<String>,
+    #[serde(default)]
+    expires: Option<String>,
+    #[serde(default)]
+    retired: bool,
+}
+
+pub fn check_file_policy() -> Result<()> {
+    let config: FilePolicyConfig = read_toml(NON_RUST_TOML)?;
+    let files = git_ls_files()?;
+    let now = today();
+
+    let mut unmatched: Vec<String> = Vec::new();
+    let mut matched_count = 0usize;
+    let mut entry_hits = vec![0usize; config.allow.len()];
+    let mut expired: Vec<&FilePolicyAllow> = Vec::new();
+    let mut missing_metadata: Vec<String> = Vec::new();
+
+    for entry in &config.allow {
+        if let Some(exp) = &entry.expires {
+            match NaiveDate::parse_from_str(exp, "%Y-%m-%d") {
+                Ok(d) if d < now => expired.push(entry),
+                Err(e) => bail!(
+                    "file-policy entry kind={} owner={}: invalid expires `{}`: {}",
+                    entry.kind,
+                    entry.owner,
+                    exp,
+                    e
+                ),
+                _ => {}
+            }
+        }
+        if matches!(
+            entry.classification.as_str(),
+            "production" | "test" | "tooling"
+        ) && entry.covered_by.is_empty()
+        {
+            missing_metadata.push(format!(
+                "kind={} surface={} owner={}: covered_by required for classification={}",
+                entry.kind, entry.surface, entry.owner, entry.classification
+            ));
+        }
+    }
+
+    for file in &files {
+        // Allowlist entries claim ownership first; default-allowed is a
+        // fallback for tracked files that have no explicit owner.
+        let mut hit = false;
+        for (idx, entry) in config.allow.iter().enumerate() {
+            if entry_matches_file(entry, file) {
+                entry_hits[idx] += 1;
+                hit = true;
+                break;
+            }
+        }
+        if hit {
+            matched_count += 1;
+            continue;
+        }
+        if is_default_allowed(file, &config.policy) {
+            matched_count += 1;
+            continue;
+        }
+        unmatched.push(file.clone());
+    }
+
+    let mut unused: Vec<&FilePolicyAllow> = Vec::new();
+    for (idx, entry) in config.allow.iter().enumerate() {
+        if entry_hits[idx] == 0 && !entry.retired {
+            unused.push(entry);
+        }
+    }
+
+    let report = FilePolicyReport {
+        total_files: files.len(),
+        matched: matched_count,
+        unmatched: unmatched.len(),
+        unused_entries: unused.len(),
+        expired_entries: expired.len(),
+        unmatched_paths: unmatched.iter().take(50).cloned().collect(),
+    };
+
+    let md = render_file_policy_md(&report, &unmatched, &unused, &expired, &missing_metadata);
+    write_outputs("file-policy", &serde_json::to_value(&report)?, &md)?;
+
+    eprintln!(
+        "file-policy: {} files; {} matched; {} unmatched; {} unused; {} expired",
+        report.total_files,
+        report.matched,
+        report.unmatched,
+        report.unused_entries,
+        report.expired_entries
+    );
+
+    if !missing_metadata.is_empty() {
+        for m in &missing_metadata {
+            eprintln!("  policy schema error: {m}");
+        }
+        bail!(
+            "file-policy: {} entries missing required metadata",
+            missing_metadata.len()
+        );
+    }
+
+    if !unmatched.is_empty() || !unused.is_empty() || !expired.is_empty() {
+        bail!(
+            "file-policy: {} unmatched, {} unused (retire or remove), {} expired",
+            unmatched.len(),
+            unused.len(),
+            expired.len()
+        );
+    }
+    Ok(())
+}
+
+fn is_default_allowed(path: &str, settings: &FilePolicySettings) -> bool {
+    let p = Path::new(path);
+    if let Some(ext) = p.extension().and_then(|s| s.to_str())
+        && settings.default_allowed_extensions.iter().any(|x| x == ext)
+    {
+        return true;
+    }
+    let basename = p.file_name().and_then(|s| s.to_str()).unwrap_or("");
+    settings
+        .default_allowed_filenames
+        .iter()
+        .any(|x| x == basename)
+}
+
+fn entry_matches_file(entry: &FilePolicyAllow, file: &str) -> bool {
+    if let Some(p) = &entry.path
+        && p == file
+    {
+        return true;
+    }
+    if let Some(g) = &entry.glob
+        && glob_match(g, file)
+    {
+        return true;
+    }
+    false
+}
+
+#[derive(Debug, Serialize)]
+struct FilePolicyReport {
+    total_files: usize,
+    matched: usize,
+    unmatched: usize,
+    unused_entries: usize,
+    expired_entries: usize,
+    unmatched_paths: Vec<String>,
+}
+
+fn render_file_policy_md(
+    report: &FilePolicyReport,
+    unmatched: &[String],
+    unused: &[&FilePolicyAllow],
+    expired: &[&FilePolicyAllow],
+    missing_metadata: &[String],
+) -> String {
+    let mut s = String::new();
+    s.push_str("# File-policy report\n\n");
+    s.push_str(&format!("- Tracked files: {}\n", report.total_files));
+    s.push_str(&format!("- Matched: {}\n", report.matched));
+    s.push_str(&format!("- Unmatched: **{}**\n", report.unmatched));
+    s.push_str(&format!("- Unused entries: {}\n", report.unused_entries));
+    s.push_str(&format!(
+        "- Expired entries: {}\n\n",
+        report.expired_entries
+    ));
+
+    if !missing_metadata.is_empty() {
+        s.push_str("## Missing metadata\n\n");
+        for m in missing_metadata {
+            s.push_str(&format!("- {m}\n"));
+        }
+        s.push('\n');
+    }
+
+    if !unmatched.is_empty() {
+        s.push_str(&format!("## Unmatched files ({})\n\n", unmatched.len()));
+        for p in unmatched.iter().take(50) {
+            s.push_str(&format!("- `{p}`\n"));
+        }
+        s.push('\n');
+    }
+    if !unused.is_empty() {
+        s.push_str(&format!("## Unused entries ({})\n\n", unused.len()));
+        for e in unused {
+            let pat = e.path.as_deref().or(e.glob.as_deref()).unwrap_or("?");
+            s.push_str(&format!(
+                "- `{}` (kind={}, owner={})\n",
+                pat, e.kind, e.owner
+            ));
+        }
+        s.push('\n');
+    }
+    if !expired.is_empty() {
+        s.push_str(&format!("## Expired entries ({})\n\n", expired.len()));
+        for e in expired {
+            let pat = e.path.as_deref().or(e.glob.as_deref()).unwrap_or("?");
+            s.push_str(&format!(
+                "- `{}` expired {}\n",
+                pat,
+                e.expires.as_deref().unwrap_or("?")
+            ));
+        }
+        s.push('\n');
+    }
+    s
+}
+
+// =============================================================================
+// lint-policy checker
+// =============================================================================
+
+#[derive(Debug, Deserialize)]
+struct LintPolicy {
+    msrv: String,
+    #[expect(dead_code, reason = "schema validation; surfaced in reports later")]
+    #[serde(default)]
+    policy: LintPolicySettings,
+    #[serde(default)]
+    planned: Vec<PlannedLint>,
+    #[serde(default)]
+    forbidden_carveouts: ForbiddenCarveouts,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[expect(dead_code, reason = "schema validation; surfaced in reports later")]
+struct LintPolicySettings {
+    #[serde(default)]
+    suppression_style: Option<String>,
+    #[serde(default)]
+    allow_test_carveouts: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlannedLint {
+    name: String,
+    #[allow(dead_code)]
+    level: String,
+    activate_when_msrv: String,
+    #[allow(dead_code)]
+    reason: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ForbiddenCarveouts {
+    #[serde(default)]
+    keys: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClippyDebt {
+    #[allow(dead_code)]
+    schema_version: Option<String>,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    id: String,
+    #[allow(dead_code)]
+    lint: String,
+    #[allow(dead_code)]
+    scope: String,
+    #[allow(dead_code)]
+    owner: String,
+    #[allow(dead_code)]
+    reason: String,
+    expires: String,
+}
+
+pub fn check_lint_policy() -> Result<()> {
+    let lp: LintPolicy = read_toml(CLIPPY_LINTS_TOML)?;
+    let mut errors: Vec<String> = Vec::new();
+
+    // 1. MSRV alignment.
+    let root_cargo = fs::read_to_string("Cargo.toml").context("read Cargo.toml")?;
+    let root_msrv = parse_workspace_rust_version(&root_cargo);
+    if let Some(rv) = &root_msrv {
+        if rv != &lp.msrv {
+            errors.push(format!(
+                "MSRV mismatch: workspace `rust-version = \"{}\"` != policy msrv `\"{}\"`",
+                rv, lp.msrv
+            ));
+        }
+    } else {
+        errors.push("could not find `[workspace.package].rust-version` in Cargo.toml".into());
+    }
+
+    // 2. clippy.toml carveouts.
+    if let Ok(c) = fs::read_to_string("clippy.toml") {
+        for key in &lp.forbidden_carveouts.keys {
+            if c.contains(key) {
+                errors.push(format!("clippy.toml contains forbidden key `{key}`"));
+            }
+        }
+    }
+
+    // 3. Every member crate has [lints] workspace = true.
+    let members = list_workspace_members(&root_cargo);
+    for m in &members {
+        let cargo = format!("{m}/Cargo.toml");
+        let raw = match fs::read_to_string(&cargo) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        if !has_workspace_lints(&raw) {
+            errors.push(format!("{cargo}: missing `[lints]\\nworkspace = true`"));
+        }
+    }
+
+    // 4. Planned lints not yet activated.
+    let active = parse_active_lints(&root_cargo);
+    for pl in &lp.planned {
+        if !msrv_reached(&lp.msrv, &pl.activate_when_msrv) && active.iter().any(|n| n == &pl.name) {
+            errors.push(format!(
+                "planned lint `{}` activated before MSRV {} (current {})",
+                pl.name, pl.activate_when_msrv, lp.msrv
+            ));
+        }
+    }
+
+    // 5. clippy-debt entries valid.
+    if Path::new(CLIPPY_DEBT_TOML).exists() {
+        let debt: ClippyDebt = read_toml(CLIPPY_DEBT_TOML)?;
+        let now = today();
+        for e in &debt.debt {
+            match NaiveDate::parse_from_str(&e.expires, "%Y-%m-%d") {
+                Ok(d) if d < now => {
+                    errors.push(format!("clippy-debt `{}` expired {}", e.id, e.expires))
+                }
+                Err(err) => errors.push(format!(
+                    "clippy-debt `{}` invalid expires `{}`: {}",
+                    e.id, e.expires, err
+                )),
+                _ => {}
+            }
+        }
+    }
+
+    // 6. Bare `#[allow(...)]` debt is advisory in Stage A; surfaced in the
+    //    report and slated to flip to error once Clippy
+    //    `allow_attributes_without_reason` is promoted. The
+    //    `policy/clippy-lints.toml` `[stage].current` field tracks this.
+    let bare_allow = scan_bare_allow_in_crates(&members)?;
+    let bare_allow_total: usize = bare_allow.iter().map(|(_, n)| *n).sum();
+
+    let report = LintPolicyReport {
+        msrv: lp.msrv.clone(),
+        members: members.len(),
+        errors: errors.clone(),
+        bare_allow_files: bare_allow.len(),
+        bare_allow_total,
+    };
+    let md = render_lint_policy_md(&report);
+    write_outputs("lint-policy", &serde_json::to_value(&report)?, &md)?;
+
+    eprintln!(
+        "lint-policy: msrv={} members={} errors={}",
+        lp.msrv,
+        members.len(),
+        errors.len()
+    );
+
+    if !errors.is_empty() {
+        for e in &errors {
+            eprintln!("  {e}");
+        }
+        bail!("lint-policy: {} error(s)", errors.len());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct LintPolicyReport {
+    msrv: String,
+    members: usize,
+    errors: Vec<String>,
+    bare_allow_files: usize,
+    bare_allow_total: usize,
+}
+
+fn render_lint_policy_md(report: &LintPolicyReport) -> String {
+    let mut s = String::new();
+    s.push_str("# Lint-policy report\n\n");
+    s.push_str(&format!("- MSRV: `{}`\n", report.msrv));
+    s.push_str(&format!("- Workspace members: {}\n", report.members));
+    s.push_str(&format!("- Errors: **{}**\n", report.errors.len()));
+    s.push_str(&format!(
+        "- Bare `#[allow(...)]` (advisory in Stage A): {} attribute(s) across {} file(s)\n\n",
+        report.bare_allow_total, report.bare_allow_files,
+    ));
+    if !report.errors.is_empty() {
+        s.push_str("## Errors\n\n");
+        for e in &report.errors {
+            s.push_str(&format!("- {e}\n"));
+        }
+    }
+    s
+}
+
+fn parse_workspace_rust_version(cargo: &str) -> Option<String> {
+    let in_pkg = cargo
+        .split("[workspace.package]")
+        .nth(1)
+        .unwrap_or("")
+        .split('\n');
+    for line in in_pkg {
+        let l = line.trim();
+        if l.starts_with('[') {
+            break;
+        }
+        if let Some(rest) = l.strip_prefix("rust-version") {
+            // form: rust-version = "1.92"
+            if let Some(eq) = rest.find('=') {
+                let val = rest[eq + 1..].trim().trim_matches('"');
+                return Some(val.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn list_workspace_members(cargo: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let after = match cargo.split("members").nth(1) {
+        Some(s) => s,
+        None => return out,
+    };
+    let body = match after.split_once('[') {
+        Some((_, b)) => b,
+        None => return out,
+    };
+    let body = match body.split_once(']') {
+        Some((b, _)) => b,
+        None => return out,
+    };
+    for line in body.lines() {
+        let l = line.trim().trim_end_matches(',').trim();
+        if l.is_empty() || l.starts_with('#') {
+            continue;
+        }
+        let l = l.trim_matches('"');
+        out.push(l.to_string());
+    }
+    out
+}
+
+fn has_workspace_lints(cargo: &str) -> bool {
+    // Match `[lints]` followed by `workspace = true` (within a few lines).
+    let needle = "[lints]";
+    let idx = match cargo.find(needle) {
+        Some(i) => i + needle.len(),
+        None => return false,
+    };
+    cargo[idx..]
+        .lines()
+        .take(8)
+        .any(|l| l.trim() == "workspace = true")
+}
+
+fn parse_active_lints(cargo: &str) -> Vec<String> {
+    // Collect lint keys under [workspace.lints.*] sections. Only keys that
+    // appear before the next top-level `[` are part of the section.
+    let mut active = Vec::new();
+    for section in ["[workspace.lints.rust]", "[workspace.lints.clippy]"] {
+        if let Some(rest) = cargo.split(section).nth(1) {
+            let group = rest.split("\n[").next().unwrap_or("");
+            let prefix = if section.ends_with("clippy]") {
+                "clippy::"
+            } else {
+                ""
+            };
+            for line in group.lines() {
+                let l = line.trim();
+                if l.is_empty() || l.starts_with('#') {
+                    continue;
+                }
+                if let Some(eq) = l.find('=') {
+                    let k = l[..eq].trim();
+                    if !k.is_empty() {
+                        active.push(format!("{prefix}{k}"));
+                    }
+                }
+            }
+        }
+    }
+    active
+}
+
+fn msrv_reached(current: &str, target: &str) -> bool {
+    fn parts(s: &str) -> Vec<u32> {
+        s.split('.').filter_map(|p| p.parse::<u32>().ok()).collect()
+    }
+    let c = parts(current);
+    let t = parts(target);
+    let n = c.len().max(t.len());
+    for i in 0..n {
+        let ci = c.get(i).copied().unwrap_or(0);
+        let ti = t.get(i).copied().unwrap_or(0);
+        if ci > ti {
+            return true;
+        }
+        if ci < ti {
+            return false;
+        }
+    }
+    true
+}
+
+fn scan_bare_allow_in_crates(_members: &[String]) -> Result<Vec<(String, usize)>> {
+    let files = git_ls_files()?;
+    // Match `#[allow(...)]` not preceded by `expect_` and not followed by quotes
+    // implying a `reason = ...`. Bare allow on its own line is the common case.
+    let bare = Regex::new(r#"#\[allow\([^)]*\)\]"#).unwrap();
+    let mut hits: Vec<(String, usize)> = Vec::new();
+    for f in files {
+        if !f.ends_with(".rs") {
+            continue;
+        }
+        let s = match fs::read_to_string(&f) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let mut count = 0;
+        for line in s.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") {
+                continue;
+            }
+            if bare.is_match(line) {
+                count += 1;
+            }
+        }
+        if count > 0 {
+            hits.push((f, count));
+        }
+    }
+    Ok(hits)
+}
+
+// =============================================================================
+// aggregate report
+// =============================================================================
+
+pub fn policy_report() -> Result<()> {
+    let mut summary: BTreeMap<&'static str, serde_json::Value> = BTreeMap::new();
+    for (name, run) in [
+        ("no-panic", run_capture(check_no_panic_family)),
+        ("file-policy", run_capture(check_file_policy)),
+        ("lint-policy", run_capture(check_lint_policy)),
+    ] {
+        summary.insert(
+            name,
+            serde_json::json!({
+                "ok": run.is_ok(),
+                "error": run.err().map(|e| e.to_string()),
+            }),
+        );
+    }
+
+    let summary = serde_json::Value::Object(
+        summary
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect(),
+    );
+    fs::create_dir_all(TARGET_DIR).ok();
+    fs::write(
+        format!("{TARGET_DIR}/policy-report.json"),
+        serde_json::to_string_pretty(&summary)?,
+    )?;
+
+    let mut md = String::new();
+    md.push_str("# Policy report (aggregate)\n\n");
+    let obj = summary
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("policy-report summary was not an object"))?;
+    for (k, v) in obj {
+        let ok = v.get("ok").and_then(|x| x.as_bool()).unwrap_or(false);
+        let symbol = if ok { "OK" } else { "FAIL" };
+        md.push_str(&format!("## {k} — {symbol}\n\n"));
+        if !ok && let Some(err) = v.get("error").and_then(|x| x.as_str()) {
+            md.push_str(&format!("Error: `{err}`\n\n"));
+        }
+        md.push_str(&format!("See `target/{k}.md` for the full report.\n\n"));
+    }
+    fs::write(format!("{TARGET_DIR}/policy-report.md"), md)?;
+
+    eprintln!("policy-report: target/policy-report.{{md,json}}");
+    Ok(())
+}
+
+fn run_capture<F: FnOnce() -> Result<()>>(f: F) -> Result<()> {
+    f()
+}
+
+// Allow integration tests to access PathBuf import without dead-code warnings
+// in case future refactors move helpers into submodules.
+#[allow(dead_code)]
+fn _unused_import_pin(_: PathBuf) {}
+
+// =============================================================================
+// tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_double_star_matches_nested() {
+        assert!(glob_match("crates/**/Cargo.toml", "crates/a/b/Cargo.toml"));
+        assert!(glob_match("crates/**/Cargo.toml", "crates/a/Cargo.toml"));
+        assert!(!glob_match("crates/**/Cargo.toml", "Cargo.toml"));
+    }
+
+    #[test]
+    fn glob_single_star_only_path_segment() {
+        assert!(glob_match("crates/*/Cargo.toml", "crates/a/Cargo.toml"));
+        assert!(!glob_match("crates/*/Cargo.toml", "crates/a/b/Cargo.toml"));
+    }
+
+    #[test]
+    fn glob_extension_matches() {
+        assert!(glob_match(
+            ".github/workflows/*.yml",
+            ".github/workflows/ci.yml"
+        ));
+        assert!(!glob_match(
+            ".github/workflows/*.yml",
+            ".github/dependabot.yml"
+        ));
+    }
+
+    #[test]
+    fn msrv_reached_compares_versions() {
+        assert!(msrv_reached("1.94", "1.94"));
+        assert!(msrv_reached("1.95", "1.94"));
+        assert!(!msrv_reached("1.92", "1.94"));
+        assert!(!msrv_reached("1.93", "1.94"));
+    }
+
+    #[test]
+    fn workspace_lints_detection_works() {
+        let cargo = "[lints]\nworkspace = true\n";
+        assert!(has_workspace_lints(cargo));
+        let cargo2 = "[lints]\n# no workspace\n";
+        assert!(!has_workspace_lints(cargo2));
+    }
+}

--- a/xtask/src/policy.rs
+++ b/xtask/src/policy.rs
@@ -855,12 +855,11 @@ struct LintPolicySettings {
 }
 
 #[derive(Debug, Deserialize)]
+#[expect(dead_code, reason = "schema validation; surfaced in reports later")]
 struct PlannedLint {
     name: String,
-    #[allow(dead_code)]
     level: String,
     activate_when_msrv: String,
-    #[allow(dead_code)]
     reason: String,
 }
 
@@ -872,22 +871,22 @@ struct ForbiddenCarveouts {
 
 #[derive(Debug, Deserialize)]
 struct ClippyDebt {
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "schema validation; surfaced in policy reports later"
+    )]
     schema_version: Option<String>,
     #[serde(default)]
     debt: Vec<DebtEntry>,
 }
 
 #[derive(Debug, Deserialize)]
+#[expect(dead_code, reason = "schema fields surfaced in policy reports later")]
 struct DebtEntry {
     id: String,
-    #[allow(dead_code)]
     lint: String,
-    #[allow(dead_code)]
     scope: String,
-    #[allow(dead_code)]
     owner: String,
-    #[allow(dead_code)]
     reason: String,
     expires: String,
 }

--- a/xtask/src/policy.rs
+++ b/xtask/src/policy.rs
@@ -5,7 +5,7 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
@@ -452,13 +452,18 @@ fn scan_panic_findings() -> Result<Vec<PanicFinding>> {
             Ok(s) => s,
             Err(_) => continue,
         };
-        for (idx, line) in content.lines().enumerate() {
+        for (idx, raw_line) in content.lines().enumerate() {
             // Skip pure-comment / doc lines as a fast first pass; this is not perfect
             // (block comments slip through) but is a reasonable signal-to-noise.
-            let trimmed = line.trim_start();
-            if trimmed.starts_with("//") || trimmed.starts_with("///") {
+            let trimmed = raw_line.trim_start();
+            if trimmed.starts_with("//") {
                 continue;
             }
+            // Strip the trailing `// ...` comment (if any) before regex matching, so
+            // that `let x = foo(); // .unwrap()` does not produce a false positive.
+            // This is a naive strip that ignores `//` inside string literals; for
+            // panic-family detection in real code that is acceptable noise.
+            let line = strip_line_comment(raw_line);
 
             // get_unwrap takes precedence over plain unwrap so we don't double-count.
             if let Some(m) = get_unwrap_re.find(line) {
@@ -542,6 +547,14 @@ fn scan_panic_findings() -> Result<Vec<PanicFinding>> {
         }
     }
     Ok(out)
+}
+
+fn strip_line_comment(line: &str) -> &str {
+    if let Some(idx) = line.find("//") {
+        &line[..idx]
+    } else {
+        line
+    }
 }
 
 // =============================================================================
@@ -1155,11 +1168,15 @@ fn scan_bare_allow_in_crates(_members: &[String]) -> Result<Vec<(String, usize)>
 
 pub fn policy_report() -> Result<()> {
     let mut summary: BTreeMap<&'static str, serde_json::Value> = BTreeMap::new();
+    let mut failures: Vec<String> = Vec::new();
     for (name, run) in [
-        ("no-panic", run_capture(check_no_panic_family)),
-        ("file-policy", run_capture(check_file_policy)),
-        ("lint-policy", run_capture(check_lint_policy)),
+        ("no-panic", check_no_panic_family()),
+        ("file-policy", check_file_policy()),
+        ("lint-policy", check_lint_policy()),
     ] {
+        if let Err(e) = &run {
+            failures.push(format!("{name}: {e}"));
+        }
         summary.insert(
             name,
             serde_json::json!({
@@ -1198,17 +1215,11 @@ pub fn policy_report() -> Result<()> {
     fs::write(format!("{TARGET_DIR}/policy-report.md"), md)?;
 
     eprintln!("policy-report: target/policy-report.{{md,json}}");
+    if !failures.is_empty() {
+        bail!("policy-report: {} check(s) failed", failures.len());
+    }
     Ok(())
 }
-
-fn run_capture<F: FnOnce() -> Result<()>>(f: F) -> Result<()> {
-    f()
-}
-
-// Allow integration tests to access PathBuf import without dead-code warnings
-// in case future refactors move helpers into submodules.
-#[allow(dead_code)]
-fn _unused_import_pin(_: PathBuf) {}
 
 // =============================================================================
 // tests
@@ -1257,5 +1268,45 @@ mod tests {
         assert!(has_workspace_lints(cargo));
         let cargo2 = "[lints]\n# no workspace\n";
         assert!(!has_workspace_lints(cargo2));
+    }
+
+    #[test]
+    fn glob_escapes_dots_and_dashes_correctly() {
+        // `.` in glob is a literal dot, not a regex any-char.
+        assert!(!glob_match("foo.yml", "fooXyml"));
+        assert!(glob_match("foo.yml", "foo.yml"));
+    }
+
+    #[test]
+    fn glob_double_star_at_root_matches_anywhere() {
+        assert!(glob_match("**/snapshots/**/*.snap", "x/snapshots/a/b.snap"));
+        assert!(glob_match("**/snapshots/**/*.snap", "snapshots/a.snap"));
+    }
+
+    #[test]
+    fn strip_line_comment_drops_trailing_comment() {
+        assert_eq!(strip_line_comment("let x = 1; // .unwrap()"), "let x = 1; ");
+        assert_eq!(strip_line_comment("plain code"), "plain code");
+        assert_eq!(strip_line_comment("// only a comment"), "");
+    }
+
+    #[test]
+    fn parse_workspace_rust_version_finds_value() {
+        let cargo = "[workspace.package]\nrust-version = \"1.92\"\nedition = \"2024\"\n";
+        assert_eq!(parse_workspace_rust_version(cargo).as_deref(), Some("1.92"));
+    }
+
+    #[test]
+    fn parse_workspace_rust_version_returns_none_when_missing() {
+        let cargo = "[workspace.package]\nedition = \"2024\"\n";
+        assert!(parse_workspace_rust_version(cargo).is_none());
+    }
+
+    #[test]
+    fn parse_active_lints_collects_from_clippy_section() {
+        let cargo = "[workspace.lints.rust]\nfoo = \"deny\"\n\n[workspace.lints.clippy]\ndbg_macro = \"deny\"\n";
+        let active = parse_active_lints(cargo);
+        assert!(active.iter().any(|l| l == "foo"));
+        assert!(active.iter().any(|l| l == "clippy::dbg_macro"));
     }
 }


### PR DESCRIPTION
## Summary

Introduce the Effortless Metrics policy stack — semantic no-panic
allowlist, non-Rust file allowlist, lint policy with planned 1.94/1.95
flips, and the xtask checkers that enforce them.

The shared principle: **deny by default, allow by receipt, expire
exceptions, measure drift.** Clippy is the immediate code-shape
detector; the semantic no-panic checker is the authoritative
exception ledger (path + family + selector identity, not line/column).

### What landed

- `policy/clippy-lints.toml` — MSRV, planned lint flips, suppression rules
- `policy/clippy-debt.toml` — receipted Clippy warn-stage debt with expiry
- `policy/no-panic-allowlist.toml` — semantic panic-family allowlist (schema 0.3)
- `policy/non-rust-allowlist.toml` — owner / surface / classification ledger
- `docs/CLIPPY_POLICY.md`, `docs/NO_PANIC_POLICY.md`, `docs/FILE_POLICY.md`,
  `docs/POLICY_ALLOWLISTS.md`
- `[workspace.lints]` with hard bans the workspace passes cleanly
  (`todo`, `unimplemented`, `dbg_macro`, `unsafe_op_in_unsafe_fn`,
  `unused_must_use`); panic-family stays in the semantic checker until Stage C
- `[lints] workspace = true` wired into all 63 members
- xtask: `check-no-panic-family`, `no-panic propose`, `check-file-policy`,
  `check-lint-policy`, `policy-report`

### Stage A posture

`cargo xtask clippy` runs with `-D warnings`, so any warn-level lint is
effectively a hard error in CI. Stage A therefore enforces only lints the
workspace is already clean against and tracks panic-family debt (4161
findings across 60+ crates) via the advisory semantic checker. Stages B and
C — moving debt into the receipted allowlist and flipping panic-family
clippy lints to `deny` — are documented in `docs/CLIPPY_POLICY.md` and
`docs/NO_PANIC_POLICY.md`.

### Verification

```
cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
cargo run -p xtask -- policy-report
```

All three policy checkers pass. The three checkers each produce
`target/<name>.{md,json}` artifacts.

```
file-policy: 1149 files; 1149 matched; 0 unmatched; 0 unused; 0 expired
lint-policy: msrv=1.92 members=63 errors=0
no-panic:    4161 finding(s); 4161 unallowlisted; 0 stale; 0 expired (mode=advisory)
```

## Test plan

- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p xtask -- check-file-policy`
- [x] `cargo run -p xtask -- check-lint-policy`
- [x] `cargo run -p xtask -- check-no-panic-family`
- [x] `cargo run -p xtask -- policy-report`
- [x] `cargo run -p xtask -- no-panic propose` (writes `target/policy-proposed/no-panic-proposed-allowlist.toml`)
- [x] `cargo test -p xtask --bins -- policy::tests` (5 unit tests)
- [x] `cargo test -p uselesskey-core` (production crate sample)

## Follow-ups

- **Stage B**: review the `target/policy-proposed/no-panic-proposed-allowlist.toml`
  baseline and move owner-classified entries into
  `policy/no-panic-allowlist.toml`, then flip the no-panic checker to
  `mode = "blocking"`.
- **Stage C**: promote panic-family Clippy lints (`unwrap_used`,
  `expect_used`, `panic`, `unreachable`, `get_unwrap`,
  `panic_in_result_fn`) to `deny` once the allowlist is the only legitimate
  route to a panic-family call site.
- **MSRV bump**: bump to 1.93 and adopt the planned lints listed in
  `policy/clippy-lints.toml`.



---
_Generated by [Claude Code](https://claude.ai/code/session_01FghJRy92RpKmHANiv4oDz9)_