### PR TITLE
feat(test-support): add fallible test helpers crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5352,6 +5352,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "uselesskey-test-support"
+version = "0.6.0"
+
+[[package]]
 name = "uselesskey-token"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "crates/uselesskey-test-grid",
+  "crates/uselesskey-test-support",
   "crates/uselesskey-feature-grid",
   "crates/uselesskey",
   "crates/uselesskey-core",
@@ -81,6 +82,7 @@ authors = ["Effortless Metrics <opensource@effortlessmetrics.com>"]
 thiserror = "2.0.18"
 
 uselesskey-test-grid = { path = "crates/uselesskey-test-grid", version = "0.6.0" }
+uselesskey-test-support = { path = "crates/uselesskey-test-support", version = "0.6.0" }
 uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid", version = "0.6.0" }
 uselesskey = { path = "crates/uselesskey", version = "0.6.0", default-features = false }
 uselesskey-cli = { path = "crates/uselesskey-cli", version = "0.6.0" }

--- a/crates/uselesskey-test-support/Cargo.toml
+++ b/crates/uselesskey-test-support/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uselesskey-test-support"
+version = "0.6.0"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Fallible test helpers (ensure!, ensure_eq!, require_some, require_ok) for the uselesskey workspace."
+categories.workspace = true
+keywords = ["test", "helpers", "fallible", "panic-free"]
+readme = "README.md"
+authors.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/uselesskey-test-support/README.md
+++ b/crates/uselesskey-test-support/README.md
@@ -1,0 +1,29 @@
+# uselesskey-test-support
+
+Fallible test helpers for the `uselesskey` workspace. Used by tests that
+return `Result<()>` instead of relying on panicking macros.
+
+This crate is a workspace dev-dependency only; it is not published.
+
+## Helpers
+
+- `ensure!(cond, msg)` — fails the test with `Err(...)` when `cond` is false.
+- `ensure_eq!(left, right)` — fails the test with `Err(...)` if `left != right`.
+- `require_some(option, msg)` — converts `Option<T>` to `Result<T, _>`.
+- `require_ok(result, msg)` — coerces `Result<T, E>` failures into the
+  test's error type with a contextual message.
+
+## Pattern
+
+```rust
+use uselesskey_test_support::{ensure_eq, require_ok};
+
+#[test]
+fn my_fallible_test() -> Result<(), Box<dyn std::error::Error>> {
+    let value = require_ok(parse_thing(input), "parse_thing should accept input")?;
+    ensure_eq!(value.kind(), Kind::Expected);
+    Ok(())
+}
+```
+
+See `docs/NO_PANIC_POLICY.md` for the broader policy context.

