### PR TITLE
feat(cli): add scanner-safe bundle profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shapes for downstream validator tests.
 - Added `uselesskey verify-bundle` to verify deterministic bundle outputs
   against their recorded `manifest.json`.
+- Added scanner-safe bundle profiles and per-artifact lane metadata to
+  `uselesskey bundle` manifests.
 - Added a public-surface map that separates public support promises from
   published internal implementation shards.
 

--- a/crates/uselesskey-cli/README.md
+++ b/crates/uselesskey-cli/README.md
@@ -49,9 +49,7 @@ directory of related fixture artifacts plus a manifest it can verify in CI.
 
 ```bash
 cargo run -p uselesskey-cli -- bundle \
-  --seed bundle-seed \
-  --label issuer \
-  --format jwk \
+  --profile scanner-safe \
   --out target/uselesskey-bundle
 
 cargo run -p uselesskey-cli -- verify-bundle \
@@ -59,4 +57,10 @@ cargo run -p uselesskey-cli -- verify-bundle \
 ```
 
 `verify-bundle` reloads `manifest.json`, regenerates the expected artifacts from
-the recorded seed/label/format, and fails if any file is missing or changed.
+the recorded seed/label/format/profile, and fails if any file or manifest
+metadata is missing or changed.
+
+`scanner-safe` is the default bundle profile. It emits public key material,
+public certificate material, scanner-safe symmetric JWK shape data, and
+near-miss token shapes. Use `--profile runtime` when a downstream test really
+needs runtime-generated private or symmetric fixture material in the bundle.

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -16,7 +16,7 @@ use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
 use uselesskey_ed25519::{Ed25519FactoryExt, Ed25519Spec};
 use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
 use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
-use uselesskey_token::{TokenFactoryExt, TokenSpec};
+use uselesskey_token::{NegativeToken, TokenFactoryExt, TokenSpec};
 use uselesskey_x509::{X509FactoryExt, X509Spec};
 
 #[derive(Parser, Debug)]
