### PR TITLE
docs: add scanner-safe bundle reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Validation lanes and the claim boundaries behind them.
 Release-candidate proof and public promise evidence.
 
 - [evidence-matrix-v0.6.1.md](release/evidence-matrix-v0.6.1.md) — v0.6.1 public fixture promise evidence matrix
+- [scanner-safe-bundle](../examples/scanner-safe-bundle/README.md) — Reference manifest, receipts, and Kubernetes/Vault payload shapes for the default bundle lane
 
 ## Explanation
 

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -44,8 +44,8 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 - [x] deterministic bundle receipts under `receipts/materialization.json` and `receipts/audit-surface.json`
 - [x] Kubernetes secret payload emitter
 - [x] Vault payload emitter
-- [ ] Reference manifests for scanner-safe fixture bundles
-- [ ] Release-facing downstream bundle recipes
+- [x] Reference manifests for scanner-safe fixture bundles
+- [x] Release-facing downstream bundle recipes
 
 ## Governance
 

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -23,7 +23,7 @@ This roadmap reflects the strategic direction for uselesskey as a **test-fixture
   scanner-safe profile metadata, deterministic receipts, and Kubernetes/Vault
   payload emitters.
 - [ ] Release governance and post-release audit automation.
-- [ ] Release-facing reference bundle manifests and downstream fixture recipes.
+- [x] Release-facing reference bundle manifests and downstream fixture recipes.
 
 ## Shipped
 

--- a/examples/scanner-safe-bundle/README.md
+++ b/examples/scanner-safe-bundle/README.md
@@ -1,0 +1,59 @@
+# Scanner-Safe Bundle Reference
+
+This example is the release-facing reference for the default bundle handoff
+lane. It shows the CLI path a platform or CI user can copy without committing
+runtime private key material or symmetric secret material.
+
+## Regenerate
+
+```bash
+cargo run -p uselesskey-cli -- bundle \
+  --profile scanner-safe \
+  --out target/uselesskey-bundle
+
+cargo run -p uselesskey-cli -- verify-bundle \
+  --path target/uselesskey-bundle
+
+cargo run -p uselesskey-cli -- export k8s \
+  --bundle-dir target/uselesskey-bundle \
+  --name uselesskey-fixtures \
+  --namespace tests \
+  --out target/uselesskey-bundle/secret.yaml
+
+cargo run -p uselesskey-cli -- export vault-kv-json \
+  --bundle-dir target/uselesskey-bundle \
+  --out target/uselesskey-bundle/kv-v2.json
+```
+
+## Reference Files
+
+The `expected/` directory records exact generated metadata outputs that are safe
+to keep in source control:
+
+- `manifest.json`
+- `receipts/materialization.json`
+- `receipts/audit-surface.json`
+
+The full generated bundle also includes per-artifact files such as
+`rsa.jwk.json`, `jwks.jwks.json`, `x509.pem`, `secret.yaml`, and `kv-v2.json`.
+Those are regenerated under `target/` by the commands above.
+
+The committed export-shape files show downstream payload structure without
+committing high-entropy encoded fixture bytes:
+
+- `secret.shape.yaml`
+- `kv-v2.shape.json`
+
+## Scanner-Safety Boundary
+
+The `scanner-safe` profile emits public key material, public certificate
+material, scanner-safe invalid symmetric JWK shape data, and near-miss token
+shapes. It is intended for parser, configuration, and platform handoff tests.
+
+Kubernetes and Vault exports intentionally encode bundle artifacts for handoff.
+Even when those artifacts are scanner-safe fixtures, committing the encoded
+payloads can still trip high-entropy secret scanners. Keep those generated files
+under `target/` and verify them in CI instead of committing them.
+
+Use `--profile runtime` only when a downstream test truly needs runtime private
+or symmetric fixture material.

--- a/examples/scanner-safe-bundle/expected/kv-v2.shape.json
+++ b/examples/scanner-safe-bundle/expected/kv-v2.shape.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "rsa.jwk.json": "<generated-artifact-text>",
+    "ecdsa.jwk.json": "<generated-artifact-text>",
+    "ed25519.jwk.json": "<generated-artifact-text>",
+    "hmac.jwk.json": "<generated-artifact-text>",
+    "token.json": "<generated-artifact-text>",
+    "x509.pem": "<generated-artifact-text>",
+    "jwk.jwk.json": "<generated-artifact-text>",
+    "jwks.jwks.json": "<generated-artifact-text>"
+  },
+  "metadata": {
+    "mode": "one_shot_export",
+    "source": "uselesskey-cli"
+  }
+}

