### PR TITLE
release: add v0.6.1 category notes and audit checklist

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,8 @@ Validation lanes and the claim boundaries behind them.
 Release-candidate proof and public promise evidence.
 
 - [evidence-matrix-v0.6.1.md](release/evidence-matrix-v0.6.1.md) — v0.6.1 public fixture promise evidence matrix
+- [v0.6.1-category-notes.md](release/v0.6.1-category-notes.md) — Release note category map and draft-audit guidance for v0.6.1
+- [post-release-audit.md](release/post-release-audit.md) — Post-publish verification checklist for public fixture promises
 - [scanner-safe-bundle](../examples/scanner-safe-bundle/README.md) — Reference manifest, receipts, and Kubernetes/Vault payload shapes for the default bundle lane
 
 ## Explanation

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -33,7 +33,7 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 - [x] Baseline performance report
 - [x] Scheduled/manual perf workflow
 - [x] CI threshold policy for benchmark trends
-- [ ] Release category notes + post-release audit
+- [x] Release category notes + post-release audit
 - [x] Public surface promise map
 
 ## v0.6.1 export bundles

--- a/docs/how-to/release.md
+++ b/docs/how-to/release.md
@@ -45,6 +45,10 @@ Before tagging, make sure the release PR has already:
 - updated `CHANGELOG.md`
 - refreshed versioned `uselesskey*` dependency snippets in README/doc examples
 - refreshed receipt docs via `cargo xtask economics` and `cargo xtask audit-surface`
+- reviewed the release category notes in
+  [`docs/release/v0.6.1-category-notes.md`](../release/v0.6.1-category-notes.md)
+- prepared the post-release audit checklist in
+  [`docs/release/post-release-audit.md`](../release/post-release-audit.md)
 
 ## Publish
 
@@ -59,3 +63,10 @@ This command handles crates.io indexing lag automatically. Current behavior:
 - backs off on rate limits (`429` / `too many requests`) with `120 s * attempt`
 - treats "already uploaded" / "already exists" as success for reruns
 - waits 30 s after each successful publish for indexing
+
+## Post-release audit
+
+After publishing, run the
+[post-release audit](../release/post-release-audit.md) before broad
+announcement. The audit verifies GitHub release visibility, crates.io/docs.rs
+state, scanner-safe bundle verification, and evidence artifact links.

--- a/docs/release/post-release-audit.md
+++ b/docs/release/post-release-audit.md
@@ -1,0 +1,102 @@
+# Post-Release Audit
+
+Run this checklist after publishing a `uselesskey` release. It verifies that the
+public fixture promises described in the release notes are visible to users and
+that evidence artifacts remain reachable.
+
+The audit is for release confidence, not production cryptographic assurance.
+`uselesskey` remains a test-fixture layer.
+
+## Inputs
+
+- Release tag, for example `v0.6.1`.
+- Published crate version, for example `0.6.1`.
+- Release evidence matrix for the candidate commit.
+- Release notes generated from `.github/release.yml`.
+
+Set local variables before running commands:
+
+```bash
+TAG=v0.6.1
+VERSION=0.6.1
+```
+
+## Immediate Checks
+
+| Check | Command | Pass condition | If it fails |
+| --- | --- | --- | --- |
+| GitHub release is visible | `gh release view "$TAG"` | Draft is published, tag points at the intended commit, release notes include the fixture-platform claim boundary. | Fix release notes if only text is wrong; otherwise stop and investigate tag/commit mismatch. |
+| Crates are visible | `cargo search uselesskey --limit 5` | The facade version appears on crates.io after indexing delay. | Wait for indexing; if still missing, inspect `cargo xtask publish` output and crates.io package pages. |
+| Facade install path resolves | `cargo search uselesskey --limit 5` plus a fresh downstream smoke crate if needed | Users can resolve the published facade version. | Open a release issue and document dependency-order or indexing symptoms. |
+| Docs.rs build started or completed | Open `https://docs.rs/crate/uselesskey/$VERSION` | docs.rs has accepted the package or shows a build in progress. | Track as a release issue; do not republish solely for docs.rs lag. |
+| Release evidence is linkable | Review the release body and uploaded workflow artifacts | Evidence matrix, receipts, mutation/perf artifacts, and bundle proof are linked or referenced. | Patch release notes with missing links. |
+
+## Public Promise Checks
+
+Run these from a clean checkout or a temporary downstream smoke project once
+crates.io indexing has settled:
+
+```bash
+cargo xtask public-surface
+cargo xtask docs-sync --check
+cargo xtask publish-preflight
+cargo xtask no-blob
+```
+
+For bundle promises, regenerate and verify the default platform lane:
+
+```bash
+cargo run -p uselesskey-cli -- bundle --profile scanner-safe --out target/post-release-bundle
+cargo run -p uselesskey-cli -- verify-bundle --path target/post-release-bundle
+cargo run -p uselesskey-cli -- inspect-bundle --path target/post-release-bundle
+cargo run -p uselesskey-cli -- export k8s \
+  --bundle-dir target/post-release-bundle \
+  --name uselesskey-fixtures \
+  --namespace tests \
+  --out target/post-release-bundle/secret.yaml
+cargo run -p uselesskey-cli -- export vault-kv-json \
+  --bundle-dir target/post-release-bundle \
+  --out target/post-release-bundle/kv-v2.json
+```
+
+For evidence promises, confirm the latest release-candidate artifacts exist:
+
+```bash
+cargo xtask economics
+cargo xtask audit-surface
+cargo xtask perf --compare
+cargo xtask mutants-nightly --scope public --dry-run
+```
+
+The dry-run mutation command verifies scope planning and survivor-ledger parsing.
+Use the scheduled/manual mutation workflow result for actual survivor evidence.
+
+## Audit Record
+
+Record the audit in the release issue or post-release tracking issue with this
+shape:
+
+```markdown
+## Post-release audit for v0.6.1
+
+- Release visible: pass/fail, link
+- Crates.io facade visible: pass/fail, link
+- Docs.rs visible: pass/fail, link
+- Public-surface/docs/package checks: pass/fail, command evidence
+- Scanner-safe bundle verify/export/inspect: pass/fail, artifact path or link
+- Receipts: pass/fail, economics/audit/perf/mutation artifact links
+- Open follow-ups:
+  - issue link or "none"
+```
+
+## Failure Handling
+
+- Text-only release note issue: edit the GitHub release and note the correction
+  in the audit record.
+- Missing docs.rs build: open a follow-up issue and link the docs.rs build log.
+- Crates.io publish gap: pause announcements until the missing crate or facade
+  path is understood.
+- Scanner-safe bundle regression: open a blocking patch issue; do not recommend
+  the affected bundle path until a fix is released.
+- Evidence artifact gap: attach the missing command output or explain why the
+  evidence is not applicable for this release.

