### PR TITLE
refactor(core-keypair-material): use fallible test helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4860,6 +4860,7 @@ dependencies = [
  "serde",
  "uselesskey-core",
  "uselesskey-core-kid",
+ "uselesskey-test-support",
 ]
 
 [[package]]

--- a/crates/uselesskey-core-keypair-material/Cargo.toml
+++ b/crates/uselesskey-core-keypair-material/Cargo.toml
@@ -22,6 +22,7 @@ uselesskey-core-kid.workspace = true
 insta.workspace = true
 proptest.workspace = true
 serde.workspace = true
+uselesskey-test-support = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-keypair-material/src/lib.rs
+++ b/crates/uselesskey-core-keypair-material/src/lib.rs
@@ -111,6 +111,7 @@ impl Pkcs8SpkiKeyMaterial {
 mod tests {
     use super::Pkcs8SpkiKeyMaterial;
     use uselesskey_core::negative::CorruptPem;
+    use uselesskey_test_support::{TestResult, require_ok};
 
     fn sample_material() -> Pkcs8SpkiKeyMaterial {
         Pkcs8SpkiKeyMaterial::new(
@@ -204,19 +205,18 @@ mod tests {
     }
 
     #[test]
-    fn tempfile_writers_round_trip_content() {
+    fn tempfile_writers_round_trip_content() -> TestResult<()> {
         let material = sample_material();
 
-        let private = material
-            .write_private_key_pkcs8_pem()
-            .expect("write private");
-        let public = material.write_public_key_spki_pem().expect("write public");
+        let private = require_ok(material.write_private_key_pkcs8_pem(), "write private")?;
+        let public = require_ok(material.write_public_key_spki_pem(), "write public")?;
 
-        let private_text = private.read_to_string().expect("read private");
-        let public_text = public.read_to_string().expect("read public");
+        let private_text = require_ok(private.read_to_string(), "read private")?;
+        let public_text = require_ok(public.read_to_string(), "read public")?;
 
         assert!(private_text.contains("BEGIN PRIVATE KEY"));
         assert!(public_text.contains("BEGIN PUBLIC KEY"));
+        Ok(())
     }
 
     mod property {

--- a/crates/uselesskey-core-keypair-material/tests/material_integration.rs
+++ b/crates/uselesskey-core-keypair-material/tests/material_integration.rs
@@ -1,7 +1,8 @@
 use uselesskey_core_keypair_material::Pkcs8SpkiKeyMaterial;
+use uselesskey_test_support::{TestResult, require_ok};
 
 #[test]
-fn material_is_usable_from_public_api() {
+fn material_is_usable_from_public_api() -> TestResult<()> {
     let material = Pkcs8SpkiKeyMaterial::new(
         vec![0x30, 0x82, 0x01, 0x22],
         "-----BEGIN PRIVATE KEY-----\nMHg=\n-----END PRIVATE KEY-----\n",
@@ -13,23 +14,16 @@ fn material_is_usable_from_public_api() {
     assert!(!material.public_key_spki_pem().is_empty());
     assert_eq!(material.private_key_pkcs8_der(), &[0x30, 0x82, 0x01, 0x22]);
 
-    let private = material
-        .write_private_key_pkcs8_pem()
-        .expect("write private key temp artifact");
-    let public = material
-        .write_public_key_spki_pem()
-        .expect("write public key temp artifact");
+    let private = require_ok(
+        material.write_private_key_pkcs8_pem(),
+        "write private key temp artifact",
+    )?;
+    let public = require_ok(
+        material.write_public_key_spki_pem(),
+        "write public key temp artifact",
+    )?;
 
-    assert!(
-        private
-            .read_to_string()
-            .expect("read private")
-            .contains("PRIVATE KEY")
-    );
-    assert!(
-        public
-            .read_to_string()
-            .expect("read public")
-            .contains("PUBLIC KEY")
-    );
+    assert!(require_ok(private.read_to_string(), "read private")?.contains("PRIVATE KEY"));
+    assert!(require_ok(public.read_to_string(), "read public")?.contains("PUBLIC KEY"));
+    Ok(())
 }

--- a/crates/uselesskey-core-keypair-material/tests/material_tests.rs
+++ b/crates/uselesskey-core-keypair-material/tests/material_tests.rs
@@ -1,5 +1,6 @@
 use uselesskey_core::negative::CorruptPem;
 use uselesskey_core_keypair_material::Pkcs8SpkiKeyMaterial;
+use uselesskey_test_support::{TestResult, require_ok};
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
@@ -413,19 +414,21 @@ fn kid_is_non_empty_for_all_key_types() {
 // ── Temp file round-trip ─────────────────────────────────────────────────
 
 #[test]
-fn tempfile_private_key_round_trip() {
+fn tempfile_private_key_round_trip() -> TestResult<()> {
     let m = rsa_like_material();
-    let tmp = m.write_private_key_pkcs8_pem().expect("write private");
-    let content = tmp.read_to_string().expect("read");
+    let tmp = require_ok(m.write_private_key_pkcs8_pem(), "write private")?;
+    let content = require_ok(tmp.read_to_string(), "read")?;
     assert_eq!(content, m.private_key_pkcs8_pem());
+    Ok(())
 }
 
 #[test]
-fn tempfile_public_key_round_trip() {
+fn tempfile_public_key_round_trip() -> TestResult<()> {
     let m = rsa_like_material();
-    let tmp = m.write_public_key_spki_pem().expect("write public");
-    let content = tmp.read_to_string().expect("read");
+    let tmp = require_ok(m.write_public_key_spki_pem(), "write public")?;
+    let content = require_ok(tmp.read_to_string(), "read")?;
     assert_eq!(content, m.public_key_spki_pem());
+    Ok(())
 }
 
 // ── Property-based tests ─────────────────────────────────────────────────

--- a/crates/uselesskey-core-keypair-material/tests/mutant_killers.rs
+++ b/crates/uselesskey-core-keypair-material/tests/mutant_killers.rs
@@ -2,6 +2,7 @@
 
 use uselesskey_core::negative::CorruptPem;
 use uselesskey_core_keypair_material::Pkcs8SpkiKeyMaterial;
+use uselesskey_test_support::{TestResult, require_ok};
 
 fn sample() -> Pkcs8SpkiKeyMaterial {
     Pkcs8SpkiKeyMaterial::new(
@@ -137,14 +138,15 @@ fn deterministic_der_corruption_stable_and_non_trivial() {
 }
 
 #[test]
-fn write_tempfiles_round_trip() {
+fn write_tempfiles_round_trip() -> TestResult<()> {
     let m = sample();
-    let priv_temp = m.write_private_key_pkcs8_pem().unwrap();
-    let pub_temp = m.write_public_key_spki_pem().unwrap();
+    let priv_temp = require_ok(m.write_private_key_pkcs8_pem(), "write private pem")?;
+    let pub_temp = require_ok(m.write_public_key_spki_pem(), "write public pem")?;
 
-    let priv_content = priv_temp.read_to_string().unwrap();
-    let pub_content = pub_temp.read_to_string().unwrap();
+    let priv_content = require_ok(priv_temp.read_to_string(), "read private")?;
+    let pub_content = require_ok(pub_temp.read_to_string(), "read public")?;
 
     assert_eq!(priv_content, m.private_key_pkcs8_pem());
     assert_eq!(pub_content, m.public_key_spki_pem());
+    Ok(())
 }

--- a/crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs
+++ b/crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs
@@ -1,6 +1,7 @@
 //! Integration tests for negative fixture support in Pkcs8SpkiKeyMaterial.
 
 use uselesskey_core_keypair_material::Pkcs8SpkiKeyMaterial;
+use uselesskey_test_support::{TestResult, require_ok, require_some};
 
 fn sample() -> Pkcs8SpkiKeyMaterial {
     Pkcs8SpkiKeyMaterial::new(
@@ -124,32 +125,37 @@ fn clone_preserves_all_accessors() {
 // ── tempfile round trips ─────────────────────────────────────────────
 
 #[test]
-fn write_private_key_tempfile_has_pem_extension() {
+fn write_private_key_tempfile_has_pem_extension() -> TestResult<()> {
     let m = sample();
-    let temp = m.write_private_key_pkcs8_pem().unwrap();
-    let ext = temp.path().extension().unwrap().to_str().unwrap();
+    let temp = require_ok(m.write_private_key_pkcs8_pem(), "write private pem")?;
+    let ext_os = require_some(temp.path().extension(), "tempfile path missing extension")?;
+    let ext = require_some(ext_os.to_str(), "tempfile extension is not utf-8")?;
     assert_eq!(ext, "pem");
+    Ok(())
 }
 
 #[test]
-fn write_public_key_tempfile_has_pem_extension() {
+fn write_public_key_tempfile_has_pem_extension() -> TestResult<()> {
     let m = sample();
-    let temp = m.write_public_key_spki_pem().unwrap();
-    let ext = temp.path().extension().unwrap().to_str().unwrap();
+    let temp = require_ok(m.write_public_key_spki_pem(), "write public pem")?;
+    let ext_os = require_some(temp.path().extension(), "tempfile path missing extension")?;
+    let ext = require_some(ext_os.to_str(), "tempfile extension is not utf-8")?;
     assert_eq!(ext, "pem");
+    Ok(())
 }
 
 #[test]
-fn tempfile_round_trip_preserves_content() {
+fn tempfile_round_trip_preserves_content() -> TestResult<()> {
     let m = sample();
-    let private_temp = m.write_private_key_pkcs8_pem().unwrap();
-    let public_temp = m.write_public_key_spki_pem().unwrap();
+    let private_temp = require_ok(m.write_private_key_pkcs8_pem(), "write private pem")?;
+    let public_temp = require_ok(m.write_public_key_spki_pem(), "write public pem")?;
     assert_eq!(
-        private_temp.read_to_string().unwrap(),
+        require_ok(private_temp.read_to_string(), "read private")?,
         m.private_key_pkcs8_pem()
     );
     assert_eq!(
-        public_temp.read_to_string().unwrap(),
+        require_ok(public_temp.read_to_string(), "read public")?,
         m.public_key_spki_pem()
     );
+    Ok(())
 }

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -16,14 +16,14 @@ generated_at = "2026-05-07"
 generated_by = "cargo xtask no-panic baseline"
 
 [summary]
-total = 4255
+total = 4231
 
 [summary.by_family]
-expect = 2245
+expect = 2233
 get_unwrap = 1
 panic_macro = 123
 unreachable = 6
-unwrap = 1880
+unwrap = 1868
 
 [[entry]]
 path = "crates/materialize-buildrs-example/build.rs"
@@ -5023,182 +5023,6 @@ family = "unwrap"
 selector_kind = "method_call"
 selector_callee = "unwrap"
 snippet = "let v = serde_json::to_value(&jwk).unwrap();"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/src/lib.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = '.expect("             ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/src/lib.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let private_text = private.read_to_string().expect("            ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/src/lib.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let public = material.write_public_key_spki_pem().expect("            ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/src/lib.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let public_text = public.read_to_string().expect("           ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/material_integration.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = '.expect("                               ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/material_integration.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = '.expect("                              ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/material_integration.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = '.expect("            ")'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/material_integration.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = '.expect("           ")'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/material_tests.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let content = tmp.read_to_string().expect("    ");'
-count = 2
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/material_tests.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let tmp = m.write_private_key_pkcs8_pem().expect("             ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/material_tests.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = 'let tmp = m.write_public_key_spki_pem().expect("            ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/mutant_killers.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let priv_content = priv_temp.read_to_string().unwrap();"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/mutant_killers.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let priv_temp = m.write_private_key_pkcs8_pem().unwrap();"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/mutant_killers.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let pub_content = pub_temp.read_to_string().unwrap();"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/mutant_killers.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let pub_temp = m.write_public_key_spki_pem().unwrap();"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let ext = temp.path().extension().unwrap().to_str().unwrap();"
-count = 2
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let private_temp = m.write_private_key_pkcs8_pem().unwrap();"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let public_temp = m.write_public_key_spki_pem().unwrap();"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let temp = m.write_private_key_pkcs8_pem().unwrap();"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let temp = m.write_public_key_spki_pem().unwrap();"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "private_temp.read_to_string().unwrap(),"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-keypair-material/tests/negative_fixtures.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "public_temp.read_to_string().unwrap(),"
 count = 1
 
 [[entry]]


### PR DESCRIPTION
## Summary

Apply the same pattern as
[#474](https://github.com/EffortlessMetrics/uselesskey/pull/474) /
[#475](https://github.com/EffortlessMetrics/uselesskey/pull/475) /
[#476](https://github.com/EffortlessMetrics/uselesskey/pull/476) to
`uselesskey-core-keypair-material`: convert 24 `.unwrap()`/`.expect()`
calls across 4 test files plus the inline `mod tests` in `src/lib.rs`
to `require_ok(...)?` / `require_some(...)?` returning `TestResult<()>`.

Tempfile read/write failures and missing-extension / non-utf8 paths now
produce labeled errors instead of bare panics.

## What landed

- 24 sites converted across `material_integration.rs`,
  `negative_fixtures.rs`, `mutant_killers.rs`, `material_tests.rs`,
  and `src/lib.rs::tests`.
- `uselesskey-test-support` added as a `[dev-dependencies]`.
- Baseline refresh: 4255 → 4231 findings, 2569 → 2547 unique baseline
  entries.

## Verification

```
cargo test -p uselesskey-core-keypair-material
cargo run -p xtask -- check-no-panic-family
no-panic: 4231 finding(s); 0 allowlisted; 4231 baselined; 0 new-debt;
          0 stale-baseline; 0 expired (mode=no-new-debt; baseline=2547/2547)

cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
cargo run -p xtask -- docs-sync --check
```

## Test plan

- [x] `cargo test -p uselesskey-core-keypair-material`
- [x] `cargo run -p xtask -- check-no-panic-family`
- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FghJRy92RpKmHANiv4oDz9)_