### PR TITLE
ci(coverage): exclude bdd runner from llvm-cov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -89,6 +89,7 @@ jobs:
             --locked \
             --all-features \
             --exclude uselesskey-bench \
+            --exclude uselesskey-bdd \
             --no-report \
             -- --test-threads=2
 

--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -26,6 +26,10 @@ The Coverage workflow runs on:
 - `workflow_dispatch` (manual trigger),
 - `pull_request` with labels `coverage` or `full-ci`.
 
+The workflow excludes the Cucumber BDD runner crate. BDD scenarios remain owned
+by `cargo xtask bdd`, because that binary is not a libtest harness and does not
+accept the `--test-threads` flag used to keep coverage runs bounded.
+
 ## Artifacts
 
 Durable receipts are:


### PR DESCRIPTION
## Summary

- exclude the Cucumber BDD runner crate from the Coverage workflow llvm-cov command
- document that BDD remains owned by `cargo xtask bdd` because its binary does not accept libtest `--test-threads`

## Verification

- `cargo xtask docs-sync --check`
- `git diff --check`

## Failure addressed

Latest main Coverage run `25492004145` failed because `cargo llvm-cov test ... -- --test-threads=2` invoked `uselesskey-bdd --test bdd`, whose Cucumber runner rejects `--test-threads`.