--- a/examples/scanner-safe-bundle/expected/manifest.json
+++ b/examples/scanner-safe-bundle/expected/manifest.json
@@ -1,0 +1,131 @@
+{
+  "version": 1,
+  "profile": "scanner-safe",
+  "seed": "uselesskey-bundle-seed",
+  "label": "bundle",
+  "format": "jwk",
+  "files": [
+    "rsa.jwk.json",
+    "ecdsa.jwk.json",
+    "ed25519.jwk.json",
+    "hmac.jwk.json",
+    "token.json",
+    "x509.pem",
+    "jwk.jwk.json",
+    "jwks.jwks.json",
+    "receipts/materialization.json",
+    "receipts/audit-surface.json"
+  ],
+  "artifacts": [
+    {
+      "path": "rsa.jwk.json",
+      "kind": "rsa",
+      "format": "jwk",
+      "profile": "scanner-safe",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "scanner_safe": true,
+      "description": "public fixture material"
+    },
+    {
+      "path": "ecdsa.jwk.json",
+      "kind": "ecdsa",
+      "format": "jwk",
+      "profile": "scanner-safe",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "scanner_safe": true,
+      "description": "public fixture material"
+    },
+    {
+      "path": "ed25519.jwk.json",
+      "kind": "ed25519",
+      "format": "jwk",
+      "profile": "scanner-safe",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "scanner_safe": true,
+      "description": "public fixture material"
+    },
+    {
+      "path": "hmac.jwk.json",
+      "kind": "hmac",
+      "format": "jwk",
+      "profile": "scanner-safe",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "scanner_safe": true,
+      "description": "scanner-safe symmetric JWK shape with invalid material"
+    },
+    {
+      "path": "token.json",
+      "kind": "token",
+      "format": "json-manifest",
+      "profile": "scanner-safe",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "scanner_safe": true,
+      "description": "scanner-safe near-miss token shape for parser tests"
+    },
+    {
+      "path": "x509.pem",
+      "kind": "x509",
+      "format": "pem",
+      "profile": "scanner-safe",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "scanner_safe": true,
+      "description": "public certificate fixture"
+    },
+    {
+      "path": "jwk.jwk.json",
+      "kind": "jwk",
+      "format": "jwk",
+      "profile": "scanner-safe",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "scanner_safe": true,
+      "description": "public fixture material"
+    },
+    {
+      "path": "jwks.jwks.json",
+      "kind": "jwks",
+      "format": "jwks",
+      "profile": "scanner-safe",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "scanner_safe": true,
+      "description": "public fixture material"
+    }
+  ],
+  "receipts": [
+    {
+      "path": "receipts/materialization.json",
+      "kind": "materialization",
+      "profile": "scanner-safe",
+      "description": "deterministic bundle materialization receipt"
+    },
+    {
+      "path": "receipts/audit-surface.json",
+      "kind": "audit-surface",
+      "profile": "scanner-safe",
+      "description": "scanner-safety and lane metadata receipt"
+    }
+  ]
+}

--- a/examples/scanner-safe-bundle/expected/receipts/audit-surface.json
+++ b/examples/scanner-safe-bundle/expected/receipts/audit-surface.json
@@ -1,0 +1,71 @@
+{
+  "artifact_count": 8,
+  "artifacts": [
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "rsa",
+      "path": "rsa.jwk.json",
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "ecdsa",
+      "path": "ecdsa.jwk.json",
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "ed25519",
+      "path": "ed25519.jwk.json",
+      "scanner_safe": true
+    },
+    {
+      "description": "scanner-safe symmetric JWK shape with invalid material",
+      "format": "jwk",
+      "kind": "hmac",
+      "path": "hmac.jwk.json",
+      "scanner_safe": true
+    },
+    {
+      "description": "scanner-safe near-miss token shape for parser tests",
+      "format": "json-manifest",
+      "kind": "token",
+      "path": "token.json",
+      "scanner_safe": true
+    },
+    {
+      "description": "public certificate fixture",
+      "format": "pem",
+      "kind": "x509",
+      "path": "x509.pem",
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "jwk",
+      "path": "jwk.jwk.json",
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwks",
+      "kind": "jwks",
+      "path": "jwks.jwks.json",
+      "scanner_safe": true
+    }
+  ],
+  "lanes": [
+    "runtime",
+    "materialized"
+  ],
+  "profile": "scanner-safe",
+  "receipt": "audit-surface",
+  "runtime_material_count": 0,
+  "scanner_safe": true,
+  "scanner_safe_count": 8,
+  "version": 1
+}

