### PR TITLE
release: bump workspace packages to v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Raised MSRV from Rust 1.92 to Rust 1.95.
+- Prepared workspace packages and retained compatibility shims for the v0.7.0
+  package line.
 - Reconciled the v0.7.0 roadmap status with the landed bundle, verification,
   Kubernetes/Vault export, scanner-safe profile, and receipt workflows.
 - Moved JWK/JWKS shape, builder, ordering, and deterministic `kid` internals

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "criterion",
  "insta",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-aws-lc-rs"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aws-lc-rs",
  "hex",
@@ -4612,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-axum"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "axum",
  "http",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-bdd-steps"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "blake3",
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-base62"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-cache"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4757,7 +4757,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-factory"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-hash"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "insta",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-hmac-spec"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-id"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwk-builder"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4824,7 +4824,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwk-shape"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-jwks-order"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4845,7 +4845,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-keypair"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-keypair-material"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-kid"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "blake3",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative-der"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4903,7 +4903,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-negative-pem"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-rustls-pki"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "rustls-pki-types",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-seed"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "blake3",
  "insta",
@@ -4940,7 +4940,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-sink"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-token"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "insta",
@@ -4965,7 +4965,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-token-shape"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "insta",
@@ -4978,7 +4978,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-chain-negative"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-derive"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -5017,7 +5017,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-negative"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core-x509-spec"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ecdsa"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "elliptic-curve 0.14.0-rc.29",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ed25519"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-entropy"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "proptest",
  "uselesskey-core",
@@ -5087,14 +5087,14 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-feature-grid"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "uselesskey-test-support",
 ]
 
 [[package]]
 name = "uselesskey-hmac"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "insta",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jose-openid"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "jsonwebtoken",
  "serde",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jsonwebtoken"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "jsonwebtoken",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jwk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "blake3",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pgp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "pgp",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pgp-native"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "pgp",
  "uselesskey-core",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pkcs11-mock"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "sha2 0.11.0",
  "uselesskey-core",
@@ -5248,7 +5248,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ring"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "hex",
  "insta",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rsa"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "insta",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustcrypto"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustls"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "hex",
  "insta",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ssh"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "proptest",
  "rand_chacha 0.3.1",
@@ -5334,14 +5334,14 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-test-grid"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "uselesskey-feature-grid",
 ]
 
 [[package]]
 name = "uselesskey-test-server"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "axum",
  "blake3",
@@ -5360,11 +5360,11 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-test-support"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "uselesskey-token"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "insta",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-token-spec"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "serde",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-tonic"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "insta",
  "proptest",
@@ -5399,7 +5399,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-webauthn"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ciborium",
  "serde_json",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-webhook"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "hex",
@@ -5424,7 +5424,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-x509"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,46 +81,46 @@ authors = ["Effortless Metrics <opensource@effortlessmetrics.com>"]
 # error handling
 thiserror = "2.0.18"
 
