### PR TITLE
fix(test-support): make fallible helpers ergonomic

### DIFF
--- a/crates/uselesskey-test-support/Cargo.toml
+++ b/crates/uselesskey-test-support/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 keywords = ["test", "helpers", "fallible", "panic-free"]
 readme = "README.md"
 authors.workspace = true
+publish = false
 
 [dependencies]
 

--- a/crates/uselesskey-test-support/README.md
+++ b/crates/uselesskey-test-support/README.md
@@ -16,10 +16,10 @@ This crate is a workspace dev-dependency only; it is not published.
 ## Pattern
 
 ```rust
-use uselesskey_test_support::{ensure_eq, require_ok};
+use uselesskey_test_support::{ensure_eq, require_ok, TestResult};
 
 #[test]
-fn my_fallible_test() -> Result<(), Box<dyn std::error::Error>> {
+fn my_fallible_test() -> TestResult<()> {
     let value = require_ok(parse_thing(input), "parse_thing should accept input")?;
     ensure_eq!(value.kind(), Kind::Expected);
     Ok(())

--- a/crates/uselesskey-test-support/src/lib.rs
+++ b/crates/uselesskey-test-support/src/lib.rs
@@ -28,6 +28,9 @@ pub type TestResult<T> = Result<T, TestError>;
 
 /// Fail a fallible test with a formatted message when `cond` is false.
 ///
+/// The enclosing function may return `TestResult<_>` or another result type
+/// whose error can be built from `TestError`.
+///
 /// Idiomatic usage:
 ///
 /// ```
@@ -50,20 +53,23 @@ macro_rules! ensure {
                     ::std::stringify!($cond),
                     ::std::file!(),
                     ::std::line!()
-                ))
+                )).into()
             );
         }
     };
     ($cond:expr, $($arg:tt)+) => {
         if !$cond {
             return ::std::result::Result::Err(
-                $crate::TestError(::std::format!($($arg)+))
+                $crate::TestError(::std::format!($($arg)+)).into()
             );
         }
     };
 }
 
 /// Fail a fallible test with a formatted message when `left != right`.
+///
+/// The operands are borrowed, matching `assert_eq!` ergonomics: passing a
+/// non-`Copy` value to `ensure_eq!` does not consume it.
 ///
 /// ```
 /// use uselesskey_test_support::{ensure_eq, TestResult};
@@ -77,18 +83,34 @@ macro_rules! ensure {
 #[macro_export]
 macro_rules! ensure_eq {
     ($left:expr, $right:expr $(,)?) => {{
-        let left_val = $left;
-        let right_val = $right;
-        if left_val != right_val {
-            return ::std::result::Result::Err($crate::TestError(::std::format!(
-                "ensure_eq!({} == {}) failed at {}:{}: left={:?} right={:?}",
-                ::std::stringify!($left),
-                ::std::stringify!($right),
-                ::std::file!(),
-                ::std::line!(),
-                left_val,
-                right_val
-            )));
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val != *right_val {
+                    return ::std::result::Result::Err($crate::TestError(::std::format!(
+                        "ensure_eq!({} == {}) failed at {}:{}: left={:?} right={:?}",
+                        ::std::stringify!($left),
+                        ::std::stringify!($right),
+                        ::std::file!(),
+                        ::std::line!(),
+                        left_val,
+                        right_val
+                    )).into());
+                }
+            }
+        }
+    }};
+    ($left:expr, $right:expr, $($arg:tt)+) => {{
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val != *right_val {
+                    return ::std::result::Result::Err($crate::TestError(::std::format!(
+                        "{}: left={:?} right={:?}",
+                        ::std::format_args!($($arg)+),
+                        left_val,
+                        right_val
+                    )).into());
+                }
+            }
         }
     }};
 }
