### PR TITLE
policy(ci): register Codecov config in file-policy allowlist

### DIFF
--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -46,6 +46,15 @@ reason = "GitHub repo metadata: settings, dependabot, funding, release notes."
 covered_by = ["GitHub schema validation"]
 
 [[allow]]
+glob = "codecov.yml"
+kind = "ci_coverage_policy"
+owner = "release/ci"
+surface = "ci"
+classification = "config"
+reason = "Codecov status and reporting configuration for cargo-llvm-cov coverage uploads."
+covered_by = ["cargo xtask check-file-policy"]
+
+[[allow]]
 glob = "lefthook.yml"
 kind = "git_hooks_config"
 owner = "repo-policy"


### PR DESCRIPTION
## Summary

Adds step 4 of the uselesskey Codecov rollout. Registers the `codecov.yml` configuration file in the repository's CI file-policy allowlist, documenting its purpose and owner.

## Changes

- Add `codecov.yml` entry to `policy/non-rust-allowlist.toml`
- Kind: `ci_coverage_policy`
- Owner: `release/ci`
- Surface: `ci`
- Reason: Codecov status and reporting configuration for cargo-llvm-cov uploads
- Covered by: `cargo xtask check-file-policy`

## CI economics

- **Default PR LEM impact**: None (policy file only)
- **Workflow touched**: None
- **Branch protection impact**: None
- **Failure mode caught**: Non-applicable (policy registration)
- **Cheaper signal considered**: No cheaper alternative
- **Rollback path**: Revert policy entry

## Notes

- The `coverage.yml` GitHub Actions workflow is already covered by the existing glob pattern `.github/workflows/*.yml` in the file-policy allowlist, so no separate entry is needed.
- The `.github/workflows/` glob pattern matches all workflow files including the new coverage.yml.

## Validation

- [x] git diff --check
- [x] TOML syntax valid (Python toml parser)
- [x] No validation failures

## Dependencies

- Requires PR #464 (Coverage workflow) to be merged
- Requires PR #465 (codecov.yml config) to be merged

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwK5n8piDiVhomdXqgs5im)_