### PR TITLE
perf: expand fixture benchmark coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   coverage for receipt drift.
 - Added a public-surface map that separates public support promises from
   published internal implementation shards.
+- Added perf receipt coverage for seed derivation, JWK/JWKS emission,
+  WebAuthn, PKCS#11 mocks, and scanner-safe materialize/verify paths.
 
 ## [0.6.0] - 2026-04-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4679,7 +4679,11 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "tempfile",
  "uselesskey",
+ "uselesskey-cli",
+ "uselesskey-pkcs11-mock",
+ "uselesskey-webauthn",
 ]
 
 [[package]]

--- a/crates/uselesskey-bench/Cargo.toml
+++ b/crates/uselesskey-bench/Cargo.toml
@@ -15,7 +15,11 @@ anyhow.workspace = true
 clap.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tempfile.workspace = true
 uselesskey = { path = "../uselesskey", features = ["full"] }
+uselesskey-cli.workspace = true
+uselesskey-pkcs11-mock = { path = "../uselesskey-pkcs11-mock", version = "0.6.0" }
+uselesskey-webauthn = { path = "../uselesskey-webauthn", version = "0.6.0" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/uselesskey-bench/src/lib.rs
+++ b/crates/uselesskey-bench/src/lib.rs
@@ -1,27 +1,62 @@
 #![forbid(unsafe_code)]
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use uselesskey::jwk::JwksBuilder;
 use uselesskey::{
     ChainSpec, EcdsaFactoryExt, EcdsaSpec, Ed25519FactoryExt, Ed25519Spec, Factory, HmacFactoryExt,
     HmacSpec, RsaFactoryExt, RsaSpec, TokenFactoryExt, TokenSpec, X509FactoryExt, X509Spec,
     negative::CorruptPem,
 };
+use uselesskey_cli::{materialize_manifest_to_dir, parse_materialize_manifest_str};
+use uselesskey_pkcs11_mock::{Pkcs11MockFactoryExt, Pkcs11MockSpec};
+use uselesskey_webauthn::{WebAuthnFactoryExt, WebAuthnSpec};
 
 pub const REQUIRED_SCENARIO_IDS: &[&str] = &[
+    "seed.derivation.v1",
     "rsa.fixture.cold",
     "rsa.fixture.warm",
     "ecdsa.fixture.p256",
     "ed25519.fixture",
+    "jwk.jwks.emit",
     "hmac.fixture.hs256",
     "token.fixture.api_key",
     "x509.self_signed",
     "x509.chain",
     "negative.fixture.corrupt_pem",
+    "webauthn.fixture.ceremony",
+    "pkcs11.provider.construct",
+    "cli.materialize_verify.shape",
 ];
+
+const MATERIALIZE_VERIFY_MANIFEST: &str = r#"
+version = 1
+
+[[fixture]]
+id = "entropy"
+kind = "entropy.bytes"
+seed = "perf-materialize"
+len = 64
+out = "entropy.bin"
+
+[[fixture]]
+id = "pem_shape"
+kind = "pem.block_shape"
+seed = "perf-materialize"
+label = "test pem"
+len = 128
+out = "shape/test.pem"
+
+[[fixture]]
+id = "ssh_shape"
+kind = "ssh.public_key_shape"
+seed = "perf-materialize"
+label = "deploy@example"
+out = "ssh/id_ed25519.pub"
+"#;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchScenario {
@@ -42,8 +77,9 @@ pub struct PerfSummary {
     pub scenarios: Vec<BenchScenario>,
 }
 
-pub fn run_perf_suite() -> PerfSummary {
+pub fn run_perf_suite() -> Result<PerfSummary> {
     let scenarios = vec![
+        benchmark_seed_derivation(),
         benchmark("rsa.fixture.cold", "rsa", 15, || {
             let fx = Factory::random();
             let kp = fx.rsa("bench-rsa-cold", RsaSpec::rs256());
@@ -60,6 +96,7 @@ pub fn run_perf_suite() -> PerfSummary {
             let kp = fx.ed25519("bench-ed25519", Ed25519Spec::new());
             kp.private_key_pkcs8_der().len() + kp.public_key_spki_der().len()
         }),
+        benchmark_jwks_emission(),
         benchmark("hmac.fixture.hs256", "hmac", 200, || {
             let fx = Factory::random();
             let secret = fx.hmac("bench-hmac", HmacSpec::hs256());
@@ -90,13 +127,39 @@ pub fn run_perf_suite() -> PerfSummary {
             let truncated = kp.private_key_pkcs8_der_truncated(32);
             corrupt.len() + truncated.len()
         }),
+        benchmark_webauthn_fixture(),
+        benchmark_pkcs11_provider(),
+        benchmark_cli_materialize_verify()?,
     ];
 
-    PerfSummary {
+    Ok(PerfSummary {
         version: 1,
         generated_at_unix: unix_now(),
         scenarios,
-    }
+    })
+}
+
+fn benchmark_seed_derivation() -> BenchScenario {
+    const ITERATIONS: usize = 1_000;
+
+    let fx = Factory::deterministic_from_str("bench-seed-derivation");
+    let labels = (0..ITERATIONS)
+        .map(|n| format!("bench-seed-{n}"))
+        .collect::<Vec<_>>();
+    let mut next = 0usize;
+
+    benchmark("seed.derivation.v1", "seed", ITERATIONS, || {
+        let label = &labels[next % labels.len()];
+        next += 1;
+        let derived = fx.get_or_init(
+            "bench:seed:derivation",
+            label,
+            b"seed-derivation-v1",
+            "good",
+            |seed| *seed.bytes(),
+        );
+        derived.len()
+    })
 }
 
 fn benchmark_warm_cache_rsa() -> BenchScenario {
@@ -122,6 +185,75 @@ fn benchmark_warm_cache_rsa() -> BenchScenario {
         allocation_bytes: None,
         notes: Some("cache-hit path with pre-primed Factory".to_owned()),
     }
+}
+
+fn benchmark_jwks_emission() -> BenchScenario {
+    let fx = Factory::deterministic_from_str("bench-jwks-emission");
+    let rsa = fx.rsa("bench-jwks-rsa", RsaSpec::rs256());
+    let ecdsa = fx.ecdsa("bench-jwks-ecdsa", EcdsaSpec::es256());
+    let ed25519 = fx.ed25519("bench-jwks-ed25519", Ed25519Spec::new());
+
+    benchmark("jwk.jwks.emit", "jwk", 500, || {
+        let jwks = JwksBuilder::new()
+            .add_public(rsa.public_jwk())
+            .add_public(ecdsa.public_jwk())
+            .add_public(ed25519.public_jwk())
+            .build();
+        json_len(jwks.to_value())
+    })
+}
+
+fn benchmark_webauthn_fixture() -> BenchScenario {
+    let spec = WebAuthnSpec::packed("bench.example.com", b"bench-challenge");
+
+    benchmark("webauthn.fixture.ceremony", "webauthn", 250, || {
+        let fx = Factory::random();
+        let registration = fx.webauthn_registration("bench-webauthn", spec.clone());
+        let assertion = fx.webauthn_assertion("bench-webauthn", spec.clone());
+
+        registration.client_data_json.len()
+            + registration.authenticator_data.len()
+            + registration.attestation_object.len()
+            + assertion.client_data_json.len()
+            + assertion.authenticator_data.len()
+            + assertion.signature.len()
+    })
+}
+
+fn benchmark_pkcs11_provider() -> BenchScenario {
+    let mut spec = Pkcs11MockSpec::basic("HSM-BENCH");
+    spec.key_labels = vec![
+        "signing-key".to_string(),
+        "rotation-key".to_string(),
+        "audit-key".to_string(),
+    ];
+
+    benchmark("pkcs11.provider.construct", "pkcs11", 250, || {
+        let fx = Factory::random();
+        let provider = fx.pkcs11_mock("bench-pkcs11", spec.clone());
+        let handles = provider.key_handles();
+        let cert_bytes = handles
+            .iter()
+            .filter_map(|handle| provider.certificate_der(*handle).map(<[u8]>::len))
+            .sum::<usize>();
+        let signature_bytes = handles
+            .first()
+            .and_then(|handle| provider.sign(*handle, b"benchmark message"))
+            .map_or(0, |signature| signature.len());
+
+        provider.slot_info().serial_number.len() + cert_bytes + signature_bytes + handles.len()
+    })
+}
+
+fn benchmark_cli_materialize_verify() -> Result<BenchScenario> {
+    let manifest = parse_materialize_manifest_str(MATERIALIZE_VERIFY_MANIFEST)?;
+
+    benchmark_checked("cli.materialize_verify.shape", "cli", 80, || {
+        let temp = tempfile::tempdir()?;
+        let written = materialize_manifest_to_dir(&manifest, temp.path(), false)?;
+        let verified = materialize_manifest_to_dir(&manifest, temp.path(), true)?;
+        Ok(sum_file_sizes(&written.files)? + verified.files.len())
+    })
 }
 
 fn benchmark(
@@ -150,6 +282,50 @@ fn benchmark(
         allocation_bytes: None,
         notes: None,
     }
+}
+
+fn benchmark_checked(
+    id: &str,
+    group: &str,
+    iterations: usize,
+    mut f: impl FnMut() -> Result<usize>,
+) -> Result<BenchScenario> {
+    let mut samples_ns = Vec::with_capacity(iterations);
+    let mut output_bytes = 0usize;
+
+    for _ in 0..iterations {
+        let started = Instant::now();
+        output_bytes = f()?;
+        std::hint::black_box(output_bytes);
+        samples_ns.push(elapsed_ns(started.elapsed()));
+    }
+
+    Ok(BenchScenario {
+        id: id.to_owned(),
+        group: group.to_owned(),
+        iterations,
+        median_ns: median(&mut samples_ns),
+        mean_ns: mean(&samples_ns),
+        output_bytes,
+        allocation_bytes: None,
+        notes: None,
+    })
+}
+
+fn json_len(value: serde_json::Value) -> usize {
+    match serde_json::to_vec(&value) {
+        Ok(bytes) => bytes.len(),
+        Err(_) => 0,
+    }
+}
+
+fn sum_file_sizes(paths: &[PathBuf]) -> Result<usize> {
+    let mut total = 0usize;
+    for path in paths {
+        let len = std::fs::metadata(path)?.len();
+        total = total.saturating_add(len.min(usize::MAX as u64) as usize);
+    }
+    Ok(total)
 }
 
 fn elapsed_ns(d: Duration) -> u64 {
@@ -192,8 +368,8 @@ mod tests {
     use std::collections::BTreeSet;
 
     #[test]
-    fn required_scenarios_are_covered() {
-        let summary = run_perf_suite();
+    fn required_scenarios_are_covered() -> Result<()> {
+        let summary = run_perf_suite()?;
         let ids = summary
             .scenarios
             .iter()
@@ -205,13 +381,15 @@ mod tests {
                 "missing required benchmark: {required}"
             );
         }
+        Ok(())
     }
 
     #[test]
-    fn summary_serializes_with_schema_version() {
-        let summary = run_perf_suite();
-        let json = serde_json::to_value(summary).expect("serialize summary");
+    fn summary_serializes_with_schema_version() -> Result<()> {
+        let summary = run_perf_suite()?;
+        let json = serde_json::to_value(summary)?;
         assert_eq!(json["version"], 1);
         assert!(json["scenarios"].is_array());
+        Ok(())
     }
 }

--- a/crates/uselesskey-bench/src/main.rs
+++ b/crates/uselesskey-bench/src/main.rs
@@ -19,7 +19,7 @@ struct Cli {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    let summary = run_perf_suite();
+    let summary = run_perf_suite()?;
     write_summary(&cli.output, &summary)?;
     eprintln!("wrote perf summary: {}", cli.output.display());
     Ok(())

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -29,10 +29,10 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 
 ## v0.6.1 benchmarks and governance
 
-- [ ] Criterion harness
-- [ ] Baseline performance report
+- [x] Criterion harness
+- [x] Baseline performance report
 - [ ] Scheduled/manual perf workflow
-- [ ] CI threshold policy for benchmark trends
+- [x] CI threshold policy for benchmark trends
 - [ ] Release category notes + post-release audit
 - [x] Public surface promise map
 

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -18,7 +18,7 @@ This roadmap reflects the strategic direction for uselesskey as a **test-fixture
 
 - [x] JWK/JWKS and token-shape negative fixture follow-ons.
 - [x] Docs/examples coverage for the remaining negative-fixture surface.
-- [ ] Performance benchmarks for key generation and materialization paths.
+- [x] Performance benchmarks for key generation and materialization paths.
 - [ ] Release governance and post-release audit automation.
 - [ ] Export-bundle integration (`uselesskey bundle`, k8s/vault payload emitters, and reference manifests).
 

--- a/docs/metadata/perf-baselines.json
+++ b/docs/metadata/perf-baselines.json
@@ -2,6 +2,13 @@
   "version": 1,
   "entries": [
     {
+      "id": "seed.derivation.v1",
+      "category": "watch",
+      "baseline_median_ns": 2000,
+      "max_regression_pct": 20.0,
+      "enforce_in_ci": false
+    },
+    {
       "id": "rsa.fixture.cold",
       "category": "hot",
       "baseline_median_ns": 507650184,
@@ -28,6 +35,13 @@
       "baseline_median_ns": 56580,
       "max_regression_pct": 10.0,
       "enforce_in_ci": true
+    },
+    {
+      "id": "jwk.jwks.emit",
+      "category": "watch",
+      "baseline_median_ns": 10000,
+      "max_regression_pct": 20.0,
+      "enforce_in_ci": false
     },
     {
       "id": "hmac.fixture.hs256",
@@ -61,6 +75,27 @@
       "id": "negative.fixture.corrupt_pem",
       "category": "rare-heavy",
       "baseline_median_ns": 396004200,
+      "max_regression_pct": 20.0,
+      "enforce_in_ci": false
+    },
+    {
+      "id": "webauthn.fixture.ceremony",
+      "category": "watch",
+      "baseline_median_ns": 10000,
+      "max_regression_pct": 20.0,
+      "enforce_in_ci": false
+    },
+    {
+      "id": "pkcs11.provider.construct",
+      "category": "watch",
+      "baseline_median_ns": 10000,
+      "max_regression_pct": 20.0,
+      "enforce_in_ci": false
+    },
+    {
+      "id": "cli.materialize_verify.shape",
+      "category": "watch",
+      "baseline_median_ns": 5000000,
       "max_regression_pct": 20.0,
       "enforce_in_ci": false
     }


### PR DESCRIPTION
## Summary
- add machine-readable perf scenarios for seed derivation, JWKS emission, WebAuthn ceremonies, PKCS#11 mock construction, and scanner-safe materialize/verify
- extend perf baseline metadata so xtask perf reports those surfaces
- mark the benchmark/report/threshold roadmap items complete

## Verification
- cargo fmt -p uselesskey-bench --check
- cargo test -p uselesskey-bench
- cargo clippy -p uselesskey-bench --all-targets -- -D warnings
- cargo xtask perf --compare
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask no-blob
- cargo xtask check-no-panic-family (advisory; existing ledger debt reported, no direct panic-family calls in crates/uselesskey-bench/src)