@@ -51,12 +51,14 @@ struct GenerateArgs {
 
 #[derive(clap::Args, Debug)]
 struct BundleArgs {
-    #[arg(long)]
+    #[arg(long, default_value = "uselesskey-bundle-seed")]
     seed: String,
-    #[arg(long)]
+    #[arg(long, default_value = "bundle")]
     label: String,
-    #[arg(long, default_value = "pem")]
+    #[arg(long, default_value = "jwk")]
     format: Format,
+    #[arg(long, default_value = "scanner-safe")]
+    profile: BundleProfile,
     #[arg(long)]
     out: Option<PathBuf>,
 }
@@ -109,6 +111,21 @@ enum Kind {
     Jwks,
 }
 
+impl Kind {
+    const fn manifest_name(self) -> &'static str {
+        match self {
+            Self::Rsa => "rsa",
+            Self::Ecdsa => "ecdsa",
+            Self::Ed25519 => "ed25519",
+            Self::Hmac => "hmac",
+            Self::Token => "token",
+            Self::X509 => "x509",
+            Self::Jwk => "jwk",
+            Self::Jwks => "jwks",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum Format {
     Pem,
@@ -119,6 +136,34 @@ enum Format {
     JsonManifest,
     #[value(name = "bundle-dir")]
     BundleDir,
+}
+
+impl Format {
+    const fn manifest_name(self) -> &'static str {
+        match self {
+            Self::Pem => "pem",
+            Self::Der => "der",
+            Self::Jwk => "jwk",
+            Self::Jwks => "jwks",
+            Self::JsonManifest => "json-manifest",
+            Self::BundleDir => "bundle-dir",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum BundleProfile {
+    ScannerSafe,
+    Runtime,
+}
+
+impl BundleProfile {
+    const fn manifest_name(self) -> &'static str {
+        match self {
+            Self::ScannerSafe => "scanner-safe",
+            Self::Runtime => "runtime",
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -156,22 +201,33 @@ fn run_bundle(args: BundleArgs) -> Result<()> {
 
     let fx = Factory::deterministic_from_str(&args.seed);
     let mut files = Vec::new();
+    let mut artifacts = Vec::new();
     for (name, kind) in bundle_entries() {
-        let bundle_format = preferred_bundle_format(kind, args.format);
-        let artifact = generate_artifact(&fx, kind, &args.label, bundle_format)
-            .with_context(|| format!("failed to generate {name}"))?;
+        let bundle_format = preferred_bundle_format(kind, args.format, args.profile);
+        let artifact =
+            generate_bundle_artifact(&fx, kind, name, &args.label, bundle_format, args.profile)
+                .with_context(|| format!("failed to generate {name}"))?;
         let ext = format_extension(bundle_format, &artifact);
-        let file = out_dir.join(format!("{name}.{ext}"));
+        let file_name = format!("{name}.{ext}");
+        let file = out_dir.join(&file_name);
         write_artifact_to_path(&artifact, &file)?;
-        files.push(file_name_string(&file)?);
+        files.push(file_name.clone());
+        artifacts.push(bundle_artifact_record(
+            kind,
+            bundle_format,
+            &file_name,
+            args.profile,
+        ));
     }
 
     let manifest = BundleManifest {
         version: 1,
+        profile: args.profile.manifest_name().to_string(),
         seed: args.seed,
         label: args.label,
-        format: format!("{:?}", args.format).to_lowercase(),
+        format: args.format.manifest_name().to_string(),
         files,
+        artifacts,
     };
     let manifest_path = out_dir.join("manifest.json");
     fs::write(&manifest_path, serde_json::to_vec_pretty(&manifest)?)?;
@@ -285,13 +341,16 @@ fn load_bundle_manifest(path: &Path) -> Result<BundleManifest> {
 
 fn verify_bundle_manifest(bundle_dir: &Path, manifest: &BundleManifest) -> Result<Vec<String>> {
     let format = parse_manifest_format(&manifest.format)?;
+    let profile = parse_manifest_profile(&manifest.profile)?;
     let fx = Factory::deterministic_from_str(&manifest.seed);
     let mut expected_files = Vec::new();
+    let mut expected_artifacts = Vec::new();
 
     for (name, kind) in bundle_entries() {
-        let bundle_format = preferred_bundle_format(kind, format);
-        let artifact = generate_artifact(&fx, kind, &manifest.label, bundle_format)
-            .with_context(|| format!("failed to regenerate {name}"))?;
+        let bundle_format = preferred_bundle_format(kind, format, profile);
+        let artifact =
+            generate_bundle_artifact(&fx, kind, name, &manifest.label, bundle_format, profile)
+                .with_context(|| format!("failed to regenerate {name}"))?;
         let ext = format_extension(bundle_format, &artifact);
         let file_name = format!("{name}.{ext}");
         let expected = artifact_bytes(&artifact)?;
@@ -305,6 +364,12 @@ fn verify_bundle_manifest(bundle_dir: &Path, manifest: &BundleManifest) -> Resul
             );
         }
         expected_files.push(file_name);
+        expected_artifacts.push(bundle_artifact_record(
+            kind,
+            bundle_format,
+            expected_files.last().expect("just pushed"),
+            profile,
+        ));
     }
 
     if manifest.files != expected_files {
@@ -312,6 +377,14 @@ fn verify_bundle_manifest(bundle_dir: &Path, manifest: &BundleManifest) -> Resul
             "bundle verification failed: manifest file list mismatch; expected {:?}, found {:?}",
             expected_files,
             manifest.files
+        );
+    }
+
+    if !manifest.artifacts.is_empty() && manifest.artifacts != expected_artifacts {
+        bail!(
+            "bundle verification failed: artifact metadata mismatch; expected {:?}, found {:?}",
+            expected_artifacts,
+            manifest.artifacts
         );
     }
 
@@ -330,6 +403,14 @@ fn parse_manifest_format(raw: &str) -> Result<Format> {
     }
 }
 
+fn parse_manifest_profile(raw: &str) -> Result<BundleProfile> {
+    match raw {
+        "scanner-safe" | "scannersafe" => Ok(BundleProfile::ScannerSafe),
+        "runtime" => Ok(BundleProfile::Runtime),
+        other => bail!("unsupported bundle manifest profile `{other}`"),
+    }
+}
+
 fn bundle_entries() -> [(&'static str, Kind); 8] {
     [
         ("rsa", Kind::Rsa),
@@ -343,7 +424,57 @@ fn bundle_entries() -> [(&'static str, Kind); 8] {
     ]
 }
 
-fn preferred_bundle_format(kind: Kind, requested: Format) -> Format {
+fn bundle_artifact_record(
+    kind: Kind,
+    format: Format,
+    path: &str,
+    profile: BundleProfile,
+) -> BundleArtifactRecord {
+    BundleArtifactRecord {
+        path: path.to_string(),
+        kind: kind.manifest_name().to_string(),
+        format: format.manifest_name().to_string(),
+        profile: profile.manifest_name().to_string(),
+        lanes: vec!["runtime".to_string(), "materialized".to_string()],
+        scanner_safe: bundle_artifact_is_scanner_safe(kind, profile),
+        description: bundle_artifact_description(kind, profile).to_string(),
+    }
+}
+
+fn bundle_artifact_is_scanner_safe(kind: Kind, profile: BundleProfile) -> bool {
+    match profile {
+        BundleProfile::ScannerSafe => true,
+        BundleProfile::Runtime => matches!(kind, Kind::Jwk | Kind::Jwks | Kind::X509),
+    }
+}
+
+fn bundle_artifact_description(kind: Kind, profile: BundleProfile) -> &'static str {
+    match (profile, kind) {
+        (BundleProfile::ScannerSafe, Kind::Hmac) => {
+            "scanner-safe symmetric JWK shape with invalid material"
+        }
+        (BundleProfile::ScannerSafe, Kind::Token) => {
+            "scanner-safe near-miss token shape for parser tests"
+        }
+        (BundleProfile::ScannerSafe, Kind::X509) => "public certificate fixture",
+        (BundleProfile::ScannerSafe, _) => "public fixture material",
+        (BundleProfile::Runtime, Kind::Jwk | Kind::Jwks | Kind::X509) => {
+            "runtime-generated public fixture material"
+        }
+        (BundleProfile::Runtime, _) => "runtime-generated fixture material",
+    }
+}
+
+fn preferred_bundle_format(kind: Kind, requested: Format, profile: BundleProfile) -> Format {
+    if matches!(profile, BundleProfile::ScannerSafe) {
+        return match kind {
+            Kind::Token => Format::JsonManifest,
+            Kind::X509 => Format::Pem,
+            Kind::Jwks => Format::Jwks,
+            Kind::Rsa | Kind::Ecdsa | Kind::Ed25519 | Kind::Hmac | Kind::Jwk => Format::Jwk,
+        };
+    }
+
     match (kind, requested) {
         (Kind::Token, _) => Format::JsonManifest,
         (Kind::X509, Format::Jwk | Format::Jwks) => Format::Pem,
@@ -351,6 +482,59 @@ fn preferred_bundle_format(kind: Kind, requested: Format) -> Format {
         (Kind::Jwk, _) => Format::Jwk,
         (Kind::Jwks, _) => Format::Jwks,
         _ => requested,
+    }
+}
+
+fn generate_bundle_artifact(
+    fx: &Factory,
+    kind: Kind,
+    name: &str,
+    label: &str,
+    format: Format,
+    profile: BundleProfile,
+) -> Result<Artifact> {
+    if matches!(profile, BundleProfile::ScannerSafe) {
+        return generate_scanner_safe_bundle_artifact(fx, kind, name, label, format);
+    }
+
+    generate_artifact(fx, kind, label, format)
+}
+
+fn generate_scanner_safe_bundle_artifact(
+    fx: &Factory,
+    kind: Kind,
+    name: &str,
+    label: &str,
+    format: Format,
+) -> Result<Artifact> {
+    match kind {
+        Kind::Hmac => {
+            if matches!(format, Format::Jwk) {
+                Ok(Artifact::Json(json!({
+                    "kty": "oct",
+                    "use": "sig",
+                    "alg": "HS256",
+                    "kid": format!("{label}-{name}"),
+                    "k": "not_base64url!*",
+                })))
+            } else {
+                unsupported(kind, format)
+            }
+        }
+        Kind::Token => {
+            let token = fx.token(label, TokenSpec::api_key());
+            if matches!(format, Format::JsonManifest) {
+                Ok(Artifact::Json(json!({
+                    "kind": "token",
+                    "label": label,
+                    "negative": NegativeToken::NearMissApiKey.variant_name(),
+                    "value": token.negative_value(NegativeToken::NearMissApiKey),
+                })))
+            } else {
+                unsupported(kind, format)
+            }
+        }
+        _ => generate_artifact(fx, kind, label, format),
     }
 }
 
@@ -505,13 +689,6 @@ fn format_extension(format: Format, artifact: &Artifact) -> &'static str {
     }
 }
 
-fn file_name_string(path: &Path) -> Result<String> {
-    path.file_name()
-        .and_then(|x| x.to_str())
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| anyhow!("invalid file name: {}", path.display()))
-}
-
 fn detect_kind(text: &str) -> &'static str {
     if text.contains("BEGIN CERTIFICATE") {
         "x509"
@@ -550,8 +727,27 @@ fn detect_json_kind(text: &str) -> Option<&'static str> {
 #[derive(Debug, Deserialize, Serialize)]
 struct BundleManifest {
     version: u32,
+    #[serde(default = "default_bundle_profile")]
+    profile: String,
     seed: String,
     label: String,
     format: String,
     files: Vec<String>,
+    #[serde(default)]
+    artifacts: Vec<BundleArtifactRecord>,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct BundleArtifactRecord {
+    path: String,
+    kind: String,
+    format: String,
+    profile: String,
+    lanes: Vec<String>,
+    scanner_safe: bool,
+    description: String,
+}
+
+fn default_bundle_profile() -> String {
+    "runtime".to_string()
 }

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -69,9 +69,117 @@ fn bundle_writes_manifest_schema() {
     let value: Value = serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
         .expect("manifest json");
     assert_eq!(value["version"], 1);
+    assert_eq!(value["profile"], "scanner-safe");
     assert_eq!(value["seed"], "det-seed");
     assert_eq!(value["label"], "bundle-label");
     assert!(value["files"].as_array().expect("array").len() >= 8);
+    let artifacts = value["artifacts"].as_array().expect("artifacts array");
+    assert_eq!(
+        artifacts.len(),
+        value["files"].as_array().expect("array").len()
+    );
+    assert!(
+        artifacts
+            .iter()
+            .all(|artifact| artifact["scanner_safe"] == true)
+    );
+    assert!(artifacts.iter().all(|artifact| {
+        artifact["lanes"]
+            .as_array()
+            .expect("lanes")
+            .iter()
+            .any(|lane| lane.as_str() == Some("runtime"))
+    }));
+    assert!(artifacts.iter().all(|artifact| {
+        artifact["lanes"]
+            .as_array()
+            .expect("lanes")
+            .iter()
+            .any(|lane| lane.as_str() == Some("materialized"))
+    }));
+}
+
+#[test]
+fn bundle_profile_scanner_safe_is_the_default_path() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("bundle");
+
+    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+    cmd.args(["bundle", "--out", bundle_dir.to_str().expect("utf-8")]);
+    cmd.assert().success();
+
+    let manifest_path = bundle_dir.join("manifest.json");
+    let value: Value = serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+        .expect("manifest json");
+    assert_eq!(value["profile"], "scanner-safe");
+    assert_eq!(value["format"], "jwk");
+    assert_eq!(value["seed"], "uselesskey-bundle-seed");
+    assert_eq!(value["label"], "bundle");
+
+    let hmac = fs::read_to_string(bundle_dir.join("hmac.jwk.json")).expect("hmac jwk");
+    assert!(hmac.contains("not_base64url!*"));
+
+    let artifacts = value["artifacts"].as_array().expect("artifacts");
+    let hmac_record = artifacts
+        .iter()
+        .find(|artifact| artifact["kind"].as_str() == Some("hmac"))
+        .expect("hmac artifact record");
+    assert_eq!(
+        hmac_record["description"],
+        "scanner-safe symmetric JWK shape with invalid material"
+    );
+    let token_record = artifacts
+        .iter()
+        .find(|artifact| artifact["kind"].as_str() == Some("token"))
+        .expect("token artifact record");
+    assert_eq!(
+        token_record["description"],
+        "scanner-safe near-miss token shape for parser tests"
+    );
+
+    let token: Value =
+        serde_json::from_slice(&fs::read(bundle_dir.join("token.json")).expect("token json"))
+            .expect("token manifest");
+    let token_value = token["value"].as_str().expect("token value");
+    assert!(token_value.starts_with("uk_tset_"));
+    assert!(!token_value.starts_with("uk_test_"));
+}
+
+#[test]
+fn bundle_profile_runtime_preserves_requested_material_format() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("bundle");
+
+    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+    cmd.args([
+        "bundle",
+        "--profile",
+        "runtime",
+        "--format",
+        "pem",
+        "--seed",
+        "det-seed",
+        "--label",
+        "issuer",
+        "--out",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    cmd.assert().success();
+
+    assert!(bundle_dir.join("rsa.pem").exists());
+    let manifest_path = bundle_dir.join("manifest.json");
+    let value: Value = serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+        .expect("manifest json");
+    assert_eq!(value["profile"], "runtime");
+    assert_eq!(value["format"], "pem");
+    assert!(
+        value["artifacts"]
+            .as_array()
+            .expect("artifacts")
+            .iter()
+            .any(|artifact| artifact["kind"].as_str() == Some("rsa")
+                && artifact["scanner_safe"] == false)
+    );
 }
 
 #[test]
@@ -116,6 +224,95 @@ fn verify_bundle_accepts_generated_bundle_and_detects_mismatch() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("content mismatch"));
+}
+
+#[test]
+fn verify_bundle_rejects_manifest_metadata_drift() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("bundle");
+
+    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    bundle.args([
+        "bundle",
+        "--profile",
+        "scanner-safe",
+        "--out",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    bundle.assert().success();
+
+    let manifest_path = bundle_dir.join("manifest.json");
+    let mut manifest: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+            .expect("manifest json");
+    manifest["artifacts"][0]["scanner_safe"] = Value::Bool(false);
+    fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+    )
+    .expect("mutate manifest");
+
+    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    verify.args([
+        "verify-bundle",
+        "--path",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    verify
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("artifact metadata mismatch"));
+}
+
+#[test]
+fn verify_bundle_accepts_legacy_manifest_without_profile_metadata() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("bundle");
+
+    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    bundle.args([
+        "bundle",
+        "--profile",
+        "runtime",
+        "--format",
+        "jwk",
+        "--seed",
+        "legacy-seed",
+        "--label",
+        "legacy",
+        "--out",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    bundle.assert().success();
+
+    let manifest_path = bundle_dir.join("manifest.json");
+    let mut manifest: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+            .expect("manifest json");
+    manifest
+        .as_object_mut()
+        .expect("manifest object")
+        .remove("profile");
+    manifest
+        .as_object_mut()
+        .expect("manifest object")
+        .remove("artifacts");
+    fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+    )
+    .expect("write legacy manifest");
+
+    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    verify.args([
+        "verify-bundle",
+        "--path",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    verify
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"status\": \"ok\""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make `uselesskey bundle` default to a `scanner-safe` profile with default seed/label/format values
- add per-artifact bundle manifest metadata for profile, lanes, scanner-safe disposition, and descriptions
- keep `--profile runtime` as the explicit path for private/symmetric material and teach `verify-bundle` to reject metadata drift

## Validation
- cargo test -p uselesskey-cli --all-features
- cargo clippy -p uselesskey-cli --all-features --all-targets -- -D warnings
- cargo run -p uselesskey-cli -- bundle --profile scanner-safe --out target/uselesskey-bundle-profile-smoke
- cargo run -p uselesskey-cli -- verify-bundle --path target/uselesskey-bundle-profile-smoke
- cargo run -p uselesskey-cli -- bundle --profile runtime --format pem --seed det-seed --label issuer --out target/uselesskey-bundle-runtime-smoke
- cargo run -p uselesskey-cli -- verify-bundle --path target/uselesskey-bundle-runtime-smoke
- cargo xtask docs-sync --check
- cargo xtask no-blob
- cargo xtask typos
- git diff --check
- cargo xtask pr reached fuzz locally after fmt, workspace clippy, CLI tests, BDD, and mutants passed; local Windows fuzz target failed to launch with STATUS_DLL_NOT_FOUND