### PR TITLE
release: backfill v0.7.0 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,47 +9,112 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - 2026-05-10
 
+The Rust 1.95 scanner-safe fixture platform release. v0.7.0 introduces the
+end-to-end scanner-safe bundle workflow (generate, verify, inspect, export),
+the OIDC/JWKS contract pack, scanner-safe negative JWK/JWKS and token
+fixtures, a public-surface promise map with compatibility shims, and a full
+release-evidence lane (RIPR, targeted/nightly mutation, perf, and release
+proofs).
+
+`uselesskey` remains a test-fixture layer. It is not production key
+management, scanner evasion, or cryptographic assurance.
+
 ### Added
 
-- Added scanner-safe JWK/JWKS and token-shape negative fixture helpers for
-  downstream parser and validator failure-path tests.
-- Added a facade example covering scanner-safe negative JWK/JWKS and token
-  shapes for downstream validator tests.
-- Added `uselesskey verify-bundle` to verify deterministic bundle outputs
-  against their recorded `manifest.json`.
-- Added scanner-safe bundle profiles and per-artifact lane metadata to
-  `uselesskey bundle` manifests.
+- Added the `uselesskey bundle` scanner-safe profile with deterministic
+  artifacts, manifest, per-artifact lane metadata, and `receipts/` files.
+- Added `uselesskey bundle --profile oidc` for an OIDC/JWKS contract pack with
+  valid JWKS and JWT-shape artifacts plus duplicate-`kid`, missing-`kid`,
+  `alg: none`, and bad-audience negatives.
+- Added `uselesskey verify-bundle` to verify deterministic bundle outputs and
+  receipts against their recorded `manifest.json`.
+- Added `uselesskey inspect-bundle` for human-readable bundle summaries that
+  do not print fixture payloads.
 - Added `uselesskey export k8s` and `uselesskey export vault-kv-json` payload
   renderers for verified bundle directories.
-- Added deterministic bundle receipt files under `receipts/` and verification
-  coverage for receipt drift.
-- Added a public-surface map that separates public support promises from
-  published internal implementation shards.
-- Added perf receipt coverage for seed derivation, JWK/JWKS emission,
-  WebAuthn, PKCS#11 mocks, and scanner-safe materialize/verify paths.
+- Added scanner-safe negative JWK/JWKS and token-shape fixture helpers in
+  `uselesskey-jwk` and `uselesskey-token` for downstream parser and validator
+  failure-path tests.
+- Added a facade example (`negative_payload_shapes`) covering scanner-safe
+  negative JWK/JWKS and token shapes for downstream validator tests.
+- Added a public-surface promise map and `cargo xtask public-surface` guard
+  separating public support promises from published-internal shards.
+- Added the release-evidence runner (`cargo xtask release-evidence
+  --summary`), scanner-safe and OIDC bundle proofs (`cargo xtask
+  bundle-proof`), and an aggregate release evidence summary.
+- Added the targeted-mutation lane: `cargo xtask mutants-pr` (PR scope) and
+  `cargo xtask mutants-nightly --scope public` (full owner scope), split from
+  the default `cargo xtask pr` gate.
+- Added `cargo xtask ripr-pr` for repo-exposure evidence and the
+  `impacted-evidence` routing command for targeted mutation/RIPR coverage on
+  changed crates.
+- Added the mutation survivor ledger (`policy/mutation-survivors.toml`) and
+  per-run survivor receipts under `target/mutation/`.
+- Added a scheduled performance evidence workflow and expanded fixture
+  benchmark coverage for seed derivation, JWK/JWKS emission, WebAuthn,
+  PKCS#11 mocks, and scanner-safe materialize/verify paths.
+- Added a Codecov advisory coverage workflow, badge, and conservative project
+  config.
+- Added the `uselesskey-test-support` crate with fallible test helpers so
+  test code can drop `unwrap`/`expect` while keeping diagnostics clear.
+- Added the panic-safety policy stack: `policy/no-panic-allowlist.toml`,
+  `policy/no-panic-baseline.toml`, `cargo xtask check-no-panic-family`, and
+  the `bare-allow` burndown flip to blocking.
+- Added the fixture failure atlas (`docs/reference/failure-atlas.md`),
+  scanner-safe bundle reference, test-evidence-lanes guide, public-surface
+  promises, PR disposition policy, v0.7.0 release category notes, evidence
+  matrix, checklist issue map, and post-release audit checklist.
 
 ### Changed
 
-- Raised MSRV from Rust 1.92 to Rust 1.95.
-- Prepared workspace packages and retained compatibility shims for the v0.7.0
-  package line.
+- Raised MSRV from Rust 1.92 to Rust 1.95 across the workspace and enabled
+  the Rust 1.95 compiler/Clippy lint floor under `-D warnings`.
 - Reconciled the v0.7.0 roadmap status with the landed bundle, verification,
