### PR TITLE
xtask: split mutation from default pr gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,10 @@ Path ignores exist but require ongoing maintenance. This crate replaces "securit
 
 ```bash
 cargo xtask ci              # Main CI pipeline: fmt + clippy + tests + matrix + guard + bdd + no-blob + mutants + fuzz
-cargo xtask pr              # PR-scoped tests based on git diff (emits JSON receipt)
+cargo xtask pr              # Fast PR-scoped tests based on git diff (emits JSON receipt)
+cargo xtask pr --with-mutants # PR-scoped tests plus targeted mutation
 cargo xtask ripr-pr         # Advisory PR oracle-exposure evidence (requires external ripr)
+cargo xtask mutants-pr --changed # Explicit PR-scoped mutation targets
 cargo xtask pr-bundles      # Bundle-ledger workflow for large PR queues: snapshot, ledger, prepare, cleanup
 cargo xtask test            # Run all tests with all features
 cargo xtask fmt --fix       # Fix formatting

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -53,7 +53,8 @@ Blocking posture:
   failures block when their affected surface is in scope;
 - `ripr` should start advisory and become blocking only for severe exposure
   gaps after the baseline is stable;
-- full mutation does not run here by default.
+- full mutation does not run here by default. Use `cargo xtask pr --with-mutants`
+  or `cargo xtask mutants-pr --changed` when PR-scoped mutation is required.
 
 ## Lane 2: PR Targeted Mutation
 
@@ -168,7 +169,8 @@ For a high-risk PR:
 1. Run the fast local gates.
 2. Run `cargo xtask ripr-pr` to find missing or weak test oracles.
 3. Add focused tests for severe exposure gaps.
-4. Run targeted mutation for the owner crate.
+4. Run `cargo xtask mutants-pr --changed` or
+   `cargo xtask mutants-pr --crate <crate> --full-owner` for the owner crate.
 5. Record the exact mutation command and result in the PR body.
 
 `cargo xtask ripr-pr` treats `ripr` as an external tool and writes advisory

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -93,9 +93,28 @@ enum Cmd {
     /// Run publish dry-runs for crates in dependency order.
     PublishCheck,
     /// Run PR-scoped tests based on git diff.
-    Pr,
+    Pr {
+        /// Include the targeted mutation step in the PR gate.
+        #[arg(long)]
+        with_mutants: bool,
+    },
     /// Run advisory ripr PR exposure evidence (requires external `ripr`).
     RiprPr,
+    /// Run PR-scoped mutation testing explicitly.
+    MutantsPr {
+        /// Run mutation testing for mutation-eligible crates changed against the PR base.
+        #[arg(long)]
+        changed: bool,
+        /// Run mutation testing for an explicit crate. Can be supplied multiple times.
+        #[arg(long = "crate", value_name = "CRATE")]
+        crates: Vec<String>,
+        /// Run mutation testing for all publish crates.
+        #[arg(long)]
+        all: bool,
+        /// Document that the selected owner crate(s) should receive full-owner mutation proof.
+        #[arg(long)]
+        full_owner: bool,
+    },
     /// Guard against multiple semver-major versions of pinned deps (e.g. rand_core).
     DepGuard,
     /// Run cucumber BDD features.
@@ -303,8 +322,14 @@ fn main() -> Result<()> {
         Cmd::PublicSurface => public_surface::public_surface_cmd(PUBLISH_CRATES),
         Cmd::ExamplesSmoke { run } => docs_sync::examples_smoke_cmd(run),
         Cmd::PublishCheck => publish_check(),
-        Cmd::Pr => pr(),
+        Cmd::Pr { with_mutants } => pr(with_mutants),
         Cmd::RiprPr => ripr_pr(),
+        Cmd::MutantsPr {
+            changed,
+            crates,
+            all,
+            full_owner,
+        } => mutants_pr(changed, crates, all, full_owner),
         Cmd::DepGuard => dep_guard(),
         Cmd::Bdd => bdd(),
         Cmd::BddMatrix => bdd_matrix(),
@@ -1651,7 +1676,7 @@ fn fuzz(target: Option<&str>, extra: &[String]) -> Result<()> {
     }
 }
 
-fn pr() -> Result<()> {
+fn pr(with_mutants: bool) -> Result<()> {
     let base_ref = resolve_base_ref();
     let changed_files = git_changed_files(&base_ref)?;
     let plan = plan::build_plan(&changed_files);
@@ -1662,7 +1687,7 @@ fn pr() -> Result<()> {
     }
     runner.set_crate_set(format!("pr:{}", plan.impacted_crates.len()));
 
-    let result = run_pr_plan(&base_ref, &changed_files, &plan, &mut runner);
+    let result = run_pr_plan(&base_ref, &changed_files, &plan, &mut runner, with_mutants);
     runner.summary();
     if let Err(err) = runner.write() {
         eprintln!("failed to write receipt: {err}");
@@ -1673,11 +1698,46 @@ fn pr() -> Result<()> {
     result
 }
 
+fn mutants_pr(changed: bool, crates: Vec<String>, all: bool, full_owner: bool) -> Result<()> {
+    let selector_count = usize::from(changed) + usize::from(!crates.is_empty()) + usize::from(all);
+    if selector_count != 1 {
+        bail!("select exactly one of --changed, --crate <CRATE>, or --all");
+    }
+
+    if full_owner {
+        eprintln!("mutants-pr: full-owner proof requested for selected target(s)");
+    }
+
+    if all {
+        return run_mutants(PUBLISH_CRATES);
+    }
+
+    if !crates.is_empty() {
+        let crate_refs = crates.iter().map(String::as_str).collect::<Vec<_>>();
+        return run_mutants(&crate_refs);
+    }
+
+    let base_ref = resolve_base_ref();
+    let changed_files = git_changed_files(&base_ref)?;
+    let plan = plan::build_plan(&changed_files);
+    let pr_crates =
+        mutation_target_crates(&base_ref, &changed_files, &plan.directly_changed_crates)?;
+
+    if pr_crates.is_empty() {
+        println!("mutants-pr: no mutant-eligible behavior changes");
+        return Ok(());
+    }
+
+    let pr_crate_refs = pr_crates.iter().map(String::as_str).collect::<Vec<_>>();
+    run_mutants(&pr_crate_refs)
+}
+
 fn run_pr_plan(
     base_ref: &str,
     changed_files: &[String],
     plan: &plan::Plan,
     runner: &mut receipt::Runner,
+    with_mutants: bool,
 ) -> Result<()> {
     runner.step(
         "detect-changes",
@@ -1762,7 +1822,7 @@ fn run_pr_plan(
         );
     }
 
-    if plan.run_mutants {
+    if plan.run_mutants && with_mutants {
         let pr_crates =
             mutation_target_crates(base_ref, changed_files, &plan.directly_changed_crates)?;
         if pr_crates.is_empty() {
@@ -1774,6 +1834,11 @@ fn run_pr_plan(
             let pr_crate_refs = pr_crates.iter().map(String::as_str).collect::<Vec<_>>();
             runner.step("mutants", None, || run_mutants(&pr_crate_refs))?;
         }
+    } else if plan.run_mutants {
+        runner.skip(
+            "mutants",
+            Some("split from default pr gate; run cargo xtask pr --with-mutants or cargo xtask mutants-pr --changed".to_string()),
+        );
     } else {
         runner.skip("mutants", Some("no crate source changes".to_string()));
     }


### PR DESCRIPTION
## Summary
- make `cargo xtask pr` a fast PR gate by skipping mutation unless `--with-mutants` is supplied
- add explicit `cargo xtask mutants-pr` selectors for `--changed`, `--crate`, and `--all`, with a `--full-owner` marker for topology/high-risk proof
- update the evidence-lane docs and agent command list with the new mutation commands

## Validation
- `cargo test -p xtask mutants`
- `cargo xtask pr`
- `cargo xtask mutants-pr --crate uselesskey-token` (82 mutants tested: 71 caught, 11 unviable)
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask lint-fix --check`
- `git diff --check`

## Notes
- This preserves mutation as an explicit paid proof path; it only removes the default PR tax.
- PR #506 timed out in the old default `xtask pr` mutation lane, so it should be updated after this lands rather than rerunning the same timeout path.
