### PR TITLE
release: retarget next evidence to v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Raised MSRV from Rust 1.92 to Rust 1.95.
-- Reconciled the v0.6.1 roadmap status with the landed bundle, verification,
+- Reconciled the v0.7.0 roadmap status with the landed bundle, verification,
   Kubernetes/Vault export, scanner-safe profile, and receipt workflows.
 - Moved JWK/JWKS shape, builder, ordering, and deterministic `kid` internals
   under `uselesskey-jwk::srp::*`, retaining the former `uselesskey-core-jwk*`,

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,9 +43,9 @@ Validation lanes and the claim boundaries behind them.
 
 Release-candidate proof and public promise evidence.
 
-- [evidence-matrix-v0.6.1.md](release/evidence-matrix-v0.6.1.md) — v0.6.1 public fixture promise evidence matrix
-- [v0.6.1-checklist.md](release/v0.6.1-checklist.md) — Release-governance issue map for v0.6.1 checklist lines
-- [v0.6.1-category-notes.md](release/v0.6.1-category-notes.md) — Release note category map and draft-audit guidance for v0.6.1
+- [evidence-matrix-v0.7.0.md](release/evidence-matrix-v0.7.0.md) — v0.7.0 public fixture promise evidence matrix
+- [v0.7.0-checklist.md](release/v0.7.0-checklist.md) — Release-governance issue map for v0.7.0 checklist lines
+- [v0.7.0-category-notes.md](release/v0.7.0-category-notes.md) — Release note category map and draft-audit guidance for v0.7.0
 - [post-release-audit.md](release/post-release-audit.md) — Post-publish verification checklist for public fixture promises
 - [scanner-safe-bundle](../examples/scanner-safe-bundle/README.md) — Reference manifest, receipts, and Kubernetes/Vault payload shapes for the default bundle lane
 

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -185,8 +185,8 @@ Signals:
 Release evidence should produce durable Markdown and JSON artifacts that can be
 linked from release notes.
 
-The v0.6.1 release-candidate checklist starts in
-[`docs/release/evidence-matrix-v0.6.1.md`](../release/evidence-matrix-v0.6.1.md).
+The v0.7.0 release-candidate checklist starts in
+[`docs/release/evidence-matrix-v0.7.0.md`](../release/evidence-matrix-v0.7.0.md).
 
 ## Change-Type Routing
 

--- a/docs/explanation/roadmap-followups-0251.md
+++ b/docs/explanation/roadmap-followups-0251.md
@@ -1,4 +1,4 @@
-# Roadmap Follow-ups (v0.6.x)
+# Roadmap Follow-ups (v0.7.0)
 
 This plan decomposes `roadmap.md` into milestone-aligned execution items.
 
@@ -13,7 +13,7 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 - [x] `cargo xtask audit-surface` receipt
 - [x] v0.6.0 release prep
 
-## v0.6.x stabilization
+## v0.7.0 stabilization
 
 - [x] Refresh advisory-blocked dependency floors
 - [x] Finish open PR queue disposition
@@ -21,13 +21,13 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 - [x] Keep mutation-proof tests aligned with touched fixture identity and shape contracts
 - [x] Review dependency bumps after code keeper branches are settled
 
-## v0.6.1 follow-on negatives
+## v0.7.0 follow-on negatives
 
 - [x] JWK/JWKS negative wave 1
 - [x] token-shape negative wave 1
 - [x] docs/examples coverage for negative fixtures
 
-## v0.6.1 benchmarks and governance
+## v0.7.0 benchmarks and governance
 
 - [x] Criterion harness
 - [x] Baseline performance report
@@ -36,7 +36,7 @@ This plan decomposes `roadmap.md` into milestone-aligned execution items.
 - [x] Release category notes + post-release audit
 - [x] Public surface promise map
 
-## v0.6.1 export bundles
+## v0.7.0 export bundles
 
 - [x] `uselesskey bundle` command design
 - [x] `uselesskey verify-bundle` deterministic manifest verifier

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -2,9 +2,9 @@
 
 This roadmap reflects the strategic direction for uselesskey as a **test-fixture layer** (not a crypto library).
 
-## Now (v0.6.x)
+## Now (v0.7.0)
 
-*Post-0.6.0 stabilization and release-hardening*
+*Rust 1.95 scanner-safe fixture platform release hardening*
 
 - [x] Ship the lane-choice release: entropy, runtime fixtures, and build-time materialization.
 - [x] Add economics and audit-surface receipts as first-class CI artifacts.
@@ -12,7 +12,7 @@ This roadmap reflects the strategic direction for uselesskey as a **test-fixture
 - [x] Finish PR queue disposition: merge reviewed keepers, close superseded duplicates, and park broken dependency bumps with explicit rationale.
 - [x] Keep mutation-proof coverage aligned with fixture identity and shape contracts for touched crates.
 
