### PR TITLE
release: add v0.6.1 checklist issue map

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Validation lanes and the claim boundaries behind them.
 Release-candidate proof and public promise evidence.
 
 - [evidence-matrix-v0.6.1.md](release/evidence-matrix-v0.6.1.md) — v0.6.1 public fixture promise evidence matrix
+- [v0.6.1-checklist.md](release/v0.6.1-checklist.md) — Release-governance issue map for v0.6.1 checklist lines
 - [v0.6.1-category-notes.md](release/v0.6.1-category-notes.md) — Release note category map and draft-audit guidance for v0.6.1
 - [post-release-audit.md](release/post-release-audit.md) — Post-publish verification checklist for public fixture promises
 - [scanner-safe-bundle](../examples/scanner-safe-bundle/README.md) — Reference manifest, receipts, and Kubernetes/Vault payload shapes for the default bundle lane

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -49,6 +49,6 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 
 ## Governance
 
-- [ ] release governance milestone and labels
+- [x] release governance milestone and labels
 - [x] roadmap link to this follow-up from `roadmap.md`
 - [ ] one issue per checklist line before milestone exit

--- a/docs/how-to/release.md
+++ b/docs/how-to/release.md
@@ -45,6 +45,8 @@ Before tagging, make sure the release PR has already:
 - updated `CHANGELOG.md`
 - refreshed versioned `uselesskey*` dependency snippets in README/doc examples
 - refreshed receipt docs via `cargo xtask economics` and `cargo xtask audit-surface`
+- mapped release checklist lines in
+  [`docs/release/v0.6.1-checklist.md`](../release/v0.6.1-checklist.md)
 - reviewed the release category notes in
   [`docs/release/v0.6.1-category-notes.md`](../release/v0.6.1-category-notes.md)
 - prepared the post-release audit checklist in

