### PR TITLE
docs: reconcile bundle roadmap status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reconciled the v0.6.1 roadmap status with the landed bundle, verification,
+  Kubernetes/Vault export, scanner-safe profile, and receipt workflows.
 - Moved JWK/JWKS shape, builder, ordering, and deterministic `kid` internals
   under `uselesskey-jwk::srp::*`, retaining the former `uselesskey-core-jwk*`,
   `uselesskey-core-jwks-order`, and `uselesskey-core-kid` crates as

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -38,10 +38,14 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 
 ## v0.6.1 export bundles
 
-- [ ] `uselesskey bundle` command design
-- [ ] Kubernetes secret payload emitter
-- [ ] Vault payload emitter
+- [x] `uselesskey bundle` command design
+- [x] `uselesskey verify-bundle` deterministic manifest verifier
+- [x] scanner-safe bundle profile with per-artifact lane metadata
+- [x] deterministic bundle receipts under `receipts/materialization.json` and `receipts/audit-surface.json`
+- [x] Kubernetes secret payload emitter
+- [x] Vault payload emitter
 - [ ] Reference manifests for scanner-safe fixture bundles
+- [ ] Release-facing downstream bundle recipes
 
 ## Governance
 

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -19,8 +19,11 @@ This roadmap reflects the strategic direction for uselesskey as a **test-fixture
 - [x] JWK/JWKS and token-shape negative fixture follow-ons.
 - [x] Docs/examples coverage for the remaining negative-fixture surface.
 - [x] Performance benchmarks for key generation and materialization paths.
+- [x] Export-bundle CLI integration: `uselesskey bundle`, `verify-bundle`,
+  scanner-safe profile metadata, deterministic receipts, and Kubernetes/Vault
+  payload emitters.
 - [ ] Release governance and post-release audit automation.
-- [ ] Export-bundle integration (`uselesskey bundle`, k8s/vault payload emitters, and reference manifests).
+- [ ] Release-facing reference bundle manifests and downstream fixture recipes.
 
 ## Shipped
 


### PR DESCRIPTION
## Summary
- mark landed bundle command, verifier, scanner-safe profile, receipts, and Kubernetes/Vault emitters as complete in the v0.6.1 roadmap
- keep release-facing reference manifests and downstream bundle recipes open
- add an Unreleased changelog note for the roadmap reconciliation

## Evidence
- verified `uselesskey bundle --profile scanner-safe` writes manifest metadata, eight scanner-safe artifacts, and deterministic receipts
- verified `uselesskey verify-bundle --path ...` returns status `ok`
- verified `uselesskey export k8s` and `uselesskey export vault-kv-json` against the generated bundle

## Validation
- `cargo xtask docs-sync --check`
- `cargo test -p uselesskey-cli export_targets`
- `git diff --check`

## Follow-up
- owner-crate negative fixture proof gap remains: add public `uselesskey-jwk` and `uselesskey-token` tests for acceptance assertions currently strongest in compatibility-shim tests