### PR TITLE
docs: add negative payload shape example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added scanner-safe JWK/JWKS and token-shape negative fixture helpers for
   downstream parser and validator failure-path tests.
+- Added a facade example covering scanner-safe negative JWK/JWKS and token
+  shapes for downstream validator tests.
 - Added a public-surface map that separates public support promises from
   published internal implementation shards.
 

--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ The [`crates/uselesskey/examples/`](crates/uselesskey/examples/) directory conta
 | [jwt_rs256_jwks](crates/uselesskey/examples/jwt_rs256_jwks.rs) | `rsa,jwk` | RSA keypairs with JWK/JWKS extraction for JWT verification flows |
 | [jwt_signing](crates/uselesskey/examples/jwt_signing.rs) | `rsa,jwk` | JWT signing with deterministic RSA, ECDSA, and HMAC keys (ECDSA/HMAC optional) |
 | [negative_fixtures](crates/uselesskey/examples/negative_fixtures.rs) | `x509` | Intentionally invalid certificates and keys for error-path testing |
+| [negative_payload_shapes](crates/uselesskey/examples/negative_payload_shapes.rs) | `rsa,jwk,token` | Scanner-safe negative JWK/JWKS and token shapes for validator tests |
 | [tempfile_paths](crates/uselesskey/examples/tempfile_paths.rs) | `rsa,ed25519` | Write key fixtures to temporary files for path-based APIs |
 | [tempfiles](crates/uselesskey/examples/tempfiles.rs) | `x509` | Write X.509 cert, key, and identity PEM to temp files |
 | [tls_server](crates/uselesskey/examples/tls_server.rs) | `x509` | Certificate chain generation for TLS server testing |

--- a/crates/uselesskey/examples/negative_payload_shapes.rs
+++ b/crates/uselesskey/examples/negative_payload_shapes.rs
@@ -1,0 +1,96 @@
+#![forbid(unsafe_code)]
+
+//! Scanner-safe negative JWK/JWKS and token payload shapes.
+//!
+//! Demonstrates negative fixtures for downstream parser and validator tests
+//! without printing secret-shaped material.
+//!
+//! Run with: cargo run -p uselesskey --example negative_payload_shapes --features "rsa,jwk,token"
+
+#[cfg(all(feature = "rsa", feature = "jwk", feature = "token"))]
+fn main() {
+    use uselesskey::jwk::{NegativeJwk, NegativeJwks};
+    use uselesskey::{
+        Factory, NegativeToken, RsaFactoryExt, RsaSpec, Seed, TokenFactoryExt, TokenSpec,
+    };
+
+    let fx = Factory::deterministic(Seed::from_env_value("negative-payload-demo").unwrap());
+
+    // -------------------------------------------------------------------------
+    // JWK negatives: keep the object realistic, but make one validation rule fail.
+    // -------------------------------------------------------------------------
+    let signing_key = fx.rsa("issuer", RsaSpec::rs256());
+    let public_jwk = signing_key.public_jwk();
+
+    let missing_kid = public_jwk.negative_value(NegativeJwk::MissingKid);
+    assert!(missing_kid.get("kid").is_none());
+    assert_eq!(missing_kid["kty"], "RSA");
+
+    let unsupported_alg = public_jwk.negative_value(NegativeJwk::UnsupportedAlg);
+    assert_eq!(unsupported_alg["alg"], "UK-UNSUPPORTED");
+
+    let malformed_field = public_jwk.negative_value(NegativeJwk::MalformedField);
+    assert!(
+        malformed_field["n"]
+            .as_str()
+            .expect("RSA modulus should stay present")
+            .contains('!'),
+        "malformed material should be scanner-safe invalid base64url"
+    );
+
+    println!("JWK negatives: missing kid, unsupported alg, malformed material");
+
+    // -------------------------------------------------------------------------
+    // JWKS negatives: exercise key-set validation, not individual keygen.
+    // -------------------------------------------------------------------------
+    let jwks = signing_key.public_jwks();
+
+    let duplicate_kid = jwks.negative_value(NegativeJwks::DuplicateKid);
+    let duplicate_kid_keys = duplicate_kid["keys"].as_array().expect("keys array");
+    assert_eq!(duplicate_kid_keys.len(), 2);
+    assert_eq!(duplicate_kid_keys[0]["kid"], duplicate_kid_keys[1]["kid"]);
+    assert_ne!(duplicate_kid_keys[0], duplicate_kid_keys[1]);
+
+    let empty = jwks.negative_value(NegativeJwks::EmptyKeys);
+    assert!(empty["keys"].as_array().expect("keys array").is_empty());
+
+    println!("JWKS negatives: duplicate kid, empty keys");
+
+    // -------------------------------------------------------------------------
+    // Token negatives: JWT/API-key/bearer near-misses that stay scanner-safe.
+    // -------------------------------------------------------------------------
+    let oauth = fx.token("auth-service", TokenSpec::oauth_access_token());
+
+    let malformed_jwt = oauth.negative_value(NegativeToken::MalformedJwtSegmentCount);
+    assert_eq!(malformed_jwt.matches('.').count(), 1);
+    assert_ne!(malformed_jwt, oauth.value());
+
+    let bad_base64url = oauth.negative_value(NegativeToken::BadBase64UrlSegment);
+    assert_eq!(bad_base64url.matches('.').count(), 2);
+    assert!(bad_base64url.contains('!'));
+
+    let alg_none = oauth.negative_value(NegativeToken::AlgNone);
+    assert_eq!(alg_none.matches('.').count(), 2);
+    assert_ne!(alg_none, oauth.value());
+
+    let bearer = fx.token("session", TokenSpec::bearer());
+    let malformed_bearer = bearer.negative_value(NegativeToken::MalformedBearer);
+    assert!(malformed_bearer.contains('!'));
+    assert_ne!(malformed_bearer, bearer.value());
+
+    let api_key = fx.token("billing", TokenSpec::api_key());
+    let near_miss = api_key.negative_value(NegativeToken::NearMissApiKey);
+    assert!(near_miss.starts_with("uk_tset_"));
+    assert!(!near_miss.starts_with("uk_test_"));
+
+    println!("Token negatives: malformed JWT, alg none, malformed bearer, API-key near miss");
+    println!("All negative payload shape checks passed");
+}
+
+#[cfg(not(all(feature = "rsa", feature = "jwk", feature = "token")))]
+fn main() {
+    eprintln!("Enable rsa, jwk, and token features:");
+    eprintln!(
+        "  cargo run -p uselesskey --example negative_payload_shapes --features \"rsa,jwk,token\""
+    );
+}

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -25,7 +25,7 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 
 - [x] JWK/JWKS negative wave 1
 - [x] token-shape negative wave 1
