### PR TITLE
refactor(entropy): use fallible test helpers instead of unwrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5080,6 +5080,7 @@ version = "0.6.0"
 dependencies = [
  "proptest",
  "uselesskey-core",
+ "uselesskey-test-support",
 ]
 
 [[package]]

--- a/crates/uselesskey-entropy/Cargo.toml
+++ b/crates/uselesskey-entropy/Cargo.toml
@@ -19,6 +19,7 @@ uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
 
 [dev-dependencies]
 proptest.workspace = true
+uselesskey-test-support = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-entropy/src/lib.rs
+++ b/crates/uselesskey-entropy/src/lib.rs
@@ -128,13 +128,18 @@ mod tests {
     use super::*;
     use proptest::prop_assert_eq;
     use uselesskey_core::Seed;
+    use uselesskey_test_support::{TestResult, require_ok};
 
     #[test]
-    fn deterministic_entropy_is_stable() {
-        let fx = Factory::deterministic(Seed::from_env_value("entropy-det").unwrap());
+    fn deterministic_entropy_is_stable() -> TestResult<()> {
+        let fx = Factory::deterministic(require_ok(
+            Seed::from_env_value("entropy-det"),
+            "entropy-det must parse as a deterministic seed",
+        )?);
         let a = fx.entropy("svc").bytes(32);
         let b = fx.entropy("svc").bytes(32);
         assert_eq!(a, b);
+        Ok(())
     }
 
     #[test]
@@ -146,25 +151,36 @@ mod tests {
     }
 
     #[test]
-    fn different_labels_produce_different_bytes() {
-        let fx = Factory::deterministic(Seed::from_env_value("entropy-labels").unwrap());
+    fn different_labels_produce_different_bytes() -> TestResult<()> {
+        let fx = Factory::deterministic(require_ok(
+            Seed::from_env_value("entropy-labels"),
+            "entropy-labels must parse as a deterministic seed",
+        )?);
         let a = fx.entropy("a").bytes(32);
         let b = fx.entropy("b").bytes(32);
         assert_ne!(a, b);
+        Ok(())
     }
 
     #[test]
-    fn different_variants_produce_different_bytes() {
-        let fx = Factory::deterministic(Seed::from_env_value("entropy-variants").unwrap());
+    fn different_variants_produce_different_bytes() -> TestResult<()> {
+        let fx = Factory::deterministic(require_ok(
+            Seed::from_env_value("entropy-variants"),
+            "entropy-variants must parse as a deterministic seed",
+        )?);
         let fixture = fx.entropy("svc");
         let good = fixture.bytes(32);
         let alt = fixture.bytes_with_variant(32, "alt");
         assert_ne!(good, alt);
+        Ok(())
     }
 
     #[test]
-    fn accessors_report_fixture_identity() {
-        let fx = Factory::deterministic(Seed::from_env_value("entropy-identity").unwrap());
+    fn accessors_report_fixture_identity() -> TestResult<()> {
+        let fx = Factory::deterministic(require_ok(
+            Seed::from_env_value("entropy-identity"),
+            "entropy-identity must parse as a deterministic seed",
+        )?);
         let default = fx.entropy("svc");
         let custom = fx.entropy_with_variant("svc-alt", "custom");
 
@@ -172,11 +188,15 @@ mod tests {
         assert_eq!(default.variant(), "good");
         assert_eq!(custom.label(), "svc-alt");
         assert_eq!(custom.variant(), "custom");
+        Ok(())
     }
 
     #[test]
-    fn fill_bytes_matches_allocating_path() {
-        let fx = Factory::deterministic(Seed::from_env_value("entropy-fill").unwrap());
+    fn fill_bytes_matches_allocating_path() -> TestResult<()> {
+        let fx = Factory::deterministic(require_ok(
+            Seed::from_env_value("entropy-fill"),
+            "entropy-fill must parse as a deterministic seed",
+        )?);
         let fixture = fx.entropy("svc");
 
         let expected = fixture.bytes(24);
@@ -184,17 +204,22 @@ mod tests {
         fixture.fill_bytes(&mut actual);
 
         assert_eq!(expected, actual);
+        Ok(())
     }
 
     #[test]
-    fn debug_does_not_include_bytes() {
-        let fx = Factory::deterministic(Seed::from_env_value("entropy-debug").unwrap());
+    fn debug_does_not_include_bytes() -> TestResult<()> {
+        let fx = Factory::deterministic(require_ok(
+            Seed::from_env_value("entropy-debug"),
+            "entropy-debug must parse as a deterministic seed",
+        )?);
         let fixture = fx.entropy("svc");
         let dbg = format!("{fixture:?}");
 
         assert!(dbg.contains("EntropyFixture"));
         assert!(dbg.contains("svc"));
         assert!(!dbg.contains("["));
+        Ok(())
     }
 
     proptest::proptest! {

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -16,14 +16,14 @@ generated_at = "2026-05-07"
 generated_by = "cargo xtask no-panic baseline"
 
 [summary]
-total = 4271
+total = 4265
 
 [summary.by_family]
 expect = 2255
 get_unwrap = 1
 panic_macro = 123
 unreachable = 6
-unwrap = 1886
+unwrap = 1880
 
 [[entry]]
 path = "crates/materialize-buildrs-example/build.rs"
@@ -8823,46 +8823,6 @@ family = "expect"
 selector_kind = "method_call"
 selector_callee = "expect"
 snippet = '.expect("                             ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-entropy/src/lib.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = 'let fx = Factory::deterministic(Seed::from_env_value("                ").unwrap());'
-count = 2
-
-[[entry]]
-path = "crates/uselesskey-entropy/src/lib.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = 'let fx = Factory::deterministic(Seed::from_env_value("              ").unwrap());'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-entropy/src/lib.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = 'let fx = Factory::deterministic(Seed::from_env_value("             ").unwrap());'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-entropy/src/lib.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = 'let fx = Factory::deterministic(Seed::from_env_value("            ").unwrap());'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-entropy/src/lib.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = 'let fx = Factory::deterministic(Seed::from_env_value("           ").unwrap());'
 count = 1
 
 [[entry]]


### PR DESCRIPTION
## Summary

Apply the same pattern as
[#474](https://github.com/EffortlessMetrics/uselesskey/pull/474) to
`uselesskey-entropy`: convert 6 `Seed::from_env_value(...).unwrap()`
calls in inline tests to `require_ok(...)?` returning `TestResult<()>`.
The error message now names the seed label on failure instead of
producing a bare panic.

## What landed

- 6 inline-test sites converted in `crates/uselesskey-entropy/src/lib.rs`.
- `uselesskey-test-support` added as a dev-dependency.
- Baseline refresh: drops the 6 disappeared entries; the no-panic
  checker now sees 4265 findings (down from 4271) and 2575 unique
  baseline entries (down from 2580).

## Verification

```
cargo test -p uselesskey-entropy            # 8 tests pass
cargo run -p xtask -- check-no-panic-family
no-panic: 4265 finding(s); 0 allowlisted; 4265 baselined; 0 new-debt;
          0 stale-baseline; 0 expired (mode=no-new-debt; baseline=2575/2575)

cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
cargo run -p xtask -- docs-sync --check
```

## Test plan

- [x] `cargo test -p uselesskey-entropy`
- [x] `cargo run -p xtask -- check-no-panic-family`
- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo run -p xtask -- docs-sync --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FghJRy92RpKmHANiv4oDz9)_