### PR TITLE
refactor(core-x509): use require_some for chain expiry tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,6 +4987,7 @@ dependencies = [
  "uselesskey-core-x509-derive",
  "uselesskey-core-x509-negative",
  "uselesskey-core-x509-spec",
+ "uselesskey-test-support",
 ]
 
 [[package]]

--- a/crates/uselesskey-core-x509/Cargo.toml
+++ b/crates/uselesskey-core-x509/Cargo.toml
@@ -25,6 +25,7 @@ proptest.workspace = true
 rstest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 uselesskey-core-seed.workspace = true
+uselesskey-test-support = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-x509/tests/negative_policy_tests.rs
+++ b/crates/uselesskey-core-x509/tests/negative_policy_tests.rs
@@ -110,29 +110,41 @@ fn not_yet_valid_spec_not_before_is_30_days_future() {
 }
 
 #[test]
-fn expired_chain_leaf_offset_exceeds_validity() {
+fn expired_chain_leaf_offset_exceeds_validity() -> uselesskey_test_support::TestResult<()> {
+    use uselesskey_test_support::require_some;
     let base = ChainSpec::new("chain-expired.example.com");
     let modified = ChainNegative::ExpiredLeaf.apply_to_spec(&base);
 
-    let offset = expect_days_ago(modified.leaf_not_before.unwrap());
+    let leaf_not_before = require_some(
+        modified.leaf_not_before,
+        "ExpiredLeaf must set leaf_not_before",
+    )?;
+    let offset = expect_days_ago(leaf_not_before);
     let validity = modified.leaf_validity_days;
     assert!(
         offset > validity,
         "offset ({offset}) must exceed validity ({validity}) for the cert to be expired"
     );
+    Ok(())
 }
 
 #[test]
-fn expired_chain_intermediate_offset_exceeds_validity() {
+fn expired_chain_intermediate_offset_exceeds_validity() -> uselesskey_test_support::TestResult<()> {
+    use uselesskey_test_support::require_some;
     let base = ChainSpec::new("chain-expired.example.com");
     let modified = ChainNegative::ExpiredIntermediate.apply_to_spec(&base);
 
-    let offset = expect_days_ago(modified.intermediate_not_before.unwrap());
+    let intermediate_not_before = require_some(
+        modified.intermediate_not_before,
+        "ExpiredIntermediate must set intermediate_not_before",
+    )?;
+    let offset = expect_days_ago(intermediate_not_before);
     let validity = modified.intermediate_validity_days;
     assert!(
         offset > validity,
         "offset ({offset}) must exceed validity ({validity}) for the cert to be expired"
     );
+    Ok(())
 }
 
 // =========================================================================

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -16,14 +16,14 @@ generated_at = "2026-05-07"
 generated_by = "cargo xtask no-panic baseline"
 
 [summary]
-total = 4226
+total = 4224
 
 [summary.by_family]
 expect = 2228
 get_unwrap = 1
 panic_macro = 123
 unreachable = 6
-unwrap = 1868
+unwrap = 1866
 
 [[entry]]
 path = "crates/materialize-buildrs-example/build.rs"
@@ -7495,22 +7495,6 @@ family = "panic_macro"
 selector_kind = "macro"
 selector_callee = "panic"
 snippet = 'other => panic!("                               "),'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-x509/tests/negative_policy_tests.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let offset = expect_days_ago(modified.intermediate_not_before.unwrap());"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-x509/tests/negative_policy_tests.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let offset = expect_days_ago(modified.leaf_not_before.unwrap());"
 count = 1
 
 [[entry]]


### PR DESCRIPTION
## Summary

Apply the same pattern as the previous burndown PRs to
`uselesskey-core-x509::tests::negative_policy_tests`: convert the 2
`Option::unwrap()` calls on `leaf_not_before` /
`intermediate_not_before` to `require_some(...)?` returning
`TestResult<()>`. Failed-to-set fields now produce a labeled error
instead of a bare panic.

## What landed

- 2 sites converted in `tests/negative_policy_tests.rs`.
- `uselesskey-test-support` added as a `[dev-dependencies]`.
- Baseline refresh: 4226 → 4224 findings, 2543 → 2541 unique baseline
  entries.

## Out of scope

The 2 sister sites in `uselesskey-core-x509-negative::tests::negative_tests`
live inside `proptest!` blocks where `?` does not compose with the
proptest macro shape; addressing those requires a different idiom
(e.g. `prop_assert!(opt.is_some())` then access) and is best handled
in a separate PR.

## Verification

```
cargo test -p uselesskey-core-x509             # passes
cargo run -p xtask -- check-no-panic-family
no-panic: 4224 finding(s); 0 allowlisted; 4224 baselined; 0 new-debt;
          0 stale-baseline; 0 expired (mode=no-new-debt; baseline=2541/2541)

cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
```

## Test plan

- [x] `cargo test -p uselesskey-core-x509`
- [x] `cargo run -p xtask -- check-no-panic-family`
- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FghJRy92RpKmHANiv4oDz9)_