-uselesskey-test-grid = { path = "crates/uselesskey-test-grid", version = "0.6.0" }
-uselesskey-test-support = { path = "crates/uselesskey-test-support", version = "0.6.0" }
-uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid", version = "0.6.0" }
-uselesskey = { path = "crates/uselesskey", version = "0.6.0", default-features = false }
-uselesskey-cli = { path = "crates/uselesskey-cli", version = "0.6.0" }
-uselesskey-entropy = { path = "crates/uselesskey-entropy", version = "0.6.0" }
-uselesskey-core = { path = "crates/uselesskey-core", version = "0.6.0" }
-uselesskey-rsa = { path = "crates/uselesskey-rsa", version = "0.6.0" }
-uselesskey-ecdsa = { path = "crates/uselesskey-ecdsa", version = "0.6.0" }
-uselesskey-ed25519 = { path = "crates/uselesskey-ed25519", version = "0.6.0" }
-uselesskey-hmac = { path = "crates/uselesskey-hmac", version = "0.6.0" }
-uselesskey-token = { path = "crates/uselesskey-token", version = "0.6.0" }
-uselesskey-x509 = { path = "crates/uselesskey-x509", version = "0.6.0" }
-uselesskey-core-base62 = { path = "crates/uselesskey-core-base62", version = "0.6.0" }
-uselesskey-core-cache = { path = "crates/uselesskey-core-cache", version = "0.6.0", default-features = false }
-uselesskey-core-factory = { path = "crates/uselesskey-core-factory", version = "0.6.0" }
-uselesskey-core-jwks-order = { path = "crates/uselesskey-core-jwks-order", version = "0.6.0" }
-uselesskey-core-hash = { path = "crates/uselesskey-core-hash", version = "0.6.0", default-features = false }
-uselesskey-core-token-shape = { path = "crates/uselesskey-core-token-shape", version = "0.6.0" }
-uselesskey-core-id = { path = "crates/uselesskey-core-id", version = "0.6.0", default-features = false }
-uselesskey-core-seed = { path = "crates/uselesskey-core-seed", version = "0.6.0", default-features = false }
-uselesskey-core-kid = { path = "crates/uselesskey-core-kid", version = "0.6.0" }
-uselesskey-core-keypair = { path = "crates/uselesskey-core-keypair", version = "0.6.0" }
-uselesskey-core-keypair-material = { path = "crates/uselesskey-core-keypair-material", version = "0.6.0" }
-uselesskey-core-negative = { path = "crates/uselesskey-core-negative", version = "0.6.0", default-features = false }
-uselesskey-core-negative-der = { path = "crates/uselesskey-core-negative-der", version = "0.6.0", default-features = false }
-uselesskey-core-negative-pem = { path = "crates/uselesskey-core-negative-pem", version = "0.6.0", default-features = false }
-uselesskey-core-token = { path = "crates/uselesskey-core-token", version = "0.6.0" }
-uselesskey-webhook = { path = "crates/uselesskey-webhook", version = "0.6.0" }
-uselesskey-token-spec = { path = "crates/uselesskey-token-spec", version = "0.6.0" }
-uselesskey-ssh = { path = "crates/uselesskey-ssh", version = "0.6.0" }
-uselesskey-core-jwk-builder = { path = "crates/uselesskey-core-jwk-builder", version = "0.6.0" }
-uselesskey-core-jwk = { path = "crates/uselesskey-core-jwk", version = "0.6.0" }
-uselesskey-core-hmac-spec = { path = "crates/uselesskey-core-hmac-spec", version = "0.6.0" }
-uselesskey-core-jwk-shape = { path = "crates/uselesskey-core-jwk-shape", version = "0.6.0" }
-uselesskey-core-x509-derive = { path = "crates/uselesskey-core-x509-derive", version = "0.6.0" }
-uselesskey-core-x509-chain-negative = { path = "crates/uselesskey-core-x509-chain-negative", version = "0.6.0" }
-uselesskey-core-x509-negative = { path = "crates/uselesskey-core-x509-negative", version = "0.6.0" }
-uselesskey-core-x509-spec = { path = "crates/uselesskey-core-x509-spec", version = "0.6.0" }
-uselesskey-core-x509 = { path = "crates/uselesskey-core-x509", version = "0.6.0" }
+uselesskey-test-grid = { path = "crates/uselesskey-test-grid", version = "0.7.0" }
+uselesskey-test-support = { path = "crates/uselesskey-test-support", version = "0.7.0" }
+uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid", version = "0.7.0" }
+uselesskey = { path = "crates/uselesskey", version = "0.7.0", default-features = false }
+uselesskey-cli = { path = "crates/uselesskey-cli", version = "0.7.0" }
+uselesskey-entropy = { path = "crates/uselesskey-entropy", version = "0.7.0" }
+uselesskey-core = { path = "crates/uselesskey-core", version = "0.7.0" }
+uselesskey-rsa = { path = "crates/uselesskey-rsa", version = "0.7.0" }
+uselesskey-ecdsa = { path = "crates/uselesskey-ecdsa", version = "0.7.0" }
+uselesskey-ed25519 = { path = "crates/uselesskey-ed25519", version = "0.7.0" }
+uselesskey-hmac = { path = "crates/uselesskey-hmac", version = "0.7.0" }
+uselesskey-token = { path = "crates/uselesskey-token", version = "0.7.0" }
+uselesskey-x509 = { path = "crates/uselesskey-x509", version = "0.7.0" }
+uselesskey-core-base62 = { path = "crates/uselesskey-core-base62", version = "0.7.0" }
+uselesskey-core-cache = { path = "crates/uselesskey-core-cache", version = "0.7.0", default-features = false }
+uselesskey-core-factory = { path = "crates/uselesskey-core-factory", version = "0.7.0" }
+uselesskey-core-jwks-order = { path = "crates/uselesskey-core-jwks-order", version = "0.7.0" }
+uselesskey-core-hash = { path = "crates/uselesskey-core-hash", version = "0.7.0", default-features = false }
+uselesskey-core-token-shape = { path = "crates/uselesskey-core-token-shape", version = "0.7.0" }
+uselesskey-core-id = { path = "crates/uselesskey-core-id", version = "0.7.0", default-features = false }
+uselesskey-core-seed = { path = "crates/uselesskey-core-seed", version = "0.7.0", default-features = false }
+uselesskey-core-kid = { path = "crates/uselesskey-core-kid", version = "0.7.0" }
+uselesskey-core-keypair = { path = "crates/uselesskey-core-keypair", version = "0.7.0" }
+uselesskey-core-keypair-material = { path = "crates/uselesskey-core-keypair-material", version = "0.7.0" }
+uselesskey-core-negative = { path = "crates/uselesskey-core-negative", version = "0.7.0", default-features = false }
+uselesskey-core-negative-der = { path = "crates/uselesskey-core-negative-der", version = "0.7.0", default-features = false }
+uselesskey-core-negative-pem = { path = "crates/uselesskey-core-negative-pem", version = "0.7.0", default-features = false }
+uselesskey-core-token = { path = "crates/uselesskey-core-token", version = "0.7.0" }
+uselesskey-webhook = { path = "crates/uselesskey-webhook", version = "0.7.0" }
+uselesskey-token-spec = { path = "crates/uselesskey-token-spec", version = "0.7.0" }
+uselesskey-ssh = { path = "crates/uselesskey-ssh", version = "0.7.0" }
+uselesskey-core-jwk-builder = { path = "crates/uselesskey-core-jwk-builder", version = "0.7.0" }
+uselesskey-core-jwk = { path = "crates/uselesskey-core-jwk", version = "0.7.0" }
+uselesskey-core-hmac-spec = { path = "crates/uselesskey-core-hmac-spec", version = "0.7.0" }
+uselesskey-core-jwk-shape = { path = "crates/uselesskey-core-jwk-shape", version = "0.7.0" }
+uselesskey-core-x509-derive = { path = "crates/uselesskey-core-x509-derive", version = "0.7.0" }
+uselesskey-core-x509-chain-negative = { path = "crates/uselesskey-core-x509-chain-negative", version = "0.7.0" }
+uselesskey-core-x509-negative = { path = "crates/uselesskey-core-x509-negative", version = "0.7.0" }
+uselesskey-core-x509-spec = { path = "crates/uselesskey-core-x509-spec", version = "0.7.0" }
+uselesskey-core-x509 = { path = "crates/uselesskey-core-x509", version = "0.7.0" }
 
 # determinism / hashing
 blake3 = "1.8.4"
