### PR TITLE
feat(policy): add no-panic baseline + no-new-debt mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,9 @@ cargo xtask typos --fix     # Auto-fix typos
 cargo xtask bdd-matrix      # BDD matrix with feature sets
 cargo xtask publish         # Publish all crates in dependency order
 cargo xtask setup           # Configure git hooks (sets core.hooksPath to .githooks)
-cargo xtask check-no-panic-family  # Semantic panic-family ledger (advisory in Stage A)
+cargo xtask check-no-panic-family  # Semantic panic-family ledger (advisory / no-new-debt / blocking)
+cargo xtask no-panic baseline      # Refresh policy/no-panic-baseline.toml without absorbing new debt
+cargo xtask no-panic baseline --reset # Explicitly reset the no-panic baseline snapshot
 cargo xtask no-panic propose       # Emit candidate no-panic allowlist under target/policy-proposed/
 cargo xtask check-file-policy      # Validate non-Rust file allowlist
 cargo xtask check-lint-policy      # Validate MSRV / [lints] inheritance / debt expiry
@@ -175,7 +177,11 @@ documented under `docs/`:
 - `policy/clippy-debt.toml` — receipted Clippy warn-stage debt with expiry.
 - `policy/no-panic-allowlist.toml` — semantic panic-family allowlist
   (path + family + selector identity); enforced by
-  `cargo xtask check-no-panic-family` (advisory in Stage A).
+  `cargo xtask check-no-panic-family`.
+- `policy/no-panic-baseline.toml` — auto-generated snapshot of existing
+  panic-family findings; absorbs pre-existing debt while `mode =
+  "no-new-debt"`. Refresh with `cargo xtask no-panic baseline`; use
+  `--reset` only for an intentional repo-policy reset.
 - `policy/non-rust-allowlist.toml` — owner/surface/classification ledger for
   every tracked non-Rust file; enforced by `cargo xtask check-file-policy`.
 

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -65,37 +65,56 @@ column = 14
 
 ## Stages
 
-- **Stage A (current)** — Clippy panic-family at `warn`. `cargo xtask
-  check-no-panic-family` runs advisory-only, reporting findings.
-- **Stage B** — debt is moved into `policy/no-panic-allowlist.toml` with
-  owner/reason/expiry; the checker becomes blocking; new findings outside the
-  allowlist fail CI.
-- **Stage C** — Clippy panic-family lints flip to `deny`. The allowlist is the
-  only legitimate route to a panic-family call site.
+- **Stage A** — Clippy panic-family at `warn`. The checker runs advisory.
+- **Stage A.5 (current)** — `mode = "no-new-debt"`: the checker now blocks
+  any panic-family finding *not* in either `policy/no-panic-allowlist.toml`
+  or `policy/no-panic-baseline.toml`. Existing baselined debt does not need
+  manual classification; new debt fails CI.
+- **Stage B** — debt is moved out of the baseline and into the allowlist
+  with owner/reason/expiry; the baseline shrinks toward empty; the checker
+  flips to `mode = "blocking"`.
+- **Stage C** — Clippy panic-family lints flip to `deny`. The allowlist is
+  the only legitimate route to a panic-family call site.
 
 ## Workflow
 
 ```bash
-# 1. Find new findings.
+# 1. Run the checker.
 cargo xtask check-no-panic-family
 
-# 2. Generate a candidate allowlist file (stays under target/).
+# 2a. Refresh the existing baseline after a deliberate burndown PR. This drops
+#     entries/counts that disappeared and refuses to add new debt.
+cargo xtask no-panic baseline
+
+# 2b. Reset the baseline only for the initial snapshot or an explicit
+#     repo-policy reset PR.
+cargo xtask no-panic baseline --reset
+
+# 2c. Generate a candidate allowlist file (stays under target/) for entries
+#     ready to graduate from the baseline into the receipted allowlist.
 cargo xtask no-panic propose
-
-# 3. Review proposed entries; copy reviewed ones into
-#    policy/no-panic-allowlist.toml with owner, reason, classification,
-#    and expiry. Re-run.
-
-cargo xtask check-no-panic-family
 ```
+
+## Modes
+
+| Mode           | When the checker fails                                                              |
+|----------------|--------------------------------------------------------------------------------------|
+| `advisory`     | Never. Only writes the report.                                                       |
+| `no-new-debt`  | Findings outside both `no-panic-allowlist.toml` and `no-panic-baseline.toml`.        |
+| `blocking`     | Any finding outside `no-panic-allowlist.toml` (the baseline is ignored).             |
+
+The `expired` and `stale` allowlist signals fail in both `no-new-debt` and
+`blocking`.
 
 ## What `check-no-panic-family` enforces
 
 - Detect panic-family calls in workspace Rust sources.
-- Match each finding to an allowlist entry by `path + family + selector`.
-- In `mode = "blocking"`, fail on unallowlisted findings.
+- Match each finding against `policy/no-panic-allowlist.toml`
+  (`path + family + selector`) and `policy/no-panic-baseline.toml`
+  (`path + family + selector + snippet`, with occurrence counts).
+- In `mode = "no-new-debt"`, fail on findings not in either set.
+- In `mode = "blocking"`, fail on unallowlisted findings (baseline ignored).
 - Fail on **expired** allowlist entries.
-- Fail on **stale** entries (entry exists but no matching finding).
-- Warn on `last_seen` drift (line/column moved more than the configured
-  tolerance).
+- Fail on **stale** allowlist entries (entry exists but no matching finding).
+- Surface **stale baseline** entries (candidate for removal on next regenerate).
 - Write `target/no-panic.md` and `target/no-panic.json` reports.

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -7,10 +7,10 @@
 # Owner: repo-policy
 # See: docs/NO_PANIC_POLICY.md, docs/POLICY_ALLOWLISTS.md
 #
-# This baseline file starts empty. Stage A keeps the no-panic checker advisory
-# (it reports findings but does not block CI). Once a baseline is generated
-# via `cargo xtask no-panic propose` and reviewed, entries are moved into this
-# file with owner/reason/expiry, and the checker is promoted to blocking.
+# The checker currently runs in no-new-debt mode: existing findings are covered
+# by `policy/no-panic-baseline.toml`, while new findings must be removed or
+# deliberately moved here with owner/reason/expiry. Once reviewed debt has moved
+# out of the baseline, this policy can advance to `mode = "blocking"`.
 schema_version = "0.3"
 
 [policy]
@@ -27,8 +27,13 @@ families = [
   "get_unwrap",
   "unchecked_time_subtraction",
 ]