--- a/crates/uselesskey-test-support/src/lib.rs
+++ b/crates/uselesskey-test-support/src/lib.rs
@@ -1,0 +1,183 @@
+#![forbid(unsafe_code)]
+//! Fallible test helpers for the `uselesskey` workspace.
+//!
+//! Tests that return `Result<()>` instead of panicking on assertion failure
+//! are easier to migrate to fully-panic-free code paths and surface failures
+//! through the same error-handling channels as production callers.
+//!
+//! See `docs/NO_PANIC_POLICY.md` for the broader policy context.
+
+use std::error::Error as StdError;
+use std::fmt;
+
+/// Error returned by the helpers in this crate. The error message preserves
+/// caller-supplied context so test runners produce a useful failure line.
+#[derive(Debug)]
+pub struct TestError(pub String);
+
+impl fmt::Display for TestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl StdError for TestError {}
+
+/// Convenience alias: `Result<T, TestError>`.
+pub type TestResult<T> = Result<T, TestError>;
+
+/// Fail a fallible test with a formatted message when `cond` is false.
+///
+/// Idiomatic usage:
+///
+/// ```
+/// use uselesskey_test_support::{ensure, TestResult};
+///
+/// fn check(x: i32) -> TestResult<()> {
+///     ensure!(x > 0, "expected positive, got {x}");
+///     Ok(())
+/// }
+/// assert!(check(1).is_ok());
+/// assert!(check(0).is_err());
+/// ```
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr $(,)?) => {
+        if !$cond {
+            return ::std::result::Result::Err(
+                $crate::TestError(::std::format!(
+                    "ensure!({}) failed at {}:{}",
+                    ::std::stringify!($cond),
+                    ::std::file!(),
+                    ::std::line!()
+                ))
+            );
+        }
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        if !$cond {
+            return ::std::result::Result::Err(
+                $crate::TestError(::std::format!($($arg)+))
+            );
+        }
+    };
+}
+
+/// Fail a fallible test with a formatted message when `left != right`.
+///
+/// ```
+/// use uselesskey_test_support::{ensure_eq, TestResult};
+///
+/// fn check() -> TestResult<()> {
+///     ensure_eq!(2 + 2, 4);
+///     Ok(())
+/// }
+/// assert!(check().is_ok());
+/// ```
+#[macro_export]
+macro_rules! ensure_eq {
+    ($left:expr, $right:expr $(,)?) => {{
+        let left_val = $left;
+        let right_val = $right;
+        if left_val != right_val {
+            return ::std::result::Result::Err($crate::TestError(::std::format!(
+                "ensure_eq!({} == {}) failed at {}:{}: left={:?} right={:?}",
+                ::std::stringify!($left),
+                ::std::stringify!($right),
+                ::std::file!(),
+                ::std::line!(),
+                left_val,
+                right_val
+            )));
+        }
+    }};
+}
+
+/// Convert `Option<T>` to `TestResult<T>`, attaching a contextual message
+/// when the value is `None`.
+///
+/// ```
+/// use uselesskey_test_support::{require_some, TestResult};
+///
+/// fn first_word(s: &str) -> TestResult<&str> {
+///     require_some(s.split_whitespace().next(), "input had no words")
+/// }
+/// assert_eq!(first_word("hello world").unwrap(), "hello");
+/// assert!(first_word("").is_err());
+/// ```
+pub fn require_some<T>(option: Option<T>, msg: impl fmt::Display) -> TestResult<T> {
+    option.ok_or_else(|| TestError(msg.to_string()))
+}
+
+/// Convert `Result<T, E>` to `TestResult<T>`, prefixing the original error
+/// with a contextual message.
+///
+/// ```
+/// use uselesskey_test_support::{require_ok, TestResult};
+///
+/// fn parse(s: &str) -> TestResult<i32> {
+///     require_ok(s.parse::<i32>(), "parsing user input")
+/// }
+/// assert_eq!(parse("42").unwrap(), 42);
+/// assert!(parse("nope").is_err());
+/// ```
+pub fn require_ok<T, E: StdError>(result: Result<T, E>, msg: impl fmt::Display) -> TestResult<T> {
+    result.map_err(|e| TestError(format!("{msg}: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok_path() -> TestResult<()> {
+        ensure!(true);
+        ensure_eq!(1 + 1, 2);
+        let v: Option<i32> = Some(7);
+        let _ = require_some(v, "should be some")?;
+        let r: Result<i32, std::num::ParseIntError> = Ok(7);
+        let _ = require_ok(r, "should parse")?;
+        Ok(())
+    }
+
+    fn ensure_fails() -> TestResult<()> {
+        ensure!(1 == 2, "1 != 2");
+        Ok(())
+    }
+
+    fn ensure_eq_fails() -> TestResult<()> {
+        ensure_eq!(1, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn happy_path_returns_ok() {
+        assert!(ok_path().is_ok());
+    }
+
+    #[test]
+    fn ensure_macro_returns_err_with_message() {
+        let err = ensure_fails().unwrap_err();
+        assert_eq!(err.to_string(), "1 != 2");
+    }
+
+    #[test]
+    fn ensure_eq_macro_includes_values() {
+        let err = ensure_eq_fails().unwrap_err();
+        assert!(err.to_string().contains("left=1"));
+        assert!(err.to_string().contains("right=2"));
+    }
+
+    #[test]
+    fn require_some_with_none_returns_err() {
+        let r: TestResult<i32> = require_some(None, "missing");
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().to_string(), "missing");
+    }
+
+    #[test]
+    fn require_ok_prefixes_message() {
+        let r: Result<i32, std::num::ParseIntError> = "x".parse();
+        let err = require_ok(r, "parsing").unwrap_err();
+        assert!(err.to_string().starts_with("parsing: "));
+    }
+}

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -22,9 +22,22 @@ The panic family includes:
 - `Result`-returning bodies that `unwrap()` internally
 
 Test assertion macros (`assert!`, `assert_eq!`, `assert_ne!`) are still test
-oracles and are NOT panic-family. A future migration may introduce fallible
-assertion helpers (`ensure_eq`, `require_some`); that is a separate policy
-decision.
+oracles and are NOT panic-family. The `uselesskey-test-support` crate
+provides fallible alternatives (`ensure!`, `ensure_eq!`, `require_some`,
+`require_ok`) that compose with `Result<()>`-returning tests for migrations
+that want to remove `unwrap`/`expect` from setup code while keeping
+panicking assertion macros for the actual oracle.
+
+```rust
+use uselesskey_test_support::{ensure_eq, require_ok, TestResult};
+
+#[test]
+fn parses_round_trip() -> TestResult<()> {
+    let parsed = require_ok("42".parse::<i32>(), "parse 42")?;
+    ensure_eq!(parsed, 42);
+    Ok(())
+}
+```
 
 ## Identity
 

--- a/docs/metadata/workspace-docs.json
+++ b/docs/metadata/workspace-docs.json
@@ -622,6 +622,15 @@
       "intended_audience": "repo-internal"
     },
     {
+      "name": "uselesskey-test-support",
+      "support_tier": "experimental",
+      "publish_status": "test-only",
+      "facade_exposed": false,
+      "semver_expectation": "No public API stability commitments; helper macros and fns may evolve.",
+      "msrv_policy": "Tracks workspace MSRV (Rust 1.92).",
+      "intended_audience": "repo-internal"
+    },
+    {
       "name": "uselesskey-test-server",
       "support_tier": "stable",
       "publish_status": "published",

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -60,6 +60,7 @@
 | `uselesskey-rustls` | `stable` | `published` | — | `adapter-users` | Stable adapter API; follows upstream compatibility windows. | Tracks workspace MSRV (Rust 1.92). | — |
 | `uselesskey-ssh` | `stable` | `published` | — | `most-users` | Normal semver guarantees for fixture APIs and OpenSSH encodings. | Tracks workspace MSRV (Rust 1.92). | — |
 | `uselesskey-test-grid` | `experimental` | `test-only` | — | `repo-internal` | No public API stability commitments. | Best effort for workspace CI only. | — |
+| `uselesskey-test-support` | `experimental` | `test-only` | — | `repo-internal` | No public API stability commitments; helper macros and fns may evolve. | Tracks workspace MSRV (Rust 1.92). | — |
 | `uselesskey-test-server` | `stable` | `published` | — | `most-users` | Normal semver guarantees for HTTP test server fixtures and JWKS encodings. | Tracks workspace MSRV (Rust 1.92). | — |
 | `uselesskey-token` | `stable` | `published` | ✓ | `most-users` | Normal semver guarantees for public APIs. | Tracks workspace MSRV (Rust 1.92). | — |
 | `uselesskey-token-spec` | `experimental` | `published` | — | `repo-internal` | Internal building blocks; APIs may change between minor releases. | Tracks workspace MSRV (Rust 1.92). | Prefer depending on `uselesskey` or key-type facade crates unless you are extending the workspace. |


### PR DESCRIPTION
## Summary

Introduce `uselesskey-test-support` — a workspace dev-dependency that
provides fallible alternatives to `unwrap`/`expect`/`assert_eq!` in
**setup code**. Tests opt in by returning `TestResult<()>` instead of
`()`. PR 6 in the policy-stack roadmap
([#456](https://github.com/EffortlessMetrics/uselesskey/pull/456),
[#462](https://github.com/EffortlessMetrics/uselesskey/pull/462),
[#470](https://github.com/EffortlessMetrics/uselesskey/pull/470)).

## What landed

- New crate `crates/uselesskey-test-support` (publishable, MSRV-aligned).
  - `ensure!(cond, ...)` returns `Err` when the condition is false.
  - `ensure_eq!(left, right)` returns `Err` when the values differ; the
    error message includes both values.
  - `require_some(option, msg)` converts `Option<T>` to `TestResult<T>`.
  - `require_ok(result, msg)` prefixes a contextual message onto an
    underlying error.
- Documents the pattern in `docs/NO_PANIC_POLICY.md` with an example.
- Wired into the workspace `[workspace.dependencies]` for downstream
  test-only adoption.

## What this does *not* do

- No existing test is migrated. Tests today use `assert!`/`assert_eq!`,
  which are still allowed (they are oracles, not panic-family debt).
- The no-panic baseline is unchanged; this PR adds new clean code and
  passes the no-new-debt gate (0 new debt).

## Verification

```
cargo test -p uselesskey-test-support  # 5 lib tests + 4 doctests pass
cargo run -p xtask -- check-no-panic-family
no-panic: 4275 finding(s); 0 allowlisted; 4275 baselined; 0 new-debt; …

cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
cargo run -p xtask -- check-file-policy   # 1163 matched / 0 unmatched
cargo run -p xtask -- check-lint-policy   # msrv=1.92 members=64 errors=0
```

## Test plan

- [x] `cargo test -p uselesskey-test-support` (lib + doctests)
- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p xtask -- check-no-panic-family` (no-new-debt mode)
- [x] `cargo run -p xtask -- check-file-policy`
- [x] `cargo run -p xtask -- check-lint-policy`

## Follow-ups

- New tests in feature branches can adopt the pattern by changing the
  test signature to `-> TestResult<()>` and using `ensure_eq!` in place
  of `assert_eq!` for setup-shaped checks.
- A panic-debt burndown PR can convert chosen `unwrap()` sites to
  `require_ok(...)?` and re-run `cargo xtask no-panic baseline` to drop
  the corresponding entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FghJRy92RpKmHANiv4oDz9)_