### PR TITLE
ci(codecov): add coverage receipt

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -103,6 +103,44 @@ jobs:
           test -s lcov.info
           test -s coverage.txt
 
+      - name: Generate coverage receipt
+        run: |
+          set -euo pipefail
+          mkdir -p target/coverage
+          python3 - <<'PYTHON'
+          import json
+          import pathlib
+
+          receipt = {
+              "schema_version": 1,
+              "repo": "uselesskey",
+              "lane": "coverage",
+              "flag": "rust-fixtures",
+              "workflow": "Coverage",
+              "artifacts": {
+                  "coverage_json": pathlib.Path("coverage.json").exists(),
+                  "coverage_text": pathlib.Path("coverage.txt").exists(),
+                  "lcov": pathlib.Path("lcov.info").exists(),
+              },
+              "claim_boundary": [
+                  "execution_surface_only",
+                  "not_crypto_correctness",
+                  "not_derivation_stability",
+                  "not_mutation_adequacy",
+                  "not_publish_preflight",
+              ],
+          }
+          pathlib.Path("target/coverage/coverage-receipt.json").write_text(
+              json.dumps(receipt, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PYTHON
+
+      - name: Validate coverage receipt
+        run: |
+          set -euo pipefail
+          test -s target/coverage/coverage-receipt.json
+          python3 -m json.tool target/coverage/coverage-receipt.json > /dev/null
       - name: Detect Codecov token
         id: codecov-token
         env:
@@ -133,4 +171,5 @@ jobs:
             coverage.json
             coverage.txt
             lcov.info
+            target/coverage/coverage-receipt.json
           retention-days: 14


### PR DESCRIPTION
## Summary

Adds step 6 of the uselesskey Codecov rollout. Adds a coverage receipt artifact that documents the Coverage lane's execution, outputs, and claim boundary in a durable JSON format.

## Changes

- Add `.github/workflows/coverage.yml` with receipt generation step
- Receipt generation creates `target/coverage/coverage-receipt.json`
- Receipt documents:
  - `schema_version`: 1
  - `repo`: uselesskey
  - `lane`: coverage
  - `flag`: rust-fixtures
  - `workflow`: Coverage
  - `artifacts`: which coverage outputs are present
  - `claim_boundary`: list of what coverage does NOT prove
- Receipt is validated and uploaded as a GitHub Actions artifact

## Receipt schema

```json
{
  "schema_version": 1,
  "repo": "uselesskey",
  "lane": "coverage",
  "flag": "rust-fixtures",
  "workflow": "Coverage",
  "artifacts": {
    "coverage_json": true,
    "coverage_text": true,
    "lcov": true
  },
  "claim_boundary": [
    "execution_surface_only",
    "not_crypto_correctness",
    "not_derivation_stability",
    "not_mutation_adequacy",
    "not_publish_preflight"
  ]
}
```

## CI economics

- **Default PR LEM impact**: ~45–60 min (includes receipt generation, negligible overhead)
- **Workflow touched**: `.github/workflows/coverage.yml`
- **Branch protection impact**: None (advisory lane)
- **Failure mode caught**: Missing coverage outputs, receipt malformation
- **Cheaper signal considered**: No cheaper alternative for durable receipt
- **Rollback path**: Remove receipt generation step from workflow

## Claim boundary

Coverage is execution-surface evidence only. The receipt documents this via the `claim_boundary` field.

## Validation

- [x] git diff --check
- [x] YAML workflow syntax valid
- [x] Python receipt generation script valid
- [x] Receipt JSON schema parseable

## Dependencies

- Depends on PR #464 (Coverage workflow)
- Should merge after PR #464 via rebase if conflicts arise

## Notes

This PR includes the complete coverage.yml workflow file with receipt generation. PR #464 also adds a coverage.yml file; when PR #464 merges, this PR will need a rebase to avoid conflicts. The final result will be a single, merged coverage.yml with receipt generation included.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwK5n8piDiVhomdXqgs5im)_