### PR TITLE
policy(rust): enable Rust 1.95 compiler lint floor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,6 +211,9 @@ opt-level = 2
 unsafe_op_in_unsafe_fn = "deny"
 unused_must_use = "deny"
 unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
+unused_visibilities = "warn"
 
 [workspace.lints.clippy]
 # Panic-family hard bans (zero-debt today; the semantic checker carries the

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -26,6 +26,45 @@ panic_family_level = "warn"
 # panic-family exceptions. Clippy is the immediate code-shape detector.
 no_panic_authoritative = "xtask"
 
+# Rustc lint floor — lints active in [workspace.lints.rust] as of this MSRV.
+# These document intent alongside the Cargo.toml configuration.
+
+[[active_rust]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+activated_at_msrv = "1.52"
+reason = "Require explicit unsafe blocks inside unsafe fns."
+
+[[active_rust]]
+name = "rust::unused_must_use"
+level = "deny"
+activated_at_msrv = "1.57"
+reason = "Ensure Results and other must-use types are consumed."
+
+[[active_rust]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+activated_at_msrv = "1.78"
+reason = "Catch misspelled or unknown cfg keys at compile time."
+
+[[active_rust]]
+name = "rust::const_item_interior_mutations"
+level = "deny"
+activated_at_msrv = "1.95"
+reason = "Catch UB-prone interior mutation of consts (e.g. Cell/Mutex in const)."
+
+[[active_rust]]
+name = "rust::function_casts_as_integer"
+level = "deny"
+activated_at_msrv = "1.95"
+reason = "Prevent function pointer casts to integer (platform-unsafe and rarely intentional)."
+
+[[active_rust]]
+name = "rust::unused_visibilities"
+level = "warn"
+activated_at_msrv = "1.95"
+reason = "Surface over-public items; warn not deny to allow gradual cleanup."
+
 # Lints that are planned to flip on once MSRV reaches the indicated version.
 # `cargo xtask check-lint-policy` verifies these are NOT active too early.
 


### PR DESCRIPTION
## Summary

Moves the workspace rustc lint floor forward by activating three new lints confirmed clean in PR #502 (compatibility spike).

**Added to `[workspace.lints.rust]` in `Cargo.toml`:**

| Lint | Level | Rationale |
|------|-------|-----------|
| `const_item_interior_mutations` | `deny` | Prevents UB-prone interior mutation of const items (e.g. `Cell`/`Mutex` in const) |
| `function_casts_as_integer` | `deny` | Prevents function pointer casts to integer (platform-unsafe, almost never intentional) |
| `unused_visibilities` | `warn` | Surfaces over-public items; warn (not deny) for gradual cleanup |

Zero existing occurrences of all three lints, confirmed by RUSTFLAGS measurement in the compatibility spike and a fresh `cargo check` here.

**Added to `policy/clippy-lints.toml`:** All six active rustc lints (3 existing + 3 new) are now documented as `[[active_rust]]` entries for full policy visibility.

## Validation

- `cargo check --workspace --all-targets --all-features --locked` → 0 errors ✓
- `cargo xtask gate --check` → all steps ok ✓
- `cargo xtask check-lint-policy` → `msrv=1.95 members=64 errors=0` ✓

## Next PR

`policy/clippy-rust-1.95-ratchets` — measure and activate staged Clippy 1.94/1.95 lints.

https://claude.ai/code/session_01UtGUK2qnkGRFFVNoSqaUYB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtGUK2qnkGRFFVNoSqaUYB)_