### PR TITLE
docs: add fixture failure atlas

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,9 @@ Task-oriented instructions for common workflows.
 - [choose-features.md](how-to/choose-features.md) — Choosing feature sets by need
 - [downstream-fixture-policy.md](how-to/downstream-fixture-policy.md) — Policy pack for downstream bots and reviewers
 - [adapter-template.md](how-to/adapter-template.md) — Scaffolding and validating new adapter crates
+- [test-oidc-jwks-validation.md](how-to/test-oidc-jwks-validation.md) — Using the OIDC/JWKS contract pack in validator tests
+- [test-jwt-negative-validation.md](how-to/test-jwt-negative-validation.md) — Using JWT-shaped negatives for policy rejection tests
+- [generate-scanner-safe-k8s-secret.md](how-to/generate-scanner-safe-k8s-secret.md) — Exporting scanner-safe Kubernetes and Vault-shaped payloads
 
 ## Contributing
 
@@ -66,6 +69,7 @@ Specifications and formal definitions.
 - [audit-surface.md](reference/audit-surface.md) — Current audit/island receipts
 - [requirements-v0.3.md](reference/requirements-v0.3.md) — v0.3 acceptance specification
 - [requirements-v0.4.md](reference/requirements-v0.4.md) — v0.4 RNG boundary refactor specification
+- [failure-atlas.md](reference/failure-atlas.md) — Failure classes covered by protocol-shaped negative fixtures
 
 ## Internal
 

--- a/docs/how-to/generate-scanner-safe-k8s-secret.md
+++ b/docs/how-to/generate-scanner-safe-k8s-secret.md
@@ -1,0 +1,74 @@
+# Generate a Scanner-Safe Kubernetes Secret
+
+Use this guide when a CI or platform test needs Kubernetes Secret-shaped data
+without committing runtime private key material or symmetric secret material.
+
+## Generate and verify the bundle
+
+```bash
+cargo run -p uselesskey-cli -- bundle \
+  --profile scanner-safe \
+  --out target/uselesskey-bundle
+
+cargo run -p uselesskey-cli -- verify-bundle \
+  --path target/uselesskey-bundle
+
+cargo run -p uselesskey-cli -- inspect-bundle \
+  --path target/uselesskey-bundle
+```
+
+The inspection step prints the profile, artifact count, scanner-safety posture,
+runtime material count, private/symmetric material flags, exports, verification
+status, and receipt kinds. It does not print fixture payloads.
+
+## Export Kubernetes and Vault-shaped payloads
+
+```bash
+cargo run -p uselesskey-cli -- export k8s \
+  --bundle-dir target/uselesskey-bundle \
+  --name uselesskey-fixtures \
+  --namespace tests \
+  --out target/uselesskey-bundle/secret.yaml
+
+cargo run -p uselesskey-cli -- export vault-kv-json \
+  --bundle-dir target/uselesskey-bundle \
+  --out target/uselesskey-bundle/kv-v2.json
+```
+
+Keep `secret.yaml` and `kv-v2.json` under `target/`. They are generated
+handoff payloads, not committed fixtures.
+
+## Positive platform test
+
+Use `target/uselesskey-bundle/secret.yaml` to test Kubernetes Secret loading,
+YAML parsing, key naming, mount wiring, or CI handoff logic. The positive case
+should prove that platform plumbing can consume the Secret-shaped payload.
+
+## Negative platform test
+
+Use the scanner-safe token and HMAC JWK shape entries in the bundle to exercise
+parser or policy rejection without introducing real symmetric material. For
+example, a downstream parser can assert that a near-miss token is rejected while
+the surrounding Kubernetes Secret shape still loads.
+
+## Scanner-safety note
+
+The `scanner-safe` profile emits public key material, public certificate
+material, invalid symmetric JWK shape data, and near-miss token shapes. Use
+`--profile runtime` only when a downstream test truly needs runtime private or
+symmetric fixture material.
+
+## What this does not prove
+
+- It does not create Kubernetes objects.
+- It does not call Vault or a cloud API.
+- It does not prove production secret rotation or access control.
+- It does not prove scanner evasion. It proves the checked bundle profile avoids
+  usable committed secret material.
+
+## Evidence
+
+```bash
+cargo xtask bundle-proof --profile scanner-safe --out target/release-evidence/scanner-safe
+cargo xtask no-blob
+```