@@ -135,7 +135,7 @@ rand_chacha10 = { package = "rand_chacha", version = "0.10.0", default-features 
 
 # sinks
 tempfile = "3.27.0"
-uselesskey-core-sink = { path = "crates/uselesskey-core-sink", version = "0.6.0" }
+uselesskey-core-sink = { path = "crates/uselesskey-core-sink", version = "0.7.0" }
 
 # testing
 proptest = "1.11.0"

--- a/README.md
+++ b/README.md
@@ -92,31 +92,31 @@ Common starting points:
 ```toml
 # Entropy-only fixtures
 [dev-dependencies]
-uselesskey = { version = "0.6.0", default-features = false, features = ["entropy"] }
+uselesskey = { version = "0.7.0", default-features = false, features = ["entropy"] }
 ```
 
 ```toml
 # RSA fixtures
 [dev-dependencies]
-uselesskey = { version = "0.6.0", features = ["rsa"] }
+uselesskey = { version = "0.7.0", features = ["rsa"] }
 ```
 
 ```toml
 # Token-only fixtures, no RSA/X.509 pull-in
 [dev-dependencies]
-uselesskey = { version = "0.6.0", default-features = false, features = ["token"] }
+uselesskey = { version = "0.7.0", default-features = false, features = ["token"] }
 ```
 
 ```toml
 # RSA + JWK/JWKS
 [dev-dependencies]
-uselesskey = { version = "0.6.0", features = ["rsa", "jwk"] }
+uselesskey = { version = "0.7.0", features = ["rsa", "jwk"] }
 ```
 
 ```toml
 # X.509 fixtures
 [dev-dependencies]
-uselesskey = { version = "0.6.0", features = ["x509"] }
+uselesskey = { version = "0.7.0", features = ["x509"] }
 ```
 
 ```bash
@@ -130,13 +130,13 @@ For `build.rs` consumers:
 ```toml
 # Common shape-only build-time path
 [build-dependencies]
-uselesskey-cli = { version = "0.6.0", default-features = false }
+uselesskey-cli = { version = "0.7.0", default-features = false }
 ```
 
 ```toml
 # Specialized RSA PKCS#8 build-time path
 [build-dependencies]
-uselesskey-cli = { version = "0.6.0", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.7.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 Use the facade for convenience. Depend on leaf crates only when compile-time minimization matters enough to justify the sharper API.
@@ -189,53 +189,53 @@ Dependency snippets:
 - **Quick start (RSA)**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa"] }
+  uselesskey = { version = "0.7.0", features = ["rsa"] }
   ```
 
 
 - **Token-only**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", default-features = false, features = ["token"] }
+  uselesskey = { version = "0.7.0", default-features = false, features = ["token"] }
   ```
 
 
 - **JWT/JWK**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa", "jwk"] }
+  uselesskey = { version = "0.7.0", features = ["rsa", "jwk"] }
   ```
 
 
 - **X.509 + rustls**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["x509"] }
-  uselesskey-rustls = { version = "0.6.0", features = ["tls-config", "rustls-ring"] }
+  uselesskey = { version = "0.7.0", features = ["x509"] }
+  uselesskey-rustls = { version = "0.7.0", features = ["tls-config", "rustls-ring"] }
   ```
 
 
 - **jsonwebtoken adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jsonwebtoken = { version = "0.6.0" }
+  uselesskey = { version = "0.7.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jsonwebtoken = { version = "0.7.0" }
   ```
 
 
 - **JOSE/OpenID adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jose-openid = { version = "0.6.0" }
+  uselesskey = { version = "0.7.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jose-openid = { version = "0.7.0" }
   ```
 
 
 - **pgp-native adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["pgp"] }
-  uselesskey-pgp-native = { version = "0.6.0" }
+  uselesskey = { version = "0.7.0", features = ["pgp"] }
+  uselesskey-pgp-native = { version = "0.7.0" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 
@@ -364,8 +364,8 @@ With the `tls-config` feature, build rustls configs in one step:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.6.0", features = ["x509"] }
-uselesskey-rustls = { version = "0.6.0", features = ["tls-config", "rustls-ring"] }
+uselesskey = { version = "0.7.0", features = ["x509"] }
+uselesskey-rustls = { version = "0.7.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```rust
@@ -383,8 +383,8 @@ let client_config = chain.client_config_rustls();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.6.0", features = ["rsa"] }
-uselesskey-ring = { version = "0.6.0", features = ["all"] }
+uselesskey = { version = "0.7.0", features = ["rsa"] }
+uselesskey-ring = { version = "0.7.0", features = ["all"] }
 ```
 
 ```rust
@@ -400,8 +400,8 @@ let ring_kp = rsa.rsa_key_pair_ring();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.6.0", features = ["rsa"] }
-uselesskey-rustcrypto = { version = "0.6.0", features = ["all"] }
+uselesskey = { version = "0.7.0", features = ["rsa"] }
+uselesskey-rustcrypto = { version = "0.7.0", features = ["all"] }
 ```
 
 ```rust
@@ -417,8 +417,8 @@ let rsa_pk = rsa.rsa_private_key();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.6.0", features = ["rsa"] }
-uselesskey-aws-lc-rs = { version = "0.6.0", features = ["native", "all"] }
+uselesskey = { version = "0.7.0", features = ["rsa"] }
+uselesskey-aws-lc-rs = { version = "0.7.0", features = ["native", "all"] }
 ```
 
 ```rust
@@ -434,8 +434,8 @@ let lc_kp = rsa.rsa_key_pair_aws_lc_rs();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.6.0", features = ["x509"] }
-uselesskey-tonic = "0.6.0"
+uselesskey = { version = "0.7.0", features = ["x509"] }
+uselesskey-tonic = "0.7.0"
 ```
 
 ```rust

--- a/crates/materialize-buildrs-example/Cargo.toml
+++ b/crates/materialize-buildrs-example/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 description = "Build-time materialization example for uselesskey fixtures."
 
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.6.0", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.7.0", default-features = false, features = ["rsa-materialize"] }
 
 [lints]
 workspace = true

--- a/crates/materialize-shape-buildrs-example/Cargo.toml
+++ b/crates/materialize-shape-buildrs-example/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 description = "Build-time shape-only materialization example for uselesskey fixtures."
 
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.6.0", default-features = false }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.7.0", default-features = false }
 
 
 [lints]

--- a/crates/uselesskey-aws-lc-rs/Cargo.toml
+++ b/crates/uselesskey-aws-lc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-aws-lc-rs"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,9 +18,9 @@ authors.workspace = true
 aws-lc-rs = { version = "1", optional = true }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -38,10 +38,10 @@ ed25519 = ["dep:uselesskey-ed25519"]
 all = ["native", "rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0" }
 aws-lc-rs = "1"
 hex = "0.4"
 serde.workspace = true

--- a/crates/uselesskey-aws-lc-rs/README.md
+++ b/crates/uselesskey-aws-lc-rs/README.md
@@ -20,7 +20,7 @@ When `native` is disabled, this crate builds as a no-op and exports no adapter t
 
 ```toml
 [dev-dependencies]
-uselesskey-aws-lc-rs = { version = "0.6.0", features = ["native", "rsa"] }
+uselesskey-aws-lc-rs = { version = "0.7.0", features = ["native", "rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-axum/Cargo.toml
+++ b/crates/uselesskey-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-axum"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -21,8 +21,8 @@ jsonwebtoken.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tower = { version = "0.5.2", features = ["util"] }
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", features = ["jwk"] }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", features = ["jwk"] }
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/uselesskey-bdd-steps/Cargo.toml
+++ b/crates/uselesskey-bdd-steps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-bdd-steps"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -36,11 +36,11 @@ x509-parser = "0.18.1"
 serde_json.workspace = true
 base64.workspace = true
 pgp = { version = "0.19.0", default-features = false }
-uselesskey-aws-lc-rs = { path = "../uselesskey-aws-lc-rs", version = "0.6.0", optional = true, default-features = false, features = ["all"] }
-uselesskey-ring = { path = "../uselesskey-ring", version = "0.6.0", optional = true, default-features = false, features = ["all"] }
-uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", version = "0.6.0", optional = true, default-features = false, features = ["all"] }
-uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.6.0", optional = true, default-features = false, features = ["x509", "tls-config", "rustls-ring"] }
-uselesskey-tonic = { path = "../uselesskey-tonic", version = "0.6.0", optional = true, default-features = false, features = ["x509"] }
+uselesskey-aws-lc-rs = { path = "../uselesskey-aws-lc-rs", version = "0.7.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-ring = { path = "../uselesskey-ring", version = "0.7.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", version = "0.7.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.7.0", optional = true, default-features = false, features = ["x509", "tls-config", "rustls-ring"] }
+uselesskey-tonic = { path = "../uselesskey-tonic", version = "0.7.0", optional = true, default-features = false, features = ["x509"] }
 hmac = { version = "0.13.0-rc.6", optional = true }
 aws-lc-rs = { version = "1", optional = true }
 ring = { workspace = true, optional = true }

--- a/crates/uselesskey-bench/Cargo.toml
+++ b/crates/uselesskey-bench/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 tempfile.workspace = true
 uselesskey = { path = "../uselesskey", features = ["full"] }
 uselesskey-cli.workspace = true
-uselesskey-pkcs11-mock = { path = "../uselesskey-pkcs11-mock", version = "0.6.0" }
-uselesskey-webauthn = { path = "../uselesskey-webauthn", version = "0.6.0" }
+uselesskey-pkcs11-mock = { path = "../uselesskey-pkcs11-mock", version = "0.7.0" }
+uselesskey-webauthn = { path = "../uselesskey-webauthn", version = "0.7.0" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/uselesskey-cli/Cargo.toml
+++ b/crates/uselesskey-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -41,7 +41,7 @@ uselesskey-core.workspace = true
 uselesskey-ecdsa = { workspace = true, features = ["jwk"], optional = true }
 uselesskey-ed25519 = { workspace = true, features = ["jwk"], optional = true }
 uselesskey-hmac = { workspace = true, features = ["jwk"], optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0" }
 uselesskey-rsa = { workspace = true, features = ["jwk"], optional = true }
 uselesskey-token.workspace = true
 uselesskey-x509 = { workspace = true, optional = true }

--- a/crates/uselesskey-cli/README.md
+++ b/crates/uselesskey-cli/README.md
@@ -27,14 +27,14 @@ cargo run -p uselesskey-cli -- verify \
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.6.0", default-features = false }
+uselesskey-cli = { version = "0.7.0", default-features = false }
 ```
 
 Specialized RSA PKCS#8 build-time lane:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.6.0", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.7.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 The workspace ships both compiled build-time examples:

--- a/crates/uselesskey-core-base62/Cargo.toml
+++ b/crates/uselesskey-core-base62/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-base62"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-cache/Cargo.toml
+++ b/crates/uselesskey-core-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-cache"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-cache"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0", default-features = false }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-factory/Cargo.toml
+++ b/crates/uselesskey-core-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-factory"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-factory"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0", default-features = false }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-hash/Cargo.toml
+++ b/crates/uselesskey-core-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-hash"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-hash"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0", default-features = false }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 blake3.workspace = true

--- a/crates/uselesskey-core-hmac-spec/Cargo.toml
+++ b/crates/uselesskey-core-hmac-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-hmac-spec"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-id/Cargo.toml
+++ b/crates/uselesskey-core-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-id"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-id"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0", default-features = false }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-jwk-builder/Cargo.toml
+++ b/crates/uselesskey-core-jwk-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-jwk-builder"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,14 +15,14 @@ documentation = "https://docs.rs/uselesskey-core-jwk-builder"
 authors.workspace = true
 
 [dependencies]
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-uselesskey-core-jwk-shape = { path = "../uselesskey-core-jwk-shape", version = "0.6.0" }
+uselesskey-core-jwk-shape = { path = "../uselesskey-core-jwk-shape", version = "0.7.0" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-core-jwk-shape/Cargo.toml
+++ b/crates/uselesskey-core-jwk-shape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-jwk-shape"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-jwk-shape"
 authors.workspace = true
 
 [dependencies]
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-jwk/Cargo.toml
+++ b/crates/uselesskey-core-jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-jwk"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-jwk"
 authors.workspace = true
 
 [dependencies]
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-jwks-order/Cargo.toml
+++ b/crates/uselesskey-core-jwks-order/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-jwks-order"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-jwks-order"
 authors.workspace = true
 
 [dependencies]
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-keypair-material/Cargo.toml
+++ b/crates/uselesskey-core-keypair-material/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-keypair-material"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-keypair-material"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-keypair/Cargo.toml
+++ b/crates/uselesskey-core-keypair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-keypair"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-keypair"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-kid/Cargo.toml
+++ b/crates/uselesskey-core-kid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-kid"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-kid"
 authors.workspace = true
 
 [dependencies]
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0", default-features = false }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 base64.workspace = true

--- a/crates/uselesskey-core-negative-der/Cargo.toml
+++ b/crates/uselesskey-core-negative-der/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-negative-der"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-negative-der"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0", default-features = false }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-negative-pem/Cargo.toml
+++ b/crates/uselesskey-core-negative-pem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-negative-pem"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-negative-pem"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0", default-features = false }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-negative/Cargo.toml
+++ b/crates/uselesskey-core-negative/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-negative"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-negative"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0", default-features = false }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-rustls-pki/Cargo.toml
+++ b/crates/uselesskey-core-rustls-pki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-rustls-pki"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,10 +18,10 @@ authors.workspace = true
 rustls-pki-types = "1"
 
 # Key type crates (all optional)
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0", optional = true }
 
 [features]
 default = ["x509"]
@@ -34,11 +34,11 @@ all = ["x509", "rsa", "ecdsa", "ed25519"]
 [dev-dependencies]
 insta.workspace = true
 serde = { workspace = true, features = ["derive"] }
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0" }
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/crates/uselesskey-core-seed/Cargo.toml
+++ b/crates/uselesskey-core-seed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-seed"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-seed"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0", default-features = false }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 blake3.workspace = true

--- a/crates/uselesskey-core-sink/Cargo.toml
+++ b/crates/uselesskey-core-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-sink"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ authors.workspace = true
 
 [dependencies]
 tempfile.workspace = true
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-token-shape/Cargo.toml
+++ b/crates/uselesskey-core-token-shape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-token-shape"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-token/Cargo.toml
+++ b/crates/uselesskey-core-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-token"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-core-x509-chain-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-chain-negative/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509-chain-negative"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,14 +15,14 @@ documentation = "https://docs.rs/uselesskey-core-x509-chain-negative"
 authors.workspace = true
 
 [dependencies]
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
 rstest.workspace = true
 serde.workspace = true
-uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.6.0" }
+uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.7.0" }
 
 [features]
 default = ["std"]

--- a/crates/uselesskey-core-x509-derive/Cargo.toml
+++ b/crates/uselesskey-core-x509-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509-derive"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-x509-derive"
 authors.workspace = true
 
 [dependencies]
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-x509-negative/Cargo.toml
+++ b/crates/uselesskey-core-x509-negative/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509-negative"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,15 +15,15 @@ documentation = "https://docs.rs/uselesskey-core-x509-negative"
 authors.workspace = true
 
 [dependencies]
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
 rstest.workspace = true
 serde = { workspace = true, features = ["derive"] }
-uselesskey-core-x509-chain-negative = { path = "../uselesskey-core-x509-chain-negative", version = "0.6.0" }
-uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.6.0" }
+uselesskey-core-x509-chain-negative = { path = "../uselesskey-core-x509-chain-negative", version = "0.7.0" }
+uselesskey-core-x509-spec = { path = "../uselesskey-core-x509-spec", version = "0.7.0" }
 
 [features]
 default = ["std"]

--- a/crates/uselesskey-core-x509-spec/Cargo.toml
+++ b/crates/uselesskey-core-x509-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509-spec"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-x509-spec"
 authors.workspace = true
 
 [dependencies]
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core-x509/Cargo.toml
+++ b/crates/uselesskey-core-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core-x509"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-core-x509"
 authors.workspace = true
 
 [dependencies]
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-core/Cargo.toml
+++ b/crates/uselesskey-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-ecdsa/Cargo.toml
+++ b/crates/uselesskey-ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ecdsa"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-ecdsa"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 uselesskey-core-keypair-material.workspace = true
 
 # Elliptic curve support from RustCrypto's current RC line
@@ -28,7 +28,7 @@ rand_core10.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0", optional = true }
 
 [features]
 default = []

--- a/crates/uselesskey-ed25519/Cargo.toml
+++ b/crates/uselesskey-ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ed25519"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-ed25519"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 uselesskey-core-keypair-material.workspace = true
 ed25519-dalek.workspace = true
 pkcs8.workspace = true
@@ -23,7 +23,7 @@ pkcs8.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0", optional = true }
 
 [features]
 default = []

--- a/crates/uselesskey-entropy/Cargo.toml
+++ b/crates/uselesskey-entropy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-entropy"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-entropy"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/uselesskey-feature-grid/Cargo.toml
+++ b/crates/uselesskey-feature-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-feature-grid"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-hmac/Cargo.toml
+++ b/crates/uselesskey-hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-hmac"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,13 +15,13 @@ documentation = "https://docs.rs/uselesskey-hmac"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 uselesskey-core-hmac-spec.workspace = true
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 
 # Optional JWK/JWKS support
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0", optional = true }
 base64 = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-jose-openid/Cargo.toml
+++ b/crates/uselesskey-jose-openid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-jose-openid"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,10 +18,10 @@ authors.workspace = true
 jsonwebtoken.workspace = true
 
 # Key type crates
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -37,11 +37,11 @@ all = ["rsa", "ecdsa", "ed25519", "hmac"]
 [dev-dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.0" }
 
 
 [lints]

--- a/crates/uselesskey-jsonwebtoken/Cargo.toml
+++ b/crates/uselesskey-jsonwebtoken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-jsonwebtoken"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -20,10 +20,10 @@ authors.workspace = true
 jsonwebtoken = { version = "10", features = ["use_pem"] }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -37,11 +37,11 @@ hmac = ["dep:uselesskey-hmac"]
 all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.0" }
 serde.workspace = true
 insta.workspace = true
 proptest.workspace = true

--- a/crates/uselesskey-jsonwebtoken/README.md
+++ b/crates/uselesskey-jsonwebtoken/README.md
@@ -24,7 +24,7 @@ Implements `JwtKeyExt` so fixture types return `jsonwebtoken::EncodingKey` and
 
 ```toml
 [dev-dependencies]
-uselesskey-jsonwebtoken = { version = "0.6.0", features = ["rsa"] }
+uselesskey-jsonwebtoken = { version = "0.7.0", features = ["rsa"] }
 jsonwebtoken = { version = "10", features = ["use_pem", "rust_crypto"] }
 ```
 

--- a/crates/uselesskey-jwk/Cargo.toml
+++ b/crates/uselesskey-jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-jwk"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-pgp-native/Cargo.toml
+++ b/crates/uselesskey-pgp-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-pgp-native"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-pgp-native"
 authors.workspace = true
 
 [dependencies]
-uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.6.0", optional = true }
+uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.7.0", optional = true }
 pgp = { version = "0.19.0", default-features = false }
 
 [package.metadata.docs.rs]
@@ -26,8 +26,8 @@ default = ["pgp-native"]
 pgp-native = ["dep:uselesskey-pgp"]
 
 [dev-dependencies]
-uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.6.0" }
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.7.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 
 
 [lints]

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-pgp"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-pgp"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 pgp = { version = "0.19.0", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }

--- a/crates/uselesskey-pkcs11-mock/Cargo.toml
+++ b/crates/uselesskey-pkcs11-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-pkcs11-mock"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,11 +15,11 @@ documentation = "https://docs.rs/uselesskey-pkcs11-mock"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 sha2.workspace = true
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 
 [lints]
 workspace = true

--- a/crates/uselesskey-ring/Cargo.toml
+++ b/crates/uselesskey-ring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ring"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,9 +18,9 @@ authors.workspace = true
 ring = "0.17"
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -33,7 +33,7 @@ ed25519 = ["dep:uselesskey-ed25519"]
 all = ["rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-ring/README.md
+++ b/crates/uselesskey-ring/README.md
@@ -17,7 +17,7 @@ Converts fixture keypairs into native ring signing key types for tests that call
 
 ```toml
 [dev-dependencies]
-uselesskey-ring = { version = "0.6.0", features = ["rsa"] }
+uselesskey-ring = { version = "0.7.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-rsa/Cargo.toml
+++ b/crates/uselesskey-rsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rsa"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-rsa"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 uselesskey-core-keypair-material.workspace = true
 rsa.workspace = true
 rsa09 = { package = "rsa", version = "0.9.10", features = ["pem"], optional = true }
@@ -27,7 +27,7 @@ rand_chacha10.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0", optional = true }
 
 [features]
 default = ["legacy-rsa09"]

--- a/crates/uselesskey-rustcrypto/Cargo.toml
+++ b/crates/uselesskey-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rustcrypto"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -23,10 +23,10 @@ hmac = { version = "0.13.0-rc.6", optional = true }
 sha2 = { version = "0.11", optional = true }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", optional = true, default-features = false }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", optional = true, default-features = false }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -40,11 +40,11 @@ hmac = ["dep:hmac", "dep:sha2", "dep:uselesskey-hmac"]
 all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", default-features = false }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", default-features = false }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.0" }
 rand_chacha10.workspace = true
 proptest.workspace = true
 rsa = { workspace = true, features = ["sha2"] }

--- a/crates/uselesskey-rustcrypto/README.md
+++ b/crates/uselesskey-rustcrypto/README.md
@@ -18,7 +18,7 @@ Converts fixture key material into native RustCrypto types (`rsa`, `p256`/`p384`
 
 ```toml
 [dev-dependencies]
-uselesskey-rustcrypto = { version = "0.6.0", features = ["rsa"] }
+uselesskey-rustcrypto = { version = "0.7.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rustls"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,14 +15,14 @@ documentation = "https://docs.rs/uselesskey-rustls"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core-rustls-pki = { path = "../uselesskey-core-rustls-pki", version = "0.6.0", default-features = false }
+uselesskey-core-rustls-pki = { path = "../uselesskey-core-rustls-pki", version = "0.7.0", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"], optional = true }
 
 # Key type crates (all optional)
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all", "tls-config", "rustls-ring"]
@@ -42,11 +42,11 @@ rustls-aws-lc-rs = ["rustls?/aws_lc_rs"]
 
 [dev-dependencies]
 rustls-pki-types = "1"
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0" }
 rustls = { version = "0.23", features = ["ring"] }
 hex = "0.4"
 serde.workspace = true

--- a/crates/uselesskey-rustls/README.md
+++ b/crates/uselesskey-rustls/README.md
@@ -30,7 +30,7 @@ optional `ServerConfig` / `ClientConfig` builders (including mTLS support).
 
 ```toml
 [dev-dependencies]
-uselesskey-rustls = { version = "0.6.0", features = ["tls-config", "rustls-ring"] }
+uselesskey-rustls = { version = "0.7.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```rust

--- a/crates/uselesskey-ssh/Cargo.toml
+++ b/crates/uselesskey-ssh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ssh"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-ssh"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 ssh-key = { version = "0.6.7", default-features = false, features = ["std", "ed25519", "rsa", "rand_core"] }
 rand_chacha = { version = "0.3.1", default-features = false }
 

--- a/crates/uselesskey-test-grid/Cargo.toml
+++ b/crates/uselesskey-test-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-grid"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-test-server/Cargo.toml
+++ b/crates/uselesskey-test-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-server"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -23,11 +23,11 @@ blake3.workspace = true
 axum = { version = "0.8.6", default-features = false, features = ["tokio", "http1", "json"] }
 http = "1.3.1"
 
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0", features = ["jwk"] }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0", features = ["jwk"] }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", features = ["jwk"] }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0", features = ["jwk"] }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0", features = ["jwk"] }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", features = ["jwk"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/uselesskey-test-support/Cargo.toml
+++ b/crates/uselesskey-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-support"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-token-spec/Cargo.toml
+++ b/crates/uselesskey-token-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-token-spec"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-token"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -19,7 +19,7 @@ base64.workspace = true
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 serde_json.workspace = true
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-tonic/Cargo.toml
+++ b/crates/uselesskey-tonic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-tonic"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ authors.workspace = true
 
 [dependencies]
 tonic = { version = "0.14.5", default-features = false, features = ["transport", "tls-ring"] }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["x509"]
@@ -26,8 +26,8 @@ default = ["x509"]
 x509 = ["dep:uselesskey-x509"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0" }
 proptest.workspace = true
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-tonic/README.md
+++ b/crates/uselesskey-tonic/README.md
@@ -19,9 +19,9 @@ Converts fixture certs and chains into `tonic::transport` TLS types:
 
 ```toml
 [dev-dependencies]
-uselesskey-tonic = "0.6.0"
-uselesskey-core = "0.6.0"
-uselesskey-x509 = "0.6.0"
+uselesskey-tonic = "0.7.0"
+uselesskey-core = "0.7.0"
+uselesskey-x509 = "0.7.0"
 ```
 
 ```rust

--- a/crates/uselesskey-webauthn/Cargo.toml
+++ b/crates/uselesskey-webauthn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-webauthn"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,13 +15,13 @@ documentation = "https://docs.rs/uselesskey-webauthn"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 serde_json.workspace = true
 ciborium.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 serde_json.workspace = true
 
 [lints]

--- a/crates/uselesskey-webhook/Cargo.toml
+++ b/crates/uselesskey-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-webhook"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-webhook"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 base64.workspace = true

--- a/crates/uselesskey-x509/Cargo.toml
+++ b/crates/uselesskey-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-x509"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,9 +15,9 @@ documentation = "https://docs.rs/uselesskey-x509"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0" }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0", optional = true }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0", optional = true }
 rcgen = "0.14.7"
 rustls-pki-types = "1"
 x509-parser = "0.18"

--- a/crates/uselesskey/Cargo.toml
+++ b/crates/uselesskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -22,20 +22,20 @@ maintenance = { status = "actively-developed" }
 features = ["full"]
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.7.0" }
 
 # Key type crates - all optional
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.6.0", optional = true }
-uselesskey-entropy = { path = "../uselesskey-entropy", version = "0.6.0", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.6.0", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.6.0", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.6.0", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.6.0", optional = true }
-uselesskey-token = { path = "../uselesskey-token", version = "0.6.0", optional = true }
-uselesskey-ssh = { path = "../uselesskey-ssh", version = "0.6.0", optional = true }
-uselesskey-webhook = { path = "../uselesskey-webhook", version = "0.6.0", optional = true }
-uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.6.0", optional = true }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.6.0", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.0", optional = true }
+uselesskey-entropy = { path = "../uselesskey-entropy", version = "0.7.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.0", optional = true }
+uselesskey-token = { path = "../uselesskey-token", version = "0.7.0", optional = true }
+uselesskey-ssh = { path = "../uselesskey-ssh", version = "0.7.0", optional = true }
+uselesskey-webhook = { path = "../uselesskey-webhook", version = "0.7.0", optional = true }
+uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.7.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.0", optional = true }
 
 [features]
 default = []
@@ -77,8 +77,8 @@ x509-parser = "0.18"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 jsonwebtoken = { workspace = true, features = ["rust_crypto"] }
-uselesskey-jsonwebtoken = { path = "../uselesskey-jsonwebtoken", version = "0.6.0", features = ["all"] }
-uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.6.0", features = ["all", "tls-config", "rustls-ring"] }
+uselesskey-jsonwebtoken = { path = "../uselesskey-jsonwebtoken", version = "0.7.0", features = ["all"] }
+uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.7.0", features = ["all", "tls-config", "rustls-ring"] }
 rustls-pki-types.workspace = true
 
 [[bench]]

--- a/crates/uselesskey/README.md
+++ b/crates/uselesskey/README.md
@@ -50,53 +50,53 @@ Dependency snippets:
 - **Quick start (RSA)**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa"] }
+  uselesskey = { version = "0.7.0", features = ["rsa"] }
   ```
 
 
 - **Token-only**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", default-features = false, features = ["token"] }
+  uselesskey = { version = "0.7.0", default-features = false, features = ["token"] }
   ```
 
 
 - **JWT/JWK**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa", "jwk"] }
+  uselesskey = { version = "0.7.0", features = ["rsa", "jwk"] }
   ```
 
 
 - **X.509 + rustls**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["x509"] }
-  uselesskey-rustls = { version = "0.6.0", features = ["tls-config", "rustls-ring"] }
+  uselesskey = { version = "0.7.0", features = ["x509"] }
+  uselesskey-rustls = { version = "0.7.0", features = ["tls-config", "rustls-ring"] }
   ```
 
 
 - **jsonwebtoken adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jsonwebtoken = { version = "0.6.0" }
+  uselesskey = { version = "0.7.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jsonwebtoken = { version = "0.7.0" }
   ```
 
 
 - **JOSE/OpenID adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jose-openid = { version = "0.6.0" }
+  uselesskey = { version = "0.7.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jose-openid = { version = "0.7.0" }
   ```
 
 
 - **pgp-native adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["pgp"] }
-  uselesskey-pgp-native = { version = "0.6.0" }
+  uselesskey = { version = "0.7.0", features = ["pgp"] }
+  uselesskey-pgp-native = { version = "0.7.0" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 
@@ -113,7 +113,7 @@ Entropy-only consumers can stay lighter still:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.6.0", default-features = false, features = ["entropy"] }
+uselesskey = { version = "0.7.0", default-features = false, features = ["entropy"] }
 ```
 
 ```rust
@@ -135,7 +135,7 @@ If you want RSA fixtures, enable `rsa` explicitly:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.6.0", features = ["rsa"] }
+uselesskey = { version = "0.7.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey/src/lib.rs
+++ b/crates/uselesskey/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! uselesskey = { version = "0.6.0", default-features = false, features = ["token"] }
+//! uselesskey = { version = "0.7.0", default-features = false, features = ["token"] }
 //! ```
 //!
 //! ```
@@ -42,7 +42,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! uselesskey = { version = "0.6.0", default-features = false, features = ["entropy"] }
+//! uselesskey = { version = "0.7.0", default-features = false, features = ["entropy"] }
 //! ```
 //!
 //! ```

--- a/docs/how-to/choose-features.md
+++ b/docs/how-to/choose-features.md
@@ -35,53 +35,53 @@ Dependency snippets:
 - **Quick start (RSA)**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa"] }
+  uselesskey = { version = "0.7.0", features = ["rsa"] }
   ```
 
 
 - **Token-only**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", default-features = false, features = ["token"] }
+  uselesskey = { version = "0.7.0", default-features = false, features = ["token"] }
   ```
 
 
 - **JWT/JWK**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa", "jwk"] }
+  uselesskey = { version = "0.7.0", features = ["rsa", "jwk"] }
   ```
 
 
 - **X.509 + rustls**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["x509"] }
-  uselesskey-rustls = { version = "0.6.0", features = ["tls-config", "rustls-ring"] }
+  uselesskey = { version = "0.7.0", features = ["x509"] }
+  uselesskey-rustls = { version = "0.7.0", features = ["tls-config", "rustls-ring"] }
   ```
 
 
 - **jsonwebtoken adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jsonwebtoken = { version = "0.6.0" }
+  uselesskey = { version = "0.7.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jsonwebtoken = { version = "0.7.0" }
   ```
 
 
 - **JOSE/OpenID adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jose-openid = { version = "0.6.0" }
+  uselesskey = { version = "0.7.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jose-openid = { version = "0.7.0" }
   ```
 
 
 - **pgp-native adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.6.0", features = ["pgp"] }
-  uselesskey-pgp-native = { version = "0.6.0" }
+  uselesskey = { version = "0.7.0", features = ["pgp"] }
+  uselesskey-pgp-native = { version = "0.7.0" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 
@@ -114,7 +114,7 @@ If you need every key family, use `all-keys`.
 - Use `uselesskey-cli verify` in CI to prove generated outputs still match the
   manifest.
 - If `build.rs` calls the library directly, use:
-  `uselesskey-cli = { version = "0.6.0", default-features = false }`
+  `uselesskey-cli = { version = "0.7.0", default-features = false }`
   for the common shape-only path.
 - Add `features = ["rsa-materialize"]` only when the build-time path needs RSA
   PKCS#8 fixtures.

--- a/docs/how-to/choose-lane.md
+++ b/docs/how-to/choose-lane.md
@@ -35,14 +35,14 @@ For shape-only build-time fixtures, depend on the slim library surface:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.6.0", default-features = false }
+uselesskey-cli = { version = "0.7.0", default-features = false }
 ```
 
 For RSA PKCS#8 build-time fixtures, opt into the specialized RSA materialize support:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.6.0", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.7.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 See `crates/materialize-shape-buildrs-example/` for the common shape-only pattern and `crates/materialize-buildrs-example/` for the specialized RSA pattern.

--- a/docs/how-to/downstream-fixture-policy.md
+++ b/docs/how-to/downstream-fixture-policy.md
@@ -53,14 +53,14 @@ Shape-only common lane:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.6.0", default-features = false }
+uselesskey-cli = { version = "0.7.0", default-features = false }
 ```
 
 Specialized RSA build-time lane:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.6.0", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.7.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 ## Materialize in CI or build scripts

--- a/docs/metadata/workspace-docs.json
+++ b/docs/metadata/workspace-docs.json
@@ -1134,7 +1134,7 @@
       "minimal_example_command": "cargo test -p uselesskey-pgp-native --no-default-features --features rsa"
     }
   ],
-  "release_version": "0.6.0",
+  "release_version": "0.7.0",
   "public_features": [
     "rsa",
     "ecdsa",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,28 +14,28 @@ keywords = ["testing", "integration", "fixtures", "crypto", "deterministic"]
 
 [dependencies]
 # Core
-uselesskey-core = { path = "../crates/uselesskey-core", version = "0.6.0" }
+uselesskey-core = { path = "../crates/uselesskey-core", version = "0.7.0" }
 blake3.workspace = true
 
 # Key types (all optional features)
-uselesskey-rsa = { path = "../crates/uselesskey-rsa", version = "0.6.0", optional = true, features = ["jwk"] }
-uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa", version = "0.6.0", optional = true, features = ["jwk"] }
-uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519", version = "0.6.0", optional = true, features = ["jwk"] }
-uselesskey-hmac = { path = "../crates/uselesskey-hmac", version = "0.6.0", optional = true, features = ["jwk"] }
-uselesskey-x509 = { path = "../crates/uselesskey-x509", version = "0.6.0", optional = true }
-uselesskey-token = { path = "../crates/uselesskey-token", version = "0.6.0", optional = true }
+uselesskey-rsa = { path = "../crates/uselesskey-rsa", version = "0.7.0", optional = true, features = ["jwk"] }
+uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa", version = "0.7.0", optional = true, features = ["jwk"] }
+uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519", version = "0.7.0", optional = true, features = ["jwk"] }
+uselesskey-hmac = { path = "../crates/uselesskey-hmac", version = "0.7.0", optional = true, features = ["jwk"] }
+uselesskey-x509 = { path = "../crates/uselesskey-x509", version = "0.7.0", optional = true }
+uselesskey-token = { path = "../crates/uselesskey-token", version = "0.7.0", optional = true }
 
 # JWK/JWKS
-uselesskey-jwk = { path = "../crates/uselesskey-jwk", version = "0.6.0", optional = true }
+uselesskey-jwk = { path = "../crates/uselesskey-jwk", version = "0.7.0", optional = true }
 
 # Adapters
-uselesskey-jsonwebtoken = { path = "../crates/uselesskey-jsonwebtoken", version = "0.6.0", optional = true, features = ["all"] }
-uselesskey-rustls = { path = "../crates/uselesskey-rustls", version = "0.6.0", optional = true, features = ["server-config", "client-config"] }
-uselesskey-ring = { path = "../crates/uselesskey-ring", version = "0.6.0", optional = true, features = ["all"] }
-uselesskey-rustcrypto = { path = "../crates/uselesskey-rustcrypto", version = "0.6.0", optional = true, features = ["all"] }
+uselesskey-jsonwebtoken = { path = "../crates/uselesskey-jsonwebtoken", version = "0.7.0", optional = true, features = ["all"] }
+uselesskey-rustls = { path = "../crates/uselesskey-rustls", version = "0.7.0", optional = true, features = ["server-config", "client-config"] }
+uselesskey-ring = { path = "../crates/uselesskey-ring", version = "0.7.0", optional = true, features = ["all"] }
+uselesskey-rustcrypto = { path = "../crates/uselesskey-rustcrypto", version = "0.7.0", optional = true, features = ["all"] }
 
 # Facade crate (for determinism tests)
-uselesskey = { path = "../crates/uselesskey", version = "0.6.0", optional = true, features = ["full"] }
+uselesskey = { path = "../crates/uselesskey", version = "0.7.0", optional = true, features = ["full"] }
 
 # External dependencies
 jsonwebtoken = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
- Bump workspace package versions and internal path dependency constraints to `0.7.0`.
- Update current README/how-to install snippets and workspace docs metadata for the `0.7.0` release line.
- Add a changelog note that the retained compatibility shims are prepared for the `v0.7.0` package line.

## Validation
- `cargo metadata --format-version 1 --no-deps`
- `cargo xtask public-surface`
- `cargo xtask publish-preflight --allow-dirty`
- `cargo xtask publish-check`
- `cargo xtask docs-sync --check`
- `cargo xtask ripr-pr`
- `cargo xtask pr`
- `cargo xtask impacted-evidence --base origin/main`
- `git diff --check origin/main...HEAD`

## Notes
- `publish-preflight` and `publish-check` report the expected publish-order skips for `0.7.0` workspace dependencies that are not on crates.io yet.
- Historical `0.6.0` references remain in the changelog, migration guide, roadmap history, and release instructions that compare from the `0.6.0` baseline.
