### PR TITLE
refactor(core-id): use fallible test helpers instead of unwrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,6 +4793,7 @@ dependencies = [
  "serde",
  "uselesskey-core-hash",
  "uselesskey-core-seed",
+ "uselesskey-test-support",
 ]
 
 [[package]]

--- a/crates/uselesskey-core-id/Cargo.toml
+++ b/crates/uselesskey-core-id/Cargo.toml
@@ -23,6 +23,7 @@ insta.workspace = true
 proptest.workspace = true
 rstest.workspace = true
 serde.workspace = true
+uselesskey-test-support = { workspace = true }
 
 [features]
 default = ["std"]

--- a/crates/uselesskey-core-id/src/lib.rs
+++ b/crates/uselesskey-core-id/src/lib.rs
@@ -93,6 +93,7 @@ fn derive_seed_v1(master: &Seed, id: &ArtifactId) -> Seed {
 #[cfg(test)]
 mod tests {
     use super::{ArtifactId, DerivationVersion, Seed, derive_seed, hash32};
+    use uselesskey_test_support::{TestResult, require_ok};
 
     #[test]
     fn artifact_id_fingerprints_spec_bytes() {
@@ -165,10 +166,17 @@ mod tests {
     }
 
     #[test]
-    fn seed_reexport_matches_core_seed() {
-        let seed = Seed::from_env_value("core-id-seed").unwrap();
-        let expected = uselesskey_core_seed::Seed::from_env_value("core-id-seed").unwrap();
+    fn seed_reexport_matches_core_seed() -> TestResult<()> {
+        let seed = require_ok(
+            Seed::from_env_value("core-id-seed"),
+            "core-id-seed must parse via the re-export",
+        )?;
+        let expected = require_ok(
+            uselesskey_core_seed::Seed::from_env_value("core-id-seed"),
+            "core-id-seed must parse via the underlying core-seed crate",
+        )?;
         assert_eq!(seed.bytes(), expected.bytes());
+        Ok(())
     }
 
     #[test]

--- a/crates/uselesskey-core-id/tests/seed_integration.rs
+++ b/crates/uselesskey-core-id/tests/seed_integration.rs
@@ -2,10 +2,14 @@
 
 use uselesskey_core_id::{ArtifactId, DerivationVersion, Seed as ReexportedSeed, derive_seed};
 use uselesskey_core_seed::Seed;
+use uselesskey_test_support::{TestResult, require_ok};
 
 #[test]
-fn seed_from_core_seed_drives_core_id_derivation() {
-    let master = Seed::from_env_value("core-seed-integration").unwrap();
+fn seed_from_core_seed_drives_core_id_derivation() -> TestResult<()> {
+    let master = require_ok(
+        Seed::from_env_value("core-seed-integration"),
+        "core-seed-integration must parse as a deterministic seed",
+    )?;
     let id = ArtifactId::new(
         "uselesskey:test",
         "entity",
@@ -17,6 +21,7 @@ fn seed_from_core_seed_drives_core_id_derivation() {
     let first = derive_seed(&master, &id);
     let second = derive_seed(&master, &id);
     assert_eq!(first.bytes(), second.bytes());
+    Ok(())
 }
 
 #[test]

--- a/crates/uselesskey-core-id/tests/snapshots_id.rs
+++ b/crates/uselesskey-core-id/tests/snapshots_id.rs
@@ -5,6 +5,7 @@
 
 use serde::Serialize;
 use uselesskey_core_id::{ArtifactId, DerivationVersion, Seed, derive_seed};
+use uselesskey_test_support::{TestResult, require_ok};
 
 #[test]
 fn snapshot_artifact_id_debug_format() {
@@ -71,7 +72,7 @@ fn snapshot_artifact_id_field_preservation() {
 }
 
 #[test]
-fn snapshot_derive_seed_properties() {
+fn snapshot_derive_seed_properties() -> TestResult<()> {
     #[derive(Serialize)]
     struct DeriveSeedCheck {
         same_inputs_match: bool,
@@ -80,7 +81,10 @@ fn snapshot_derive_seed_properties() {
         derived_seed_byte_count: usize,
     }
 
-    let master = Seed::from_env_value("snapshot-master").unwrap();
+    let master = require_ok(
+        Seed::from_env_value("snapshot-master"),
+        "snapshot-master must parse as a deterministic seed",
+    )?;
 
     let id_a = ArtifactId::new("d", "label-a", b"spec", "v", DerivationVersion::V1);
     let id_b = ArtifactId::new("d", "label-b", b"spec", "v", DerivationVersion::V1);
@@ -99,6 +103,7 @@ fn snapshot_derive_seed_properties() {
     };
 
     insta::assert_yaml_snapshot!("derive_seed_properties", result);
+    Ok(())
 }
 
 #[test]

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -16,14 +16,14 @@ generated_at = "2026-05-07"
 generated_by = "cargo xtask no-panic baseline"
 
 [summary]
-total = 4275
+total = 4271
 
 [summary.by_family]
 expect = 2255
 get_unwrap = 1
 panic_macro = 123
 unreachable = 6
-unwrap = 1890
+unwrap = 1886
 
 [[entry]]
 path = "crates/materialize-buildrs-example/build.rs"
@@ -3839,38 +3839,6 @@ family = "panic_macro"
 selector_kind = "macro"
 selector_callee = "panic"
 snippet = 'other => panic!("                       "),'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-id/src/lib.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = 'let expected = uselesskey_core_seed::Seed::from_env_value("            ").unwrap();'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-id/src/lib.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = 'let seed = Seed::from_env_value("            ").unwrap();'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-id/tests/seed_integration.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = 'let master = Seed::from_env_value("                     ").unwrap();'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-id/tests/snapshots_id.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = 'let master = Seed::from_env_value("               ").unwrap();'
 count = 1
 
 [[entry]]


### PR DESCRIPTION
## Summary

Demonstrate the migration pattern enabled by `uselesskey-test-support` on a small crate: replace four `Seed::from_env_value(...).unwrap()` calls in `uselesskey-core-id` tests/inline-tests with `require_ok(...)?` returning `TestResult<()>`.

This is intentionally a small crate-scoped burndown. Subsequent PRs can apply the same pattern crate-by-crate.

## What landed

- `uselesskey-core-id`: four test-only seed parsing sites converted to fallible helpers.
- `uselesskey-core-id`: adds `uselesskey-test-support` as a dev-dependency only.
- `policy/no-panic-baseline.toml`: drops the four disappeared unwrap entries.

## Current no-panic state

```text
no-panic: 4271 finding(s); 0 allowlisted; 4271 baselined; 0 new-debt; 0 stale-baseline; 0 expired (mode=no-new-debt; baseline=2580/2580)
```

## Verification

```powershell
cargo test -p uselesskey-core-id
cargo xtask check-no-panic-family
cargo xtask no-panic baseline
cargo xtask docs-sync --check
cargo xtask lint-fix --check
cargo xtask pr
```

`cargo xtask pr` passed the Rust/test/feature/BDD/mutants lanes it reached, then failed only at the local Windows fuzz runtime step with `STATUS_DLL_NOT_FOUND` while launching the fuzz target. Hosted Linux PR CI is the authoritative check for that lane.