### PR TITLE
ci: upload ripr PR evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       - name: cargo deny advisories
         run: cargo deny check advisories
 
+      - name: ripr PR evidence
+        run: cargo xtask ripr-pr
+
       - name: xtask pr
         run: cargo xtask pr
 
@@ -111,6 +114,14 @@ jobs:
             target/xtask/audit-surface/latest.md
             docs/reference/dependency-economics.md
             docs/reference/audit-surface.md
+        if: always()
+
+      - name: Upload ripr PR evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: ripr-pr
+          path: target/ripr/pr
+          if-no-files-found: warn
         if: always()
 
       - name: Upload receipt

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -178,6 +178,8 @@ artifacts under `target/ripr/pr/`:
 - `summary.md`;
 - `review.md`.
 
+Pull request CI uploads that directory as the `ripr-pr` artifact.
+
 If `ripr` is not installed, the command writes skipped artifacts with a clear
 reason and exits successfully. Other `ripr` runtime failures should fail the
 command so the tool integration does not silently mask bad evidence.


### PR DESCRIPTION
## Summary
- run `cargo xtask ripr-pr` in the pull-request CI job before the heavier `xtask pr` gate
- upload `target/ripr/pr` as the `ripr-pr` artifact on every PR job
- document the PR artifact in the test evidence lanes guide

## Validation
- `cargo xtask ripr-pr`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `git diff --check`

## Notes
- This keeps `ripr` advisory and external. If the tool is unavailable, `cargo xtask ripr-pr` writes skipped artifacts and exits successfully.
- This does not split mutation out of `cargo xtask pr`; that remains a separate follow-up slice.
