### PR TITLE
feat(cli): export bundle payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against their recorded `manifest.json`.
 - Added scanner-safe bundle profiles and per-artifact lane metadata to
   `uselesskey bundle` manifests.
+- Added `uselesskey export k8s` and `uselesskey export vault-kv-json` payload
+  renderers for verified bundle directories.
 - Added a public-surface map that separates public support promises from
   published internal implementation shards.
 

--- a/crates/uselesskey-cli/README.md
+++ b/crates/uselesskey-cli/README.md
@@ -54,11 +54,25 @@ cargo run -p uselesskey-cli -- bundle \
 
 cargo run -p uselesskey-cli -- verify-bundle \
   --path target/uselesskey-bundle
+
+cargo run -p uselesskey-cli -- export k8s \
+  --bundle-dir target/uselesskey-bundle \
+  --name uselesskey-fixtures \
+  --namespace tests \
+  --out target/uselesskey-bundle/secret.yaml
+
+cargo run -p uselesskey-cli -- export vault-kv-json \
+  --bundle-dir target/uselesskey-bundle \
+  --out target/uselesskey-bundle/kv-v2.json
 ```
 
 `verify-bundle` reloads `manifest.json`, regenerates the expected artifacts from
 the recorded seed/label/format/profile, and fails if any file or manifest
 metadata is missing or changed.
+
+The `export` subcommands verify the bundle first, then render handoff payloads
+for downstream tools. They write local files only; they do not call Kubernetes,
+Vault, cloud APIs, or long-running secret stores.
 
 `scanner-safe` is the default bundle profile. It emits public key material,
 public certificate material, scanner-safe symmetric JWK shape data, and

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -9,7 +9,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use uselesskey_cli::{
+    ArtifactType as ExportArtifactType, ExportArtifact, ManifestArtifact,
     emit_include_bytes_module, load_materialize_manifest, materialize_manifest_to_dir,
+    render_k8s_secret_yaml, render_vault_kv_json,
 };
 use uselesskey_core::Factory;
 use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
@@ -31,6 +33,7 @@ enum Commands {
     Generate(GenerateArgs),
     Bundle(BundleArgs),
     VerifyBundle(VerifyBundleArgs),
+    Export(ExportArgs),
     Inspect(InspectArgs),
     Materialize(MaterializeArgs),
     Verify(VerifyArgs),
@@ -67,6 +70,38 @@ struct BundleArgs {
 struct VerifyBundleArgs {
     #[arg(long = "bundle-dir", alias = "path")]
     bundle_dir: PathBuf,
+}
+
+#[derive(clap::Args, Debug)]
+struct ExportArgs {
+    #[command(subcommand)]
+    target: ExportTarget,
+}
+
+#[derive(Subcommand, Debug)]
+enum ExportTarget {
+    K8s(ExportK8sArgs),
+    VaultKvJson(ExportVaultKvJsonArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct ExportK8sArgs {
+    #[arg(long = "bundle-dir", alias = "path")]
+    bundle_dir: PathBuf,
+    #[arg(long)]
+    name: String,
+    #[arg(long)]
+    namespace: Option<String>,
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+#[derive(clap::Args, Debug)]
+struct ExportVaultKvJsonArgs {
+    #[arg(long = "bundle-dir", alias = "path")]
+    bundle_dir: PathBuf,
+    #[arg(long)]
+    out: Option<PathBuf>,
 }
 
 #[derive(clap::Args, Debug)]
@@ -179,6 +214,7 @@ fn main() -> Result<()> {
         Commands::Generate(args) => run_generate(args),
         Commands::Bundle(args) => run_bundle(args),
         Commands::VerifyBundle(args) => run_verify_bundle(args),
+        Commands::Export(args) => run_export(args),
         Commands::Inspect(args) => run_inspect(args),
         Commands::Materialize(args) => run_materialize(args),
         Commands::Verify(args) => run_verify(args),
@@ -257,6 +293,25 @@ fn run_verify_bundle(args: VerifyBundleArgs) -> Result<()> {
         })),
         None,
     )
+}
+
+fn run_export(args: ExportArgs) -> Result<()> {
+    match args.target {
+        ExportTarget::K8s(export) => run_export_k8s(export),
+        ExportTarget::VaultKvJson(export) => run_export_vault_kv_json(export),
+    }
+}
+
+fn run_export_k8s(args: ExportK8sArgs) -> Result<()> {
+    let artifacts = load_bundle_export_artifacts(&args.bundle_dir)?;
+    let payload = render_k8s_secret_yaml(&args.name, args.namespace.as_deref(), &artifacts);
+    emit_artifact(&Artifact::Text(payload), args.out.as_deref())
+}
+
+fn run_export_vault_kv_json(args: ExportVaultKvJsonArgs) -> Result<()> {
+    let artifacts = load_bundle_export_artifacts(&args.bundle_dir)?;
+    let payload = render_vault_kv_json(&artifacts).context("failed to render Vault KV payload")?;
+    emit_artifact(&Artifact::Text(payload), args.out.as_deref())
 }
 
 fn run_inspect(args: InspectArgs) -> Result<()> {
@@ -389,6 +444,49 @@ fn verify_bundle_manifest(bundle_dir: &Path, manifest: &BundleManifest) -> Resul
     }
 
     Ok(expected_files)
+}
+
+fn load_bundle_export_artifacts(bundle_dir: &Path) -> Result<Vec<ExportArtifact>> {
+    let manifest_path = bundle_dir.join("manifest.json");
+    let manifest = load_bundle_manifest(&manifest_path)
+        .with_context(|| format!("invalid bundle manifest {}", manifest_path.display()))?;
+    verify_bundle_manifest(bundle_dir, &manifest)
+        .with_context(|| format!("failed to verify bundle {}", bundle_dir.display()))?;
+
+    if manifest.artifacts.is_empty() {
+        bail!(
+            "bundle manifest {} does not contain artifact metadata; rerun `uselesskey bundle`",
+            manifest_path.display()
+        );
+    }
+
+    let mut artifacts = Vec::with_capacity(manifest.artifacts.len());
+    for record in &manifest.artifacts {
+        let path = bundle_dir.join(&record.path);
+        let bytes =
+            fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
+        let value = String::from_utf8(bytes).with_context(|| {
+            format!(
+                "bundle artifact {} is not UTF-8; export payloads require text artifacts",
+                path.display()
+            )
+        })?;
+        artifacts.push(ExportArtifact {
+            key: record.path.clone(),
+            value,
+            manifest: ManifestArtifact {
+                artifact_type: ExportArtifactType::Opaque,
+                source_seed: Some(manifest.seed.clone()),
+                source_label: manifest.label.clone(),
+                output_paths: vec![record.path.clone()],
+                fingerprints: Vec::new(),
+                env_var_names: Vec::new(),
+                external_key_ref: None,
+            },
+        });
+    }
+
+    Ok(artifacts)
 }
 
 fn parse_manifest_format(raw: &str) -> Result<Format> {

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -316,6 +316,67 @@ fn verify_bundle_accepts_legacy_manifest_without_profile_metadata() {
 }
 
 #[test]
+fn export_k8s_and_vault_payloads_from_scanner_safe_bundle() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("bundle");
+    let k8s_path = dir.path().join("secret.yaml");
+    let vault_path = dir.path().join("kv-v2.json");
+
+    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    bundle.args([
+        "bundle",
+        "--profile",
+        "scanner-safe",
+        "--out",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    bundle.assert().success();
+
+    let mut k8s = Command::cargo_bin("uselesskey").expect("bin exists");
+    k8s.args([
+        "export",
+        "k8s",
+        "--bundle-dir",
+        bundle_dir.to_str().expect("utf-8"),
+        "--name",
+        "uselesskey-fixtures",
+        "--namespace",
+        "tests",
+        "--out",
+        k8s_path.to_str().expect("utf-8"),
+    ]);
+    k8s.assert().success();
+
+    let rendered_k8s = fs::read_to_string(&k8s_path).expect("k8s payload");
+    assert!(rendered_k8s.contains("kind: Secret"));
+    assert!(rendered_k8s.contains("  name: uselesskey-fixtures"));
+    assert!(rendered_k8s.contains("  namespace: tests"));
+    assert!(rendered_k8s.contains("  token.json: "));
+
+    let mut vault = Command::cargo_bin("uselesskey").expect("bin exists");
+    vault.args([
+        "export",
+        "vault-kv-json",
+        "--bundle-dir",
+        bundle_dir.to_str().expect("utf-8"),
+        "--out",
+        vault_path.to_str().expect("utf-8"),
+    ]);
+    vault.assert().success();
+
+    let vault_json: Value =
+        serde_json::from_slice(&fs::read(&vault_path).expect("vault payload")).expect("vault json");
+    assert_eq!(vault_json["metadata"]["source"], "uselesskey-cli");
+    assert_eq!(vault_json["metadata"]["mode"], "one_shot_export");
+    assert!(
+        vault_json["data"]["token.json"]
+            .as_str()
+            .expect("token payload")
+            .contains("uk_tset_")
+    );
+}
+
+#[test]
 fn inspect_reads_stdin_writes_json() {
     let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
     cmd.args(["inspect", "--format", "pem"])


### PR DESCRIPTION
## Summary
- add `uselesskey export k8s` and `uselesskey export vault-kv-json` for verified bundle directories
- reuse existing local payload renderers and verify `manifest.json` before exporting
- keep export behavior local-only; no Kubernetes, Vault, cloud API, or secret-store calls

## Validation
- `cargo test -p uselesskey-cli --all-features`
- `cargo clippy -p uselesskey-cli --all-features --all-targets -- -D warnings`
- live smoke:
  - `cargo run -p uselesskey-cli -- bundle --profile scanner-safe --out target/uselesskey-export-payload-smoke`
  - `cargo run -p uselesskey-cli -- export k8s --bundle-dir target/uselesskey-export-payload-smoke --name uselesskey-fixtures --namespace tests --out target/uselesskey-export-payload-smoke/secret.yaml`
  - `cargo run -p uselesskey-cli -- export vault-kv-json --bundle-dir target/uselesskey-export-payload-smoke --out target/uselesskey-export-payload-smoke/kv-v2.json`
  - `cargo run -p uselesskey-cli -- verify-bundle --path target/uselesskey-export-payload-smoke`
- `cargo xtask docs-sync --check`
- `cargo xtask no-blob`
- `cargo xtask typos`
- `git diff --check`
- `cargo xtask pr` reached fuzz after fmt, workspace clippy, CLI tests, BDD, and mutants passed; local Windows fuzz target launch failed with `STATUS_DLL_NOT_FOUND` for `adapter_jsonwebtoken_roundtrip`