--- a/docs/release/v0.6.1-category-notes.md
+++ b/docs/release/v0.6.1-category-notes.md
@@ -1,0 +1,87 @@
+# v0.6.1 Release Category Notes
+
+Use this note when preparing the v0.6.1 release draft. The release should be
+presented as a fixture-platform stabilization release: deterministic fixtures,
+scanner-safe bundles, negative protocol shapes, public-surface discipline, and
+evidence receipts.
+
+This document explains the category intent behind `.github/release.yml`. It is
+not a replacement for reviewing the actual merged PR list before publishing.
+
+## Category Map
+
+| Release category | Labels | Include | Review rule |
+| --- | --- | --- | --- |
+| Features | `enhancement`, `adapters` | New user-facing fixture lanes, bundle/profile commands, adapter surfaces, and public workflow improvements. | Confirm the PR creates or expands a supported user promise. |
+| Fixes | `bug` | Behavior corrections and regression fixes. | Confirm the release note names the affected user workflow or fixture promise. |
+| Docs | `docs`, `documentation` | How-to guides, reference docs, roadmap reconciliation, and release evidence docs. | Keep docs-only entries concise unless they change the recommended user path. |
+| Fixture | `fixtures`, `negatives` | Valid and negative fixture shape work, scanner-safe defaults, deterministic bundle contents, and failure-path coverage. | Prefer failure mode wording, such as duplicate `kid` or `alg: none`, over internal crate names. |
+| Performance | `perf` | Benchmark harness, baseline, scheduled/manual performance evidence, or cost-regression changes. | Link the evidence artifact or command when a release note makes a performance claim. |
+| Maintenance | `dependencies`, `release`, `rust` | Dependency floors, MSRV/toolchain changes, release prep, public-surface governance, and compatibility shims. | Separate user-visible release risk from internal upkeep. |
+| Other Changes | `*` | Anything uncategorized by labels. | Audit this section before publishing; recategorize or intentionally leave only low-signal cleanup. |
+
+## v0.6.1 Draft Shape
+
+### Fixture Platform
+
+Use for the headline user value:
+
+- scanner-safe bundle generation and verification;
+- Kubernetes and Vault-shaped exports;
+- OIDC/JWKS contract pack generation;
+- JWK/JWKS and token-shape negative fixtures;
+- owner-crate proof for supported import surfaces.
+
+### Evidence and Release Proof
+
+Use for proof-oriented changes:
+
+- `cargo xtask ripr-pr` and impacted evidence routing;
+- targeted mutation PR lanes;
+- scheduled/manual mutation and performance evidence;
+- public release evidence matrix;
+- bundle reference manifests and receipts.
+
+### Public Surface and Compatibility
+
+Use for topology and support-surface changes:
+
+- public-surface guardrails;
+- JWK/token/core/X.509 demicrocrate folds;
+- compatibility shims for formerly internal published crates;
+- support matrix and metadata alignment.
+
+### Dependency and Tooling Maintenance
+
+Use for non-product maintenance:
+
+- dependency-floor updates;
+- Rust/MSRV and Clippy policy updates;
+- CI workflow hardening;
+- publish-preflight and package-proof changes.
+
+## Release Note Audit
+
+Before publishing the draft:
+
+1. Generate the release notes from `v0.6.0` to the release candidate.
+2. Review the generated `Other Changes` section.
+3. Confirm every PR with a user-facing fixture, bundle, adapter, or evidence
+   change has a category other than `Other Changes`.
+4. Keep dependency-only and internal cleanup entries out of the headline unless
+   they change release risk.
+5. Confirm the final release summary repeats the claim boundary:
+   `uselesskey` is a test-fixture layer, not production key management or a
+   cryptographic assurance tool.
+
+Useful review commands:
+
+```bash
+gh pr list --state merged --base main --search "merged:>=2026-04-08" \
+  --json number,title,labels,mergedAt,url
+
+gh release create v0.6.1 --draft --generate-notes --notes-start-tag v0.6.0
+```
+
+Do not publish the generated draft until the release evidence matrix has been
+refreshed for the candidate commit.


### PR DESCRIPTION
## Summary

- add v0.6.1 release category notes that map `.github/release.yml` labels to fixture-platform release-note intent
- add a post-release audit checklist for GitHub release, crates.io/docs.rs visibility, scanner-safe bundle verification, and evidence artifacts
- link both docs from the docs index and release how-to
- mark the roadmap follow-up item for release category notes + post-release audit complete

## Validation

- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask impacted-evidence --base origin/main`
- `cargo xtask ripr-pr`
- `cargo xtask pr`
- `git diff --check origin/main..HEAD`