### PR TITLE
ci: add scheduled performance evidence workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,111 @@
+name: Performance Evidence
+
+on:
+  schedule:
+    - cron: "37 8 * * 1"
+  workflow_dispatch:
+    inputs:
+      compare:
+        description: Compare latest measurements against docs/metadata/perf-baselines.json.
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  perf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      # actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Install NASM
+        run: sudo apt-get update && sudo apt-get install -y nasm
+
+      - name: Run performance evidence
+        shell: bash
+        run: |
+          compare="${{ inputs.compare }}"
+
+          args=()
+          if [[ -z "$compare" || "$compare" == "true" ]]; then
+            args+=(--compare)
+          fi
+
+          cargo xtask perf "${args[@]}"
+
+      - name: Write performance receipt summary
+        if: always()
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          out_dir = Path("target/xtask/perf")
+          out_dir.mkdir(parents=True, exist_ok=True)
+          latest_path = out_dir / "latest.json"
+          markdown_path = out_dir / "latest.md"
+
+          lines = ["# Performance Evidence", ""]
+
+          if latest_path.exists():
+              latest = json.loads(latest_path.read_text(encoding="utf-8"))
+              scenarios = latest.get("scenarios") or []
+              lines.append(f"- Schema version: `{latest.get('version', 'unknown')}`")
+              lines.append(f"- Generated at unix: `{latest.get('generated_at_unix', 'unknown')}`")
+              lines.append(f"- Scenarios: `{len(scenarios)}`")
+              lines.append("")
+              lines.append("| Scenario | Group | Iterations | Median ns | Mean ns | Output bytes |")
+              lines.append("| --- | --- | ---: | ---: | ---: | ---: |")
+              for scenario in scenarios:
+                  lines.append(
+                      "| `{id}` | `{group}` | {iterations} | {median_ns} | {mean_ns} | {output_bytes} |".format(
+                          id=scenario.get("id", ""),
+                          group=scenario.get("group", ""),
+                          iterations=scenario.get("iterations", 0),
+                          median_ns=scenario.get("median_ns", 0),
+                          mean_ns=scenario.get("mean_ns", 0),
+                          output_bytes=scenario.get("output_bytes", 0),
+                      )
+                  )
+          else:
+              lines.append("- Status: `missing latest.json`")
+              lines.append("- The benchmark command failed before writing a report.")
+
+          lines.append("")
+          lines.append("## Claim Boundary")
+          lines.append("")
+          lines.append("- Performance evidence is host- and runner-sensitive.")
+          lines.append("- It guards fixture-generation cost trends, not cryptographic correctness.")
+          lines.append("- Baseline comparison only blocks entries with `enforce_in_ci = true`.")
+
+          text = "\n".join(lines) + "\n"
+          markdown_path.write_text(text, encoding="utf-8")
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a", encoding="utf-8") as fh:
+                  fh.write(text)
+          else:
+              print(text)
+          PY
+
+      # actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: always()
+        with:
+          name: performance-evidence
+          path: target/xtask/perf
+          if-no-files-found: warn

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -138,6 +138,27 @@ The nightly lane also writes `target/mutation/nightly-receipt.json` and
 scheduled/manual runs parse cargo-mutants `outcomes.json` files into found,
 caught, survived, unviable, timeout, and other counts.
 
+## Performance Evidence
+
+Performance evidence runs in the PR/main CI perf job and in the dedicated
+scheduled/manual workflow at `.github/workflows/performance.yml`.
+
+Run the local performance evidence command with:
+
+```bash
+cargo xtask perf --compare
+```
+
+`cargo xtask perf` writes the machine-readable benchmark report to
+`target/xtask/perf/latest.json`. The scheduled/manual workflow also writes a
+human-readable `target/xtask/perf/latest.md` summary, uploads
+`target/xtask/perf/` as the `performance-evidence` artifact, and compares the
+latest report against `docs/metadata/perf-baselines.json` by default.
+
+This lane is evidence for fixture-generation cost trends. It is runner-sensitive
+and does not prove cryptographic correctness, scanner safety, or deterministic
+identity by itself.
+
 ## Lane 4: Release Evidence
 
 Runs for release branches, release candidates, or tag candidates.
@@ -159,6 +180,7 @@ Signals:
 - docs/examples smoke;
 - adapter matrix checks;
 - receipt drift checks.
+- scheduled/manual performance evidence.
 
 Release evidence should produce durable Markdown and JSON artifacts that can be
 linked from release notes.

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -31,7 +31,7 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 
 - [x] Criterion harness
 - [x] Baseline performance report
-- [ ] Scheduled/manual perf workflow
+- [x] Scheduled/manual perf workflow
 - [x] CI threshold policy for benchmark trends
 - [ ] Release category notes + post-release audit
 - [x] Public surface promise map

--- a/docs/release/evidence-matrix-v0.6.1.md
+++ b/docs/release/evidence-matrix-v0.6.1.md
@@ -25,6 +25,7 @@ tool.
 | RIPR exposure | `cargo xtask ripr-pr` / `target/ripr/pr/*` | Changed release-candidate behavior has oracle-exposure evidence. | Pending RC run |
 | Public mutation scope | `cargo xtask mutants-nightly --scope public` / `target/mutation/*` | Public fixture owners have survivor-regression evidence. | Pending RC run |
 | Survivor ledger | `policy/mutation-survivors.toml` / `target/mutation/survivors.*` | Mutation survivors are classified instead of rediscovered. | Pending RC run |
+| Performance evidence | `cargo xtask perf --compare` / `target/xtask/perf/*` / `.github/workflows/performance.yml` | Fixture-generation and materialization cost trends stay inside enforced budgets or produce a release-visible regression. | Pending RC run |
 | Receipt drift | `cargo xtask economics` and `cargo xtask audit-surface` | Cost and audit-surface receipts are current. | Pending RC run |
 | Scanner guard | `cargo xtask no-blob` | Docs/examples/fixtures do not introduce committed secret-shaped blobs. | Pending RC run |
 | Examples smoke | `cargo xtask examples-smoke` | User-facing examples compile or run according to the curated list. | Pending RC run |


### PR DESCRIPTION
## Summary

- add a dedicated scheduled/manual Performance Evidence workflow
- run `cargo xtask perf --compare` with pinned GitHub actions and minimal permissions
- upload `target/xtask/perf` as the `performance-evidence` artifact, including a human-readable `latest.md` summary
- mark the v0.6.1 scheduled/manual perf workflow item complete and add perf evidence to the release matrix

## Validation

- `cargo test -p xtask perf_baseline_schema_is_valid`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask perf --compare`
- `cargo xtask impacted-evidence --base origin/main`
- `cargo xtask pr`
- `cargo xtask ripr-pr`
- `git diff --check origin/main..HEAD`