### PR TITLE
feat(cli): add bundle receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uselesskey bundle` manifests.
 - Added `uselesskey export k8s` and `uselesskey export vault-kv-json` payload
   renderers for verified bundle directories.
+- Added deterministic bundle receipt files under `receipts/` and verification
+  coverage for receipt drift.
 - Added a public-surface map that separates public support promises from
   published internal implementation shards.
 

--- a/crates/uselesskey-cli/README.md
+++ b/crates/uselesskey-cli/README.md
@@ -68,7 +68,9 @@ cargo run -p uselesskey-cli -- export vault-kv-json \
 
 `verify-bundle` reloads `manifest.json`, regenerates the expected artifacts from
 the recorded seed/label/format/profile, and fails if any file or manifest
-metadata is missing or changed.
+metadata is missing or changed. Bundles also include deterministic
+`receipts/materialization.json` and `receipts/audit-surface.json` metadata files;
+`verify-bundle` regenerates those receipts and fails on drift.
 
 The `export` subcommands verify the bundle first, then render handoff payloads
 for downstream tools. They write local files only; they do not call Kubernetes,

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -255,6 +255,22 @@ fn run_bundle(args: BundleArgs) -> Result<()> {
             args.profile,
         ));
     }
+    let fixture_files = files.clone();
+    let receipts = bundle_receipt_records(args.profile);
+    for receipt in &receipts {
+        let receipt_artifact = generate_bundle_receipt_artifact(
+            &receipt.kind,
+            &args.seed,
+            &args.label,
+            args.format,
+            args.profile,
+            &fixture_files,
+            &artifacts,
+        )?;
+        let file = out_dir.join(&receipt.path);
+        write_artifact_to_path(&receipt_artifact, &file)?;
+        files.push(receipt.path.clone());
+    }
 
     let manifest = BundleManifest {
         version: 1,
@@ -264,6 +280,7 @@ fn run_bundle(args: BundleArgs) -> Result<()> {
         format: args.format.manifest_name().to_string(),
         files,
         artifacts,
+        receipts,
     };
     let manifest_path = out_dir.join("manifest.json");
     fs::write(&manifest_path, serde_json::to_vec_pretty(&manifest)?)?;
@@ -426,6 +443,32 @@ fn verify_bundle_manifest(bundle_dir: &Path, manifest: &BundleManifest) -> Resul
             profile,
         ));
     }
+    let fixture_files = expected_files.clone();
+    let mut expected_receipts = Vec::new();
+    if !manifest.receipts.is_empty() {
+        expected_receipts = bundle_receipt_records(profile);
+        for receipt in &expected_receipts {
+            let expected = artifact_bytes(&generate_bundle_receipt_artifact(
+                &receipt.kind,
+                &manifest.seed,
+                &manifest.label,
+                format,
+                profile,
+                &fixture_files,
+                &expected_artifacts,
+            )?)?;
+            let path = bundle_dir.join(&receipt.path);
+            let actual =
+                fs::read(&path).with_context(|| format!("failed to read {}", path.display()))?;
+            if actual != expected {
+                bail!(
+                    "bundle verification failed: {} receipt mismatch",
+                    path.display()
+                );
+            }
+            expected_files.push(receipt.path.clone());
+        }
+    }
 
     if manifest.files != expected_files {
         bail!(
@@ -440,6 +483,18 @@ fn verify_bundle_manifest(bundle_dir: &Path, manifest: &BundleManifest) -> Resul
             "bundle verification failed: artifact metadata mismatch; expected {:?}, found {:?}",
             expected_artifacts,
             manifest.artifacts
+        );
+    }
+
+    if !manifest.artifacts.is_empty() && manifest.receipts.is_empty() {
+        bail!("bundle verification failed: receipt metadata missing");
+    }
+
+    if !manifest.receipts.is_empty() && manifest.receipts != expected_receipts {
+        bail!(
+            "bundle verification failed: receipt metadata mismatch; expected {:?}, found {:?}",
+            expected_receipts,
+            manifest.receipts
         );
     }
 
@@ -561,6 +616,86 @@ fn bundle_artifact_description(kind: Kind, profile: BundleProfile) -> &'static s
         }
         (BundleProfile::Runtime, _) => "runtime-generated fixture material",
     }
+}
+
+fn bundle_receipt_records(profile: BundleProfile) -> Vec<BundleReceiptRecord> {
+    vec![
+        BundleReceiptRecord {
+            path: "receipts/materialization.json".to_string(),
+            kind: "materialization".to_string(),
+            profile: profile.manifest_name().to_string(),
+            description: "deterministic bundle materialization receipt".to_string(),
+        },
+        BundleReceiptRecord {
+            path: "receipts/audit-surface.json".to_string(),
+            kind: "audit-surface".to_string(),
+            profile: profile.manifest_name().to_string(),
+            description: "scanner-safety and lane metadata receipt".to_string(),
+        },
+    ]
+}
+
+fn generate_bundle_receipt_artifact(
+    kind: &str,
+    seed: &str,
+    label: &str,
+    format: Format,
+    profile: BundleProfile,
+    fixture_files: &[String],
+    artifacts: &[BundleArtifactRecord],
+) -> Result<Artifact> {
+    match kind {
+        "materialization" => Ok(Artifact::Json(json!({
+            "receipt": "materialization",
+            "version": 1,
+            "profile": profile.manifest_name(),
+            "seed": seed,
+            "label": label,
+            "format": format.manifest_name(),
+            "artifact_count": artifacts.len(),
+            "files": fixture_files,
+            "lanes": bundle_lanes(artifacts),
+            "artifacts": artifacts,
+        }))),
+        "audit-surface" => {
+            let scanner_safe_count = artifacts
+                .iter()
+                .filter(|artifact| artifact.scanner_safe)
+                .count();
+            Ok(Artifact::Json(json!({
+                "receipt": "audit-surface",
+                "version": 1,
+                "profile": profile.manifest_name(),
+                "scanner_safe": scanner_safe_count == artifacts.len(),
+                "artifact_count": artifacts.len(),
+                "scanner_safe_count": scanner_safe_count,
+                "runtime_material_count": artifacts.len() - scanner_safe_count,
+                "lanes": bundle_lanes(artifacts),
+                "artifacts": artifacts.iter().map(|artifact| {
+                    json!({
+                        "path": artifact.path,
+                        "kind": artifact.kind,
+                        "format": artifact.format,
+                        "scanner_safe": artifact.scanner_safe,
+                        "description": artifact.description,
+                    })
+                }).collect::<Vec<_>>(),
+            })))
+        }
+        other => bail!("unsupported bundle receipt `{other}`"),
+    }
+}
+
+fn bundle_lanes(artifacts: &[BundleArtifactRecord]) -> Vec<String> {
+    let mut lanes = Vec::new();
+    for artifact in artifacts {
+        for lane in &artifact.lanes {
+            if !lanes.contains(lane) {
+                lanes.push(lane.clone());
+            }
+        }
+    }
+    lanes
 }
 
 fn preferred_bundle_format(kind: Kind, requested: Format, profile: BundleProfile) -> Format {
@@ -833,6 +968,8 @@ struct BundleManifest {
     files: Vec<String>,
     #[serde(default)]
     artifacts: Vec<BundleArtifactRecord>,
+    #[serde(default)]
+    receipts: Vec<BundleReceiptRecord>,
 }
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -843,6 +980,14 @@ struct BundleArtifactRecord {
     profile: String,
     lanes: Vec<String>,
     scanner_safe: bool,
+    description: String,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct BundleReceiptRecord {
+    path: String,
+    kind: String,
+    profile: String,
     description: String,
 }
 

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -73,11 +73,37 @@ fn bundle_writes_manifest_schema() {
     assert_eq!(value["seed"], "det-seed");
     assert_eq!(value["label"], "bundle-label");
     assert!(value["files"].as_array().expect("array").len() >= 8);
+    assert!(bundle_dir.join("receipts/materialization.json").exists());
+    assert!(bundle_dir.join("receipts/audit-surface.json").exists());
+    assert!(
+        value["files"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|file| file.as_str() == Some("receipts/materialization.json"))
+    );
+    assert!(
+        value["files"]
+            .as_array()
+            .expect("array")
+            .iter()
+            .any(|file| file.as_str() == Some("receipts/audit-surface.json"))
+    );
     let artifacts = value["artifacts"].as_array().expect("artifacts array");
     assert_eq!(
         artifacts.len(),
-        value["files"].as_array().expect("array").len()
+        value["files"].as_array().expect("array").len() - 2
     );
+    let receipts = value["receipts"].as_array().expect("receipts array");
+    assert_eq!(receipts.len(), 2);
+    assert!(receipts.iter().any(|receipt| {
+        receipt["path"].as_str() == Some("receipts/materialization.json")
+            && receipt["kind"].as_str() == Some("materialization")
+    }));
+    assert!(receipts.iter().any(|receipt| {
+        receipt["path"].as_str() == Some("receipts/audit-surface.json")
+            && receipt["kind"].as_str() == Some("audit-surface")
+    }));
     assert!(
         artifacts
             .iter()
@@ -143,6 +169,33 @@ fn bundle_profile_scanner_safe_is_the_default_path() {
     let token_value = token["value"].as_str().expect("token value");
     assert!(token_value.starts_with("uk_tset_"));
     assert!(!token_value.starts_with("uk_test_"));
+
+    let materialization: Value = serde_json::from_slice(
+        &fs::read(bundle_dir.join("receipts/materialization.json"))
+            .expect("materialization receipt"),
+    )
+    .expect("materialization receipt json");
+    assert_eq!(materialization["receipt"], "materialization");
+    assert_eq!(materialization["profile"], "scanner-safe");
+    assert_eq!(
+        materialization["artifact_count"].as_u64(),
+        Some(artifacts.len() as u64)
+    );
+    assert!(
+        materialization["lanes"]
+            .as_array()
+            .expect("lanes")
+            .iter()
+            .any(|lane| lane.as_str() == Some("runtime"))
+    );
+
+    let audit: Value = serde_json::from_slice(
+        &fs::read(bundle_dir.join("receipts/audit-surface.json")).expect("audit receipt"),
+    )
+    .expect("audit receipt json");
+    assert_eq!(audit["receipt"], "audit-surface");
+    assert_eq!(audit["scanner_safe"], true);
+    assert_eq!(audit["runtime_material_count"], 0);
 }
 
 #[test]
@@ -265,6 +318,120 @@ fn verify_bundle_rejects_manifest_metadata_drift() {
 }
 
 #[test]
+fn verify_bundle_rejects_receipt_drift() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("bundle");
+
+    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    bundle.args([
+        "bundle",
+        "--profile",
+        "scanner-safe",
+        "--out",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    bundle.assert().success();
+
+    fs::write(
+        bundle_dir.join("receipts/materialization.json"),
+        "{\"receipt\":\"materialization\",\"mutated\":true}\n",
+    )
+    .expect("mutate receipt");
+
+    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    verify.args([
+        "verify-bundle",
+        "--path",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    verify
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("receipt mismatch"));
+}
+
+#[test]
+fn verify_bundle_rejects_receipt_metadata_drift() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("bundle");
+
+    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    bundle.args([
+        "bundle",
+        "--profile",
+        "scanner-safe",
+        "--out",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    bundle.assert().success();
+
+    let manifest_path = bundle_dir.join("manifest.json");
+    let mut manifest: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+            .expect("manifest json");
+    manifest["receipts"][0]["description"] = Value::String("mutated receipt".to_string());
+    fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+    )
+    .expect("mutate manifest");
+
+    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    verify.args([
+        "verify-bundle",
+        "--path",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    verify
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("receipt metadata mismatch"));
+}
+
+#[test]
+fn verify_bundle_rejects_missing_receipt_metadata_on_current_manifest() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("bundle");
+
+    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    bundle.args([
+        "bundle",
+        "--profile",
+        "scanner-safe",
+        "--out",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    bundle.assert().success();
+
+    let manifest_path = bundle_dir.join("manifest.json");
+    let mut manifest: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
+            .expect("manifest json");
+    manifest
+        .as_object_mut()
+        .expect("manifest object")
+        .remove("receipts");
+    let files = manifest["files"].as_array_mut().expect("files array");
+    files.retain(|file| !file.as_str().expect("file string").starts_with("receipts/"));
+    fs::write(
+        &manifest_path,
+        serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+    )
+    .expect("write manifest");
+
+    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    verify.args([
+        "verify-bundle",
+        "--path",
+        bundle_dir.to_str().expect("utf-8"),
+    ]);
+    verify
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("receipt metadata missing"));
+}
+
+#[test]
 fn verify_bundle_accepts_legacy_manifest_without_profile_metadata() {
     let dir = tempdir().expect("tempdir");
     let bundle_dir = dir.path().join("bundle");
@@ -297,6 +464,12 @@ fn verify_bundle_accepts_legacy_manifest_without_profile_metadata() {
         .as_object_mut()
         .expect("manifest object")
         .remove("artifacts");
+    manifest
+        .as_object_mut()
+        .expect("manifest object")
+        .remove("receipts");
+    let files = manifest["files"].as_array_mut().expect("files array");
+    files.retain(|file| !file.as_str().expect("file string").starts_with("receipts/"));
     fs::write(
         &manifest_path,
         serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),


### PR DESCRIPTION
## Summary
- add deterministic `receipts/materialization.json` and `receipts/audit-surface.json` files to `uselesskey bundle`
- record receipt metadata in `manifest.json` while keeping fixture artifacts separate from receipts
- extend `verify-bundle` to regenerate receipt files and reject receipt file, receipt metadata, and current-manifest receipt omissions

## Validation
- `cargo test -p uselesskey-cli --all-features`
- `cargo clippy -p uselesskey-cli --all-features --all-targets -- -D warnings`
- live smoke:
  - `cargo run -p uselesskey-cli -- bundle --profile scanner-safe --out target/uselesskey-bundle-receipt-smoke`
  - `cargo run -p uselesskey-cli -- verify-bundle --path target/uselesskey-bundle-receipt-smoke`
- `cargo xtask docs-sync --check`
- `cargo xtask no-blob`
- `cargo xtask typos`
- `git diff --check`
- `cargo xtask pr` passed fmt, workspace clippy, CLI tests, BDD, and mutants; local Windows fuzz target launch failed with `STATUS_DLL_NOT_FOUND` for `adapter_jsonwebtoken_roundtrip`