--- a/docs/how-to/test-jwt-negative-validation.md
+++ b/docs/how-to/test-jwt-negative-validation.md
@@ -1,0 +1,88 @@
+# Test JWT Negative Validation
+
+Use this guide when a downstream token parser or validator needs
+JWT-shaped negative inputs that are realistic enough to reach policy checks.
+
+## Generate bundle files
+
+For file-based tests, use the OIDC contract pack:
+
+```bash
+cargo run -p uselesskey-cli -- bundle \
+  --profile oidc \
+  --out target/oidc-fixtures
+
+cargo run -p uselesskey-cli -- verify-bundle \
+  --path target/oidc-fixtures
+```
+
+Use these token files:
+
+| File | Intended failure |
+| --- | --- |
+| `tokens/valid-rs256.json` | positive parser control |
+| `tokens/negative-alg-none.json` | reject insecure `alg: none` policy |
+| `tokens/negative-bad-audience.json` | reject wrong audience |
+
+Each file is JSON with metadata and a `value` field containing the token-shaped
+string. Load the value in the downstream test and assert the validator's policy
+failure.
+
+## Generate in Rust tests
+
+For runtime test generation:
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.7", default-features = false, features = ["token"] }
+```
+
+```rust
+use uselesskey::{Factory, NegativeToken, TokenFactoryExt, TokenSpec};
+
+let fx = Factory::deterministic_from_str("jwt-negative");
+let token = fx.token("api", TokenSpec::oauth_access_token());
+
+let alg_none = token.negative_value(NegativeToken::AlgNone);
+assert!(validator_rejects_alg_none(&alg_none));
+
+let bad_audience = token.negative_value(NegativeToken::BadAudience);
+assert!(validator_rejects_bad_audience(&bad_audience));
+```
+
+Keep the test assertion specific. A useful test distinguishes "rejected because
+the algorithm is forbidden" from "failed to parse any token at all."
+
+## Near-miss API keys
+
+Use `NegativeToken::NearMissApiKey` for parser or scanner-safety tests where the
+input should look close to an API key but must not be a usable `uk_test_` token:
+
+```rust
+let api_key = fx.token("billing", TokenSpec::api_key());
+let near_miss = api_key.negative_value(NegativeToken::NearMissApiKey);
+
+assert!(!near_miss.starts_with("uk_test_"));
+assert!(api_key_parser_rejects(&near_miss));
+```
+
+## Scanner-safety note
+
+Token negatives are scanner-safe fixture shapes. They are for parser and
+validator tests, not for production authorization decisions.
+
+## What this does not prove
+
+- It does not prove signature validation by itself.
+- It does not prove production issuer or audience configuration.
+- It does not prove cryptographic assurance.
+- It does not replace adapter-specific tests such as `uselesskey-jsonwebtoken`
+  when native downstream types matter.
+
+## Evidence
+
+```bash
+cargo test -p uselesskey-token --all-features
+cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc
+cargo xtask no-blob
+```

--- a/docs/how-to/test-oidc-jwks-validation.md
+++ b/docs/how-to/test-oidc-jwks-validation.md
@@ -1,0 +1,89 @@
+# Test OIDC JWKS Validation
+
+Use this guide when a downstream OIDC or JWT validator needs a deterministic
+JWKS contract pack with both valid and negative key-set shapes.
+
+## Generate the pack
+
+```bash
+cargo run -p uselesskey-cli -- bundle \
+  --profile oidc \
+  --out target/oidc-fixtures
+
+cargo run -p uselesskey-cli -- verify-bundle \
+  --path target/oidc-fixtures
+
+cargo run -p uselesskey-cli -- inspect-bundle \
+  --path target/oidc-fixtures
+```
+
+The profile writes:
+
+- `jwks/valid.json`
+- `jwks/negative-duplicate-kid.json`
+- `jwks/negative-missing-kid.json`
+- `tokens/valid-rs256.json`
+- `tokens/negative-alg-none.json`
+- `tokens/negative-bad-audience.json`
+- `receipts/materialization.json`
+- `receipts/audit-surface.json`
+
+## Positive case
+
+Serve or load `target/oidc-fixtures/jwks/valid.json` in the downstream validator
+test. The positive case should prove that the validator can load the fixture
+pack and select a key from a normal JWKS shape.
+
+## Negative cases
+
+Use `target/oidc-fixtures/jwks/negative-duplicate-kid.json` when the validator
+should reject ambiguous key selection. The file contains two distinct key shapes
+with the same `kid`.
+
+Use `target/oidc-fixtures/jwks/negative-missing-kid.json` when the validator
+should reject or fail key selection for a key without `kid` metadata.
+
+## Rust test lane
+
+For Rust tests that do not need files, use the public fixture surface directly:
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.7", default-features = false, features = ["rsa", "jwk"] }
+```
+
+```rust
+use uselesskey::jwk::NegativeJwks;
+use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
+
+let fx = Factory::deterministic_from_str("oidc-negative");
+let issuer = fx.rsa("issuer", RsaSpec::rs256());
+let jwks = issuer.public_jwks();
+
+let duplicate_kid = jwks.negative_value(NegativeJwks::DuplicateKid);
+assert!(validator_rejects(duplicate_kid));
+```
+
+Replace `validator_rejects` with the downstream validator assertion. The useful
+assertion is the validator's rejection reason, not just that JSON parsing failed.
+
+## Scanner-safety note
+
+The OIDC profile is scanner-safe by default. It is intended for key-set parsing,
+token-shape parsing, and validator failure-path tests. Keep generated files
+under `target/` and verify them in CI instead of committing generated payloads.
+
+## What this does not prove
+
+- It does not prove OpenID discovery behavior.
+- It does not prove production signing-key custody.
+- It does not prove cryptographic correctness.
+- It does not prove real JWT signature validation unless your downstream test
+  adds runtime signing fixtures and adapter-specific assertions.
+
+## Evidence
+
+```bash
+cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc
+cargo xtask no-blob
+```

