### PR TITLE
docs(readme): add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # uselesskey
 
 [![CI](https://github.com/EffortlessMetrics/uselesskey/actions/workflows/ci.yml/badge.svg)](https://github.com/EffortlessMetrics/uselesskey/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/EffortlessMetrics/uselesskey/graph/badge.svg?branch=main)](https://codecov.io/gh/EffortlessMetrics/uselesskey)
 [![Crates.io](https://img.shields.io/crates/v/uselesskey.svg)](https://crates.io/crates/uselesskey)
 [![docs.rs](https://docs.rs/uselesskey/badge.svg)](https://docs.rs/uselesskey)
 [![MSRV](https://img.shields.io/badge/MSRV-1.92-blue.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)


### PR DESCRIPTION
## Summary

Adds step 3 of the uselesskey Codecov rollout. Adds the Codecov coverage badge to the README badge block, positioned immediately after the CI badge.

## Changes

- Add Codecov badge to README.md
- Badge links to codecov.io dashboard for EffortlessMetrics/uselesskey

## CI economics

- **Default PR LEM impact**: None (docs only)
- **Workflow touched**: None
- **Branch protection impact**: None
- **Failure mode caught**: Non-applicable (docs)
- **Cheaper signal considered**: No cheaper alternative
- **Rollback path**: Remove badge line

## Claim boundary

Coverage is execution-surface evidence only. The badge reflects data from the Coverage workflow, which itself does not prove cryptographic correctness, fixture safety, mutation adequacy, or publish readiness.

## Validation

- [x] git diff --check
- [x] Badge markdown syntax valid

## Dependencies

- Requires PR #464 (Coverage workflow) to be merged
- Requires PR #465 (codecov.yml config) to be merged

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwK5n8piDiVhomdXqgs5im)_