-# Stage A: advisory only. The checker reports but does not fail.
-mode = "advisory"
+# Modes:
+#   - `advisory`: report findings, never fail.
+#   - `no-new-debt`: fail when a finding is *not* covered by either this
+#     allowlist or `policy/no-panic-baseline.toml`. New panic-family debt
+#     introduced by a PR fails CI; existing baselined debt does not.
+#   - `blocking`: fail on any finding not in the allowlist (ignores baseline).
+mode = "no-new-debt"
 
 # Each [[allow]] looks like:
 #

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -1,0 +1,20698 @@
+# Effortless Metrics — no-panic baseline snapshot
+#
+# This file pins the panic-family findings present at the time of
+# generation. New findings outside this baseline are blocked when the
+# no-panic checker is in `mode = "no-new-debt"`. Move entries into
+# `policy/no-panic-allowlist.toml` (with owner/reason/expiry) as they
+# are reviewed; entries that disappear naturally are dropped on next
+# refresh. Normal refreshes refuse to add new entries; use --reset
+# only for an intentional baseline reset.
+#
+# Refresh: `cargo xtask no-panic baseline`
+# Reset:   `cargo xtask no-panic baseline --reset`
+
+schema_version = "1.0"
+generated_at = "2026-05-07"
+generated_by = "cargo xtask no-panic baseline"
+
+[summary]
+total = 4275
+
+[summary.by_family]
+expect = 2255
+get_unwrap = 1
+panic_macro = 123
+unreachable = 6
+unwrap = 1890
+
+[[entry]]
+path = "crates/materialize-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/materialize-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/materialize-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let manifest_dir = PathBuf::from(env::var_os("                  ").expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/materialize-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let out_dir = PathBuf::from(env::var_os("       ").expect("       "));'
+count = 1
+
+[[entry]]
+path = "crates/materialize-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'uselesskey_cli::load_materialize_manifest(&manifest_path).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/materialize-buildrs-example/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwt = std::str::from_utf8(TOKEN).expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/materialize-shape-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/materialize-shape-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/materialize-shape-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let manifest_dir = PathBuf::from(env::var_os("                  ").expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/materialize-shape-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let out_dir = PathBuf::from(env::var_os("       ").expect("       "));'
+count = 1
+
+[[entry]]
+path = "crates/materialize-shape-buildrs-example/build.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'uselesskey_cli::load_materialize_manifest(&manifest_path).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/materialize-shape-buildrs-example/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwt = std::str::from_utf8(TOKEN).expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/materialize-shape-buildrs-example/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pem = std::str::from_utf8(PEM_SHAPE).expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/materialize-shape-buildrs-example/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ssh = std::str::from_utf8(SSH_SHAPE).expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = kp.sign(&rng, msg).expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'public_key.verify(msg, &sig).expect("      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'public_key.verify(msg, sig.as_ref()).expect("      ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                            ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'hmac::verify(&key, msg, tag.as_ref()).expect("                                ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'hmac::verify(&key, original_msg, tag.as_ref()).expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                       ", bits, e));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                    ", bits, e));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                                         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                                       ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                                     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = aws_a.sign(&rng, msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = aws_keypair.sign(&rng, original_msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig1 = aws1.sign(&rng, msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig2 = aws2.sign(&rng, msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("    ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, &sig).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, &sig).expect("      ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|_| panic!("                  "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|_| panic!("                 "));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                 ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = kp.sign(&rng, msg.as_bytes()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/aws_lc_rs_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let sig = kp1.sign(&rng, b"                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("              ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("    ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'ec_pk.verify(msg, ec_sig.as_ref()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'ed_pk.verify(msg, ed_sig.as_ref()).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ec384_sig = aws_ec384.sign(&rng, msg).expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ec_sig = aws_ec.sign(&rng, msg).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = aws_kp.sign(&rng, msg).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = aws_kp.sign(&rng, msg).expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(&msg, &sig).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(&msg, sig.as_ref()).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(b"        ", sig.as_ref()).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(b"", sig.as_ref()).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, &sig).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, &sig).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, &sig).expect("      ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, sig.as_ref()).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, sig.as_ref()).expect("      ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'rsa_pk.verify(msg, &rsa_sig).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let ec_sig = ec_kp.sign(&rng, b"   ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                 ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("              ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let sig = aws_a.sign(&rng, b"              ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/integration_aws.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let sig = aws_kp.sign(&rng, b"        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/prop_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/prop_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = aws_kp.sign(&rng, &msg).expect("                   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-aws-lc-rs/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                               ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                               "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                  ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                    ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("                     ").expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.oneshot(Request::builder().uri("   ").body(Body::empty()).unwrap())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap(),"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-axum/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'Factory::deterministic(Seed::from_env_value("                         ").expect("    "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("                              ").expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.oneshot(Request::builder().uri("   ").body(Body::empty()).unwrap())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap(),"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 10
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let value = serde_json::from_slice::<serde_json::Value>(&body).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::from_slice::<serde_json::Value>(&jwks_body).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-axum/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::from_slice::<serde_json::Value>(&oidc_body).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                      ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ");'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                 ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 9
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 20
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                            ");'
+count = 17
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 19
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 21
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 9
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ");'
+count = 14
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ");'
+count = 8
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ");'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ");'
+count = 16
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                  ");'
+count = 11
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                 ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                 ");'
+count = 25
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("              ")'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("            ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("           ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.unwrap_or_else(|| decode_header(token).expect("             ").alg);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.unwrap_or_else(|| decode_header(token.as_str()).expect("             ").alg);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'SignedPublicKey::from_armor_single(Cursor::new(armor)).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'SignedSecretKey::from_armor_single(Cursor::new(armor)).expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'SigningKey::from_pkcs8_der(der).expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'VerifyingKey::from_public_key_der(der).expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'VerifyingKey::from_public_key_pem(pem).expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&Header::new(alg), &claims, &key.encoding_key()).expect("          ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, cert) = x509_parser::parse_x509_certificate(chain.leaf_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, cert) = x509_parser::parse_x509_certificate(chain.root_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, cert) = x509_parser::parse_x509_certificate(der).expect("                  ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, cert) = x509_parser::parse_x509_certificate(der).expect("          ");'
+count = 10
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, expired_cert) = x509_parser::parse_x509_certificate(der).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, nyv_cert) = x509_parser::parse_x509_certificate(der).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let _ = jwt_verify_last_signer(world).expect("                               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let _keys = jwks["    "].as_array().expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let _pgp = world.pgp.as_ref().expect("           ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let actual = key["   "].as_str().expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let cert = world.x509.as_ref().expect("                  ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let chain = world.x509_chain.as_ref().expect("                   ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let chain = world.x509_chain.as_ref().expect("                  ");'
+count = 31
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let contents = tf.read_to_bytes().expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let contents = tf.read_to_string().expect("           ");'
+count = 10
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let count = world.rustls_chain_count.expect("                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let current = world.jwt_token.as_ref().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der = tf.read_to_bytes().expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der = world.spki_der_1.as_ref().expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der = world.spki_der_1.as_ref().expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der = world.truncated_der.as_ref().expect("                     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der1 = world.spki_der_1.as_ref().expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der2 = world.spki_der_2.as_ref().expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ecdsa = world.ecdsa.as_ref().expect("             ");'
+count = 19
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ecdsa = world.ecdsa_keys.first().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ecdsa = world.ecdsa_keys.get(1).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ecdsa_key = world.ecdsa.as_ref().expect("             ");'
+count = 10
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ed25519 = world.ed25519.as_ref().expect("               ");'
+count = 17
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ed25519_key = world.ed25519.as_ref().expect("               ");'
+count = 10
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let es256 = world.ecdsa_keys.first().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let es384 = world.ecdsa_keys.get(1).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let expired = world.x509_expired.as_ref().expect("                    ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let fx = world.factory.as_ref().expect("               ");'
+count = 60
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let good = world.spki_der_1.as_ref().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let good_pub = p384::PublicKey::from_public_key_der(good).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let header = decode_header(token).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = """let header = value.split('.').next().expect("              ");"""
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let hmac = world.hmac.as_ref().expect("            ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let hs256 = world.hmac_keys.first().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let hs384 = world.hmac_keys.get(1).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let hs512 = world.hmac_keys.get(2).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let json: Value = serde_json::from_slice(&decoded).expect("                  ");'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let json: Value = serde_json::from_slice(&decoded).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwks = world.jwks_filtered.as_ref().expect("                     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwks = world.jwks_output_1.as_ref().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwks = world.jwks_output_1.as_ref().expect("            ");'
+count = 20
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwks1 = world.jwks_output_1.as_ref().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwks2 = world.jwks_output_2.as_ref().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let key = keys.iter().next().expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let key = world.ecdsa.as_ref().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let key = world.ed25519.as_ref().expect("                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let key = world.hmac.as_ref().expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let key = world.rsa.as_ref().expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("                    ");'
+count = 20
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let kid = key["   "].as_str().expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let kp = world.ecdsa.as_ref().expect("                 ");'
+count = 12
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let kp = world.ed25519.as_ref().expect("                   ");'
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let kp = world.rsa.as_ref().expect("               ");'
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let label = world.label.as_ref().expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let n_2048 = jwk_2048[" "].as_str().expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let n_4096 = jwk_4096[" "].as_str().expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let original = world.x509_chain.as_ref().expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = """let payload = value.split('.').nth(1).expect("               ");"""
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pem = world.corrupted_pem.as_ref().expect("                     ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pgp = world.pgp.as_ref().expect("           ");'
+count = 16
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let recorded = world.recorded_der.as_ref().expect("                    ");'
+count = 8
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rs256 = world.rsa_keys.first().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rs384 = world.rsa_keys.get(1).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rsa = world.rsa.as_ref().expect("           ");'
+count = 22
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rsa = world.rsa_keys.first().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rsa = world.rsa_keys.get(1).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rsa_2048 = world.rsa_keys.first().expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rsa_4096 = world.rsa_keys.get(2).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rsa_key = world.rsa.as_ref().expect("           ");'
+count = 13
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let secret = world.hmac.as_ref().expect("                   ");'
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let secret = world.hmac.as_ref().expect("            ");'
+count = 8
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = uselesskey::Seed::from_env_value(&seed).expect("          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = p256::ecdsa::DerSignature::from_bytes(sig_bytes).expect("         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = p384::ecdsa::DerSignature::from_bytes(sig_bytes).expect("         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, AWS_LC_RS_TEST_MSG).expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, RING_TEST_MSG).expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = rsa::pkcs1v15::Signature::try_from(sig_bytes.as_slice()).expect("         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let signer = world.jwt_signed_with.expect("                       ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let tf = world.pgp_tempfile.as_ref().expect("                    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = world.jwt_token.as_deref().expect("           ");'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = world.jwt_token.clone().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = world.jwt_token.clone().expect("           ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let truncated = world.truncated_der.as_ref().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let valid = world.x509.as_ref().expect("            ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let value = world.token_value_1.as_ref().expect("                     ");'
+count = 12
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let x509 = world.x509.as_ref().expect("            ");'
+count = 26
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'match key["   "].as_str().expect("                    ") {'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p256::PublicKey::from_public_key_der(&mismatch).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p384::PublicKey::from_public_key_der(&mismatch).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'parsed.expect("                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'parsed.expect("                           ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'rsa::RsaPrivateKey::from_pkcs8_der(chain.leaf_private_key_pkcs8_der()).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'rsa::RsaPrivateKey::from_pkcs8_der(der).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'rsa::RsaPrivateKey::from_pkcs8_pem(pem).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'rsa::RsaPublicKey::from_public_key_der(cert.public_key().raw).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'rsa::RsaPublicKey::from_public_key_der(der).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'rsa::RsaPublicKey::from_public_key_pem(pem).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.ecdsa.as_ref().expect("             "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.ed25519.as_ref().expect("               "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.hmac.as_ref().expect("            "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.pgp_public_tempfile = Some(pgp.write_public_key_armored().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.pgp_tempfile = Some(pgp.write_private_key_armored().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.private_tempfile = Some(rsa.write_private_key_pkcs8_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.public_tempfile = Some(rsa.write_public_key_spki_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.rsa.as_ref().expect("               "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.rsa.as_ref().expect("           "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.x509_cert_der_tempfile = Some(x509.write_cert_der().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.x509_cert_tempfile = Some(chain.write_leaf_cert_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.x509_cert_tempfile = Some(x509.write_cert_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.x509_chain_pem_tempfile = Some(chain.write_chain_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.x509_chain_tempfile = Some(x509.write_identity_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.x509_full_chain_tempfile = Some(chain.write_full_chain_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.x509_key_tempfile = Some(chain.write_leaf_private_key_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.x509_key_tempfile = Some(x509.write_private_key_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'world.x509_root_cert_tempfile = Some(chain.write_root_cert_pem().expect("            "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(chain.intermediate_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(chain.leaf_cert_der()).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(der).expect("                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(der).expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(der).expect("                         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(der).expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(expired.leaf_cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(int_der).expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(leaf_der).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(root_der).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(valid.cert_der()).expect("          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(wrong.cert_der()).expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '_ => panic!("                                "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '_ => panic!("                  "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                             "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'panic!("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '!jwk["   "].as_str().unwrap().is_empty(),'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '!jwk[" "].as_str().unwrap().is_empty(),'
+count = 8
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'key[" "].as_str().unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let ecdsa_kty = ecdsa_jwk["   "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let es256_crv = es256_jwk["   "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let es384_crv = es384_jwk["   "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let good_pub = VerifyingKey::from_public_key_der(good).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let good_pub = rsa::RsaPublicKey::from_public_key_der(good).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mismatch_pub = VerifyingKey::from_public_key_der(&mismatch).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mismatch_pub = rsa::RsaPublicKey::from_public_key_der(&mismatch).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub1 = rsa::RsaPublicKey::from_public_key_der(der1).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub2 = rsa::RsaPublicKey::from_public_key_der(der2).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub_key = rsa::RsaPublicKey::from_public_key_der(der).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let rs256_alg = rs256_jwk["   "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let rs384_alg = rs384_jwk["   "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let rsa_kty = rsa_jwk["   "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = ed25519_dalek::Signature::from_bytes(sig_bytes.as_slice().try_into().unwrap());"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_factory_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let fx = world.factory.as_ref().expect("               ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_id_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_id_steps.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|err| panic!("                                   ")),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_keypair_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_keypair_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_keypair_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_keypair_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_keypair_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_keypair_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_keypair_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let private_text = private.read_to_string().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_keypair_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let public_text = public.read_to_string().expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_kid_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_kid_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_negative_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let base = world.corrupted_pem.as_ref().expect("                  ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_negative_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let base = world.truncated_der.as_ref().expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_seed_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_seed_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_token_shape_steps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-bdd-steps/src/steps/core_token_shape_steps.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                               "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rendered = String::from_utf8(bytes).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'expected_files.last().expect("           "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '"          ": output1.lines().next().expect("      "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '"         ": output1.lines().last().expect("      "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '&fs::read(bundle_dir.join("                           ")).expect("             "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ")'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("              ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("             ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("             ");'
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("     ")'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'String::from_utf8(assert.get_output().stdout.clone()).expect("    ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'assert!(value["     "].as_array().expect("     ").len() >= 8);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'bundle_dir.to_str().expect("     "),'
+count = 18
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'cmd.args(["      ", "     ", bundle_dir.to_str().expect("     ")]);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'files.retain(|file| !file.as_str().expect("           ").starts_with("         "));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::write(&actual, b"       ").expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::write(&manifest_path, manifest).expect("                          ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::write(bundle_dir.join("          "), "       ").expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'k8s_path.to_str().expect("     "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let artifacts = value["         "].as_array().expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let artifacts = value["         "].as_array().expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let dir = tempdir().expect("       ");'
+count = 13
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let emitted = fs::read_to_string(&module_path).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let entropy = fs::read(out_dir.join("        ")).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let files = manifest["     "].as_array_mut().expect("           ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let hmac = fs::read_to_string(bundle_dir.join("             ")).expect("        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwt = fs::read_to_string(out_dir.join("           ")).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut bundle = Command::cargo_bin("          ").expect("          ");'
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut check = Command::cargo_bin("          ").expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut cmd = Command::cargo_bin("          ").expect("          ");'
+count = 11
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut k8s = Command::cargo_bin("          ").expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut vault = Command::cargo_bin("          ").expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut verify = Command::cargo_bin("          ").expect("          ");'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut verify_bad = Command::cargo_bin("          ").expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut write = Command::cargo_bin("          ").expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let receipts = value["        "].as_array().expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rendered_k8s = fs::read_to_string(&k8s_path).expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token_value = token["     "].as_str().expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let value: Value = serde_json::from_slice(&fs::read(&manifest_path).expect("             "))'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let value: Value = serde_json::from_str(&out).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'manifest_path.to_str().expect("     "),'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'module_path.to_str().expect("     "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'out_dir.to_str().expect("     "),'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_slice(&fs::read(&manifest_path).expect("             "))'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_slice(&fs::read(&vault_path).expect("             ")).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_slice(&fs::read(bundle_dir.join("          ")).expect("          "))'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::to_vec_pretty(&manifest).expect("                  "),'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'value["     "].as_array().expect("     ").len() - 2'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/cli.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'vault_path.to_str().expect("     "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::read_to_string("                            ").expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::read_to_string("                            ").expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::read_to_string("                          ").expect("                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::read_to_string("                          ").expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::read_to_string("                       ").expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::read_to_string(env_root.join("             ")).expect("              "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::read_to_string(flat_root.join("          ")).expect("                "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let env_written = uselesskey_cli::export_envdir(&env_root, &artifacts).expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: Value = serde_json::from_str(&vault_json).expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let temp = tempdir().expect("       ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let vault_json = render_vault_kv_json(&artifacts).expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let written = fs::read_to_string(&path).expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'manifest.write_json(&path).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-cli/tests/export_targets.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'uselesskey_cli::export_flat_files(&flat_root, &artifacts).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = "panic!("
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_a).unwrap(), 1);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_b).unwrap(), 2);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let msg = err.downcast_ref::<String>().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<u32> = handles.into_iter().map(|h| *h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'h.join().expect("               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let val = cache.get_typed::<u64>(&id).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(Arc::ptr_eq(&first, &cache.get_typed::<u64>(&id).unwrap()));"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&base).unwrap(), 0);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_256).unwrap(), 100);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_384).unwrap(), 200);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_alice).unwrap(), 10);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_bob).unwrap(), 20);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_corrupt).unwrap(), 2);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_ec).unwrap(), 2);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_good).unwrap(), 1);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_mismatch).unwrap(), 3);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_rsa).unwrap(), 1);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_v1).unwrap(), 10);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_v2).unwrap(), 20);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u64>(&id).unwrap(), i as u64);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let again = cache.get_typed::<Vec<u8>>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fetched = cache.get_typed::<Vec<u8>>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<Arc<u64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let val = cache.get_typed::<String>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/cache_perf.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let val = cache.get_typed::<Vec<u8>>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'h.join().expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "*cache.get_typed::<u32>(id).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(*cache.get_typed::<String>(&id_str).unwrap(), "     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<Vec<u8>>(&id_vec).unwrap(), vec![1, 2, 3]);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id).unwrap(), 10);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id).unwrap(), 20);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_rs256).unwrap(), 256);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_rs384).unwrap(), 384);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_u32).unwrap(), 42);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u64>(&id_v1).unwrap(), 1);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u64>(&id_v2).unwrap(), 2);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fetched = cache.get_typed::<u64>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let got = cache.get_typed::<u64>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(*cache.get_typed::<u32>(&id_a).unwrap(), 1);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(*cache.get_typed::<u32>(&id_b).unwrap(), 2);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/concurrency.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'h.join().expect("               ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/concurrency.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let val = cache.get_typed::<u64>(&id).expect("                 ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fetched = cache.get_typed::<u32>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u64>(&id).unwrap(), 42);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "h.join().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<u64> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let val = cache.get_typed::<String>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let val = cache.get_typed::<u64>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'h.join().expect("                       ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let got = cache.get_typed::<String>(&id).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let got = cache.get_typed::<u32>(&id).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_a).unwrap(), 1);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_b).unwrap(), 2);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_bad).unwrap(), 20);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_ec).unwrap(), 200);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_good).unwrap(), 10);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(*cache.get_typed::<u32>(&id_rsa).unwrap(), 100);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fetched = cache.get_typed::<u64>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let got = cache.get_typed::<u32>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let val = cache.get_typed::<u64>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration_cache.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let retrieved = cache.get_typed::<u64>(&id).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration_cache.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let val = cache.get_typed::<u64>(&id).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration_cache.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fetched = cache.get_typed::<String>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/integration_cache.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let retrieved = cache.get_typed::<KeyPair>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let val = cache.get_typed::<u32>(&id(" ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/prop_cache.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let got = cache.get_typed::<u64>(&id).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/prop_cache.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(*cache.get_typed::<u32>(&id_a).unwrap(), 1);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/prop_cache.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(*cache.get_typed::<u32>(&id_a).unwrap(), va);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/prop_cache.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(*cache.get_typed::<u32>(&id_b).unwrap(), 2);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-cache/tests/prop_cache.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(*cache.get_typed::<u32>(&id_b).unwrap(), vb);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'Mode::Random => panic!("          "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'panic!("                                                                ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/tests/edge_cases.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'panic!("                                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut results: Vec<(String, u64)> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<u64> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/tests/factory_concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let (label, val) = h.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/tests/factory_concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let expected: u32 = label.strip_prefix("    ").unwrap().parse().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/tests/factory_concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<Arc<u64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-factory/tests/mutant_killers.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'Mode::Random => panic!("                      "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-hmac-spec/tests/prop_hmac_spec.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                       "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-id/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let expected = uselesskey_core_seed::Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-id/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-id/tests/seed_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let master = Seed::from_env_value("                     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-id/tests/snapshots_id.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let master = Seed::from_env_value("               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = v["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let v: serde_json::Value = serde_json::from_str(&json).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(parsed["    "].as_array().unwrap().is_empty());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(v.as_object().unwrap().contains_key("    "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(v["    "].as_array().unwrap().len(), 0);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let from_display: Value = serde_json::from_str(&jwks.to_string()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json1 = serde_json::to_string(&build_jwks()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json2 = serde_json::to_string(&build_jwks()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json_str = serde_json::to_string(&jwks).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = v["    "].as_array().unwrap();'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let ktys: Vec<&str> = keys.iter().map(|k| k["   "].as_str().unwrap()).collect();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&display_str).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&json_str).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&jwks1).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&jwks2).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/jwk_prop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let original_index = jwk.n.parse::<usize>().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/jwk_prop.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'panic!("                                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let from_display: Value = serde_json::from_str(&jwks.to_string()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json1 = serde_json::to_string(&build()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json2 = serde_json::to_string(&build()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json_str = serde_json::to_string(&jwks).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = parsed["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = v["    "].as_array().unwrap();'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let ktys: Vec<&str> = keys.iter().map(|k| k["   "].as_str().unwrap()).collect();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&json_str).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-builder/tests/snapshots_jwk_builder.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.map(|k| k.to_value()["   "].as_str().unwrap().to_string())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pub_round_trip: Value = serde_json::from_str(&pub_text).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let s = serde_json::to_string(self).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let s = serde_json::to_string(self).expect("             ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let v: Value = serde_json::from_str(&json).expect("          ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&private_text).expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::to_value(self).expect("              ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::to_value(self).expect("             ")'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'Box::new(|| serde_json::to_string(&ec_private(" ")).unwrap()),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'Box::new(|| serde_json::to_string(&ec_public(" ")).unwrap()),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'Box::new(|| serde_json::to_string(&oct_jwk(" ")).unwrap()),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'Box::new(|| serde_json::to_string(&okp_private(" ")).unwrap()),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'Box::new(|| serde_json::to_string(&okp_public(" ")).unwrap()),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'Box::new(|| serde_json::to_string(&rsa_private(" ")).unwrap()),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'Box::new(|| serde_json::to_string(&rsa_public(" ")).unwrap()),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(v["    "].as_array().unwrap().is_empty());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(parsed["    "].as_array().unwrap().len(), 100);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(parsed["    "].as_array().unwrap().len(), 2);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(v.as_object().unwrap().len(), 12);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(v.as_object().unwrap().len(), 5);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(v.as_object().unwrap().len(), 6);"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(v.as_object().unwrap().len(), 7);"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(v.as_object().unwrap().len(), 8);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(v["    "].as_array().unwrap().len(), 1);'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(v["    "].as_array().unwrap().len(), 100);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(v["    "].as_array().unwrap().len(), 7);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let any_v = serde_json::to_value(AnyJwk::from(PublicJwk::Ec(ec_public(" ")))).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let from_display: Value = serde_json::from_str(&any.to_string()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let from_display: Value = serde_json::from_str(&jwk.to_string()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let from_display: Value = serde_json::from_str(&jwks.to_string()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json_str = serde_json::to_string(&jwks).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = v["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let obj = v.as_object().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&any_priv.to_string()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&any_pub.to_string()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&json).unwrap();"
+count = 13
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&json_str).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let priv_v = serde_json::to_value(PrivateJwk::Oct(oct_jwk(" "))).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let pub_v = serde_json::to_value(PublicJwk::Rsa(rsa_public(" "))).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(ec_private("  ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(ec_public("  ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(ec_public(" ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(oct_jwk("  ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(oct_jwk(" ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(okp_private("  ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(okp_public("  ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(okp_public(" ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(rsa_private("  ")).unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(rsa_public("  ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let v = serde_json::to_value(rsa_public(" ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&build()).unwrap(),"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&cloned).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&jwks).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_value(cloned).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_value(jwk).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let raw_keys = round_trip["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let round_trip: serde_json::Value = serde_json::from_str(&json).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/jwk_shape_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: Value = serde_json::from_str(&json_str).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/jwk_shape_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(v["    "].as_array().unwrap().len(), 0);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/jwk_shape_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = v["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/jwk_shape_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let v = serde_json::to_value(&jwk).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(v["    "].as_array().unwrap().len(), 1);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let v: Value = serde_json::from_str(&json).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/negative_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'value["    "].as_array().expect("          ").as_slice()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(!v.as_object().unwrap().contains_key("       "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(!v.as_object().unwrap().contains_key("      "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(!v.as_object().unwrap().contains_key("   "));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(v.as_object().unwrap().contains_key(" "));'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parsed, serde_json::to_value(&jwk).unwrap());"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let direct = serde_json::to_value(&jwk).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let direct = serde_json::to_value(&jwks).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let direct = serde_json::to_value(jwk).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let direct_value = serde_json::to_value(&jwk).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let from_display: Value = serde_json::from_str(&jwk.to_string()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let from_display: Value = serde_json::from_str(&jwks.to_string()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let json = serde_json::to_string(&rsa_private("       ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json1 = serde_json::to_string(&jwk).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json1 = serde_json::to_string(&jwks).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json2 = serde_json::to_string(&jwk).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json2 = serde_json::to_string(&jwks).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json_str = serde_json::to_string(&jwk).unwrap();"
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json_str = serde_json::to_string(&jwks).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json_str = serde_json::to_string(jwk).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = v["    "].as_array().unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let obj = v.as_object().unwrap();"
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&json_str).unwrap();"
+count = 11
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let v = serde_json::to_value(&jwk).unwrap();"
+count = 16
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let v = serde_json::to_value(&jwks).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let v: Value = serde_json::from_str(minimal).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&ec_private("   ")).unwrap(),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&ec_public("   ")).unwrap(),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&ec_public(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&oct_jwk("   ")).unwrap(),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&oct_jwk(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&okp_private("   ")).unwrap(),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&okp_public("   ")).unwrap(),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&okp_public(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&rsa_private("   ")).unwrap(),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&rsa_public("   ")).unwrap(),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_string(&rsa_public(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/shape_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let from_display: Value = serde_json::from_str(&jwks.to_string()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/shape_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: Value = serde_json::from_str(&json).expect("          ");'
+count = 9
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/shape_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let v = serde_json::to_value(&jwk).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(v["    "].as_array().unwrap().len(), 0);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = v["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'key_count: parsed["    "].as_array().unwrap().len(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'kty: jwk.to_value()["   "].as_str().unwrap().to_string(),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(&display).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk-shape/tests/snapshots_jwk_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let value = serde_json::to_value(&jwk).unwrap();"
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = val["    "].as_array().expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: Value = serde_json::from_str(&json_str).expect("                                 ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&any.to_string()).expect("                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&json_str).expect("                                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&text).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let direct = serde_json::to_value(&any).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json1 = serde_json::to_string(&build()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json2 = serde_json::to_string(&build()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json_str = serde_json::to_string(&any).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json_str = serde_json::to_string(&jwks).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = parsed["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: Value = serde_json::from_str(&json_str).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-jwk/tests/serde_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let v = serde_json::to_value(&jwk).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let private_text = private.read_to_string().expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let public = material.write_public_key_spki_pem().expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let public_text = public.read_to_string().expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/material_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/material_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/material_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("            ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/material_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("           ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/material_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let content = tmp.read_to_string().expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/material_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let tmp = m.write_private_key_pkcs8_pem().expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/material_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let tmp = m.write_public_key_spki_pem().expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let priv_content = priv_temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let priv_temp = m.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub_content = pub_temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub_temp = m.write_public_key_spki_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let ext = temp.path().extension().unwrap().to_str().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let private_temp = m.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let public_temp = m.write_public_key_spki_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = m.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = m.write_public_key_spki_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "private_temp.read_to_string().unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "public_temp.read_to_string().unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair/tests/comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let content = tmp.read_to_string().expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-keypair/tests/comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let tmp = m.write_private_key_pkcs8_pem().expect("     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-keypair/tests/comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let tmp = m.write_public_key_spki_pem().expect("     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-keypair/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let content = tmp.read_to_string().expect("             ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-keypair/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let tmp = m.write_private_key_pkcs8_pem().expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-keypair/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let tmp = m.write_public_key_spki_pem().expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-kid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-kid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-kid/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(kid.as_bytes()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-kid/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(&kid).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-kid/tests/prop_kid.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(kid.as_bytes()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-negative-der/src/lib.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable"
+snippet = "unreachable!()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-negative-pem/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-negative-pem/src/lib.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable"
+snippet = "unreachable!()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-negative-pem/tests/integration.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable"
+snippet = "unreachable!()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-negative-pem/tests/pem_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-negative-pem/tests/pem_tests.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable"
+snippet = "unreachable!()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-negative-pem/tests/pem_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "*lines.last().unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-negative-pem/tests/pem_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let first_line = out.lines().next().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-negative-pem/tests/pem_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let last_non_empty = out.lines().last().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-rustls-pki/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_ne!(seed, Seed::from_env_value(&text).unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_ne!(seed, Seed::from_env_value(text).unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let result = parse_hex_32(&hex).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("   ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value(&format!("         ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(&hex).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(&input).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-seed/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(hex).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let expected = Seed::from_env_value("     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("           ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(&hex).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(&long).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed1 = Seed::from_env_value("                      ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed1 = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed1 = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("                      ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("      ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let hashed = Seed::from_env_value(&hex63).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let hashed = Seed::from_env_value(&hex65).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let result = Seed::from_env_value(&hex).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(&hex).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value(&format!("         ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(&hex).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let a = Seed::from_env_value(&hex).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let a = Seed::from_env_value(&lower).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let a = Seed::from_env_value(&s).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let a = Seed::from_env_value(&s1).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let b = Seed::from_env_value(&hex).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let b = Seed::from_env_value(&padded).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let b = Seed::from_env_value(&s).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let b = Seed::from_env_value(&s2).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let b = Seed::from_env_value(&upper).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let with = Seed::from_env_value(&format!("       ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/prop_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let without = Seed::from_env_value(&hex).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/seed_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed = Seed::from_env_value(&hex).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/seed_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/seed_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("  ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/seed_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/seed_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(&hex).unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/seed_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(&s).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/snapshots_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let a = Seed::from_env_value("             ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/snapshots_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let b = Seed::from_env_value("             ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/snapshots_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let c = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/snapshots_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/snapshots_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/snapshots_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(&hex).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-seed/tests/trait_impls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_bytes().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_string().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &bytes).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "       ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "   ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", text).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(a.read_to_string().unwrap(), "          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(b.read_to_string().unwrap(), "          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(temp.path().extension().unwrap(), "   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(temp.read_to_bytes().unwrap(), data);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let a = TempArtifact::new_string("     ", "    ", "          ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let b = TempArtifact::new_string("     ", "    ", "          ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let content = std::fs::read(temp.path()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let content = std::fs::read_to_string(temp.path()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let content = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_bytes().unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let s = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("         ", "    ", &data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("         ", "    ", data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &[0x30]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &[]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &bytes).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &data).unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &secret).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("         ", "    ", text).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "       ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "    ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", pem).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("       ", "    ", pem).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_bytes().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let s = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("      ", "    ", &[]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("      ", "    ", &bytes).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("      ", "    ", &data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("      ", "    ", "     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("      ", "    ", "    ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("      ", "    ", "   ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("      ", "    ", text).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let _ = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_bytes().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &data).unwrap();'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", &suffix, &data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", &content).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", &text).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parent = temp.path().parent().expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'TempArtifact::new_string("       ", "    ", &content).unwrap()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(pem.read_to_string().unwrap().contains("         "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(artifact.read_to_string().unwrap(), expected);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(bin.read_to_bytes().unwrap().len(), 128);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(der.read_to_bytes().unwrap(), vec![0x30, 0x82]);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(temp.read_to_bytes().unwrap(), data);"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(temp.read_to_string().unwrap(), text);"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(txt.read_to_string().unwrap(), "          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "from_bytes.read_to_bytes().unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "from_string.read_to_bytes().unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let bin = TempArtifact::new_bytes("       ", "    ", &[0x00; 128]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let der = TempArtifact::new_bytes("       ", "    ", &[0x30, 0x82]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let from_bytes = TempArtifact::new_bytes("      ", "    ", text.as_bytes()).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let from_string = TempArtifact::new_string("      ", "    ", text).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let metadata = std::fs::metadata(temp.path()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_bytes().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", data).unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("       ", "    ", &data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("      ", "    ", data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("      ", suffix, &[0x01]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("          ", "    ", "    ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("         ", "    ", "             ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("         ", "    ", &content).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "    ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", &text).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", text).unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("       ", "    ", "    ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("       ", "    ", content).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("      ", "    ", text).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let txt = TempArtifact::new_string("       ", "    ", "          ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let via_api = temp.read_to_bytes().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let via_api = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let via_fs = std::fs::read(temp.path()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let via_fs = std::fs::read_to_string(temp.path()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/sink_rstest.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "temp.path().extension().and_then(|e| e.to_str()).unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let rb = temp_bytes.read_to_bytes().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_bytes().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_string().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let rs = temp_str.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &bytes).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "           ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", content).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp_bytes = TempArtifact::new_bytes("        ", "    ", &bytes_data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/snapshots_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp_str = TempArtifact::new_string("        ", "    ", string_data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'TempArtifact::new_string("        ", "    ", &content).expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let read_back = temp.read_to_bytes().expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let read_back = temp.read_to_string().expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &data).expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.map(|_| TempArtifact::new_string("         ", "    ", " ").unwrap())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'TempArtifact::new_string("        ", "    ", &content).unwrap()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(crt.read_to_string().unwrap().contains("           "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(pem.read_to_string().unwrap().contains("           "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(crt.path().extension().unwrap(), "   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(der.path().extension().unwrap(), "   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(der.read_to_bytes().unwrap(), vec![0x30, 0x82, 0x01]);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(pem.path().extension().unwrap(), "   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(temp.read_to_bytes().unwrap(), vec![0x42]);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(temp.read_to_string().unwrap(), text);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let a = TempArtifact::new_string("", "    ", " ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let artifacts: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let b = TempArtifact::new_string("", "    ", " ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let bytes_temp = TempArtifact::new_bytes("      ", "    ", &[0x01, 0x02]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let content = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let der = TempArtifact::new_bytes("         ", "    ", &[0x30, 0x82, 0x01]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let meta = std::fs::metadata(temp.path()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let metadata = std::fs::metadata(temp.path()).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_bytes().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let read_back = temp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let string_temp = TempArtifact::new_string("      ", "    ", "           ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &[0x30, 0x82]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("        ", "    ", &data).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("       ", "    ", &der).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_bytes("      ", "    ", &[0x42]).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("                    ", "    ", "    ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("           ", "    ", "    ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("          ", "    ", pem).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("         ", "    ", "           ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", "    ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", &text).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("        ", "    ", text).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-sink/tests/tempfile_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("   ", "          ", "    ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                              ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let decoded = URL_SAFE_NO_PAD.decode(value).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let header = parts.next().expect("                  ").to_string();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let json = serde_json::to_vec(value).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let json: serde_json::Value = serde_json::from_slice(&payload).expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let payload = parts.next().expect("                   ").to_string();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let payload_json = serde_json::to_vec(&payload).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let signature = parts.next().expect("                     ").to_string();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let value: Value = serde_json::from_slice(&bytes).expect("                                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(s.chars().next().unwrap().is_ascii_alphanumeric());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(claims["   "].as_str().unwrap(), label);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let claims: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();"
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(sig).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header1 = h1.split('.').next().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header2 = h2.split('.').next().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let jti = claims["   "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let jti_decoded = URL_SAFE_NO_PAD.decode(jti).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_bytes = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_bytes = URL_SAFE_NO_PAD.decode(payload_segment).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_segment = token.split('.').nth(1).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/comprehensive_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = token.split('.').nth(2).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(s.chars().next().unwrap().is_ascii_alphanumeric());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(&token).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_bytes = URL_SAFE_NO_PAD.decode(header_segment).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_segment = token.split('.').next().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_bytes = URL_SAFE_NO_PAD.decode(payload_segment).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_segment = token.split('.').nth(1).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/negative_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/negative_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'assert!(payload["   "].as_u64().expect("                     ") > 2_000_000_000u64);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/negative_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let bytes = URL_SAFE_NO_PAD.decode(segment).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/negative_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_slice(&bytes).expect("                      ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/prop_token_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json: serde_json::Value = serde_json::from_slice(&payload).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/prop_token_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/prop_token_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(decoded.unwrap().len(), BEARER_RANDOM_BYTES);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/prop_token_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'prop_assert_eq!(json["   "].as_str().unwrap(), "          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/prop_token_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'prop_assert_eq!(json["   "].as_str().unwrap(), label.as_str());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let claims: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(&token).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(sig_segment).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_bytes = URL_SAFE_NO_PAD.decode(header_segment).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_segment = token.split('.').next().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let jti = claims["   "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let jti_decoded = URL_SAFE_NO_PAD.decode(jti).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_bytes = URL_SAFE_NO_PAD.decode(payload_segment).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_segment = token.split('.').nth(1).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig_segment = token.split('.').nth(2).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token-shape/tests/shape_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'prop_assert_eq!(claims["   "].as_str().unwrap(), label.as_str());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(token).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header = URL_SAFE_NO_PAD.decode(parts[0]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json: serde_json::Value = serde_json::from_slice(&header).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json: serde_json::Value = serde_json::from_slice(&payload).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let suffix = key.strip_prefix("        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".decode(t1.split('.').nth(1).unwrap())"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".decode(t2.split('.').nth(1).unwrap())"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".decode(token.split('.').nth(1).unwrap())"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap(),"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(decoded.unwrap().len(), OAUTH_SIGNATURE_BYTES);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(&token).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_bytes = URL_SAFE_NO_PAD.decode(header_segment).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_segment = token.split('.').next().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_bytes = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = token.split('.').nth(2).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let suffix = key.strip_prefix(API_KEY_PREFIX).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'payload["   "].as_str().unwrap().to_string()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-token/tests/token_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(decoded.unwrap().len(), BEARER_RANDOM_BYTES);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-chain-negative/tests/comprehensive_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-chain-negative/tests/comprehensive_tests.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-chain-negative/tests/comprehensive_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'NotBeforeOffset::DaysFromNow(days) => panic!("                                         "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-chain-negative/tests/comprehensive_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "expect_days_ago(modified.leaf_not_before.unwrap()) - modified.leaf_validity_days;"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-chain-negative/tests/comprehensive_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let days_since_expired = expect_days_ago(modified.intermediate_not_before.unwrap())"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-chain-negative/tests/comprehensive_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let offset = expect_days_ago(modified.intermediate_not_before.unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-chain-negative/tests/comprehensive_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let offset = expect_days_ago(modified.leaf_not_before.unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-derive/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-derive/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let epoch = OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-derive/tests/comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let epoch = OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).unwrap();"
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-core-x509-derive/tests/derivation_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let epoch = time::OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-x509-derive/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let epoch = time::OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-x509-derive/tests/integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let epoch = time::OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-x509-derive/tests/mutant_killers.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let epoch = OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core-x509-derive/tests/prop_x509_derive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let epoch = time::OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core-x509-derive/tests/trait_impls.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'time::OffsetDateTime::from_unix_timestamp(BASE_TIME_EPOCH_UNIX).expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-negative/tests/negative_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'NotBeforeOffset::DaysFromNow(days) => panic!("                                         "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-negative/tests/negative_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                                   "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-negative/tests/negative_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                               "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-negative/tests/negative_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'panic!("                                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-negative/tests/negative_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'panic!("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-negative/tests/negative_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let offset = expect_days_ago(modified.intermediate_not_before.unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-negative/tests/negative_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let offset = expect_days_ago(modified.leaf_not_before.unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509-spec/src/chain_spec.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable"
+snippet = 'unreachable!("                                ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509/tests/negative_policy_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'NotBeforeOffset::DaysFromNow(days) => panic!("                                         "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509/tests/negative_policy_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '_ => panic!("                                "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509/tests/negative_policy_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                                   "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509/tests/negative_policy_tests.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                               "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509/tests/negative_policy_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let offset = expect_days_ago(modified.intermediate_not_before.unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core-x509/tests/negative_policy_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let offset = expect_days_ago(modified.leaf_not_before.unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/src/sink/mod.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core/src/sink/mod.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let read = artifact.read_to_bytes().expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/src/sink/mod.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let text = artifact.read_to_string().expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/concurrency_stress.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'Err(_) => panic!("                                                   "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/concurrency_stress.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "Ok(()) => handle.join().unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/concurrency_stress.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "h.join().unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-core/tests/concurrency_stress.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<Arc<u64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/core_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let seed = result.unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core/tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'Factory::deterministic(Seed::from_env_value("  ").unwrap())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx42 = Factory::deterministic(Seed::from_env_value("  ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx43 = Factory::deterministic(Seed::from_env_value("  ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/edge_cases.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'Mode::Random => panic!("                           "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "h.join().unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-core/tests/factory_env.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/factory_env.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let fx = Factory::deterministic_from_env(&var).expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/factory_env.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'Mode::Random => panic!("                           "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/factory_env.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                           "),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core/tests/factory_env.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let expected = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/factory_text_seed.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'Mode::Random => panic!("                           "),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-core/tests/factory_text_seed.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_ne!(*master, Seed::from_env_value(&hex_shaped).unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-core/tests/snapshots_core.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'panic!("                    ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                             ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'SigningKey::try_generate_from_rng(rng).expect("                                          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let decoded = URL_SAFE_NO_PAD.decode(d).expect("               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let priv_contents = std::fs::read_to_string(priv_tf.path()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let priv_tf = key.write_private_key_pkcs8_pem().expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pub_contents = std::fs::read_to_string(pub_tf.path()).expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pub_tf = key.write_public_key_spki_pem().expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let d = jwk[" "].as_str().unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                ").unwrap());'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("               ").unwrap());'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed1 = Seed::from_env_value("                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/format_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = v["    "].as_array().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'URL_SAFE_NO_PAD.decode(v).expect("               ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let d = decode_b64url(jwk[" "].as_str().expect(" "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let x = decode_b64url(jwk[" "].as_str().expect(" "));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let y = decode_b64url(jwk[" "].as_str().expect(" "));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '!jwk[" "].as_str().unwrap().is_empty(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let d = jwk[" "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                       ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                      ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("               ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("          ").unwrap());'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("         ").unwrap());'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let good = p256::PublicKey::from_public_key_der(good).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let good = p384::PublicKey::from_public_key_der(good).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let other = p256::PublicKey::from_public_key_der(other).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let other = p384::PublicKey::from_public_key_der(other).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let priv_contents = std::fs::read_to_string(priv_tf.path()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let priv_tf = key.write_private_key_pkcs8_pem().expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pub_contents = std::fs::read_to_string(pub_tf.path()).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pub_tf = key.write_public_key_spki_pem().expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p256::PublicKey::from_public_key_der(der).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p256::PublicKey::from_public_key_pem(pem).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p256::SecretKey::from_pkcs8_der(der).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p256::SecretKey::from_pkcs8_pem(pem).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p384::PublicKey::from_public_key_der(der).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p384::PublicKey::from_public_key_pem(pem).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p384::SecretKey::from_pkcs8_der(der).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p384::SecretKey::from_pkcs8_pem(pem).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                 ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("         ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/mutation_hardening.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'jwk["   "].as_str().unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'jwk[" "].as_str().unwrap(),'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let d = URL_SAFE_NO_PAD.decode(jwk[" "].as_str().unwrap()).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let x = URL_SAFE_NO_PAD.decode(jwk[" "].as_str().unwrap()).unwrap();'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let y = URL_SAFE_NO_PAD.decode(jwk[" "].as_str().unwrap()).unwrap();'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                  ").unwrap());'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                 ").unwrap());'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let good_pub = p256::PublicKey::from_public_key_der(kp.public_key_spki_der()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mm_pub = p256::PublicKey::from_public_key_der(&mm_der).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let secret = p256::SecretKey::from_pkcs8_der(kp.private_key_pkcs8_der()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                 ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ecdsa/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                  ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(tmp.read_to_string().unwrap(), kp.private_key_pkcs8_pem());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(tmp.read_to_string().unwrap(), kp.public_key_spki_pem());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp = kp.write_public_key_spki_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/format_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = v["    "].as_array().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'URL_SAFE_NO_PAD.decode(v).expect("               ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let d = decode_b64url(jwk[" "].as_str().expect(" "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let x = decode_b64url(jwk[" "].as_str().expect(" "));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '!jwk[" "].as_str().unwrap().is_empty(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let d = jwk[" "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                         ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                        ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                  ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                 ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("             ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/jwk_private.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'SigningKey::from_pkcs8_der(der).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'SigningKey::from_pkcs8_pem(pem).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'VerifyingKey::from_public_key_der(der).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'VerifyingKey::from_public_key_pem(pem).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let good = VerifyingKey::from_public_key_der(good).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let other = VerifyingKey::from_public_key_der(other).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let priv_contents = std::fs::read_to_string(priv_tf.path()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let priv_tf = key.write_private_key_pkcs8_pem().expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pub_contents = std::fs::read_to_string(pub_tf.path()).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pub_tf = key.write_public_key_spki_pem().expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                   ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("             ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/mutation_hardening.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/mutation_hardening.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.decode(jwk[" "].as_str().unwrap())'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(jwk["   "].as_str().unwrap(), kp.kid());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mm_vk = VerifyingKey::from_public_key_der(&mm_der).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                   ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                  ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let signing_key = SigningKey::from_pkcs8_der(kp.private_key_pkcs8_der()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ed25519/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-entropy/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                ").unwrap());'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-entropy/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-entropy/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("             ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-entropy/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-entropy/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-feature-grid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-feature-grid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-feature-grid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-feature-grid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-feature-grid/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|| panic!("                               "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-feature-grid/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|| panic!("                      "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-feature-grid/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = "panic!("
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-hmac/src/secret.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let decoded = URL_SAFE_NO_PAD.decode(k).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/src/secret.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/src/secret.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/src/secret.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("         ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/src/secret.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("        ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/src/secret.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let k = jwk[" "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/cache_coherence.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = v["    "].as_array().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let decoded = URL_SAFE_NO_PAD.decode(k).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let k = jwk[" "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed1 = Seed::from_env_value("                  ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("                  ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/hmac_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/hmac_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let k = jwk[" "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/hmac_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/mutation_hardening.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(jwk["   "].as_str().unwrap(), secret.kid());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-hmac/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("          ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der_sig = p384::ecdsa::DerSignature::try_from(sig.as_ref()).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = aws_kp.sign(&rng, msg).expect("        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, msg).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("          ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'public_key.verify(msg, &sig).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/all_adapters.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'public_key.verify(msg, &sig).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                  ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                 ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("          ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'ed25519_dalek::Signature::from_slice(sig.as_ref()).expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'jsonwebtoken::encode(&header, &claims, &keypair.encoding_key()).expect("          ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = aws_kp.sign(&rng, msg).expect("        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, msg).expect("         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p256::ecdsa::DerSignature::try_from(sig.as_ref()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pkcs1v15::Signature::try_from(sig.as_slice()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.writer().write_all(payload).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                         ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                      ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                     ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.process_new_packets().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.reader().read_exact(&mut received).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                                ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                          ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                  ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'ed25519_dalek::Signature::from_slice(sig.as_ref()).expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'hmac::Hmac::<sha2::Sha256>::new_from_slice(&key_bytes).expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("          ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pkcs1v15::Signature::try_from(sig.as_slice()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.decode(jwk[" "].as_str().unwrap())'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.writer().write_all(payload).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = jwks["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                       ".try_into().unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.process_new_packets().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.reader().read_exact(&mut received).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_interop_matrix.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                            ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let serialized = serde_json::to_string(&jwk).expect("                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, msg).expect("         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("          ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&serialized).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.decode(jwk[" "].as_str().unwrap())'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let e = jwk[" "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let n = jwk[" "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                          ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "root_store.add(chain.root_certificate_der_rustls()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_roundtrip.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                  ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                             ");'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'ed25519_dalek::Signature::from_slice(sig.as_ref()).expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = aws_kp.sign(&rng, msg).expect("        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, msg).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p256::ecdsa::DerSignature::try_from(sig.as_ref()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_signing.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pkcs1v15::Signature::try_from(sig.as_slice()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "               ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_adapter_tls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                      ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = aws_kp.sign(&rng, msg).expect("        ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let signature = pkcs1v15::Signature::try_from(sig.as_slice()).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("          ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p256::ecdsa::DerSignature::try_from(sig.as_ref()).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p384::ecdsa::DerSignature::try_from(sig.as_ref()).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/interop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/interop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/interop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/interop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/interop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/interop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/interop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/pem_der_compat.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/pem_der_compat.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                 ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/pem_der_compat.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/pem_der_compat.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/pem_der_compat.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/pem_der_compat.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/pem_der_compat.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/pem_der_compat.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'rsa::RsaPrivateKey::from_pkcs8_pem(pem).expect("                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                 ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                        ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("          ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'ed25519_dalek::Signature::from_slice(sig.as_ref()).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der_sig = p256::ecdsa::DerSignature::try_from(sig.as_ref()).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der_sig = p384::ecdsa::DerSignature::try_from(sig.as_ref()).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, msg).expect("         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = jsonwebtoken::encode(&header, &claims, &kp.encoding_key()).expect("          ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pkcs1v15::Signature::try_from(sig.as_slice()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                     ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                  ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/random_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.process_new_packets().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.reader().read_exact(&mut received).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.writer().write_all(client_msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.writer().write_all(payload).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut client = rustls::ClientConnection::new(client_config, server_name).unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                         ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                    ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                   ".try_into().unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let server_name = "                  ".try_into().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.process_new_packets().unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.reader().read_exact(&mut received).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-interop-tests/tests/x509_tls_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.writer().write_all(server_msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/examples/jwt_jose_openid.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/examples/jwt_jose_openid.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                               ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                              ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                             ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                            ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                           ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jose-openid/tests/integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&Header::new(Algorithm::ES384), &claims, &key.encoding_key()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                             ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                         ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                        ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "decode::<TestClaims>(&token, &keypair.decoding_key(), &validation).unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "decode::<TestClaims>(&token, &secret.decoding_key(), &validation).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &keypair.encoding_key()).unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &secret.encoding_key()).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "encode(&Header::new(Algorithm::RS256), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::ES256), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::EdDSA), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::HS256), &claims, &sec.encoding_key()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::RS256), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                      ", bits, e));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                 ", e));'
+count = 12
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                                          ", other),'
+count = 11
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<TestClaims>(&token, &keypair.decoding_key(), &validation).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded1 = decode::<TestClaims>(&token1, &dec_key1, &validation).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded1 = decode::<TestClaims>(&token1, &key1.decoding_key(), &validation).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded1 = decode::<TestClaims>(&token1, &secret1.decoding_key(), &validation).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded2 = decode::<TestClaims>(&token2, &dec_key2, &validation).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded2 = decode::<TestClaims>(&token2, &key2.decoding_key(), &validation).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded2 = decode::<TestClaims>(&token2, &secret2.decoding_key(), &validation).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                       ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &key_a.encoding_key()).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &keypair.encoding_key()).unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &rsa.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &rsa_key.encoding_key()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &secret.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &secret_a.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token1 = encode(&header, &claims, &enc_key1).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token1 = encode(&header, &claims, &key1.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token1 = encode(&header, &claims, &secret1.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token2 = encode(&header, &claims, &enc_key2).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token2 = encode(&header, &claims, &key2.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token2 = encode(&header, &claims, &secret2.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                    "));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &kp.decoding_key(), &validation).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &kp2.decoding_key(), &validation).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &s.decoding_key(), &validation).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("              ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let t1 = encode(&header, &claims, &kp1.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let t2 = encode(&header, &claims, &kp2.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::ES256), &claims, &ec.encoding_key()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::ES256), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::EdDSA), &claims, &ed.encoding_key()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::EdDSA), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::HS256), &claims, &s_a.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::RS256), &claims, &kp.encoding_key()).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::RS256), &claims, &rsa.encoding_key()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &kp.encoding_key()).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &kp1.encoding_key()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_extended.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &s.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_roundtrip_all_algos.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                            "));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_roundtrip_all_algos.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 9
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_roundtrip_all_algos.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "encode(&Header::new(Algorithm::ES256), &c, &kp.encoding_key()).unwrap()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_roundtrip_all_algos.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                      ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_roundtrip_all_algos.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                    ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_roundtrip_all_algos.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tampered_payload = String::from_utf8(payload_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/jwt_roundtrip_all_algos.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tampered_sig = String::from_utf8(sig_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/negative_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &kp.decoding_key(), &Validation::new(Algorithm::ES256)).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &kp.decoding_key(), &Validation::new(Algorithm::ES384)).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &kp.decoding_key(), &Validation::new(Algorithm::EdDSA)).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &kp.decoding_key(), &Validation::new(Algorithm::RS256)).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &kp2.decoding_key(), &Validation::new(Algorithm::RS256)).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &secret.decoding_key(), &Validation::new(Algorithm::HS256)).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &secret.decoding_key(), &Validation::new(Algorithm::HS384)).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &secret.decoding_key(), &Validation::new(Algorithm::HS512)).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::ES256), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::ES384), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::EdDSA), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::HS256), &claims, &secret.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::HS384), &claims, &secret.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::HS512), &claims, &secret.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::RS256), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::RS256), &claims, &kp1.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/prop_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::RS256), &claims, &kp_a.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "encode(&Header::new(Algorithm::ES256), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "encode(&Header::new(Algorithm::ES384), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "encode(&Header::new(Algorithm::EdDSA), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "encode(&Header::new(Algorithm::HS256), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "encode(&Header::new(Algorithm::HS384), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "encode(&Header::new(Algorithm::HS512), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "encode(&Header::new(Algorithm::RS256), &claims, &kp.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &keypair.decoding_key(), &validation).unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = decode::<Claims>(&token, &secret.decoding_key(), &validation).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &keypair.encoding_key()).unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&header, &claims, &secret.encoding_key()).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/snapshots_jwt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "token_header_len: token.split('.').next().unwrap().len(),"
+count = 8
+
+[[entry]]
+path = "crates/uselesskey-jsonwebtoken/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                            ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&ec.to_string()).expect("                                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&ec.to_string()).expect("                                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&jwks.to_string()).expect("                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(json["    "].as_array().unwrap().len(), 2);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_value(ec_private(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_value(ec_public(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_value(oct_jwk(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_value(okp_private(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_value(okp_public(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_value(rsa_private(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/jwk_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'serde_json::to_value(rsa_public(" ")).unwrap(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/negative_reexports.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = value["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/snapshots_jwk_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'key_count: parsed["    "].as_array().unwrap().len(),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-jwk/tests/snapshots_jwk_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(&display).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp-native/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp-native/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp-native/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp-native/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                               ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'public.verify_bindings().expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'secret.verify_bindings().expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                  ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                 ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("               ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("         ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/src/keypair.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("       ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/tests/pgp_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/tests/pgp_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed1 = Seed::from_env_value("                 ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/tests/pgp_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("                 ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pgp/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let body_len = u16::from_be_bytes(der[2..4].try_into().expect("               "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let der = provider.certificate_der(handle).expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut guard = self.inner.next_sign_count.lock().expect("                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = provider.sign(handle, msg).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let slot_id = u64::from_le_bytes(seed[0..8].try_into().expect("                      "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = "panic!("
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                 ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("             ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-pkcs11-mock/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, msg).expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'public_key.verify(msg, &sig).expect("      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'public_key.verify(msg, sig.as_ref()).expect("      ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-ring/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'ring::rsa::KeyPair::from_pkcs8(self.private_key_pkcs8_der()).expect("                    ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, msg).expect("    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(b"        ", sig.as_ref()).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, &sig).expect("      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, sig.as_ref()).expect("      ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk1.verify(msg, &sig2).expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("              ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("           ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = ring_a.sign(&rng, msg).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let sig = ring_kp.sign(&rng, b"        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/prop_tests_ring.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/prop_tests_ring.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let sig = ring_kp.sign(&rng, &msg).expect("                   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                       ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'hmac::verify(&key, msg, tag.as_ref()).expect("                                ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'hmac::verify(&key, original_msg, tag.as_ref()).expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                       ", bits, e));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                    ", bits, e));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                             ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                           ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = ring_a.sign(&rng, msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = ring_keypair.sign(&rng, original_msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig1 = ring1.sign(&rng, msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig2 = ring2.sign(&rng, msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                 ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(&msg, &sig).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(&msg, sig.as_ref()).expect("            ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(b"", &sig).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(b"", sig.as_ref()).expect("            ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, &sig).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, &sig).expect("                   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, &sig).expect("                 ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'pk.verify(msg, sig.as_ref()).expect("                    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                  ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                 ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = kp.sign(&rng, &msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let sig = kp.sign(&rng, b"").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/ring_multi_scheme.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = kp1.sign(&rng, msg).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ring/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                              ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                              ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                           ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                           ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("    ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let dp = private.dp().expect("  ").to_be_bytes_trimmed_vartime();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let dq = private.dq().expect("  ").to_be_bytes_trimmed_vartime();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let private = rsa10::RsaPrivateKey::new(&mut rng, spec.bits).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/src/keypair.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let private09 = RsaPrivateKey::new(&mut rng, spec.bits).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.decode(kp_2048.public_jwk().to_value()[" "].as_str().unwrap())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.decode(kp_3072.public_jwk().to_value()[" "].as_str().unwrap())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.decode(kp_4096.public_jwk().to_value()[" "].as_str().unwrap())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let good = rsa::RsaPublicKey::from_public_key_der(kp.public_key_spki_der()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "rsa::RsaPublicKey::from_public_key_der(&kp.mismatched_public_key_spki_der()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let content = tmp.read_to_string().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp = kp.write_public_key_spki_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let good_pub = rsa::RsaPublicKey::from_public_key_der(kp.public_key_spki_der()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/error_paths.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "rsa::RsaPublicKey::from_public_key_der(&kp.mismatched_public_key_spki_der()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/format_roundtrip.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = v["    "].as_array().expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/mutation_hardening.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/mutation_hardening.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(jwk["   "].as_str().unwrap(), kp.kid());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/negative_validation.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let good_pub = rsa::RsaPublicKey::from_public_key_der(kp.public_key_spki_der()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("               ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/negative_validation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("              ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let e_str = jwk[" "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("               ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("         ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("        ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let good_pub = rsa::RsaPublicKey::from_public_key_der(rsa.public_key_spki_der()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = jwks["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let n_bytes = n_decoded.unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let n_str = jwk[" "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let val = jwk[key].as_str().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/rsa_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "rsa::RsaPublicKey::from_public_key_der(&rsa.mismatched_public_key_spki_der()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rsa/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ")'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("      ");'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'mac2.verify(&result.into_bytes()).expect("      ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let decoded = ed25519_dalek::SigningKey::from_pkcs8_der(der_bytes).expect("      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let decoded = p256::ecdsa::SigningKey::from_pkcs8_der(encoded.as_bytes()).expect("      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let decoded = p384::ecdsa::SigningKey::from_pkcs8_der(encoded.as_bytes()).expect("      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let decoded = rsa::RsaPrivateKey::from_pkcs8_der(re_encoded.as_bytes()).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let encoded = signing_key.to_pkcs8_der().expect("      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let re_encoded = private_key.to_pkcs8_der().expect("      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'mac2.verify(&result.into_bytes()).expect("      ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'verifying_key.verify(b"          ", &sig).expect("      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("          ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value(seed_str).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'mac2.verify(&tag).expect("                  ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'verifying.verify(msg, &sig).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'verifying.verify(msg, &sig).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'verifying.verify(msg, &sig).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'verifying.verify(b"         ", &sig).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'verifying.verify(b"    ", &sig).unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'm2.verify(&tag).expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'verifying.verify(&msg, &sig).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'verifying.verify(b"           ", &sig).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                 ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/rustcrypto_cross_verify.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("               ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustcrypto/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ")'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ")'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ")'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ");'
+count = 8
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.process_new_packets().unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = """let server_name: rustls::pki_types::ServerName<'_> = "                ".try_into().unwrap();"""
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.process_new_packets().unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/config.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/src/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'try_handshake(&mut server, &mut client).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '_ => panic!("                       "),'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                   ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                  ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = """let server_name: rustls::pki_types::ServerName<'_> = "                ".try_into().unwrap();"""
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/adapter_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut client = rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = """let server_name: rustls::pki_types::ServerName<'_> = "                ".try_into().unwrap();"""
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value(seed_str).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'try_handshake(&mut server, &mut client).expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'try_handshake(&mut server, &mut client).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = """let server_name: rustls::pki_types::ServerName<'_> = "                ".try_into().unwrap();"""
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = """let wrong_name: rustls::pki_types::ServerName<'_> = "                 ".try_into().unwrap();"""
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "rustls::ClientConnection::new(client_config, wrong_name.to_owned()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/rustls_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'client.process_new_packets().expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'server.process_new_packets().expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'Err(e) => panic!("                        "),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.read_tls(&mut &buf[..]).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.write_tls(&mut buf).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "client.writer().write_all(request).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let client = rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut client = rustls::ClientConnection::new(client_config, server_name.to_owned()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let mut server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                   ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let server = rustls::ServerConnection::new(server_config).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = """let server_name: rustls::pki_types::ServerName<'_> = "                ".try_into().unwrap();"""
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let server_name: rustls::pki_types::ServerName<'_> = domain.try_into().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.process_new_packets().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.read_tls(&mut &buf[..]).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.write_tls(&mut buf).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-rustls/tests/tls_data_transfer.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "server.writer().write_all(response).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'Certificate::from_openssh(self.certificate_openssh()).expect("                          ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'PrivateKey::random(&mut rng, Algorithm::Ed25519).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'PrivateKey::random(&mut rng, Algorithm::Ed25519).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'builder.serial(0).expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'certificate_openssh: cert.to_openssh().expect("                            "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let cert = builder.sign(&ca_private).expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = Certificate::from_openssh(&encoded).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let encoded = cert.to_openssh().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                   ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/key.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/key.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/key.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/key.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("             ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/key.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed_private = PrivateKey::from_openssh(k.private_key_openssh()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/src/key.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed_public = PublicKey::from_openssh(k.authorized_key_line()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/tests/ssh_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/tests/ssh_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/tests/ssh_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-ssh/tests/ssh_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                  ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                 ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("              ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("            ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("            ");'
+count = 8
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("           ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("           ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("      ")'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("      ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.map(|key| key["   "].as_str().expect("   "))'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let body = serde_json::to_vec(&payload).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwks_body = serde_json::to_vec(&jwks_json).expect("                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("                ").expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-test-server/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'server.with_phase("       ").expect("            ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let header: serde_json::Value = serde_json::from_slice(&header_bytes).expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let suffix = value.strip_prefix("        ").expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_slice(&payload_bytes).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                  ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("             ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-token/src/token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("         ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_snapshots.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let claims: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_snapshots.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_bytes = URL_SAFE_NO_PAD.decode(payload_segment).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_snapshots.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_segment = tok.value().split('.').nth(1).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'claims["   "].as_str().unwrap().to_string()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let claims: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(sig).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(tok.value()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let exp = claims["   "].as_u64().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("          ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx1 = Factory::deterministic(Seed::from_env_value("          ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx1 = Factory::deterministic(Seed::from_env_value("       ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fx1 = Factory::deterministic(Seed::from_env_value(seed_val).unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx2 = Factory::deterministic(Seed::from_env_value("          ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx2 = Factory::deterministic(Seed::from_env_value("       ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fx2 = Factory::deterministic(Seed::from_env_value(seed_val).unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_bytes = URL_SAFE_NO_PAD.decode(header_segment).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_segment = tok.value().split('.').next().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let jti = claims["   "].as_str().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let jti_decoded = URL_SAFE_NO_PAD.decode(jti).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_bytes = URL_SAFE_NO_PAD.decode(payload_segment).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_segment = tok.value().split('.').nth(1).unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_segment = token_value.split('.').nth(1).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed1 = Seed::from_env_value("        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = tok.value().split('.').nth(2).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let suffix = tok.value().strip_prefix("        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let claims: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_bytes = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let suffix = tok.value().strip_prefix("        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/comprehensive_token_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'prop_assert_eq!(claims["   "].as_str().unwrap(), label.as_str());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let payload_bytes = URL_SAFE_NO_PAD.decode(parts[1]).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(decoded.unwrap().len(), 32);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                     ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/negative_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let bytes = URL_SAFE_NO_PAD.decode(payload).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/negative_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = """let payload = token.split('.').nth(1).expect("                   ");"""
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/negative_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_slice(&bytes).expect("             ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                     ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                  ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                 ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let claims: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let decoded = URL_SAFE_NO_PAD.decode(sig).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let exp = claims["   "].as_u64().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx1 = Factory::deterministic(Seed::from_env_value("               ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx1 = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx1 = Factory::deterministic(Seed::from_env_value("        ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fx1 = Factory::deterministic(Seed::from_env_value(seed_val).unwrap());"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx2 = Factory::deterministic(Seed::from_env_value("               ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx2 = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx2 = Factory::deterministic(Seed::from_env_value("        ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fx2 = Factory::deterministic(Seed::from_env_value(seed_val).unwrap());"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_bytes = URL_SAFE_NO_PAD.decode(header_segment).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let header_segment = tok.value().split('.').next().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_bytes = URL_SAFE_NO_PAD.decode(payload_segment).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let payload_segment = tok.value().split('.').nth(1).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let sig = tok.value().split('.').nth(2).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let suffix = tok.value().strip_prefix("        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_prop.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "decoded.unwrap().len(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let header: serde_json::Value = serde_json::from_slice(&header_bytes).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let header_bytes = URL_SAFE_NO_PAD.decode(parts[0]).expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let payload_bytes = URL_SAFE_NO_PAD.decode(parts[1]).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                 ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed1 = Seed::from_env_value("                   ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed1 = Seed::from_env_value("                 ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("                   ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-token/tests/token_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("                 ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("                    ").expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/error_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("              ").expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/extended_tonic.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/extended_tonic.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("            ").expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/pem_structure.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/pem_structure.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/pem_structure.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                    ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/pem_structure.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/thread_safety.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.map(|h| h.join().expect("                       "))'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/thread_safety.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'h.join().expect("                       ");'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/tonic_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/tonic_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let fx_a = Factory::deterministic(Seed::from_env_value("            ").expect("    "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/tonic_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let fx_b = Factory::deterministic(Seed::from_env_value("            ").expect("    "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/tonic_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("                 ").expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-tonic/tests/tonic_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("               ").expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'into_writer(&map, &mut out).expect("                               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'into_writer(&root, &mut attestation_object).expect("                            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let v: Value = from_reader(encoded.as_slice()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let v: Value = from_reader(reg.attestation_object.as_slice()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let x = bytes_by_integer_key(&entries, -2).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let y = bytes_by_integer_key(&entries, -3).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_slice(&reg.client_data_json).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::to_vec(&val).expect("                        ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '_ => panic!("                                   "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '_ => panic!("                           "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable"
+snippet = '_ => unreachable!("                                                     "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(u16::from_be_bytes(reg[53..55].try_into().unwrap()), 4);"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                   ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webauthn/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webhook/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let mut mac = hmac::Hmac::<Sha256>::new_from_slice(secret).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webhook/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let stripe_header = st.headers.get("                ").expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webhook/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&fixture.payload).expect("                                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webhook/src/lib.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::to_string(value).expect("                                        ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webhook/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                    ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webhook/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                 ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webhook/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webhook/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("               ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-webhook/src/lib.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("          ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_key, &PKCS_RSA_SHA256).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(cert_ago.cert_der()).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(cert_future.cert_der()).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(cert.cert_der()).expect("          ");'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let cert = params.self_signed(&key_pair).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let cn = parsed.subject().iter_common_name().next().expect("  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'san.clone().try_into().expect("              "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                                   ", other),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                           ", other),'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(cn.as_str().unwrap(), "                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let cert_der_file = cert.write_cert_der().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let cert_file = cert.write_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let factory = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let identity_file = cert.write_identity_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let key_file = cert.write_private_key_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/cert.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("              ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'Some(crl.pem().expect("       ")),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(chain.intermediate_cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, int) = X509Certificate::from_der(chain.intermediate_cert_der()).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(chain.leaf_cert_der()).expect("          ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, root) = X509Certificate::from_der(chain.root_cert_der()).expect("          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let crl = crl_params.signed_by(&int_issuer).expect("       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let root_cert = root_params.self_signed(&root_kp).expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'san.clone().try_into().expect("              "),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let chain_file = chain.write_chain_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let full_chain_file = chain.write_full_chain_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let leaf_cert = chain.write_leaf_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let leaf_cert_der = chain.write_leaf_cert_der().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let leaf_key = chain.write_leaf_private_key_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let root_cert = chain.write_root_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("         ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(bad.intermediate_cert_der()).expect("                  ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(expired.intermediate_cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(future.leaf_cert_der()).expect("                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(revoked.leaf_cert_der()).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(unknown.root_cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, good_root) = X509Certificate::from_der(chain.root_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(expired.leaf_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(mismatched.leaf_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let cn_str = cn.as_str().expect("                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let crl_der = revoked.crl_der().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let next_update = crl.next_update().expect("           ").timestamp();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(revoked1.crl_der().unwrap(), revoked2.crl_der().unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(revoked1.crl_pem().unwrap(), revoked2.crl_pem().unwrap());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let crl_der_file = revoked.write_crl_der().unwrap().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let crl_pem = revoked.crl_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let crl_pem_file = revoked.write_crl_pem().unwrap().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/chain_negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/src/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(not_yet.cert_der()).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, good_parsed) = X509Certificate::from_der(cert.cert_der()).expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(ca_variant.cert_der()).expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(cert.cert_der()).expect("          ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(expired.cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(wrong.cert_der()).expect("                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                           ", other),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                      ", other),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/coverage_gaps.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/error_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(cert.cert_der()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/error_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(chain.root_cert_der()).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/error_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(expired.cert_der()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/error_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(future.cert_der()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/error_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(wrong.cert_der()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("              ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(expired.intermediate_cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(variant.cert_der()).expect("                   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, bad_root) = X509Certificate::from_der(bad.root_cert_der()).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, exp) = X509Certificate::from_der(expired.cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, good) = X509Certificate::from_der(cert.cert_der()).expect("               ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, good_root) = X509Certificate::from_der(chain.root_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(bad.leaf_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(expired.leaf_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(bad.cert_der()).expect("          ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(cert.cert_der()).expect("          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(expired.cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(nyv.cert_der()).expect("                        ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                           ", other),'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "Factory::deterministic(Seed::from_env_value(seed_str).unwrap())"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(cn.as_str().unwrap(), "                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/negative_x509.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "cn.as_str().unwrap(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/snapshots_x509.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(cert.cert_der()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                  ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("             ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("            ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("            ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("          ")'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(bad.intermediate_cert_der()).expect("                  ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(chain.intermediate_cert_der()).expect("                  ");'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(chain.intermediate_cert_der()).expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(chain.leaf_cert_der()).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(chain.root_cert_der()).expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(expired.intermediate_cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(future.intermediate_cert_der()).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, bad) = X509Certificate::from_der(nyv.cert_der()).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, bad_root) = X509Certificate::from_der(bad.root_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, bad_root) = X509Certificate::from_der(bad.root_cert_der()).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, bad_root) = X509Certificate::from_der(bad.root_cert_der()).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, good) = X509Certificate::from_der(cert.cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, good_root) = X509Certificate::from_der(chain.root_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, int) = X509Certificate::from_der(chain.intermediate_cert_der()).expect("   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(bad.leaf_cert_der()).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(chain.leaf_cert_der()).expect("          ");'
+count = 7
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(chain.leaf_cert_der()).expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(expired.leaf_cert_der()).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(future.leaf_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(revoked.leaf_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(bad.cert_der()).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(cert.cert_der()).expect("     ");'
+count = 10
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(expired.cert_der()).expect("     ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, root) = X509Certificate::from_der(chain.root_cert_der()).expect("          ");'
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, root) = X509Certificate::from_der(chain.root_cert_der()).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, root) = X509Certificate::from_der(chain.root_cert_der()).expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, root) = X509Certificate::from_der(expired.root_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (remaining, parsed) = X509Certificate::from_der(der).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let crl_der = revoked.crl_der().expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pem = revoked.crl_pem().expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::revocation_list::CertificateRevocationList::from_der(crl_der).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                         "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                 "));'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                           ", other),'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'other => panic!("                      ", other),'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 13
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 6
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "Factory::deterministic(Seed::from_env_value(seed_str).unwrap())"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(cn.as_str().unwrap(), "                 ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let file_bytes = std::fs::read(tmpfile.path()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let file_content = std::fs::read_to_string(tmpfile.path()).unwrap();"
+count = 4
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmpfile = cert.write_cert_der().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmpfile = cert.write_identity_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmpfile = cert.write_private_key_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmpfile = chain.write_chain_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmpfile = chain.write_full_chain_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(chain.intermediate_cert_der()).expect("                  ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, leaf) = X509Certificate::from_der(chain.leaf_cert_der()).expect("          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, root) = X509Certificate::from_der(chain.root_cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let cert_file = cert.write_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let file_content = std::fs::read_to_string(cert_file.path()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let file_content = std::fs::read_to_string(leaf_file.path()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey-x509/tests/x509_unit.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let leaf_file = chain.write_leaf_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/benches/keygen.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("          ").expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/adapter_jsonwebtoken.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 5
+
+[[entry]]
+path = "crates/uselesskey/examples/adapter_jsonwebtoken.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let ec_token = encode(&Header::new(Algorithm::ES256), &claims, &ec.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/adapter_jsonwebtoken.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let ed_token = encode(&Header::new(Algorithm::EdDSA), &claims, &ed.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/adapter_jsonwebtoken.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = encode(&Header::new(Algorithm::RS256), &claims, &rsa.encoding_key()).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/adapter_rustls.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/basic_rsa.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/basic_token.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("          ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/basic_usage.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let temp = rsa.write_private_key_pkcs8_pem().expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/basic_usage.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/deterministic.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx2 = Factory::deterministic(Seed::from_env_value("               ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/deterministic.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx3 = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/deterministic.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("               ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/deterministic_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx2 = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/deterministic_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx3 = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/deterministic_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx_other = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/deterministic_mode.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_generation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_generation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'hmac.jwks().to_value()["    "].as_array().unwrap().len()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_generation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                   ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_generation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = jwks_val["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_jwks.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'ec_jwks["    "].as_array().unwrap().len()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_jwks.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'ed_jwks["    "].as_array().unwrap().len()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_jwks.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'hmac_jwks["    "].as_array().unwrap().len()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_jwks.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("        ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_jwks.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = jwks_val["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwk_jwks.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'rsa_jwks["    "].as_array().unwrap().len()'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwks_server_mock.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/examples/jwks_server_mock.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(rotation_value["    "].as_array().unwrap().len(), 2);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwks_server_mock.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(value["    "].as_array().unwrap().len(), 1);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwks_server_mock.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx2 = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwks_server_mock.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = multi_value["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwks_server_mock.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("              ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/jwt_rs256_jwks.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/negative_fixtures.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/examples/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/negative_fixtures.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/negative_payload_shapes.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/negative_payload_shapes.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'assert!(empty["    "].as_array().expect("          ").is_empty());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/negative_payload_shapes.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let duplicate_kid_keys = duplicate_kid["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/negative_payload_shapes.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                     ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/tempfile_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/examples/tempfile_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey/examples/tempfile_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/examples/tempfile_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let manual_content = std::fs::read_to_string(manual_file.path()).expect("                   ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/tempfile_paths.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'manual_file.flush().expect("               ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/tempfiles.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let cert_file = cert.write_cert_pem().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/tempfiles.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let identity_file = cert.write_identity_pem().expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/tempfiles.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let key_file = cert.write_private_key_pem().expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/tls_server.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/examples/token_generation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx = Factory::deterministic(Seed::from_env_value("          ").unwrap());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/x509_certificates.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/x509_certificates.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let cert_file = cert.write_cert_pem().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/x509_certificates.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let chain_file = chain.write_chain_pem().expect("           ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/x509_certificates.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let id_file = cert.write_identity_pem().expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/x509_certificates.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let key_file = cert.write_private_key_pem().expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/x509_certificates.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let root_file = chain.write_root_cert_pem().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/x509_certificates.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/examples/x509_certificates.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/cache_perf_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/dep_guard_policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/dep_guard_policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                       ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/dep_guard_policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let content = std::fs::read_to_string(root.join("         ")).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/dep_guard_policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let packages = meta["        "].as_array().expect("              ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/dep_guard_policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_slice(&output.stdout).expect("                              ");'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/dep_guard_policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'std::fs::read_to_string(root.join("          ")).expect("                       ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/dep_guard_policy.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'PathBuf::from(meta["              "].as_str().unwrap())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/determinism_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "Factory::deterministic(Seed::from_env_value(seed_str).unwrap())"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/determinism_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let fx_43 = Factory::deterministic(Seed::from_env_value("  ").unwrap());'
+count = 5
+
+[[entry]]
+path = "crates/uselesskey/tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let line2 = pem.lines().nth(1).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("  ").unwrap();'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: serde_json::Value = serde_json::from_str(&json).expect("                      ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed_priv = pem::parse(pem_priv).expect("                        ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed_pub = pem::parse(pem_pub).expect("                       ");'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value(seed_str).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.map(|k| k["   "].as_str().unwrap().to_string())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(parsed["    "].as_array().unwrap().len(), 4);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let priv_content = priv_pem_tmp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let priv_pem_tmp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let priv_tmp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub_content = pub_pem_tmp.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub_pem_tmp = kp.write_public_key_spki_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub_tmp = kp.write_public_key_spki_pem().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "priv_pem_tmp.read_to_string().unwrap() == kp.private_key_pkcs8_pem(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "priv_tmp.read_to_string().unwrap().len(),"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "pub_pem_tmp.read_to_string().unwrap() == kp.public_key_spki_pem(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/e2e_pipeline.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "pub_tmp.read_to_string().unwrap().len(),"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("           ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_e2e.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value(original).expect("    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_e2e.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value(seed_str).expect("         ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = jwks["    "].as_array().expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = val["    "].as_array().expect("          ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_cert_der().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_cert_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_identity_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_private_key_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_chain_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_full_chain_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_leaf_cert_der().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_leaf_cert_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_leaf_private_key_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_root_cert_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(revoked.crl_pem().unwrap().contains("              "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fx = Factory::deterministic_from_env(var_name).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let ktys: Vec<&str> = keys.iter().map(|k| k["   "].as_str().unwrap()).collect();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let priv_tmp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub_tmp = kp.write_public_key_spki_pem().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_integration.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(rev.crl_pem().unwrap().contains("              "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let der_file = rev.write_crl_der().unwrap().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/facade_negative.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pem_file = rev.write_crl_pem().unwrap().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                    ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(val["    "].as_array().unwrap().len(), 0);'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(val["    "].as_array().unwrap().len(), 1);'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = val["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let ktys: Vec<&str> = keys.iter().map(|k| k["   "].as_str().unwrap()).collect();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                  ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                 ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("              ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("             ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = uselesskey::Seed::from_env_value("           ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed2 = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_combinations.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let token = jsonwebtoken::encode(&header, &claims, &enc).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_isolation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(val["    "].as_array().unwrap().is_empty());'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_isolation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                   ").unwrap();'
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_isolation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/feature_isolation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("              ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "Factory::deterministic(Seed::from_env_value(seed).unwrap())"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_cert_der().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_cert_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_identity_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_private_key_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_chain_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_full_chain_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_leaf_cert_der().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_leaf_cert_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_leaf_private_key_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(chain.write_root_cert_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(kp.write_private_key_armored().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(kp.write_public_key_armored().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(rev.crl_pem().unwrap().contains("              "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "h.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let _ = Seed::from_env_value("            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let content = std::fs::read_to_string(tmp.path()).unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let fx = Factory::deterministic_from_env(var).unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = jwks.to_value()["    "].as_array().unwrap().clone();'
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = v["    "].as_array().unwrap();'
+count = 4
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let ktys: Vec<&str> = keys.iter().map(|k| k["   "].as_str().unwrap()).collect();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let priv_tmp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub_tmp = kp.write_public_key_spki_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("             ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp = kp().write_private_key_pkcs8_pem().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp = kp().write_public_key_spki_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/integration_facade.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/multi_algorithm_isolation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                  ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/multi_algorithm_isolation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/negative_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/negative_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("  ")'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/negative_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::prelude::X509Certificate::from_der(c.root_cert_der()).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/negative_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::prelude::X509Certificate::from_der(expired.cert_der()).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/negative_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::prelude::X509Certificate::from_der(mm.leaf_cert_der()).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/negative_comprehensive.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::prelude::X509Certificate::from_der(nyv.cert_der()).expect("     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/negative_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/negative_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/negative_comprehensive.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'Factory::deterministic(Seed::from_env_value("                           ").unwrap())'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/security_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                       ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/security_tests.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                   ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/snapshots_facade.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let keys = val["    "].as_array().expect("             ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/snapshots_facade.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'x509_parser::parse_x509_certificate(cert.cert_der()).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(priv_temp.read_to_string().unwrap().contains("           "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(pub_temp.read_to_string().unwrap().contains("          "));'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(temp.read_to_bytes().unwrap(), chain.leaf_cert_der());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(temp.read_to_string().unwrap(), "                ");'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(temp.read_to_string().unwrap(), kp.private_key_pkcs8_pem());"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "cert.write_cert_der().unwrap().path().to_path_buf(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "cert.write_cert_pem().unwrap().path().to_path_buf(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "cert.write_identity_pem().unwrap().path().to_path_buf(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "cert.write_private_key_pem().unwrap().path().to_path_buf(),"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let (ec_path, _ec_temp) = ec_handle.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let (ed_path, _ed_temp) = ed_handle.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let a = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let b = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let cert_content = cert_file.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let cert_der = cert.write_cert_der().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let cert_file = cert.write_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let cert_pem = cert.write_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let content = temp.read_to_bytes().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let content = temp.read_to_string().unwrap();"
+count = 14
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let filename = temp.path().file_name().unwrap().to_string_lossy();"
+count = 6
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let identity = cert.write_identity_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let key_content = key_file.read_to_string().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let key_file = cert.write_private_key_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let key_pem = cert.write_private_key_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let priv_temp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let pub_temp = kp.write_public_key_spki_pem().unwrap();"
+count = 2
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("          ", "    ", "                         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let temp = TempArtifact::new_string("          ", "    ", "                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = cert.write_cert_der().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = cert.write_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = cert.write_identity_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = cert.write_private_key_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = chain.write_chain_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = chain.write_full_chain_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = chain.write_leaf_cert_der().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = chain.write_leaf_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = chain.write_leaf_private_key_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = chain.write_root_cert_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 9
+
+[[entry]]
+path = "crates/uselesskey/tests/tempfile_sink.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let temp = kp.write_public_key_spki_pem().unwrap();"
+count = 3
+
+[[entry]]
+path = "crates/uselesskey/tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                             ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/core_keypair_material.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                         ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/core_keypair_material.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                        ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/factory_concurrent_access.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/fuzz_factory_concurrent.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/fuzz_jwk_serialization.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let key_json = serde_json::to_string(key).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/fuzz_jwk_serialization.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&json_str).expect("                                     ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/fuzz_jwk_serialization.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&key_json).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/fuzz_jwk_serialization.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&manual_json).expect("                              ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/fuzz_jwk_serialization.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(parsed["    "].as_array().unwrap().len(), input.keys.len());'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/fuzz_kid_generation.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'URL_SAFE_NO_PAD.decode(s.as_bytes()).expect("                           ")'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/fuzz_label_edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let a = *iter.next().unwrap();"
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/fuzz_label_edge_cases.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let b = *iter.next().unwrap();"
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwk_builder.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("         ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwk_serde.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let single_json = serde_json::to_string(&jwk).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwk_serde.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&jwks_json).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwk_serde.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&single_json).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwk_shape.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("                              ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwk_shape.rs"
+family = "get_unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert!(!key.get("   ").unwrap().as_str().unwrap().is_empty());'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwk_shape.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'for key in parsed["    "].as_array().unwrap() {'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwks_builder.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: serde_json::Value = serde_json::from_str(&json).expect("                       ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwks_builder.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(parsed["    "].as_array().unwrap().len(), count);'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwks_builder_ordering.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: serde_json::Value = serde_json::from_str(&json).expect("          ");'
+count = 1
+
+[[entry]]
+path = "fuzz/fuzz_targets/jwks_builder_ordering.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'parsed["    "].as_array().unwrap().len(),'
+count = 1
+
+[[entry]]
+path = "tests/api_surface.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_cert_der().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "tests/api_surface.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_cert_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "tests/api_surface.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_identity_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "tests/api_surface.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(cert.write_private_key_pem().unwrap().path().exists());"
+count = 1
+
+[[entry]]
+path = "tests/api_surface.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = uselesskey_core::Seed::from_env_value("                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "tests/api_surface.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp_priv = kp.write_private_key_pkcs8_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "tests/api_surface.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let tmp_pub = kp.write_public_key_spki_pem().unwrap();"
+count = 1
+
+[[entry]]
+path = "tests/builder_patterns.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("          ");'
+count = 1
+
+[[entry]]
+path = "tests/builder_patterns.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value("            ").expect("          ");'
+count = 1
+
+[[entry]]
+path = "tests/builder_patterns.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let seed = Seed::from_env_value(&hex).expect("              ");'
+count = 1
+
+[[entry]]
+path = "tests/builder_patterns.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = '.map(|k| k.to_value()["   "].as_str().unwrap().to_string())'
+count = 1
+
+[[entry]]
+path = "tests/builder_patterns.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(parsed["    "].as_array().unwrap().len(), 2);'
+count = 1
+
+[[entry]]
+path = "tests/builder_patterns.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let s1 = Seed::from_env_value("          ").unwrap();'
+count = 1
+
+[[entry]]
+path = "tests/builder_patterns.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let s1 = Seed::from_env_value("      ").unwrap();'
+count = 1
+
+[[entry]]
+path = "tests/builder_patterns.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let s2 = Seed::from_env_value("          ").unwrap();'
+count = 1
+
+[[entry]]
+path = "tests/builder_patterns.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let s2 = Seed::from_env_value("      ").unwrap();'
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'return handle.join().expect("               ");'
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = "panic!("
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(expected, h.join().unwrap());"
+count = 3
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(ref_ec256, t2.join().unwrap());"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(ref_ec384, t3.join().unwrap());"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(ref_ed, t4.join().unwrap());"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(ref_hmac, t5.join().unwrap());"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert_eq!(ref_rsa, t1.join().unwrap());"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "h.join().unwrap();"
+count = 4
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let ecdsa_pem = t_ecdsa.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let ed_pem = t_ed.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let hmac_bytes = t_hmac.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let len = h.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 3
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<Vec<u8>> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 2
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 3
+
+[[entry]]
+path = "tests/concurrency.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let rsa_pem = t_rsa.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                           ");'
+count = 2
+
+[[entry]]
+path = "tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                       ");'
+count = 2
+
+[[entry]]
+path = "tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 2
+
+[[entry]]
+path = "tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ");'
+count = 1
+
+[[entry]]
+path = "tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'ed25519_dalek::Signature::from_bytes(ring_sig.as_ref().try_into().expect("        "));'
+count = 1
+
+[[entry]]
+path = "tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let rc_sig = rsa::pkcs1v15::Signature::try_from(sig_buf.as_slice()).expect("         ");'
+count = 1
+
+[[entry]]
+path = "tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let ring_sig = ring_kp.sign(&rng, msg).expect("         ");'
+count = 1
+
+[[entry]]
+path = "tests/cross_adapter.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'p256::ecdsa::DerSignature::from_bytes(ring_sig.as_ref()).expect("                   ");'
+count = 1
+
+[[entry]]
+path = "tests/cross_crate_determinism.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 1
+
+[[entry]]
+path = "tests/crypto_backend_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                       ");'
+count = 1
+
+[[entry]]
+path = "tests/crypto_backend_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                     ");'
+count = 2
+
+[[entry]]
+path = "tests/crypto_backend_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 2
+
+[[entry]]
+path = "tests/crypto_backend_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                        ");'
+count = 4
+
+[[entry]]
+path = "tests/determinism.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let (r, e, d) = h.join().unwrap();"
+count = 1
+
+[[entry]]
+path = "tests/determinism.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "tests/determinism.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[entry]]
+path = "tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'insta::internals::Content::from(v1["   "].as_str().unwrap())'
+count = 12
+
+[[entry]]
+path = "tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = val["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let kids: Vec<&str> = keys.iter().map(|k| k["   "].as_str().unwrap()).collect();'
+count = 1
+
+[[entry]]
+path = "tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&jwks.to_value()).unwrap()"
+count = 1
+
+[[entry]]
+path = "tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&jwks1.to_value()).unwrap(),"
+count = 1
+
+[[entry]]
+path = "tests/determinism_regression.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&jwks2.to_value()).unwrap(),"
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                            ");'
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 3
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ");'
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'DecodingKey::from_jwk(&jwk_json).expect("                                     ");'
+count = 3
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'decode::<JwtClaims>(&token, &decoding_key, &validation).expect("                    ");'
+count = 2
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&header, &claims, &issuer.encoding_key()).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&header, &claims, &keypair.encoding_key()).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&header, &claims, &new_key.encoding_key()).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwk_json: Jwk = serde_json::from_value(jwk_value).expect("                         ");'
+count = 2
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwk_value = serde_json::to_value(jwk).expect("                       ");'
+count = 3
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = encode(&header, &claims, &key1.encoding_key()).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(&jwks_json).expect("                         ");'
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_value(jwk_value).expect("                         ");'
+count = 1
+
+[[entry]]
+path = "tests/e2e_workflows.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(parsed["    "].as_array().unwrap().len(), 2);'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                           ");'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                    ")'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                        ");'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ")'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 2
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                           ");'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ")'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'std::fs::read_to_string(root.join("                            ")).expect("           ");'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'std::fs::read_to_string(root.join("                 ")).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                          "));'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                           ", args.join(" ")))'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("             ", path.display()))'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'panic!("                                  ")'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'std::fs::read_to_string(path).unwrap_or_else(|e| panic!("            ", path.display()));'
+count = 1
+
+[[entry]]
+path = "tests/governance.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".map(|v| v.as_str().unwrap().to_string())"
+count = 1
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                 ");'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                               ");'
+count = 10
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                         ");'
+count = 1
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                      ");'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 1
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'DecodingKey::from_jwk(&jwk_json).expect("                                     ");'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&header, &claims, &issuer2.encoding_key()).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&header, &claims, &keypair.encoding_key()).expect("                    ");'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&header, &claims, &keypair1.encoding_key()).expect("                      ");'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&header, &claims, &keypair2.encoding_key()).expect("                      ");'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&header, &claims, &new_key.encoding_key()).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'encode(&header, &claims, &secret1.encoding_key()).expect("                    ");'
+count = 1
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwk_json: Jwk = serde_json::from_value(jwk_value).expect("                         ");'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let jwk_value = serde_json::to_value(jwk).expect("                       ");'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                      ", bits, e));'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                  ", key_type, e));'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                 ", e));'
+count = 2
+
+[[entry]]
+path = "tests/jwt_integration.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '_ => panic!("                    ", key_type),'
+count = 2
+
+[[entry]]
+path = "tests/key_rotation.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                 ");'
+count = 1
+
+[[entry]]
+path = "tests/key_rotation.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ");'
+count = 1
+
+[[entry]]
+path = "tests/key_rotation.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = encode(&header, &claims, &kp_v1.encoding_key()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "tests/key_rotation.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = encode(&header, &claims, &kp_v2.encoding_key()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "tests/key_rotation.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let token = encode(&header, &claims, &s1.encoding_key()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "tests/key_rotation.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let seed = Seed::from_env_value("                  ").unwrap();'
+count = 1
+
+[[entry]]
+path = "tests/kid_stability.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "Factory::deterministic(Seed::from_env_value(seed_str).unwrap())"
+count = 1
+
+[[entry]]
+path = "tests/kid_stability.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(jwk["   "].as_str().unwrap(), kid);'
+count = 1
+
+[[entry]]
+path = "tests/kid_stability.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(keys[0]["   "].as_str().unwrap(), kid);'
+count = 1
+
+[[entry]]
+path = "tests/kid_stability.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(priv_jwk["   "].as_str().unwrap(), kid);'
+count = 2
+
+[[entry]]
+path = "tests/kid_stability.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(pub_jwk["   "].as_str().unwrap(), kid);'
+count = 2
+
+[[entry]]
+path = "tests/kid_stability.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let keys = jwks["    "].as_array().unwrap();'
+count = 1
+
+[[entry]]
+path = "tests/kid_stability.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'priv_jwk["   "].as_str().unwrap(),'
+count = 1
+
+[[entry]]
+path = "tests/kid_stability.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'pub_jwk["   "].as_str().unwrap(),'
+count = 1
+
+[[entry]]
+path = "tests/msrv_check.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                    ")'
+count = 1
+
+[[entry]]
+path = "tests/msrv_check.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                          ");'
+count = 3
+
+[[entry]]
+path = "tests/msrv_check.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                     ");'
+count = 1
+
+[[entry]]
+path = "tests/msrv_check.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ")'
+count = 1
+
+[[entry]]
+path = "tests/msrv_check.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                          ");'
+count = 1
+
+[[entry]]
+path = "tests/msrv_check.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("             ", path.display()))'
+count = 1
+
+[[entry]]
+path = "tests/msrv_check.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'std::fs::read_to_string(path).unwrap_or_else(|e| panic!("            ", path.display()));'
+count = 1
+
+[[entry]]
+path = "tests/msrv_check.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".map(|v| v.as_str().unwrap().to_string())"
+count = 1
+
+[[entry]]
+path = "tests/msrv_check.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "val.as_str().unwrap()"
+count = 1
+
+[[entry]]
+path = "tests/no_blob_policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                                    ")'
+count = 1
+
+[[entry]]
+path = "tests/no_blob_policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'std::fs::read_to_string(root.join("          ")).expect("                     ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                         ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                 ");'
+count = 2
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                   ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'X509Certificate::from_der(cert.cert_der()).expect("                                     ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = X509Certificate::from_der(cert.cert_der()).expect("          ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = der_parser::parse_der(der).expect("                                        ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = der_parser::parse_der(der).expect("                                      ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = der_parser::parse_der(der).expect("                                    ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = der_parser::parse_der(der).expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, parsed) = der_parser::parse_der(der).expect("                               ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, seq) = der_parser::parse_der(der).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, seq) = der_parser::parse_der(der).expect("            ");'
+count = 3
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (_, seq) = der_parser::parse_der(der).expect("          ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let items = parsed.as_sequence().expect("                        ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let items = seq.as_sequence().expect("                       ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let items = seq.as_sequence().expect("                     ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let items = seq.as_sequence().expect("                  ");'
+count = 3
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                               "))'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                    "));'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                   "));'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                  "));'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                                 "));'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                               "));'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                             "));'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|e| panic!("                          "));'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = 'der_parser::parse_der(der).unwrap_or_else(|e| panic!("                       "));'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(cn.as_str().unwrap(), "                 ");'
+count = 2
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'assert_eq!(items[0].as_u32().unwrap(), 0, "                          ");'
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "items[0].as_u32().unwrap(),"
+count = 1
+
+[[entry]]
+path = "tests/pem_der_format.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let version = items[0].as_u32().unwrap();"
+count = 2
+
+[[entry]]
+path = "tests/security_invariants.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let root = Path::new(env!("                  ")).parent().unwrap();'
+count = 1
+
+[[entry]]
+path = "tests/testutil.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                         ");'
+count = 1
+
+[[entry]]
+path = "tests/tls_integration.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                 ")'
+count = 3
+
+[[entry]]
+path = "xtask/src/docs_sync.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/docs_sync.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let metadata: DocsMetadata = serde_json::from_str(raw).expect("               ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                            ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                     ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                 ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                            ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                     ");'
+count = 3
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                    ");'
+count = 3
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                  ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                 ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("               ")'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("         ")'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'assert!(!contains_pem_markers(&no).expect("         "));'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'assert!(contains_pem_markers(&ssh_dss).expect("         "));'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'assert!(contains_pem_markers(&ssh_ed).expect("         "));'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'assert!(contains_pem_markers(&ssh_pub).expect("         "));'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'assert!(contains_pem_markers(&yes).expect("         "));'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'classify_by_content(bytes.as_bytes(), false).expect("                           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'collect_dependency_version_snippet_errors(&[readme], &versions).expect("       ");'
+count = 2
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'env::set_current_dir(path).expect("               ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::create_dir_all(&features_dir).expect("                   ");'
+count = 2
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::create_dir_all(&fuzz_dir).expect("                   ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::read_to_string(workspace_path(PERF_BASELINE_PATH)).expect("                  ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::write("           ", "      ").expect("          ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::write("           ", "    ").expect("             ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::write("          ", "     ").expect("            ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'fs::write("         ", "     ").expect("           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'git_changed_files("           ").expect("                                  ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (kind, suggestion) = classify_by_content(bytes, true).expect("                   ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let changed = git_changed_files("           ").expect("                            ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let counts = count_bdd_scenarios().expect("               ");'
+count = 2
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let dir = tempfile::tempdir().expect("       ");'
+count = 20
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let files = versioned_dependency_snippet_files().expect("                               ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let has = contains_pem_markers(&path).expect("         ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let name = caps.name("    ").expect("            ").as_str();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let parsed: PerfBaselineFile = serde_json::from_str(&json).expect("                   ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let pct = parse_lcov_coverage(lcov.to_str().unwrap()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let prev = env::current_dir().expect("           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let targets = list_fuzz_targets().expect("            ");'
+count = 2
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'walk_for_blobs(root, root, &mut offenders).expect("              ");'
+count = 2
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "panic_macro"
+selector_kind = "macro"
+selector_callee = "panic"
+snippet = '.unwrap_or_else(|err| panic!("                           ", args.join(" ")));'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 2
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 10
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "assert!(parse_lcov_coverage(lcov.to_str().unwrap()).is_none());"
+count = 2
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::create_dir_all(root.join("                ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::create_dir_all(root.join("               ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::create_dir_all(root.join("            ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::create_dir_all(root.join("          ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::create_dir_all(root.join("        ")).unwrap();'
+count = 3
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::create_dir_all(root.join("     ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::create_dir_all(root.join("   ")).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "fs::write(&der_file, [0x00, 0x01, 0x02]).unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(&lcov, "                                          ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(&lcov, "").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(&no, "         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(&path, "                                             ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(&ssh_dss, "                                         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(&ssh_pub, "                                         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "fs::write(&state_path, &json).unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(&yes, "                                             ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(fuzz_dir.join("         "), "      ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(fuzz_dir.join("    "), "            ").unwrap();'
+count = 2
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("                          "), "        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("                       "), "              ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("                     "), "            ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("                  "), embedded).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("                 "), "                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("                 "), [0x30, 0x82, 0x01]).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("                "), "                ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("               "), "              ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("               "), "         ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'fs::write(root.join("              "), "        ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let _cwd_lock = CWD_LOCK.lock().unwrap();"
+count = 9
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let _lock = ENV_LOCK.lock().unwrap();"
+count = 3
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let dir = Path::new(PUBLISH_STATE_PATH).parent().unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let idx = resolve_start_index(None, false).unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let idx = resolve_start_index(Some("                    "), false).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let idx = resolve_start_index(Some("          "), false).unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&state).unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string_pretty(&state).unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let parsed: PublishState = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let pct = parse_lcov_coverage(lcov.to_str().unwrap()).expect("            ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let w = wait.unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "wait.unwrap(),"
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'Regex::new(&re).expect("                     ")'
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'Regex::new(r"                                             ").expect("           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let expect_re = Regex::new(r"             ").expect("           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let line = r#"        "use .unwrap()"              ".expect()" "#;'
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let panic_macro_re = Regex::new(r"             ").expect("           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let todo_re = Regex::new(r"            ").expect("           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let unimplemented_re = Regex::new(r"                     ").expect("           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let unreachable_re = Regex::new(r"                   ").expect("           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let unwrap_re = Regex::new(r"                  ").expect("           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/policy.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'let line = r#"        "use .unwrap()"              ".expect()" "#;'
+count = 1
+
+[[entry]]
+path = "xtask/src/pr_bundles.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                             ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/pr_bundles.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("                                     ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/pr_bundles.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let (score, pr) = best.expect("                          ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/pr_bundles.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(SAMPLE_SNAPSHOT_JSON).expect("                           ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/pr_bundles.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::from_str(SAMPLE_SNAPSHOT_JSON).expect("             ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/pr_bundles.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string_pretty(&snapshot).unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/pr_bundles.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let name = path.file_name().unwrap().to_string_lossy().to_string();"
+count = 1
+
+[[entry]]
+path = "xtask/src/pr_bundles.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let round_tripped: BundleSnapshot = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/pr_bundles.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = "let snap: BundleSnapshot = serde_json::from_str(json).unwrap();"
+count = 1
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = '.expect("       ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let bdd_pos = report.find("   ").expect("                    ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let clippy_pos = report.find("      ").expect("                       ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let dir = tempfile::tempdir().expect("       ");'
+count = 3
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let fmt_pos = report.find("   ").expect("                    ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let json = fs::read_to_string(&path).expect("            ");'
+count = 3
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'let tests_pos = report.find("     ").expect("                      ");'
+count = 1
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'runner.write().expect("             ");'
+count = 3
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "expect"
+selector_kind = "method_call"
+selector_callee = "expect"
+snippet = 'serde_json::to_string_pretty(&sarif).expect("                                   ")'
+count = 1
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 2
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'writeln!(out, "                          ").unwrap();'
+count = 1
+
+[[entry]]
+path = "xtask/src/receipt.rs"
+family = "unwrap"
+selector_kind = "method_call"
+selector_callee = "unwrap"
+snippet = 'writeln!(out, "           ", "", width = max_name_len + 26).unwrap();'
+count = 1

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -186,6 +186,15 @@ enum NoBlobCmd {
 enum NoPanicCmd {
     /// Generate a candidate allowlist file under target/policy-proposed/.
     Propose,
+    /// Regenerate `policy/no-panic-baseline.toml` from current findings.
+    Baseline {
+        /// Replace the baseline with all current findings.
+        ///
+        /// Without this flag, regeneration only drops disappeared baseline
+        /// entries and refuses to absorb new panic-family debt.
+        #[arg(long)]
+        reset: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -302,6 +311,7 @@ fn main() -> Result<()> {
         Cmd::CheckNoPanicFamily => policy::check_no_panic_family(),
         Cmd::NoPanic { action } => match action {
             NoPanicCmd::Propose => policy::no_panic_propose(),
+            NoPanicCmd::Baseline { reset } => policy::no_panic_baseline(reset),
         },
         Cmd::CheckFilePolicy => policy::check_file_policy(),
         Cmd::CheckLintPolicy => policy::check_lint_policy(),

--- a/xtask/src/policy.rs
+++ b/xtask/src/policy.rs
@@ -3,7 +3,7 @@
 //! See `docs/CLIPPY_POLICY.md`, `docs/NO_PANIC_POLICY.md`, `docs/FILE_POLICY.md`,
 //! and `docs/POLICY_ALLOWLISTS.md`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -14,6 +14,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 const NO_PANIC_TOML: &str = "policy/no-panic-allowlist.toml";
+const NO_PANIC_BASELINE_TOML: &str = "policy/no-panic-baseline.toml";
 const NON_RUST_TOML: &str = "policy/non-rust-allowlist.toml";
 const CLIPPY_LINTS_TOML: &str = "policy/clippy-lints.toml";
 const CLIPPY_DEBT_TOML: &str = "policy/clippy-debt.toml";
@@ -181,6 +182,133 @@ pub struct PanicFinding {
     pub snippet: String,
 }
 
+#[derive(Debug, Deserialize, Serialize, Default)]
+struct NoPanicBaseline {
+    #[serde(default)]
+    schema_version: Option<String>,
+    #[serde(default)]
+    generated_at: Option<String>,
+    #[serde(default)]
+    generated_by: Option<String>,
+    #[serde(default)]
+    summary: BaselineSummary,
+    #[serde(default)]
+    entry: Vec<BaselineEntry>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default)]
+struct BaselineSummary {
+    #[serde(default)]
+    total: usize,
+    #[serde(default)]
+    by_family: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct BaselineKey {
+    path: String,
+    family: String,
+    selector_kind: String,
+    selector_callee: String,
+    snippet: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+struct BaselineEntry {
+    path: String,
+    family: String,
+    #[serde(default)]
+    selector_kind: String,
+    selector_callee: String,
+    #[serde(default)]
+    snippet: String,
+    #[serde(default = "default_baseline_count")]
+    count: usize,
+}
+
+impl BaselineEntry {
+    fn from_key(key: BaselineKey, count: usize) -> Self {
+        Self {
+            path: key.path,
+            family: key.family,
+            selector_kind: key.selector_kind,
+            selector_callee: key.selector_callee,
+            snippet: key.snippet,
+            count,
+        }
+    }
+}
+
+fn default_baseline_count() -> usize {
+    1
+}
+
+fn baseline_key(f: &PanicFinding) -> BaselineKey {
+    BaselineKey {
+        path: f.path.clone(),
+        family: f.family.clone(),
+        selector_kind: f.selector_kind.clone(),
+        selector_callee: f.selector_callee.clone(),
+        snippet: f.snippet.clone(),
+    }
+}
+
+fn baseline_entry_key(e: &BaselineEntry) -> BaselineKey {
+    BaselineKey {
+        path: e.path.clone(),
+        family: e.family.clone(),
+        selector_kind: e.selector_kind.clone(),
+        selector_callee: e.selector_callee.clone(),
+        snippet: e.snippet.clone(),
+    }
+}
+
+fn baseline_counts(entries: &[BaselineEntry]) -> HashMap<BaselineKey, usize> {
+    let mut counts = HashMap::new();
+    for entry in entries {
+        *counts.entry(baseline_entry_key(entry)).or_default() += entry.count;
+    }
+    counts
+}
+
+fn baseline_entries_from_findings(
+    findings: &[PanicFinding],
+    config: &NoPanicConfig,
+) -> Vec<BaselineEntry> {
+    let mut counts: BTreeMap<BaselineKey, usize> = BTreeMap::new();
+    for finding in findings {
+        if config
+            .allow
+            .iter()
+            .any(|entry| entry_matches(entry, finding))
+        {
+            continue;
+        }
+        *counts.entry(baseline_key(finding)).or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .map(|(key, count)| BaselineEntry::from_key(key, count))
+        .collect()
+}
+
+fn new_baseline_debt<'a>(
+    current_entries: &'a [BaselineEntry],
+    existing_counts: &HashMap<BaselineKey, usize>,
+) -> Vec<(&'a BaselineEntry, usize)> {
+    current_entries
+        .iter()
+        .filter_map(|entry| {
+            let current = entry.count;
+            let existing = existing_counts
+                .get(&baseline_entry_key(entry))
+                .copied()
+                .unwrap_or(0);
+            (current > existing).then_some((entry, current - existing))
+        })
+        .collect()
+}
+
 pub fn check_no_panic_family() -> Result<()> {
     let config: NoPanicConfig = if Path::new(NO_PANIC_TOML).exists() {
         read_toml(NO_PANIC_TOML)?
@@ -188,10 +316,29 @@ pub fn check_no_panic_family() -> Result<()> {
         bail!("missing {NO_PANIC_TOML}");
     };
 
+    let baseline: NoPanicBaseline = if Path::new(NO_PANIC_BASELINE_TOML).exists() {
+        read_toml(NO_PANIC_BASELINE_TOML)?
+    } else {
+        NoPanicBaseline::default()
+    };
+    let baseline_counts = baseline_counts(&baseline.entry);
+
+    match config.policy.mode.as_str() {
+        "advisory" | "no-new-debt" | "blocking" => {}
+        other => bail!(
+            "unknown no-panic policy mode `{other}` (expected advisory, no-new-debt, or blocking)"
+        ),
+    }
+
     let findings = scan_panic_findings()?;
     let mut report = NoPanicReport::default();
     let mut matched = vec![false; config.allow.len()];
     let mut unallowlisted: Vec<&PanicFinding> = Vec::new();
+    let mut new_findings: Vec<&PanicFinding> = Vec::new();
+    let mut baseline_used_counts: HashMap<BaselineKey, usize> = HashMap::new();
+    let mut allowlisted_count = 0usize;
+    let mut baselined_count = 0usize;
+    let baseline_active = config.policy.mode != "blocking";
 
     for finding in &findings {
         let mut matched_one = false;
@@ -202,9 +349,21 @@ pub fn check_no_panic_family() -> Result<()> {
                 break;
             }
         }
-        if !matched_one {
-            unallowlisted.push(finding);
+        if matched_one {
+            allowlisted_count += 1;
+            continue;
         }
+        let key = baseline_key(finding);
+        let used = baseline_used_counts.get(&key).copied().unwrap_or(0);
+        let baseline_limit = baseline_counts.get(&key).copied().unwrap_or(0);
+        if baseline_active && used < baseline_limit {
+            baseline_used_counts.insert(key, used + 1);
+            baselined_count += 1;
+            continue;
+        }
+        // Unallowlisted *and* not in the baseline → genuinely new debt.
+        unallowlisted.push(finding);
+        new_findings.push(finding);
     }
 
     let mut stale: Vec<&NoPanicAllow> = Vec::new();
@@ -227,11 +386,33 @@ pub fn check_no_panic_family() -> Result<()> {
         }
     }
 
+    let stale_baseline_entries: Vec<&BaselineEntry> = if baseline_active {
+        baseline
+            .entry
+            .iter()
+            .filter(|e| {
+                baseline_used_counts
+                    .get(&baseline_entry_key(e))
+                    .copied()
+                    .unwrap_or(0)
+                    < e.count
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     report.total_findings = findings.len();
-    report.allowlisted = findings.len().saturating_sub(unallowlisted.len());
+    report.allowlisted = allowlisted_count;
+    report.baselined = baselined_count;
     report.unallowlisted = unallowlisted.len();
     report.stale_entries = stale.len();
     report.expired_entries = expired.len();
+    report.baseline_total = baseline.entry.len();
+    report.baseline_finding_total = baseline.entry.iter().map(|entry| entry.count).sum();
+    report.baseline_unique_hit = baseline_used_counts.len();
+    report.baseline_stale = stale_baseline_entries.len();
+    report.new_debt = new_findings.len();
     report.mode = config.policy.mode.clone();
     report.by_family = group_by_family(&findings);
     report.by_crate = group_by_crate(&findings);
@@ -240,25 +421,147 @@ pub fn check_no_panic_family() -> Result<()> {
     write_outputs("no-panic", &serde_json::to_value(&report)?, &markdown)?;
 
     eprintln!(
-        "no-panic: {} finding(s); {} unallowlisted; {} stale; {} expired (mode={})",
+        "no-panic: {} finding(s); {} allowlisted; {} baselined; {} new-debt; {} stale-baseline; {} expired (mode={}; baseline={}/{})",
         report.total_findings,
-        report.unallowlisted,
-        report.stale_entries,
+        report.allowlisted,
+        report.baselined,
+        report.new_debt,
+        report.baseline_stale,
         report.expired_entries,
-        report.mode
+        report.mode,
+        report.baseline_unique_hit,
+        report.baseline_total,
     );
 
-    let blocking = config.policy.mode == "blocking";
-    if blocking
-        && (report.unallowlisted > 0 || report.stale_entries > 0 || report.expired_entries > 0)
-    {
-        bail!(
-            "no-panic policy is blocking and there are {} unallowlisted, {} stale, {} expired",
-            report.unallowlisted,
-            report.stale_entries,
-            report.expired_entries
-        );
+    match config.policy.mode.as_str() {
+        "blocking" => {
+            if report.unallowlisted > 0 || report.stale_entries > 0 || report.expired_entries > 0 {
+                bail!(
+                    "no-panic policy is blocking and there are {} unallowlisted, {} stale, {} expired",
+                    report.unallowlisted,
+                    report.stale_entries,
+                    report.expired_entries
+                );
+            }
+        }
+        "no-new-debt" => {
+            if report.new_debt > 0 || report.stale_entries > 0 || report.expired_entries > 0 {
+                if !new_findings.is_empty() {
+                    eprintln!("no-panic: new debt sites:");
+                    for f in new_findings.iter().take(20) {
+                        eprintln!(
+                            "  {}:{} ({} via {})",
+                            f.path, f.line, f.family, f.selector_callee
+                        );
+                    }
+                }
+                bail!(
+                    "no-panic policy is no-new-debt and there are {} new debt site(s), {} stale allowlist entries, and {} expired allowlist entries",
+                    report.new_debt,
+                    report.stale_entries,
+                    report.expired_entries
+                );
+            }
+        }
+        _ => {}
     }
+    Ok(())
+}
+
+pub fn no_panic_baseline(reset: bool) -> Result<()> {
+    let config: NoPanicConfig = if Path::new(NO_PANIC_TOML).exists() {
+        read_toml(NO_PANIC_TOML)?
+    } else {
+        bail!("missing {NO_PANIC_TOML}");
+    };
+    let findings = scan_panic_findings()?;
+    let current_entries = baseline_entries_from_findings(&findings, &config);
+
+    let entries = if reset {
+        current_entries
+    } else {
+        if !Path::new(NO_PANIC_BASELINE_TOML).exists() {
+            bail!(
+                "missing {NO_PANIC_BASELINE_TOML}; use `cargo xtask no-panic baseline --reset` for an intentional initial baseline"
+            );
+        }
+        let existing: NoPanicBaseline = read_toml(NO_PANIC_BASELINE_TOML)?;
+        let existing_counts = baseline_counts(&existing.entry);
+        let new_debt = new_baseline_debt(&current_entries, &existing_counts);
+        if !new_debt.is_empty() {
+            eprintln!("no-panic baseline: refusing to absorb new debt:");
+            for (entry, added) in new_debt.iter().take(20) {
+                eprintln!(
+                    "  {} ({}, {} via {}, +{}): {}",
+                    entry.path,
+                    entry.family,
+                    entry.selector_kind,
+                    entry.selector_callee,
+                    added,
+                    entry.snippet
+                );
+            }
+            bail!(
+                "no-panic baseline refresh would add {} new baseline entry/count change(s); remove or allowlist the new debt, or use --reset only for an intentional baseline reset",
+                new_debt.len()
+            );
+        }
+
+        current_entries
+            .into_iter()
+            .filter_map(|mut entry| {
+                let key = baseline_entry_key(&entry);
+                let existing_count = existing_counts.get(&key).copied()?;
+                entry.count = entry.count.min(existing_count);
+                (entry.count > 0).then_some(entry)
+            })
+            .collect()
+    };
+
+    let mut by_family: BTreeMap<String, usize> = BTreeMap::new();
+    for f in &findings {
+        *by_family.entry(f.family.clone()).or_default() += 1;
+    }
+
+    let baseline = NoPanicBaseline {
+        schema_version: Some("1.0".into()),
+        generated_at: Some(today().format("%Y-%m-%d").to_string()),
+        generated_by: Some(if reset {
+            "cargo xtask no-panic baseline --reset".into()
+        } else {
+            "cargo xtask no-panic baseline".into()
+        }),
+        summary: BaselineSummary {
+            total: findings.len(),
+            by_family,
+        },
+        entry: entries,
+    };
+
+    let mut buf = String::new();
+    buf.push_str("# Effortless Metrics — no-panic baseline snapshot\n");
+    buf.push_str("#\n");
+    buf.push_str("# This file pins the panic-family findings present at the time of\n");
+    buf.push_str("# generation. New findings outside this baseline are blocked when the\n");
+    buf.push_str("# no-panic checker is in `mode = \"no-new-debt\"`. Move entries into\n");
+    buf.push_str("# `policy/no-panic-allowlist.toml` (with owner/reason/expiry) as they\n");
+    buf.push_str("# are reviewed; entries that disappear naturally are dropped on next\n");
+    buf.push_str("# refresh. Normal refreshes refuse to add new entries; use --reset\n");
+    buf.push_str("# only for an intentional baseline reset.\n");
+    buf.push_str("#\n");
+    buf.push_str("# Refresh: `cargo xtask no-panic baseline`\n");
+    buf.push_str("# Reset:   `cargo xtask no-panic baseline --reset`\n\n");
+    buf.push_str(&toml::to_string(&baseline).context("serialize baseline")?);
+
+    fs::write(NO_PANIC_BASELINE_TOML, buf)
+        .with_context(|| format!("write {NO_PANIC_BASELINE_TOML}"))?;
+    eprintln!(
+        "no-panic baseline: wrote {} ({} unique entries from {} findings; reset={})",
+        NO_PANIC_BASELINE_TOML,
+        baseline.entry.len(),
+        findings.len(),
+        reset,
+    );
     Ok(())
 }
 
@@ -323,10 +626,24 @@ fn entry_matches(entry: &NoPanicAllow, finding: &PanicFinding) -> bool {
 #[derive(Debug, Default, Serialize)]
 struct NoPanicReport {
     total_findings: usize,
+    /// Findings matched by an entry in `policy/no-panic-allowlist.toml`.
     allowlisted: usize,
+    /// Findings absorbed by `policy/no-panic-baseline.toml`.
+    baselined: usize,
+    /// Findings matched neither by the allowlist nor by the baseline.
     unallowlisted: usize,
     stale_entries: usize,
     expired_entries: usize,
+    /// Number of entries in the baseline file.
+    baseline_total: usize,
+    /// Total finding count represented by all baseline entries.
+    baseline_finding_total: usize,
+    /// Number of distinct baseline entries hit at least once during the scan.
+    baseline_unique_hit: usize,
+    /// Baseline entries with no matching finding (candidate for removal).
+    baseline_stale: usize,
+    /// Findings that are not in the allowlist *and* not in the baseline.
+    new_debt: usize,
     mode: String,
     by_family: BTreeMap<String, usize>,
     by_crate: BTreeMap<String, usize>,
@@ -363,10 +680,25 @@ fn render_no_panic_md(
         report.total_findings
     ));
     s.push_str(&format!("- Allowlisted: {}\n", report.allowlisted));
-    s.push_str(&format!("- Unallowlisted: **{}**\n", report.unallowlisted));
-    s.push_str(&format!("- Stale entries: {}\n", report.stale_entries));
     s.push_str(&format!(
-        "- Expired entries: {}\n\n",
+        "- Baselined: {} (across {}/{} baseline entries; {} total baseline finding slots; {} stale)\n",
+        report.baselined,
+        report.baseline_unique_hit,
+        report.baseline_total,
+        report.baseline_finding_total,
+        report.baseline_stale,
+    ));
+    s.push_str(&format!("- New debt: **{}**\n", report.new_debt));
+    s.push_str(&format!(
+        "- Unallowlisted (allowlist + baseline gap): **{}**\n",
+        report.unallowlisted
+    ));
+    s.push_str(&format!(
+        "- Stale allowlist entries: {}\n",
+        report.stale_entries
+    ));
+    s.push_str(&format!(
+        "- Expired allowlist entries: {}\n\n",
         report.expired_entries
     ));
 
@@ -463,7 +795,12 @@ fn scan_panic_findings() -> Result<Vec<PanicFinding>> {
             // that `let x = foo(); // .unwrap()` does not produce a false positive.
             // This is a naive strip that ignores `//` inside string literals; for
             // panic-family detection in real code that is acceptable noise.
-            let line = strip_line_comment(raw_line);
+            let stripped = strip_line_comment(raw_line);
+            // Replace same-line string bodies with whitespace so panic-family
+            // names embedded inside string literals (e.g. `"use .unwrap()"`) are
+            // not flagged. Multi-line string contents are not handled here.
+            let stripped_owned = blank_string_literals_on_line(stripped);
+            let line = stripped_owned.as_str();
 
             // get_unwrap takes precedence over plain unwrap so we don't double-count.
             if let Some(m) = get_unwrap_re.find(line) {
@@ -555,6 +892,40 @@ fn strip_line_comment(line: &str) -> &str {
     } else {
         line
     }
+}
+
+/// Replace the body of every same-line `"..."` string literal with spaces so
+/// regex-based scanners don't pick up panic-family names embedded inside
+/// strings. Escaped quotes and raw-string literals are not handled (the
+/// false-positive surface they introduce is small in practice).
+fn blank_string_literals_on_line(line: &str) -> String {
+    let bytes = line.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut in_string = false;
+    let mut escape = false;
+    for &b in bytes {
+        if in_string {
+            out.push(b' ');
+            if escape {
+                escape = false;
+            } else if b == b'\\' {
+                escape = true;
+            } else if b == b'"' {
+                in_string = false;
+                // overwrite the closing quote we just blanked with the actual quote
+                let last = out.len() - 1;
+                out[last] = b'"';
+            }
+        } else {
+            out.push(b);
+            if b == b'"' {
+                in_string = true;
+            }
+        }
+    }
+    // SAFETY: input was UTF-8 and we only replaced characters with ASCII spaces
+    // or kept them; the result is still valid UTF-8.
+    String::from_utf8(out).unwrap_or_else(|_| line.to_string())
 }
 
 // =============================================================================
@@ -1579,5 +1950,96 @@ const RAW: &str = r#"#[allow(dead_code)]"#;
 const BYTES: &[u8] = b"#[allow(dead_code)]";
 "##;
         assert_eq!(count_bare_allow_attributes(source), 0);
+    }
+
+    #[test]
+    fn baseline_key_uses_path_family_callee_and_snippet() {
+        let f = PanicFinding {
+            path: "crates/x/src/lib.rs".into(),
+            family: "unwrap".into(),
+            line: 42,
+            column: 10,
+            selector_kind: "method_call".into(),
+            selector_callee: "unwrap".into(),
+            snippet: ".unwrap()".into(),
+        };
+        let key = baseline_key(&f);
+        assert_eq!(
+            key,
+            BaselineKey {
+                path: "crates/x/src/lib.rs".into(),
+                family: "unwrap".into(),
+                selector_kind: "method_call".into(),
+                selector_callee: "unwrap".into(),
+                snippet: ".unwrap()".into(),
+            }
+        );
+
+        let entry = BaselineEntry::from_key(key.clone(), 1);
+        assert_eq!(baseline_entry_key(&entry), key);
+    }
+
+    #[test]
+    fn blank_string_literals_replaces_string_body_with_spaces() {
+        let line = r#"let s = "use .unwrap()"; let other = ".expect()";"#;
+        let blanked = blank_string_literals_on_line(line);
+        // The string bodies are blanked (replaced with spaces) but the quotes
+        // remain so the regex panic-family matchers don't fire.
+        assert!(!blanked.contains(".unwrap()"));
+        assert!(!blanked.contains(".expect()"));
+        assert!(blanked.contains("let s = "));
+    }
+
+    #[test]
+    fn baseline_entries_count_duplicate_finding_shapes() {
+        let config = NoPanicConfig {
+            schema_version: None,
+            policy: NoPanicPolicy::default(),
+            allow: Vec::new(),
+        };
+        let findings = [
+            PanicFinding {
+                path: "a.rs".into(),
+                family: "unwrap".into(),
+                line: 1,
+                column: 1,
+                selector_kind: "method_call".into(),
+                selector_callee: "unwrap".into(),
+                snippet: ".unwrap()".into(),
+            },
+            PanicFinding {
+                path: "a.rs".into(),
+                family: "unwrap".into(),
+                line: 99,
+                column: 1,
+                selector_kind: "method_call".into(),
+                selector_callee: "unwrap".into(),
+                snippet: ".unwrap()".into(),
+            },
+        ];
+        let entries = baseline_entries_from_findings(&findings, &config);
+        assert_eq!(
+            entries.len(),
+            1,
+            "two findings with same key collapse to one baseline entry",
+        );
+        assert_eq!(entries[0].count, 2);
+    }
+
+    #[test]
+    fn new_baseline_debt_detects_count_increase() {
+        let key = BaselineKey {
+            path: "a.rs".into(),
+            family: "unwrap".into(),
+            selector_kind: "method_call".into(),
+            selector_callee: "unwrap".into(),
+            snippet: ".unwrap()".into(),
+        };
+        let existing = vec![BaselineEntry::from_key(key.clone(), 1)];
+        let current = vec![BaselineEntry::from_key(key, 2)];
+        let existing_counts = baseline_counts(&existing);
+        let new = new_baseline_debt(&current, &existing_counts);
+        assert_eq!(new.len(), 1);
+        assert_eq!(new[0].1, 1);
     }
 }


### PR DESCRIPTION
## Summary

Add a baselining mechanism so the no-panic checker can enforce "no new panic-family debt" without first classifying every existing finding. Third installment of the policy stack after #456 and #462.

The reviewed version makes the baseline a counted snapshot of concrete finding shapes instead of a coarse per-file/per-family allowance. A normal refresh can only drop disappeared entries/counts; absorbing new debt requires the explicit `--reset` lane.

## What landed

- `cargo xtask no-panic baseline` refreshes `policy/no-panic-baseline.toml` without absorbing new findings or count increases.
- `cargo xtask no-panic baseline --reset` is the explicit full-snapshot lane for initial setup or an intentional repo-policy reset.
- `mode = "no-new-debt"` fails when a finding is in neither the receipted allowlist nor the counted baseline.
- `mode = "blocking"` ignores the baseline and requires allowlist coverage for remaining panic-family findings.
- The baseline is keyed by `path + family + selector_kind + selector_callee + snippet`, with occurrence counts for duplicate shapes.
- Reports distinguish allowlisted, baselined, new-debt, stale baseline, stale allowlist, and expired allowlist signals.
- Scanner false positives from same-line string literal bodies stay suppressed.

## Current baseline

- 4,275 panic-family findings
- 2,584 unique counted baseline entries
- 0 allowlisted findings
- 0 new-debt findings under `mode = "no-new-debt"`

## Verification

```powershell
cargo xtask check-no-panic-family
cargo xtask no-panic baseline
cargo test -p xtask
cargo xtask docs-sync --check
cargo xtask policy-report
cargo xtask lint-fix --check
cargo xtask pr
```

Additional negative checks performed locally:

- Adding a temporary `unwrap()` made `cargo xtask check-no-panic-family` fail with new debt.
- Adding the same temporary `unwrap()` made `cargo xtask no-panic baseline` refuse to absorb the new baseline entry/count.

## Follow-ups

- Burndown PRs should remove real panic-family debt, then run `cargo xtask no-panic baseline` to drop disappeared baseline entries/counts.
- Panic-family sites that are intentionally retained should move from the generated baseline into `policy/no-panic-allowlist.toml` with owner/reason/expiry.
- Flip to `mode = "blocking"` only after the baseline is empty or intentionally retired.