-  Kubernetes/Vault export, scanner-safe profile, and receipt workflows.
-- Moved JWK/JWKS shape, builder, ordering, and deterministic `kid` internals
-  under `uselesskey-jwk::srp::*`, retaining the former `uselesskey-core-jwk*`,
-  `uselesskey-core-jwks-order`, and `uselesskey-core-kid` crates as
-  published-internal compatibility shims.
-- Moved token spec, base62, token-shape, and negative-token internals under
+  Kubernetes/Vault export, scanner-safe profile, OIDC contract pack, and
+  receipt workflows.
+- Folded JWK/JWKS shape, builder, ordering, and deterministic `kid`
+  internals into `uselesskey-jwk::srp::*`, retaining the former
+  `uselesskey-core-jwk*`, `uselesskey-core-jwks-order`, and
+  `uselesskey-core-kid` crates as published-internal compatibility shims.
+- Folded token spec, base62, token-shape, and negative-token internals into
   `uselesskey-token::srp::*`, retaining the former `uselesskey-token-spec`,
   `uselesskey-core-base62`, `uselesskey-core-token-shape`, and
   `uselesskey-core-token` crates as published-internal compatibility shims.
-- Moved core cache, factory, hash, identity, seed, sink, keypair material, and
-  generic negative-fixture internals under `uselesskey-core::srp::*`, retaining
-  the former `uselesskey-core-*` implementation crates as published-internal
-  compatibility shims.
-- Moved X.509 spec, deterministic derive, and negative-policy internals under
-  `uselesskey-x509::srp::*`, retaining the former `uselesskey-core-x509*`
-  crates as published-internal compatibility shims.
+- Folded core cache, factory, hash, identity, seed, sink, keypair, keypair
+  material, and generic negative-fixture internals into
+  `uselesskey-core::srp::*`, retaining the former `uselesskey-core-*` shards
+  as published-internal compatibility shims.
+- Folded X.509 spec, deterministic derive, and negative/chain-negative
+  policy internals into `uselesskey-x509::srp::*`, retaining the former
+  `uselesskey-core-x509*` crates as published-internal compatibility shims.
+- Refreshed advisory-blocked dependency floors so PR checks start from a
+  clean security baseline; bumped `blake3`, `sha2`, `insta`, and
+  `aws-lc-rs` to current floors.
+- Replaced direct `unwrap`/`expect` use in workspace tests with fallible
+  helpers from `uselesskey-test-support` across entropy, core-id,
+  core-keypair, core-keypair-material, feature-grid, core-x509, and
+  core-x509-negative.
+
+### Fixed
+
+- Honored byte-budget and UTF-8 boundaries when truncating PEM in negative
+  fixtures, preventing oversized or invalid-UTF-8 outputs.
+- Fixed the WebAuthn stable-bytes encoding for fields larger than
+  `u16::MAX` so deterministic ceremony fixtures stay stable for large
+  inputs.
+- Failed fast on oversized `u16` fixture encodings in `uselesskey-pkcs11-mock`
+  and normalized empty-label provider specs to a default signing key.
+- Escaped labels safely in `uselesskey-webhook` canonical JSON payload
+  fixtures so generated bodies remain valid JSON for adversarial labels.
+- Supported uppercase `0X` seed prefix parsing alongside lowercase `0x`.
+- Made `uselesskey-core-factory` tests run without `std` so
+  no-default-features lanes stay green.
+- Made `cargo xtask pr` resilient when `origin/main` is missing in fresh
+  checkouts.
+- Hardened BDD matrix feature isolation, added missing `uk-ssh` wiring, and
+  made `cargo xtask bdd` ignore commented/docstring scenario text in feature
+  counts.
+- Silenced `uselesskey-bdd-steps` unused warnings in default builds.
 
 ## [0.6.0] - 2026-04-08
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Start with the cheapest lane that preserves the test's semantics.
 | JWT / bearer / API-token shapes only | `uselesskey-token` or facade `features = ["token"]` | token-shaped fixtures without RSA/X.509 pull-in |
 | valid runtime crypto semantics | leaf crates such as `uselesskey-rsa`, `uselesskey-x509`, `uselesskey-ssh` | real PKCS#8/JWK/X.509/SSH fixture behavior |
 | build-time materialized fixtures | `uselesskey-cli materialize` + `verify` | clean shape-only `OUT_DIR` / `include_bytes!` workflow, with RSA materialization as an explicit opt-in |