--- a/docs/release/v0.6.1-checklist.md
+++ b/docs/release/v0.6.1-checklist.md
@@ -1,0 +1,94 @@
+# v0.6.1 Release Checklist Map
+
+This checklist maps each v0.6.1 release evidence line to a GitHub tracking
+issue slot. It is the handoff artifact for the roadmap rule:
+
+```text
+one issue per checklist line before milestone exit
+```
+
+Do not close the release-governance milestone until every `Issue` cell below is
+either a concrete GitHub issue link or an explicit `Not needed` rationale.
+
+## Governance State
+
+Current GitHub state observed for this checklist:
+
+| Surface | Required state | Current state | Status |
+| --- | --- | --- | --- |
+| Milestone | Release governance milestone exists. | `release governance` milestone is open. | Ready |
+| Release labels | Release-note labels exist for `.github/release.yml` categories. | `enhancement`, `adapters`, `bug`, `docs`, `documentation`, `fixtures`, `negatives`, `perf`, `dependencies`, `release`, and `rust` exist. | Ready |
+| Checklist issues | One issue per checklist line. | Issue slots are defined below. | Pending |
+
+## Required Release Gates
+
+| Checklist line | Issue | Labels | Exit evidence |
+| --- | --- | --- | --- |
+| Public-surface guard | TODO | `release` | `cargo xtask public-surface` result on the release candidate. |
+| Docs drift guard | TODO | `release`, `docs` | `cargo xtask docs-sync --check` result on the release candidate. |
+| Package proof | TODO | `release` | `cargo xtask publish-preflight` result and artifact summary. |
+| Publish dry-run | TODO | `release` | `cargo xtask publish-check` result. |
+| PR evidence lane | TODO | `release` | `cargo xtask pr` result and PR evidence summary artifact. |
+| RIPR exposure | TODO | `release` | `cargo xtask ripr-pr` result and `target/ripr/pr/*` artifact. |
+| Public mutation scope | TODO | `release` | `cargo xtask mutants-nightly --scope public` or scheduled workflow artifact. |
+| Survivor ledger | TODO | `release` | `policy/mutation-survivors.toml` plus `target/mutation/survivors.*`. |
+| Performance evidence | TODO | `release`, `perf` | `cargo xtask perf --compare` or scheduled/manual performance workflow artifact. |
+| Receipt drift | TODO | `release` | `cargo xtask economics`, `cargo xtask audit-surface`, and docs drift result. |
+| Scanner guard | TODO | `release` | `cargo xtask no-blob` result. |
+| Examples smoke | TODO | `release`, `docs` | `cargo xtask examples-smoke` result. |
+| Bundle verifier and inspection | TODO | `release`, `fixtures` | `verify-bundle` and `inspect-bundle` results against the release-candidate bundle. |
+
+## Public Promise Checks
+
+| Checklist line | Issue | Labels | Exit evidence |
+| --- | --- | --- | --- |
+| Default Rust fixture facade | TODO | `release`, `fixtures` | `cargo test -p uselesskey --no-default-features` and `cargo test -p uselesskey --all-features`. |
+| Core deterministic identity | TODO | `release`, `fixtures` | `cargo test -p uselesskey-core --all-features`; no-default core check; mutation evidence when core behavior changed. |
+| JWK/JWKS fixtures and negatives | TODO | `release`, `fixtures`, `negatives` | `cargo test -p uselesskey-jwk --all-features` and mutation evidence when JWK behavior changed. |
+| Token-shape fixtures and negatives | TODO | `release`, `fixtures`, `negatives` | `cargo test -p uselesskey-token --all-features`; `cargo test -p uselesskey-jsonwebtoken --all-features`; mutation evidence when token behavior changed. |
+| Scanner-safe bundle default | TODO | `release`, `fixtures` | `bundle --profile scanner-safe`, `verify-bundle`, `inspect-bundle`, and `cargo xtask no-blob`. |
+| OIDC/JWKS contract pack | TODO | `release`, `fixtures`, `negatives` | `bundle --profile oidc`, `verify-bundle`, and `bundle_profile_oidc_writes_contract_pack`. |
+| Kubernetes and Vault export handoff | TODO | `release`, `fixtures` | `export k8s` and `export vault-kv-json` against a verified scanner-safe bundle. |
+| X.509 and TLS fixtures | TODO | `release`, `fixtures`, `negatives` | `cargo test -p uselesskey-x509 --all-features`; `cargo test -p uselesskey-rustls --all-features`; `cargo test -p uselesskey-tonic --all-features`. |
+| RSA/ECDSA/Ed25519 fixtures | TODO | `release`, `fixtures` | `cargo test -p uselesskey-rsa --all-features`; `cargo test -p uselesskey-ecdsa --all-features`; `cargo test -p uselesskey-ed25519 --all-features`. |
+| HMAC and entropy fixtures | TODO | `release`, `fixtures` | `cargo test -p uselesskey-hmac --all-features`; `cargo test -p uselesskey-entropy --all-features`. |
+| Webhook, WebAuthn, and PKCS#11 test infrastructure | TODO | `release`, `fixtures` | `cargo test -p uselesskey-webhook --all-features`; `cargo test -p uselesskey-webauthn --all-features`; `cargo test -p uselesskey-pkcs11-mock --all-features`. |
+| Native adapter contracts | TODO | `release`, `adapters` | Adapter crate tests plus `cargo xtask examples-smoke`. |
+
+## Issue Creation Template
+
+Use one issue per row above. Keep each issue narrow and attach it to the
+`release governance` milestone.
+
+```markdown
+## Release checklist line
+
+<copy one checklist line>
+
+## Required evidence
+
+- [ ] <copy command or artifact from this checklist>
+- [ ] Link the workflow run, artifact, or local command output in this issue.
+- [ ] Update `docs/release/evidence-matrix-v0.6.1.md` if this line is promoted
+      from `Pending RC run` to concrete evidence.
+
+## Claim boundary
+
+This proves release readiness for a test-fixture promise. It does not prove
+cryptographic correctness or production key-management suitability.
+```
+
+Recommended issue title pattern:
+
+```text
+release(v0.6.1): prove <checklist line>
+```
+
+Recommended labels:
+
+```text
+release
+```
+
+Add `fixtures`, `negatives`, `adapters`, `docs`, or `perf` when the checklist
+line belongs to that surface.


### PR DESCRIPTION
## Summary

- add `docs/release/v0.6.1-checklist.md` as the release-governance issue map
- record the current milestone/label state and every required evidence-matrix checklist line
- link the checklist from the docs index and release how-to
- mark the release governance milestone/labels roadmap item complete while keeping issue creation open

## Validation

- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask impacted-evidence --base origin/main`
- `cargo xtask ripr-pr`
- `cargo xtask pr`
- `git diff --check origin/main..HEAD`