@@ -102,7 +124,7 @@ macro_rules! ensure_eq {
 /// fn first_word(s: &str) -> TestResult<&str> {
 ///     require_some(s.split_whitespace().next(), "input had no words")
 /// }
-/// assert_eq!(first_word("hello world").unwrap(), "hello");
+/// assert_eq!(first_word("hello world").ok(), Some("hello"));
 /// assert!(first_word("").is_err());
 /// ```
 pub fn require_some<T>(option: Option<T>, msg: impl fmt::Display) -> TestResult<T> {
@@ -118,16 +140,26 @@ pub fn require_some<T>(option: Option<T>, msg: impl fmt::Display) -> TestResult<
 /// fn parse(s: &str) -> TestResult<i32> {
 ///     require_ok(s.parse::<i32>(), "parsing user input")
 /// }
-/// assert_eq!(parse("42").unwrap(), 42);
+/// assert_eq!(parse("42").ok(), Some(42));
 /// assert!(parse("nope").is_err());
 /// ```
-pub fn require_ok<T, E: StdError>(result: Result<T, E>, msg: impl fmt::Display) -> TestResult<T> {
+pub fn require_ok<T, E: fmt::Display>(
+    result: Result<T, E>,
+    msg: impl fmt::Display,
+) -> TestResult<T> {
     result.map_err(|e| TestError(format!("{msg}: {e}")))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn expect_error<T>(result: TestResult<T>, msg: &str) -> TestResult<TestError> {
+        match result {
+            Ok(_) => Err(TestError(msg.to_string())),
+            Err(err) => Ok(err),
+        }
+    }
 
     fn ok_path() -> TestResult<()> {
         ensure!(true);
@@ -150,34 +182,83 @@ mod tests {
     }
 
     #[test]
-    fn happy_path_returns_ok() {
-        assert!(ok_path().is_ok());
+    fn happy_path_returns_ok() -> TestResult<()> {
+        ok_path()
     }
 
     #[test]
-    fn ensure_macro_returns_err_with_message() {
-        let err = ensure_fails().unwrap_err();
-        assert_eq!(err.to_string(), "1 != 2");
+    fn ensure_macro_returns_err_with_message() -> TestResult<()> {
+        let err = expect_error(ensure_fails(), "ensure should fail")?;
+        ensure_eq!(err.to_string(), "1 != 2");
+        Ok(())
     }
 
     #[test]
-    fn ensure_eq_macro_includes_values() {
-        let err = ensure_eq_fails().unwrap_err();
-        assert!(err.to_string().contains("left=1"));
-        assert!(err.to_string().contains("right=2"));
+    fn ensure_eq_macro_includes_values() -> TestResult<()> {
+        let err = expect_error(ensure_eq_fails(), "ensure_eq should fail")?;
+        ensure!(err.to_string().contains("left=1"));
+        ensure!(err.to_string().contains("right=2"));
+        Ok(())
     }
 
     #[test]
-    fn require_some_with_none_returns_err() {
+    fn ensure_eq_macro_supports_custom_message() -> TestResult<()> {
+        fn fail() -> TestResult<()> {
+            ensure_eq!(1, 2, "numbers differed");
+            Ok(())
+        }
+
+        let err = expect_error(fail(), "ensure_eq should fail")?;
+        ensure!(err.to_string().contains("numbers differed"));
+        ensure!(err.to_string().contains("left=1"));
+        ensure!(err.to_string().contains("right=2"));
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_eq_macro_borrows_operands() -> TestResult<()> {
+        let value = String::from("same");
+        ensure_eq!(value, "same");
+        ensure_eq!(value.len(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn ensure_macros_work_with_boxed_error_results() -> TestResult<()> {
+        fn fail() -> Result<(), Box<dyn StdError>> {
+            ensure!(false, "boxed error");
+            Ok(())
+        }
+
+        let err = match fail() {
+            Ok(()) => return Err(TestError("expected boxed error".into())),
+            Err(err) => err,
+        };
+        ensure_eq!(err.to_string(), "boxed error");
+        Ok(())
+    }
+
+    #[test]
+    fn require_some_with_none_returns_err() -> TestResult<()> {
         let r: TestResult<i32> = require_some(None, "missing");
-        assert!(r.is_err());
-        assert_eq!(r.unwrap_err().to_string(), "missing");
+        let err = expect_error(r, "require_some should fail")?;
+        ensure_eq!(err.to_string(), "missing");
+        Ok(())
     }
 
     #[test]
-    fn require_ok_prefixes_message() {
+    fn require_ok_prefixes_message() -> TestResult<()> {
         let r: Result<i32, std::num::ParseIntError> = "x".parse();
-        let err = require_ok(r, "parsing").unwrap_err();
-        assert!(err.to_string().starts_with("parsing: "));
+        let err = expect_error(require_ok(r, "parsing"), "require_ok should fail")?;
+        ensure!(err.to_string().starts_with("parsing: "));
+        Ok(())
+    }
+
+    #[test]
+    fn require_ok_accepts_display_only_errors() -> TestResult<()> {
+        let r: Result<i32, String> = Err("not an error trait".to_string());
+        let err = expect_error(require_ok(r, "context"), "require_ok should fail")?;
+        ensure_eq!(err.to_string(), "context: not an error trait");
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Follow-up review fix for #472's new `uselesskey-test-support` crate.

- Mark `uselesskey-test-support` as `publish = false`, matching its README/workspace-only status and fixing the red `main` governance failure.
- Make `ensure!` / `ensure_eq!` return errors convertible from `TestError`, so they work in `TestResult<_>` and compatible fallible test result types.
- Make `ensure_eq!` borrow operands like `assert_eq!` instead of moving non-`Copy` values.
- Let `require_ok` accept any `Display` error, including `Result<T, String>`, because it only formats the error.
- Remove unwrap-style examples/tests from the helper crate and cover the new ergonomics.

## CI root cause fixed

Latest `main` failed in both CI and Coverage on `tests/governance.rs::publish_crates_list_is_complete`:

```text
publishable crates missing from PUBLISH_CRATES: ["uselesskey-test-support"]
```

Because this crate is documented as workspace-only and not public, the fix is to opt it out of publishing rather than add another public package to `PUBLISH_CRATES`.

## Verification

```powershell
cargo test -p uselesskey-test-support
cargo test -p uselesskey-integration-tests --test governance publish_crates_list_is_complete
cargo xtask check-no-panic-family
cargo xtask docs-sync --check
cargo xtask lint-fix --check
cargo xtask pr
```

Note: before the branch had an upstream/base diff configuration, local `cargo xtask pr` reported only `detect-changes`; the explicit crate test, governance reproduction, no-panic, docs-sync, and lint/clippy gates above covered the actual touched surface.