### PR TITLE
docs(ci): document coverage lane

### DIFF
--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -1,0 +1,52 @@
+# Coverage
+
+Coverage is an execution-surface signal.
+
+It answers:
+
+> Did tests execute this Rust surface?
+
+It does not answer:
+
+- whether fixture generation is cryptographically appropriate,
+- whether deterministic derivation is stable,
+- whether negative fixtures are semantically valid,
+- whether scanners will treat outputs correctly,
+- whether mutation adequacy is strong,
+- whether supply-chain risk is acceptable,
+- whether publish preflight is complete.
+
+Those are separate lanes: xtask receipts, mutation, publish preflight, cargo-deny, audit-surface, economics, and fixture-specific tests.
+
+## Workflow triggers
+
+The Coverage workflow runs on:
+
+- `push` to `main`,
+- `workflow_dispatch` (manual trigger),
+- `pull_request` with labels `coverage` or `full-ci`.
+
+## Artifacts
+
+Durable receipts are:
+
+- `coverage.json` — structured coverage metrics (upload to GitHub Actions artifact),
+- `coverage.txt` — human-readable coverage summary (upload to GitHub Actions artifact),
+- `lcov.info` — LCOV format coverage data (upload to both GitHub Actions artifact and Codecov),
+- the GitHub Actions artifact bundle (14-day retention),
+- the [Codecov dashboard](https://codecov.io/gh/EffortlessMetrics/uselesskey).
+
+## Configuration
+
+The `codecov.yml` file configures coverage statuses:
+
+- Project coverage: auto target, 5% threshold, informational only
+- Patch coverage: 70% target, 20% threshold, informational only
+- Comments disabled (no noisy Codecov PR comments)
+- Annotations disabled
+
+## Status
+
+Coverage is currently **advisory**. It does not block merges or CI.
+
+Once baseline data is established, the lane may move to informational or blocking status via `codecov.yml` updates.


### PR DESCRIPTION
## Summary

Adds step 5 of the uselesskey Codecov rollout. Documents the Coverage lane purpose, claim boundary, and current advisory status in `docs/ci/coverage.md`.

## Changes

- Add `docs/ci/coverage.md`
- Explains what coverage measures (execution surface)
- Explains what coverage does NOT measure (crypto correctness, fixture validity, mutation adequacy, etc.)
- Documents workflow triggers (push to main, workflow_dispatch, labeled PRs)
- Documents durable artifacts (coverage.json, coverage.txt, lcov.info, GitHub artifact, Codecov dashboard)
- Documents codecov.yml configuration
- Notes current advisory status

## CI economics

- **Default PR LEM impact**: None (docs only)
- **Workflow touched**: None
- **Branch protection impact**: None
- **Failure mode caught**: Non-applicable (docs)
- **Cheaper signal considered**: No cheaper alternative
- **Rollback path**: Delete docs/ci/coverage.md

## Claim boundary

Coverage documents its own claim boundary: it is execution-surface evidence only. It does not prove cryptographic correctness, fixture safety, deterministic derivation stability, negative fixture semantics, scanner safety, mutation adequacy, supply-chain posture, or publish readiness.

## Validation

- [x] git diff --check
- [x] Markdown syntax valid

## Dependencies

- Requires PR #464 (Coverage workflow) to be merged
- Requires PR #465 (codecov.yml config) to be merged
- Requires PR #467 (policy registration) to be merged

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwK5n8piDiVhomdXqgs5im)_