### PR TITLE
refactor(core-x509-negative): use TestCaseError for proptest options

### DIFF
--- a/crates/uselesskey-core-x509-negative/tests/negative_tests.rs
+++ b/crates/uselesskey-core-x509-negative/tests/negative_tests.rs
@@ -3,6 +3,7 @@
 use std::collections::HashSet;
 
 use proptest::prelude::*;
+use proptest::test_runner::TestCaseError;
 use rstest::rstest;
 use uselesskey_core_x509_negative::{ChainNegative, X509Negative};
 use uselesskey_core_x509_spec::{ChainSpec, KeyUsage, NotBeforeOffset, X509Spec};
@@ -608,7 +609,10 @@ proptest! {
         let base = ChainSpec::new(&leaf);
         let modified = ChainNegative::ExpiredLeaf.apply_to_spec(&base);
 
-        let offset = expect_days_ago(modified.leaf_not_before.unwrap());
+        let leaf_not_before = modified.leaf_not_before.ok_or_else(|| {
+            TestCaseError::fail("ExpiredLeaf must set leaf_not_before")
+        })?;
+        let offset = expect_days_ago(leaf_not_before);
         let validity = modified.leaf_validity_days;
         // not_after = base_time - offset + validity; must be well in the past.
         prop_assert!(offset > validity, "offset({offset}) must exceed validity({validity})");
@@ -619,7 +623,10 @@ proptest! {
         let base = ChainSpec::new(&leaf);
         let modified = ChainNegative::ExpiredIntermediate.apply_to_spec(&base);
 
-        let offset = expect_days_ago(modified.intermediate_not_before.unwrap());
+        let intermediate_not_before = modified.intermediate_not_before.ok_or_else(|| {
+            TestCaseError::fail("ExpiredIntermediate must set intermediate_not_before")
+        })?;
+        let offset = expect_days_ago(intermediate_not_before);
         let validity = modified.intermediate_validity_days;
         prop_assert!(offset > validity, "offset({offset}) must exceed validity({validity})");
     }

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -16,14 +16,14 @@ generated_at = "2026-05-07"
 generated_by = "cargo xtask no-panic baseline"
 
 [summary]
-total = 4226
+total = 4224
 
 [summary.by_family]
 expect = 2228
 get_unwrap = 1
 panic_macro = 123
 unreachable = 6
-unwrap = 1868
+unwrap = 1866
 
 [[entry]]
 path = "crates/materialize-buildrs-example/build.rs"
@@ -7439,22 +7439,6 @@ family = "panic_macro"
 selector_kind = "macro"
 selector_callee = "panic"
 snippet = 'panic!("                        ");'
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-x509-negative/tests/negative_tests.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let offset = expect_days_ago(modified.intermediate_not_before.unwrap());"
-count = 1
-
-[[entry]]
-path = "crates/uselesskey-core-x509-negative/tests/negative_tests.rs"
-family = "unwrap"
-selector_kind = "method_call"
-selector_callee = "unwrap"
-snippet = "let offset = expect_days_ago(modified.leaf_not_before.unwrap());"
 count = 1
 
 [[entry]]


### PR DESCRIPTION
## Summary

Apply the fallible-helper pattern to the proptest body in
`uselesskey-core-x509-negative::tests::negative_tests`: convert the 2
`Option::unwrap()` calls inside `proptest!` to use
`Option::ok_or_else(TestCaseError::fail)?`. Failed-to-set fields now
short-circuit the property test with a labeled `TestCaseError` instead
of producing a bare panic.

This complements
[#479](https://github.com/EffortlessMetrics/uselesskey/pull/479) (which
converted the regular `#[test]` cases in `uselesskey-core-x509`) and
demonstrates the proptest-compatible shape: inside `proptest!` the
body returns `Result<(), TestCaseError>`, so we use
`ok_or_else(...)?` instead of `require_some(...)?`.

## What landed

- 2 sites converted in
  `crates/uselesskey-core-x509-negative/tests/negative_tests.rs`.
- Baseline refresh: 4226 → 4224 findings, 2543 → 2541 unique baseline
  entries (relative to current main; merges cleanly with #479).

## Verification

```
cargo test -p uselesskey-core-x509-negative   # 17 tests pass
cargo run -p xtask -- check-no-panic-family
no-panic: 4224 finding(s); 0 allowlisted; 4224 baselined; 0 new-debt;
          0 stale-baseline; 0 expired (mode=no-new-debt; baseline=2541/2541)

cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
```

## Test plan

- [x] `cargo test -p uselesskey-core-x509-negative`
- [x] `cargo run -p xtask -- check-no-panic-family`
- [x] `cargo clippy --workspace --no-deps --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FghJRy92RpKmHANiv4oDz9)_