### PR TITLE
refactor(core-keypair): use fallible test helpers instead of expect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4848,6 +4848,7 @@ dependencies = [
  "serde",
  "uselesskey-core-keypair-material",
  "uselesskey-core-negative",
+ "uselesskey-test-support",
 ]
 
 [[package]]

--- a/crates/uselesskey-core-keypair/Cargo.toml
+++ b/crates/uselesskey-core-keypair/Cargo.toml
@@ -22,6 +22,7 @@ insta.workspace = true
 proptest.workspace = true
 serde.workspace = true
 uselesskey-core-negative.workspace = true
+uselesskey-test-support = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-keypair/tests/comprehensive.rs
+++ b/crates/uselesskey-core-keypair/tests/comprehensive.rs
@@ -13,6 +13,7 @@
 use std::sync::Arc;
 use uselesskey_core_keypair::Pkcs8SpkiKeyMaterial;
 use uselesskey_core_negative::CorruptPem;
+use uselesskey_test_support::{TestResult, require_ok};
 
 // ── helpers ──────────────────────────────────────────────────────────
 
@@ -220,41 +221,45 @@ fn different_deterministic_der_variants_produce_different_output() {
 // ── Tempfile content fidelity ────────────────────────────────────────
 
 #[test]
-fn tempfile_private_key_matches_pem_exactly() {
+fn tempfile_private_key_matches_pem_exactly() -> TestResult<()> {
     let m = sample();
-    let tmp = m.write_private_key_pkcs8_pem().expect("write");
-    let content = tmp.read_to_string().expect("read");
+    let tmp = require_ok(m.write_private_key_pkcs8_pem(), "write private pem")?;
+    let content = require_ok(tmp.read_to_string(), "read tempfile")?;
     assert_eq!(content, m.private_key_pkcs8_pem());
+    Ok(())
 }
 
 #[test]
-fn tempfile_public_key_matches_pem_exactly() {
+fn tempfile_public_key_matches_pem_exactly() -> TestResult<()> {
     let m = sample();
-    let tmp = m.write_public_key_spki_pem().expect("write");
-    let content = tmp.read_to_string().expect("read");
+    let tmp = require_ok(m.write_public_key_spki_pem(), "write public pem")?;
+    let content = require_ok(tmp.read_to_string(), "read tempfile")?;
     assert_eq!(content, m.public_key_spki_pem());
+    Ok(())
 }
 
 #[test]
-fn tempfile_private_key_path_has_pem_extension() {
+fn tempfile_private_key_path_has_pem_extension() -> TestResult<()> {
     let m = sample();
-    let tmp = m.write_private_key_pkcs8_pem().expect("write");
+    let tmp = require_ok(m.write_private_key_pkcs8_pem(), "write private pem")?;
     let path_str = tmp.path().to_string_lossy();
     assert!(
         path_str.ends_with(".pkcs8.pem"),
         "expected .pkcs8.pem suffix, got: {path_str}"
     );
+    Ok(())
 }
 
 #[test]
-fn tempfile_public_key_path_has_pem_extension() {
+fn tempfile_public_key_path_has_pem_extension() -> TestResult<()> {
     let m = sample();
-    let tmp = m.write_public_key_spki_pem().expect("write");
+    let tmp = require_ok(m.write_public_key_spki_pem(), "write public pem")?;
     let path_str = tmp.path().to_string_lossy();
     assert!(
         path_str.ends_with(".spki.pem"),
         "expected .spki.pem suffix, got: {path_str}"
     );
+    Ok(())
 }
 
 // ── Clone independence ───────────────────────────────────────────────

--- a/crates/uselesskey-core-keypair/tests/integration.rs
+++ b/crates/uselesskey-core-keypair/tests/integration.rs
@@ -5,6 +5,7 @@
 //! helpers (corrupt PEM/DER), and tempfile writers.
 
 use uselesskey_core_keypair::Pkcs8SpkiKeyMaterial;
+use uselesskey_test_support::{TestResult, require_ok};
 
 // ── helpers ──────────────────────────────────────────────────────────
 
@@ -171,17 +172,19 @@ fn der_corrupt_deterministic_is_stable() {
 // ── tempfile writers ─────────────────────────────────────────────────
 
 #[test]
-fn write_private_key_creates_readable_tempfile() {
+fn write_private_key_creates_readable_tempfile() -> TestResult<()> {
     let m = material_a();
-    let tmp = m.write_private_key_pkcs8_pem().expect("write private pem");
-    let content = tmp.read_to_string().expect("read tempfile");
+    let tmp = require_ok(m.write_private_key_pkcs8_pem(), "write private pem")?;
+    let content = require_ok(tmp.read_to_string(), "read tempfile")?;
     assert!(content.contains("BEGIN PRIVATE KEY"));
+    Ok(())
 }
 
 #[test]
-fn write_public_key_creates_readable_tempfile() {
+fn write_public_key_creates_readable_tempfile() -> TestResult<()> {
     let m = material_a();
-    let tmp = m.write_public_key_spki_pem().expect("write public pem");
-    let content = tmp.read_to_string().expect("read tempfile");
+    let tmp = require_ok(m.write_public_key_spki_pem(), "write public pem")?;
+    let content = require_ok(tmp.read_to_string(), "read tempfile")?;
     assert!(content.contains("BEGIN PUBLIC KEY"));
+    Ok(())
 }

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -16,10 +16,10 @@ generated_at = "2026-05-07"
 generated_by = "cargo xtask no-panic baseline"
 
 [summary]
-total = 4265
+total = 4255
 
 [summary.by_family]
-expect = 2255
+expect = 2245
 get_unwrap = 1
 panic_macro = 123
 unreachable = 6
@@ -5199,54 +5199,6 @@ family = "unwrap"
 selector_kind = "method_call"
 selector_callee = "unwrap"
 snippet = "public_temp.read_to_string().unwrap(),"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair/tests/comprehensive.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let content = tmp.read_to_string().expect("    ");'
-count = 2
-
-[[entry]]
-path = "crates/uselesskey-core-keypair/tests/comprehensive.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let tmp = m.write_private_key_pkcs8_pem().expect("     ");'
-count = 2
-
-[[entry]]
-path = "crates/uselesskey-core-keypair/tests/comprehensive.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let tmp = m.write_public_key_spki_pem().expect("     ");'
-count = 2
-
-[[entry]]
-path = "crates/uselesskey-core-keypair/tests/integration.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let content = tmp.read_to_string().expect("             ");'
-count = 2
-
-[[entry]]
-path = "crates/uselesskey-core-keypair/tests/integration.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let tmp = m.write_private_key_pkcs8_pem().expect("                 ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair/tests/integration.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let tmp = m.write_public_key_spki_pem().expect("                ");'
 count = 1
 
 [[entry]]


### PR DESCRIPTION
## Summary

Apply the same pattern as
[#474](https://github.com/EffortlessMetrics/uselesskey/pull/474) /
[#475](https://github.com/EffortlessMetrics/uselesskey/pull/475) to
`uselesskey-core-keypair`: convert 10 `.expect("...")` calls in
`tests/comprehensive.rs` and `tests/integration.rs` to `require_ok(...)?`
returning `TestResult<()>`. Tempfile read/write failures now produce a
labeled error message instead of a bare panic.

## What landed

- 10 sites converted across 2 test files.
- `uselesskey-test-support` added as a `[dev-dependencies]`.
- Baseline refresh: drops the 10 disappeared entries; the no-panic
  checker now sees 4255 findings (down from 4265) and 2569 unique
  baseline entries (down from 2575).

## Verification

```
cargo test -p uselesskey-core-keypair
cargo run -p xtask -- check-no-panic-family
no-panic: 4255 finding(s); 0 allowlisted; 4255 baselined; 0 new-debt;
          0 stale-baseline; 0 expired (mode=no-new-debt; baseline=2569/2569)

cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
```

## Test plan

- [x] `cargo test -p uselesskey-core-keypair`
- [x] `cargo run -p xtask -- check-no-panic-family`
- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FghJRy92RpKmHANiv4oDz9)_