-## Next (v0.6.1+)
+## Next (after v0.7.0)
 
 *Planned follow-up*
 
@@ -22,7 +22,7 @@ This roadmap reflects the strategic direction for uselesskey as a **test-fixture
 - [x] Export-bundle CLI integration: `uselesskey bundle`, `verify-bundle`,
   scanner-safe profile metadata, deterministic receipts, and Kubernetes/Vault
   payload emitters.
-- [ ] Release governance and post-release audit automation.
+- [x] Release governance and post-release audit automation.
 - [x] Release-facing reference bundle manifests and downstream fixture recipes.
 
 ## Shipped

--- a/docs/how-to/release.md
+++ b/docs/how-to/release.md
@@ -46,9 +46,9 @@ Before tagging, make sure the release PR has already:
 - refreshed versioned `uselesskey*` dependency snippets in README/doc examples
 - refreshed receipt docs via `cargo xtask economics` and `cargo xtask audit-surface`
 - mapped release checklist lines in
-  [`docs/release/v0.6.1-checklist.md`](../release/v0.6.1-checklist.md)
+  [`docs/release/v0.7.0-checklist.md`](../release/v0.7.0-checklist.md)
 - reviewed the release category notes in
-  [`docs/release/v0.6.1-category-notes.md`](../release/v0.6.1-category-notes.md)
+  [`docs/release/v0.7.0-category-notes.md`](../release/v0.7.0-category-notes.md)
 - prepared the post-release audit checklist in
   [`docs/release/post-release-audit.md`](../release/post-release-audit.md)
 

--- a/docs/release/evidence-matrix-v0.7.0.md
+++ b/docs/release/evidence-matrix-v0.7.0.md
@@ -1,9 +1,14 @@
-# v0.6.1 Public Fixture Evidence Matrix
+# v0.7.0 Public Fixture Evidence Matrix
 
 This matrix ties release evidence to user-facing fixture promises. It is not a
-replacement for the release run itself. Before cutting v0.6.1, refresh each
+replacement for the release run itself. Before cutting v0.7.0, refresh each
 listed command on the release candidate and replace `Pending RC run` with the
 actual result, artifact, or issue link.
+
+v0.6.0 is the Rust 1.92 crates.io baseline. v0.7.0 is the next release and the
+Rust 1.95 scanner-safe fixture platform release. It keeps published internal
+implementation shards as compatibility shims for this release while directing
+users to the owner crates and facade surfaces.
 
 The release claim is narrow:
 
@@ -15,7 +20,7 @@ tool.
 
 ## Required Release Gates
 
-| Gate | Command or artifact | Release claim covered | v0.6.1 status |
+| Gate | Command or artifact | Release claim covered | v0.7.0 status |
 | --- | --- | --- | --- |
 | Public-surface guard | `cargo xtask public-surface` | Public crates match the documented support promises. | Pending RC run |
 | Docs drift guard | `cargo xtask docs-sync --check` | User docs, snippets, and support metadata are synchronized. | Pending RC run |
@@ -33,7 +38,7 @@ tool.
 
 ## Public Promise Matrix
 
-| Public promise | Crates or surfaces | Required evidence | Artifact or command | v0.6.1 status |
+| Public promise | Crates or surfaces | Required evidence | Artifact or command | v0.7.0 status |
 | --- | --- | --- | --- | --- |
 | Default Rust fixture facade | `uselesskey` | No-default and feature-enabled facade checks; docs snippets remain synchronized. | `cargo test -p uselesskey --no-default-features`; `cargo test -p uselesskey --all-features`; `cargo xtask docs-sync --check` | Pending RC run |
 | Core deterministic identity | `uselesskey-core` | Derivation, seed, identity, cache, sink, and negative-helper behavior retain focused tests and mutation evidence. | `cargo test -p uselesskey-core --all-features`; `cargo test -p uselesskey-core --no-default-features`; `cargo xtask mutants-pr --crate uselesskey-core --full-owner` when core behavior changed | Pending RC run |
@@ -50,9 +55,8 @@ tool.
 
 ## Bundle Reference Evidence
 
-The v0.6.1 roadmap still tracks release-facing reference manifests and
-downstream fixture recipes separately. Until those examples land, the release
-candidate must at least attach or link a generated scanner-safe bundle proof:
+The v0.7.0 release candidate must attach or link a generated scanner-safe bundle
+proof:
 
 ```bash
 cargo run -p uselesskey-cli -- bundle --profile scanner-safe --out target/uselesskey-bundle

--- a/docs/release/post-release-audit.md
+++ b/docs/release/post-release-audit.md
@@ -9,16 +9,16 @@ The audit is for release confidence, not production cryptographic assurance.
 
 ## Inputs
 
-- Release tag, for example `v0.6.1`.
-- Published crate version, for example `0.6.1`.
+- Release tag, for example `v0.7.0`.
+- Published crate version, for example `0.7.0`.
 - Release evidence matrix for the candidate commit.
 - Release notes generated from `.github/release.yml`.
 
 Set local variables before running commands:
 
 ```bash