--- a/docs/reference/failure-atlas.md
+++ b/docs/reference/failure-atlas.md
@@ -1,0 +1,72 @@
+# Fixture Failure Atlas
+
+Use this reference when choosing a negative fixture for a validator, parser, or
+platform-handoff test. The goal is not random invalid data. The goal is an input
+that is realistic enough to reach the downstream check and fail for the reason
+the test is meant to cover.
+
+`uselesskey` is a test-fixture layer. These fixtures do not prove production
+cryptographic correctness, production key-management behavior, or scanner
+evasion.
+
+## OIDC and JWKS
+
+| Fixture | Failure class | Expected downstream rejection | Generate with |
+| --- | --- | --- | --- |
+| `jwks/valid.json` | valid key-set shape | validator accepts the key set shape for positive-path tests | `uselesskey bundle --profile oidc` |
+| `jwks/negative-duplicate-kid.json` | ambiguous key selection | validator refuses a JWKS where two distinct keys share one `kid` | `uselesskey bundle --profile oidc` |
+| `jwks/negative-missing-kid.json` | key identification failure | validator refuses or cannot select a key without `kid` metadata | `uselesskey bundle --profile oidc` |
+| `NegativeJwks::DuplicateKid` | ambiguous key selection in Rust tests | key-selection code rejects duplicate `kid` values | `uselesskey_jwk` or facade `jwk` feature |
+| `NegativeJwk::MissingKid` | key identification failure in Rust tests | code requiring `kid` rejects a JWK without one | `uselesskey_jwk` or facade `jwk` feature |
+
+The OIDC bundle profile is shape-first. Use it to test routing, key-set parsing,
+manifest verification, and validator failure paths. If a downstream test must
+verify real signatures, use runtime fixtures and the appropriate adapter in that
+test.
+
+## JWT and Token Shapes
+
+| Fixture | Failure class | Expected downstream rejection | Generate with |
+| --- | --- | --- | --- |
+| `tokens/valid-rs256.json` | valid JWT-shaped positive control | parser accepts the JWT shape and expected metadata | `uselesskey bundle --profile oidc` |
+| `tokens/negative-alg-none.json` | insecure algorithm | validator rejects `alg: none` or refuses unsigned-token policy | `uselesskey bundle --profile oidc` |
+| `tokens/negative-bad-audience.json` | authorization failure | validator rejects the wrong `aud` claim | `uselesskey bundle --profile oidc` |
+| `NegativeToken::AlgNone` | insecure algorithm in Rust tests | validator rejects an unsigned-algorithm header | `uselesskey-token` or facade `token` feature |
+| `NegativeToken::BadAudience` | authorization failure in Rust tests | validator rejects a token with the wrong audience | `uselesskey-token` or facade `token` feature |
+| `NegativeToken::NearMissApiKey` | scanner-safe parser test | parser rejects a token-like value that is close to, but not, the real test prefix | `uselesskey-token` or facade `token` feature |
+
+Token fixtures are protocol-shaped test values. They are not production JWTs and
+do not make an authorization decision meaningful by themselves.
+
+## Scanner-Safe Bundle Handoff
+
+| Fixture or payload | Failure class | Expected downstream rejection | Generate with |
+| --- | --- | --- | --- |
+| scanner-safe HMAC JWK shape | non-usable symmetric material | parser handles the JWK shape without a real shared secret | `uselesskey bundle --profile scanner-safe` |
+| near-miss token shape | scanner-safe parser test | parser or scanner-policy tests reject a non-real token value | `uselesskey bundle --profile scanner-safe` |
+| Kubernetes Secret export | platform shape handoff | CI can load the Secret-shaped payload without committed runtime material | `uselesskey export k8s` |
+| Vault KV JSON export | platform shape handoff | CI can load Vault-shaped JSON without committed runtime material | `uselesskey export vault-kv-json` |
+
+The scanner-safe profile emits public material, invalid symmetric JWK shape data,
+and near-miss token shapes. It is for parser, configuration, and platform
+plumbing tests. Use `--profile runtime` only when a downstream test really needs
+private or symmetric fixture material.
+
+## Evidence Commands
+
+Run the same evidence lane that the release uses when changing these fixtures or
+docs:
+
+```bash
+cargo xtask bundle-proof --profile scanner-safe --out target/release-evidence/scanner-safe
+cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc
+cargo xtask no-blob
+cargo xtask examples-smoke
+```
+
+For behavior changes in owner crates, add targeted evidence:
+
+```bash
+cargo xtask impacted-evidence --base origin/main
+cargo xtask mutants-pr --changed
+```


### PR DESCRIPTION
## Summary
- add a failure atlas mapping OIDC/JWKS, JWT, token, and scanner-safe bundle fixtures to expected downstream failure classes
- add task-first how-tos for OIDC JWKS validation, JWT negative validation, and scanner-safe Kubernetes/Vault-shaped export
- wire the new docs into the documentation index

## Validation
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask examples-smoke
- cargo xtask no-blob
- cargo xtask impacted-evidence --base origin/main
- cargo xtask ripr-pr
- cargo xtask pr
- git diff --check origin/main...HEAD

## Evidence notes
- impacted-evidence reports docs-only changes, no owner crates, and no targeted mutation required
- ripr-pr reports 0 findings and 0 severe gaps