### PR TITLE
release: link v0.6.1 checklist issues

### DIFF
--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -51,4 +51,4 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 
 - [x] release governance milestone and labels
 - [x] roadmap link to this follow-up from `roadmap.md`
-- [ ] one issue per checklist line before milestone exit
+- [x] one issue per checklist line before milestone exit

--- a/docs/release/v0.6.1-checklist.md
+++ b/docs/release/v0.6.1-checklist.md
@@ -18,42 +18,42 @@ Current GitHub state observed for this checklist:
 | --- | --- | --- | --- |
 | Milestone | Release governance milestone exists. | `release governance` milestone is open. | Ready |
 | Release labels | Release-note labels exist for `.github/release.yml` categories. | `enhancement`, `adapters`, `bug`, `docs`, `documentation`, `fixtures`, `negatives`, `perf`, `dependencies`, `release`, and `rust` exist. | Ready |
-| Checklist issues | One issue per checklist line. | Issue slots are defined below. | Pending |
+| Checklist issues | One issue per checklist line. | Issues [#527](https://github.com/EffortlessMetrics/uselesskey/issues/527)-[#551](https://github.com/EffortlessMetrics/uselesskey/issues/551) are linked below. | Ready |
 
 ## Required Release Gates
 
 | Checklist line | Issue | Labels | Exit evidence |
 | --- | --- | --- | --- |
-| Public-surface guard | TODO | `release` | `cargo xtask public-surface` result on the release candidate. |
-| Docs drift guard | TODO | `release`, `docs` | `cargo xtask docs-sync --check` result on the release candidate. |
-| Package proof | TODO | `release` | `cargo xtask publish-preflight` result and artifact summary. |
-| Publish dry-run | TODO | `release` | `cargo xtask publish-check` result. |
-| PR evidence lane | TODO | `release` | `cargo xtask pr` result and PR evidence summary artifact. |
-| RIPR exposure | TODO | `release` | `cargo xtask ripr-pr` result and `target/ripr/pr/*` artifact. |
-| Public mutation scope | TODO | `release` | `cargo xtask mutants-nightly --scope public` or scheduled workflow artifact. |
-| Survivor ledger | TODO | `release` | `policy/mutation-survivors.toml` plus `target/mutation/survivors.*`. |
-| Performance evidence | TODO | `release`, `perf` | `cargo xtask perf --compare` or scheduled/manual performance workflow artifact. |
-| Receipt drift | TODO | `release` | `cargo xtask economics`, `cargo xtask audit-surface`, and docs drift result. |
-| Scanner guard | TODO | `release` | `cargo xtask no-blob` result. |
-| Examples smoke | TODO | `release`, `docs` | `cargo xtask examples-smoke` result. |
-| Bundle verifier and inspection | TODO | `release`, `fixtures` | `verify-bundle` and `inspect-bundle` results against the release-candidate bundle. |
+| Public-surface guard | [#527](https://github.com/EffortlessMetrics/uselesskey/issues/527) | `release` | `cargo xtask public-surface` result on the release candidate. |
+| Docs drift guard | [#528](https://github.com/EffortlessMetrics/uselesskey/issues/528) | `release`, `docs` | `cargo xtask docs-sync --check` result on the release candidate. |
+| Package proof | [#529](https://github.com/EffortlessMetrics/uselesskey/issues/529) | `release` | `cargo xtask publish-preflight` result and artifact summary. |
+| Publish dry-run | [#530](https://github.com/EffortlessMetrics/uselesskey/issues/530) | `release` | `cargo xtask publish-check` result. |
+| PR evidence lane | [#531](https://github.com/EffortlessMetrics/uselesskey/issues/531) | `release` | `cargo xtask pr` result and PR evidence summary artifact. |
+| RIPR exposure | [#532](https://github.com/EffortlessMetrics/uselesskey/issues/532) | `release` | `cargo xtask ripr-pr` result and `target/ripr/pr/*` artifact. |
+| Public mutation scope | [#533](https://github.com/EffortlessMetrics/uselesskey/issues/533) | `release` | `cargo xtask mutants-nightly --scope public` or scheduled workflow artifact. |
+| Survivor ledger | [#534](https://github.com/EffortlessMetrics/uselesskey/issues/534) | `release` | `policy/mutation-survivors.toml` plus `target/mutation/survivors.*`. |
+| Performance evidence | [#535](https://github.com/EffortlessMetrics/uselesskey/issues/535) | `release`, `perf` | `cargo xtask perf --compare` or scheduled/manual performance workflow artifact. |
+| Receipt drift | [#536](https://github.com/EffortlessMetrics/uselesskey/issues/536) | `release` | `cargo xtask economics`, `cargo xtask audit-surface`, and docs drift result. |
+| Scanner guard | [#537](https://github.com/EffortlessMetrics/uselesskey/issues/537) | `release` | `cargo xtask no-blob` result. |
+| Examples smoke | [#538](https://github.com/EffortlessMetrics/uselesskey/issues/538) | `release`, `docs` | `cargo xtask examples-smoke` result. |
+| Bundle verifier and inspection | [#539](https://github.com/EffortlessMetrics/uselesskey/issues/539) | `release`, `fixtures` | `verify-bundle` and `inspect-bundle` results against the release-candidate bundle. |
 
 ## Public Promise Checks
 
 | Checklist line | Issue | Labels | Exit evidence |
 | --- | --- | --- | --- |
-| Default Rust fixture facade | TODO | `release`, `fixtures` | `cargo test -p uselesskey --no-default-features` and `cargo test -p uselesskey --all-features`. |
-| Core deterministic identity | TODO | `release`, `fixtures` | `cargo test -p uselesskey-core --all-features`; no-default core check; mutation evidence when core behavior changed. |
-| JWK/JWKS fixtures and negatives | TODO | `release`, `fixtures`, `negatives` | `cargo test -p uselesskey-jwk --all-features` and mutation evidence when JWK behavior changed. |
-| Token-shape fixtures and negatives | TODO | `release`, `fixtures`, `negatives` | `cargo test -p uselesskey-token --all-features`; `cargo test -p uselesskey-jsonwebtoken --all-features`; mutation evidence when token behavior changed. |
-| Scanner-safe bundle default | TODO | `release`, `fixtures` | `bundle --profile scanner-safe`, `verify-bundle`, `inspect-bundle`, and `cargo xtask no-blob`. |
-| OIDC/JWKS contract pack | TODO | `release`, `fixtures`, `negatives` | `bundle --profile oidc`, `verify-bundle`, and `bundle_profile_oidc_writes_contract_pack`. |
-| Kubernetes and Vault export handoff | TODO | `release`, `fixtures` | `export k8s` and `export vault-kv-json` against a verified scanner-safe bundle. |
-| X.509 and TLS fixtures | TODO | `release`, `fixtures`, `negatives` | `cargo test -p uselesskey-x509 --all-features`; `cargo test -p uselesskey-rustls --all-features`; `cargo test -p uselesskey-tonic --all-features`. |
-| RSA/ECDSA/Ed25519 fixtures | TODO | `release`, `fixtures` | `cargo test -p uselesskey-rsa --all-features`; `cargo test -p uselesskey-ecdsa --all-features`; `cargo test -p uselesskey-ed25519 --all-features`. |
-| HMAC and entropy fixtures | TODO | `release`, `fixtures` | `cargo test -p uselesskey-hmac --all-features`; `cargo test -p uselesskey-entropy --all-features`. |
-| Webhook, WebAuthn, and PKCS#11 test infrastructure | TODO | `release`, `fixtures` | `cargo test -p uselesskey-webhook --all-features`; `cargo test -p uselesskey-webauthn --all-features`; `cargo test -p uselesskey-pkcs11-mock --all-features`. |
-| Native adapter contracts | TODO | `release`, `adapters` | Adapter crate tests plus `cargo xtask examples-smoke`. |
+| Default Rust fixture facade | [#540](https://github.com/EffortlessMetrics/uselesskey/issues/540) | `release`, `fixtures` | `cargo test -p uselesskey --no-default-features` and `cargo test -p uselesskey --all-features`. |
+| Core deterministic identity | [#541](https://github.com/EffortlessMetrics/uselesskey/issues/541) | `release`, `fixtures` | `cargo test -p uselesskey-core --all-features`; no-default core check; mutation evidence when core behavior changed. |
+| JWK/JWKS fixtures and negatives | [#542](https://github.com/EffortlessMetrics/uselesskey/issues/542) | `release`, `fixtures`, `negatives` | `cargo test -p uselesskey-jwk --all-features` and mutation evidence when JWK behavior changed. |
+| Token-shape fixtures and negatives | [#543](https://github.com/EffortlessMetrics/uselesskey/issues/543) | `release`, `fixtures`, `negatives` | `cargo test -p uselesskey-token --all-features`; `cargo test -p uselesskey-jsonwebtoken --all-features`; mutation evidence when token behavior changed. |
+| Scanner-safe bundle default | [#544](https://github.com/EffortlessMetrics/uselesskey/issues/544) | `release`, `fixtures` | `bundle --profile scanner-safe`, `verify-bundle`, `inspect-bundle`, and `cargo xtask no-blob`. |
+| OIDC/JWKS contract pack | [#545](https://github.com/EffortlessMetrics/uselesskey/issues/545) | `release`, `fixtures`, `negatives` | `bundle --profile oidc`, `verify-bundle`, and `bundle_profile_oidc_writes_contract_pack`. |
+| Kubernetes and Vault export handoff | [#546](https://github.com/EffortlessMetrics/uselesskey/issues/546) | `release`, `fixtures` | `export k8s` and `export vault-kv-json` against a verified scanner-safe bundle. |
+| X.509 and TLS fixtures | [#547](https://github.com/EffortlessMetrics/uselesskey/issues/547) | `release`, `fixtures`, `negatives` | `cargo test -p uselesskey-x509 --all-features`; `cargo test -p uselesskey-rustls --all-features`; `cargo test -p uselesskey-tonic --all-features`. |
+| RSA/ECDSA/Ed25519 fixtures | [#548](https://github.com/EffortlessMetrics/uselesskey/issues/548) | `release`, `fixtures` | `cargo test -p uselesskey-rsa --all-features`; `cargo test -p uselesskey-ecdsa --all-features`; `cargo test -p uselesskey-ed25519 --all-features`. |
+| HMAC and entropy fixtures | [#549](https://github.com/EffortlessMetrics/uselesskey/issues/549) | `release`, `fixtures` | `cargo test -p uselesskey-hmac --all-features`; `cargo test -p uselesskey-entropy --all-features`. |
+| Webhook, WebAuthn, and PKCS#11 test infrastructure | [#550](https://github.com/EffortlessMetrics/uselesskey/issues/550) | `release`, `fixtures` | `cargo test -p uselesskey-webhook --all-features`; `cargo test -p uselesskey-webauthn --all-features`; `cargo test -p uselesskey-pkcs11-mock --all-features`. |
+| Native adapter contracts | [#551](https://github.com/EffortlessMetrics/uselesskey/issues/551) | `release`, `adapters` | Adapter crate tests plus `cargo xtask examples-smoke`. |
 
 ## Issue Creation Template
 


### PR DESCRIPTION
## Summary

- link every v0.6.1 release checklist row to its GitHub tracking issue (#527-#551)
- mark the release-governance checklist issue slot as ready
- mark the roadmap follow-up for one issue per checklist line complete

## Validation

- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask impacted-evidence --base origin/main`
- `cargo xtask ripr-pr`
- `cargo xtask pr`
- `git diff --check`

## Notes

Created the linked issues under the `release governance` milestone with the checklist labels from `docs/release/v0.6.1-checklist.md`.