-- [ ] docs/examples coverage for negative fixtures
+- [x] docs/examples coverage for negative fixtures
 
 ## v0.6.1 benchmarks and governance
 

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -17,7 +17,7 @@ This roadmap reflects the strategic direction for uselesskey as a **test-fixture
 *Planned follow-up*
 
 - [x] JWK/JWKS and token-shape negative fixture follow-ons.
-- [ ] Docs/examples coverage for the remaining negative-fixture surface.
+- [x] Docs/examples coverage for the remaining negative-fixture surface.
 - [ ] Performance benchmarks for key generation and materialization paths.
 - [ ] Release governance and post-release audit automation.
 - [ ] Export-bundle integration (`uselesskey bundle`, k8s/vault payload emitters, and reference manifests).

--- a/docs/metadata/workspace-docs.json
+++ b/docs/metadata/workspace-docs.json
@@ -816,6 +816,13 @@
       "run_smoke": true
     },
     {
+      "name": "negative_payload_shapes",
+      "path": "crates/uselesskey/examples/negative_payload_shapes.rs",
+      "feature_set": "rsa,jwk,token",
+      "description": "Scanner-safe negative JWK/JWKS and token shapes for validator tests",
+      "run_smoke": true
+    },
+    {
       "name": "tempfile_paths",
       "path": "crates/uselesskey/examples/tempfile_paths.rs",
       "feature_set": "rsa,ed25519",


### PR DESCRIPTION
## Summary
- add a facade example for scanner-safe negative JWK/JWKS and token payload shapes
- register the example in docs metadata so the README runnable-example table stays generated
- mark the v0.6.1 negative-fixture docs/examples follow-up complete

## Validation
- cargo run -p uselesskey --example negative_payload_shapes --no-default-features --features "rsa,jwk,token"
- cargo xtask examples-smoke
- cargo test -p uselesskey --all-features
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask no-blob
- git diff --check
- cargo xtask pr