### PR TITLE
ci(codecov): add conservative Codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...85"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-fixtures
+
+    patch:
+      default:
+        target: 70%
+        threshold: 20%
+        informational: true
+        flags:
+          - rust-fixtures
+
+comment: false
+
+github_checks:
+  annotations: false
+
+ignore:
+  - "target/**"
+  - "fuzz/**"
+  - "crates/uselesskey-bench/**"


### PR DESCRIPTION
## Summary

Adds step 2 of the uselesskey Codecov rollout. Introduces a conservative, quiet Codecov configuration with advisory statuses and no PR comments.

## Changes

- Add `codecov.yml`
- Project coverage: auto target, 5% threshold, informational only
- Patch coverage: 70% target, 20% threshold, informational only
- Comments disabled (no noisy Codecov PR comments)
- GitHub check annotations disabled
- Excludes benchmark crate and fuzz targets from coverage

## CI economics

- **Default PR LEM impact**: None (config file only)
- **Workflow touched**: None (used by coverage.yml from PR 1)
- **Branch protection impact**: None (advisory statuses)
- **Failure mode caught**: Non-applicable (policy/configuration)
- **Cheaper signal considered**: No cheaper alternative (statuses configure Codecov behavior)
- **Rollback path**: Delete `codecov.yml`

## Claim boundary

Coverage is execution-surface evidence only. It does not prove:
- cryptographic correctness
- fixture safety or validity
- deterministic derivation stability
- negative fixture semantics
- scanner safety
- mutation adequacy
- supply-chain posture
- publish readiness

## Validation

- [x] codecov.yml parses (python3 yaml.safe_load)
- [x] git diff --check

## Dependencies

- Requires PR #464 (Coverage workflow) to be merged first

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwK5n8piDiVhomdXqgs5im)_