### PR TITLE
refactor(feature-grid): use fallible test helpers for matrix lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5088,6 +5088,9 @@ dependencies = [
 [[package]]
 name = "uselesskey-feature-grid"
 version = "0.6.0"
+dependencies = [
+ "uselesskey-test-support",
+]
 
 [[package]]
 name = "uselesskey-hmac"

--- a/crates/uselesskey-feature-grid/Cargo.toml
+++ b/crates/uselesskey-feature-grid/Cargo.toml
@@ -17,6 +17,7 @@ documentation = "https://docs.rs/uselesskey-feature-grid"
 [dependencies]
 
 [dev-dependencies]
+uselesskey-test-support = { workspace = true }
 
 
 

--- a/crates/uselesskey-feature-grid/src/lib.rs
+++ b/crates/uselesskey-feature-grid/src/lib.rs
@@ -192,6 +192,7 @@ pub const BDD_FEATURE_SETS: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uselesskey_test_support::{TestResult, require_some};
 
     #[test]
     fn core_matrix_has_unique_names() {
@@ -266,27 +267,29 @@ mod tests {
     }
 
     #[test]
-    fn core_matrix_no_default_has_flag() {
-        let no_default = CORE_FEATURE_MATRIX
-            .iter()
-            .find(|e| e.name == "no-default")
-            .expect("matrix must include 'no-default'");
+    fn core_matrix_no_default_has_flag() -> TestResult<()> {
+        let no_default = require_some(
+            CORE_FEATURE_MATRIX.iter().find(|e| e.name == "no-default"),
+            "matrix must include 'no-default'",
+        )?;
         assert!(
             no_default.cargo_args.contains(&"--no-default-features"),
             "no-default entry must pass --no-default-features"
         );
+        Ok(())
     }
 
     #[test]
-    fn core_matrix_default_has_no_args() {
-        let default = CORE_FEATURE_MATRIX
-            .iter()
-            .find(|e| e.name == "default")
-            .expect("matrix must include 'default'");
+    fn core_matrix_default_has_no_args() -> TestResult<()> {
+        let default = require_some(
+            CORE_FEATURE_MATRIX.iter().find(|e| e.name == "default"),
+            "matrix must include 'default'",
+        )?;
         assert!(
             default.cargo_args.is_empty(),
             "default entry must have no extra cargo args"
         );
+        Ok(())
     }
 
     #[test]
@@ -351,15 +354,18 @@ mod tests {
     // --- Wave 81: additional coverage ---
 
     #[test]
-    fn core_matrix_all_features_has_flag() {
-        let all = CORE_FEATURE_MATRIX
-            .iter()
-            .find(|e| e.name == "all-features")
-            .expect("matrix must include 'all-features'");
+    fn core_matrix_all_features_has_flag() -> TestResult<()> {
+        let all = require_some(
+            CORE_FEATURE_MATRIX
+                .iter()
+                .find(|e| e.name == "all-features"),
+            "matrix must include 'all-features'",
+        )?;
         assert!(
             all.cargo_args.contains(&"--all-features"),
             "all-features entry must pass --all-features"
         );
+        Ok(())
     }
 
     #[test]
@@ -538,14 +544,12 @@ mod tests {
     }
 
     #[test]
-    fn bdd_matrix_feature_values_are_valid_uk_tags() {
+    fn bdd_matrix_feature_values_are_valid_uk_tags() -> TestResult<()> {
         for entry in BDD_FEATURE_MATRIX {
-            // Find the value after "--features"
-            let feature_idx = entry
-                .cargo_args
-                .iter()
-                .position(|a| *a == "--features")
-                .expect("BDD entry must have --features");
+            let feature_idx = require_some(
+                entry.cargo_args.iter().position(|a| *a == "--features"),
+                "BDD entry must have --features",
+            )?;
             let features_csv = entry.cargo_args[feature_idx + 1];
             for tag in features_csv.split(',') {
                 assert!(
@@ -555,6 +559,7 @@ mod tests {
                 );
             }
         }
+        Ok(())
     }
 
     #[test]
@@ -628,13 +633,12 @@ mod tests {
     }
 
     #[test]
-    fn bdd_matrix_every_entry_references_uk_all() {
+    fn bdd_matrix_every_entry_references_uk_all() -> TestResult<()> {
         for entry in BDD_FEATURE_MATRIX {
-            let feat_idx = entry
-                .cargo_args
-                .iter()
-                .position(|a| *a == "--features")
-                .expect("BDD entry must have --features");
+            let feat_idx = require_some(
+                entry.cargo_args.iter().position(|a| *a == "--features"),
+                "BDD entry must have --features",
+            )?;
             let features_csv = entry.cargo_args[feat_idx + 1];
             let tags: Vec<&str> = features_csv.split(',').collect();
             assert!(
@@ -643,6 +647,7 @@ mod tests {
                 entry.name
             );
         }
+        Ok(())
     }
 
     #[test]

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -16,10 +16,10 @@ generated_at = "2026-05-07"
 generated_by = "cargo xtask no-panic baseline"
 
 [summary]
-total = 4231
+total = 4226
 
 [summary.by_family]
-expect = 2233
+expect = 2228
 get_unwrap = 1
 panic_macro = 123
 unreachable = 6
@@ -8595,38 +8595,6 @@ count = 1
 
 [[entry]]
 path = "crates/uselesskey-ed25519/tests/testutil.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = '.expect("                             ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-feature-grid/src/lib.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = '.expect("                                  ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-feature-grid/src/lib.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = '.expect("                                ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-feature-grid/src/lib.rs"
-family = "expect"
-selector_kind = "method_call"
-selector_callee = "expect"
-snippet = '.expect("                              ");'
-count = 2
-
-[[entry]]
-path = "crates/uselesskey-feature-grid/src/lib.rs"
 family = "expect"
 selector_kind = "method_call"
 selector_callee = "expect"


### PR DESCRIPTION
## Summary

Apply the same pattern as the previous burndown PRs to
`uselesskey-feature-grid`: convert 5 `.expect("matrix must include
...")` and `.expect("BDD entry must have --features")` calls in the
inline test module to `require_some(...)?` returning `TestResult<()>`.
Failed matrix lookups now produce a labeled error instead of a bare
panic.

## What landed

- 5 sites converted in `src/lib.rs::tests`.
- `uselesskey-test-support` added as a `[dev-dependencies]`.
- Baseline refresh: 4231 → 4226 findings, 2547 → 2543 unique baseline
  entries.

## Verification

```
cargo test -p uselesskey-feature-grid          # 40 tests pass
cargo run -p xtask -- check-no-panic-family
no-panic: 4226 finding(s); 0 allowlisted; 4226 baselined; 0 new-debt;
          0 stale-baseline; 0 expired (mode=no-new-debt; baseline=2543/2543)

cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
```

## Test plan

- [x] `cargo test -p uselesskey-feature-grid`
- [x] `cargo run -p xtask -- check-no-panic-family`
- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FghJRy92RpKmHANiv4oDz9)_