-TAG=v0.6.1
-VERSION=0.6.1
+TAG=v0.7.0
+VERSION=0.7.0
 ```
 
 ## Immediate Checks
@@ -77,7 +77,7 @@ Record the audit in the release issue or post-release tracking issue with this
 shape:
 
 ```markdown
-## Post-release audit for v0.6.1
+## Post-release audit for v0.7.0
 
 - Release visible: pass/fail, link
 - Crates.io facade visible: pass/fail, link

--- a/docs/release/v0.7.0-category-notes.md
+++ b/docs/release/v0.7.0-category-notes.md
@@ -1,9 +1,9 @@
-# v0.6.1 Release Category Notes
+# v0.7.0 Release Category Notes
 
-Use this note when preparing the v0.6.1 release draft. The release should be
-presented as a fixture-platform stabilization release: deterministic fixtures,
-scanner-safe bundles, negative protocol shapes, public-surface discipline, and
-evidence receipts.
+Use this note when preparing the v0.7.0 release draft. The release should be
+presented as the Rust 1.95 scanner-safe fixture platform release: deterministic
+fixtures, scanner-safe bundles, negative protocol shapes, public-surface
+discipline, and evidence receipts.
 
 This document explains the category intent behind `.github/release.yml`. It is
 not a replacement for reviewing the actual merged PR list before publishing.
@@ -20,7 +20,7 @@ not a replacement for reviewing the actual merged PR list before publishing.
 | Maintenance | `dependencies`, `release`, `rust` | Dependency floors, MSRV/toolchain changes, release prep, public-surface governance, and compatibility shims. | Separate user-visible release risk from internal upkeep. |
 | Other Changes | `*` | Anything uncategorized by labels. | Audit this section before publishing; recategorize or intentionally leave only low-signal cleanup. |
 
-## v0.6.1 Draft Shape
+## v0.7.0 Draft Shape
 
 ### Fixture Platform
 
@@ -56,7 +56,7 @@ Use for topology and support-surface changes:
 Use for non-product maintenance:
 
 - dependency-floor updates;
-- Rust/MSRV and Clippy policy updates;
+- Rust/MSRV 1.95 and Clippy policy updates;
 - CI workflow hardening;
 - publish-preflight and package-proof changes.
 
@@ -80,7 +80,7 @@ Useful review commands:
 gh pr list --state merged --base main --search "merged:>=2026-04-08" \
   --json number,title,labels,mergedAt,url
 
-gh release create v0.6.1 --draft --generate-notes --notes-start-tag v0.6.0
+gh release create v0.7.0 --draft --generate-notes --notes-start-tag v0.6.0
 ```
 
 Do not publish the generated draft until the release evidence matrix has been

--- a/docs/release/v0.7.0-checklist.md
+++ b/docs/release/v0.7.0-checklist.md
@@ -1,6 +1,6 @@
-# v0.6.1 Release Checklist Map
+# v0.7.0 Release Checklist Map
 
-This checklist maps each v0.6.1 release evidence line to a GitHub tracking
+This checklist maps each v0.7.0 release evidence line to a GitHub tracking
 issue slot. It is the handoff artifact for the roadmap rule:
 
 ```text
@@ -69,7 +69,7 @@ Use one issue per row above. Keep each issue narrow and attach it to the
 
 - [ ] <copy command or artifact from this checklist>
 - [ ] Link the workflow run, artifact, or local command output in this issue.
-- [ ] Update `docs/release/evidence-matrix-v0.6.1.md` if this line is promoted
+- [ ] Update `docs/release/evidence-matrix-v0.7.0.md` if this line is promoted
       from `Pending RC run` to concrete evidence.
 
 ## Claim boundary
@@ -81,7 +81,7 @@ cryptographic correctness or production key-management suitability.
 Recommended issue title pattern:
 
 ```text
-release(v0.6.1): prove <checklist line>
+release(v0.7.0): prove <checklist line>
 ```
 
 Recommended labels:


### PR DESCRIPTION
## Summary

- retarget next-release evidence docs from v0.6.1 to v0.7.0
- rename the release matrix, checklist, and category notes files to v0.7.0
- record v0.6.0 as the Rust 1.92 crates.io baseline and v0.7.0 as the Rust 1.95 scanner-safe fixture platform release
- update roadmap, release guide, docs index, post-release audit examples, and changelog wording

## GitHub tracking

- retitled checklist issues #527-#551 from `release(v0.6.1): ...` to `release(v0.7.0): ...`
- updated those issue bodies to point at `docs/release/evidence-matrix-v0.7.0.md`

## Validation

- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask impacted-evidence --base origin/main`
- `cargo xtask ripr-pr`
- `cargo xtask pr`
- `git diff --check origin/main..HEAD`