### PR TITLE
release: prove v0.7.0 publish candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-10
+
 ### Added
 
 - Added scanner-safe JWK/JWKS and token-shape negative fixture helpers for
@@ -422,7 +424,8 @@ Repository organised into four layers:
 - **Determinism regression** — hardcoded expected-value snapshots ensure
   derivation stability across releases
 
-[Unreleased]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.4.1...v0.5.0


### PR DESCRIPTION
## Summary
- freeze the changelog payload under `## [0.7.0] - 2026-05-10`
- reset the `Unreleased` compare link to start at `v0.7.0`
- add the `v0.7.0` compare link from the `v0.6.0` crates.io baseline

## Publish-candidate evidence
Full release evidence was regenerated after the changelog commit, and the receipt records candidate SHA `66fa000c6c205ce2865323e762ad5edc3ca1b3de`.

```bash
cargo xtask release-evidence --version 0.7.0 --out target/release-evidence --summary
```

Key local artifacts from that run:
- `target/release-evidence/summary.md`
- `target/release-evidence/release-evidence.md`
- `target/release-evidence/scanner-safe/scanner-safe-bundle-proof.md`
- `target/release-evidence/oidc/oidc-contract-pack-proof.md`
- `target/mutation/nightly-summary.md`
- `target/mutation/nightly-receipt.md`
- `target/mutation/survivors.md`
- `target/xtask/perf/latest.md`
- `target/xtask/economics/latest.md`
- `target/xtask/audit-surface/latest.md`
- `target/ripr/pr/summary.md`

The release-evidence summary reported all gate areas `ok` and no open issues.

## Validation
- `cargo xtask release-evidence --version 0.7.0 --out target/release-evidence --summary`
- `cargo xtask typos`
- `git diff --check origin/main...HEAD`