--- a/examples/scanner-safe-bundle/expected/receipts/materialization.json
+++ b/examples/scanner-safe-bundle/expected/receipts/materialization.json
@@ -1,0 +1,121 @@
+{
+  "artifact_count": 8,
+  "artifacts": [
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "rsa",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "rsa.jwk.json",
+      "profile": "scanner-safe",
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "ecdsa",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "ecdsa.jwk.json",
+      "profile": "scanner-safe",
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "ed25519",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "ed25519.jwk.json",
+      "profile": "scanner-safe",
+      "scanner_safe": true
+    },
+    {
+      "description": "scanner-safe symmetric JWK shape with invalid material",
+      "format": "jwk",
+      "kind": "hmac",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "hmac.jwk.json",
+      "profile": "scanner-safe",
+      "scanner_safe": true
+    },
+    {
+      "description": "scanner-safe near-miss token shape for parser tests",
+      "format": "json-manifest",
+      "kind": "token",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "token.json",
+      "profile": "scanner-safe",
+      "scanner_safe": true
+    },
+    {
+      "description": "public certificate fixture",
+      "format": "pem",
+      "kind": "x509",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "x509.pem",
+      "profile": "scanner-safe",
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "jwk",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "jwk.jwk.json",
+      "profile": "scanner-safe",
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwks",
+      "kind": "jwks",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "jwks.jwks.json",
+      "profile": "scanner-safe",
+      "scanner_safe": true
+    }
+  ],
+  "files": [
+    "rsa.jwk.json",
+    "ecdsa.jwk.json",
+    "ed25519.jwk.json",
+    "hmac.jwk.json",
+    "token.json",
+    "x509.pem",
+    "jwk.jwk.json",
+    "jwks.jwks.json"
+  ],
+  "format": "jwk",
+  "label": "bundle",
+  "lanes": [
+    "runtime",
+    "materialized"
+  ],
+  "profile": "scanner-safe",
+  "receipt": "materialization",
+  "seed": "uselesskey-bundle-seed",
+  "version": 1
+}

--- a/examples/scanner-safe-bundle/expected/secret.shape.yaml
+++ b/examples/scanner-safe-bundle/expected/secret.shape.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uselesskey-fixtures
+  namespace: tests
+type: Opaque
+data:
+  rsa.jwk.json: <generated-base64-artifact>
+  ecdsa.jwk.json: <generated-base64-artifact>
+  ed25519.jwk.json: <generated-base64-artifact>
+  hmac.jwk.json: <generated-base64-artifact>
+  token.json: <generated-base64-artifact>
+  x509.pem: <generated-base64-artifact>
+  jwk.jwk.json: <generated-base64-artifact>
+  jwks.jwks.json: <generated-base64-artifact>


### PR DESCRIPTION
## Summary
- add a release-facing scanner-safe bundle reference example with exact manifest and receipt outputs
- document the copy-paste bundle, verify, Kubernetes export, and Vault export workflow
- include low-entropy Kubernetes/Vault export shape files instead of committed encoded payloads, and mark the roadmap items complete

## Validation
- cargo run -p uselesskey-cli -- bundle --profile scanner-safe --out target/uselesskey-bundle
- cargo run -p uselesskey-cli -- verify-bundle --path target/uselesskey-bundle
- cargo run -p uselesskey-cli -- export k8s --bundle-dir target/uselesskey-bundle --name uselesskey-fixtures --namespace tests --out target/uselesskey-bundle/secret.yaml
- cargo run -p uselesskey-cli -- export vault-kv-json --bundle-dir target/uselesskey-bundle --out target/uselesskey-bundle/kv-v2.json
- Get-FileHash comparison between expected manifest/receipts and regenerated target manifest/receipts
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask no-blob
- cargo xtask examples-smoke
- git diff --check
- cargo xtask pr
- cargo xtask ripr-pr

## Notes
- Replaces closed #520. That PR committed the generated Kubernetes Secret payload and GitGuardian correctly flagged a base64 high-entropy value. This branch keeps exact metadata references and only commits low-entropy export shapes; generated export payloads stay under `target/`.