+| reproducible fixture bundles + handoff | `uselesskey-cli bundle` + `verify-bundle` + `inspect-bundle` + `export` | deterministic scanner-safe bundle of fixtures, manifest, and receipts; Kubernetes/Vault payload handoff without committing real secrets |
 
 Start with [docs/how-to/choose-features.md](docs/how-to/choose-features.md) for feature selection.
 Use [docs/how-to/choose-lane.md](docs/how-to/choose-lane.md) when deciding between entropy, token, semantic, and materialized fixture workflows.
@@ -351,6 +352,40 @@ assert!(api_key.value().starts_with("uk_test_"));
 assert!(bearer.authorization_header().starts_with("Bearer "));
 assert_eq!(oauth.value().split('.').count(), 3);
 ```
+
+## Scanner-safe bundles and exports
+
+The `uselesskey-cli` bundle workflow generates a deterministic directory of fixtures, a manifest, and per-artifact receipts that downstream tests can verify, inspect, and hand off to Kubernetes or Vault without committing real secret material.
+
+```bash
+# Generate a scanner-safe fixture bundle (default profile)
+cargo run -p uselesskey-cli -- bundle --profile scanner-safe --out target/uselesskey-bundle
+
+# Verify the bundle against its recorded manifest and receipts
+cargo run -p uselesskey-cli -- verify-bundle --path target/uselesskey-bundle
+
+# Print a human-readable summary without exposing fixture payloads
+cargo run -p uselesskey-cli -- inspect-bundle --path target/uselesskey-bundle
+
+# Render Kubernetes / Vault payloads from the verified bundle
+cargo run -p uselesskey-cli -- export k8s \
+    --bundle-dir target/uselesskey-bundle \
+    --name uselesskey-fixtures \
+    --namespace tests \
+    --out target/uselesskey-bundle/secret.yaml
+
+cargo run -p uselesskey-cli -- export vault-kv-json \
+    --bundle-dir target/uselesskey-bundle \
+    --out target/uselesskey-bundle/kv-v2.json
+```
+
+The `oidc` profile emits an OIDC/JWKS contract pack with valid JWKS and JWT-shape fixtures plus duplicate-`kid`, missing-`kid`, `alg: none`, and bad-audience negatives:
+
+```bash
+cargo run -p uselesskey-cli -- bundle --profile oidc --out target/uselesskey-oidc
+```
+
+For the reference manifest, receipts, and payload shapes see [`examples/scanner-safe-bundle/README.md`](examples/scanner-safe-bundle/README.md). For OIDC/JWT validator-test recipes see [`docs/how-to/test-oidc-jwks-validation.md`](docs/how-to/test-oidc-jwks-validation.md) and [`docs/how-to/test-jwt-negative-validation.md`](docs/how-to/test-jwt-negative-validation.md).
 
 ## Adapter crates
 

--- a/docs/release/v0.7.0-category-notes.md
+++ b/docs/release/v0.7.0-category-notes.md
@@ -85,3 +85,81 @@ gh release create v0.7.0 --draft --generate-notes --notes-start-tag v0.6.0
 
 Do not publish the generated draft until the release evidence matrix has been
 refreshed for the candidate commit.
+
+## Draft release body
+
+Use this as the `gh release create` body when publishing v0.7.0. Tighten or
+trim before publish, but keep the headline framing, the claim boundary, and
+the evidence links.
+
+```markdown
+# uselesskey v0.7.0
+
+The Rust 1.95 scanner-safe fixture platform release.
+
+## What's new
+
+### Scanner-safe bundles, verification, inspection, and handoff
+- `uselesskey bundle --profile scanner-safe` produces a deterministic
+  fixture directory with a manifest and per-artifact receipts.
+- `uselesskey verify-bundle` checks bundle outputs against the recorded
+  `manifest.json` and receipts.
+- `uselesskey inspect-bundle` prints a human-readable summary without
+  exposing fixture payloads.
+- `uselesskey export k8s` and `uselesskey export vault-kv-json` render
+  Kubernetes and Vault payloads from a verified bundle.
+
+### OIDC/JWKS contract pack
+- `uselesskey bundle --profile oidc` emits valid JWKS and JWT-shape
+  fixtures plus duplicate-`kid`, missing-`kid`, `alg: none`, and
+  bad-audience negatives for downstream validator tests.
+
+### Negative payload shapes
+- Scanner-safe negative JWK/JWKS and token-shape helpers in
+  `uselesskey-jwk` and `uselesskey-token`.
+- A new facade example, `negative_payload_shapes`, demonstrates the
+  failure-path workflow end-to-end.
+
+### Public surface and compatibility
+- A public-surface promise map separates supported public crates from
+  published-internal implementation shards.
+- `cargo xtask public-surface` enforces the map.
+- Internal JWK, token, core, and X.509 shards have been folded into their
+  owner crates; the former `uselesskey-core-*`, `uselesskey-token-spec`,
+  and `uselesskey-core-x509*` crates remain published as compatibility
+  shims for this release.
+
+### Evidence lanes
+- RIPR PR exposure, targeted PR mutation, nightly public-scope mutation,
+  scheduled performance evidence, and a release-evidence runner with
+  scanner-safe and OIDC bundle proofs.
+- Mutation survivor ledger and per-run receipts.
+
+### Documentation
+- Failure atlas covering protocol-shaped negative fixtures.
+- Scanner-safe bundle reference and OIDC/JWT validator how-tos.
+- Release category notes, evidence matrix, checklist issue map, and
+  post-release audit checklist.
+
+## Toolchain change
+
+This release raises MSRV from Rust 1.92 to Rust 1.95 and enables the
+Rust 1.95 compiler/Clippy lint floor. Downstreams pinned to 1.92 should
+remain on v0.6.x or upgrade their toolchain.
+
+## Claim boundary
+
+`uselesskey` is a test-fixture layer. It is not production key
+management, scanner evasion, or cryptographic assurance.
+
+## Evidence
+
+- `target/release-evidence/summary.md`
+- `target/release-evidence/release-evidence.md`
+- `target/release-evidence/scanner-safe/scanner-safe-bundle-proof.md`
+- `target/release-evidence/oidc/oidc-contract-pack-proof.md`
+- `target/mutation/nightly-receipt.md`
+- `target/xtask/perf/latest.md`
+
+See `CHANGELOG.md` for the full v0.7.0 list.
+```


### PR DESCRIPTION
## Summary

Backfill the v0.7.0 changelog, surface the scanner-safe bundle workflow in the README, and add a concrete release-body draft so `gh release create` has hand-written narrative instead of an auto-generated `Other Changes` fallback.

The v0.7.0 entry that landed in #561 was scoped to the freeze itself. This PR expands it to cover what actually shipped between v0.6.0 and v0.7.0, modeled on the v0.6.0 entry's style.

## Changes

- **CHANGELOG.md** — expanded `[0.7.0] - 2026-05-10`:
  - **Added** now covers `bundle --profile scanner-safe`, `bundle --profile oidc`, `verify-bundle`, `inspect-bundle`, `export k8s` / `export vault-kv-json`, scanner-safe negative JWK/JWKS and token shapes, the `negative_payload_shapes` facade example, public-surface promise map and `cargo xtask public-surface` guard, release-evidence runner / scanner-safe / OIDC bundle proofs, targeted-mutation lane and nightly mutation, RIPR PR exposure, mutation survivor ledger, scheduled performance evidence workflow and expanded benchmark coverage, Codecov advisory workflow, `uselesskey-test-support` fallible-helpers crate, panic-safety policy stack, fixture failure atlas, scanner-safe bundle reference, test-evidence-lanes guide, and v0.7.0 release governance docs.
  - **Changed** documents the MSRV bump (1.92 -> 1.95) and Rust 1.95 lint floor, plus the JWK / token / core / X.509 fold into owner crates with compatibility shims, advisory-blocked dependency floors, and the workspace-wide migration to fallible test helpers.
  - **Fixed** captures the earlier April-cycle codex bug fixes (PEM truncate UTF-8 boundary, WebAuthn `u16::MAX` field encoding, pkcs11-mock label normalization, webhook label JSON escaping, uppercase `0X` seed prefix, no-default-features `core-factory` tests, `xtask pr` resilience, BDD matrix isolation, etc).
- **README.md** — added a `reproducible fixture bundles + handoff` row to **Pick The Lane First** and a new **Scanner-safe bundles and exports** section showing `bundle` / `verify-bundle` / `inspect-bundle` / `export k8s` / `export vault-kv-json` / `bundle --profile oidc`. Headline v0.7.0 feature was previously invisible from the README.
- **docs/release/v0.7.0-category-notes.md** — added a **Draft release body** section with hand-written markdown ready for `gh release create`. Covers the bundle workflow, OIDC pack, negative payload shapes, public-surface and compatibility shims, evidence lanes, MSRV bump, claim boundary, and evidence links.

No source or behavior changes.

## Validation

- `cargo xtask docs-sync --check` — passed
- `cargo xtask typos` — passed
- `cargo xtask no-blob` — passed
- `git diff --check` — clean (no whitespace/conflict markers)
- All v0.7.0 release-evidence gates remain green from #561 (`target/release-evidence/summary.md`).

## Test plan

- [ ] CI green
- [ ] Reviewer confirms changelog accurately reflects merged PRs since v0.6.0 (#405 onward)
- [ ] Reviewer confirms README scanner-safe bundle section reads as a starting point, not a reference
- [ ] Reviewer confirms release-body draft is suitable for `gh release create`