### PR TITLE
docs: mark rust-1.95 compatibility audit as historical record

### DIFF
--- a/docs/audits/rust-1.95-compatibility.md
+++ b/docs/audits/rust-1.95-compatibility.md
@@ -1,5 +1,12 @@
 # Rust 1.95 Compatibility Audit
 
+> **Historical record.** This document is the pre-bump compatibility audit
+> for the workspace MSRV change from 1.92 to 1.95. The MSRV bump has since
+> landed on `main` — see `Cargo.toml` (`rust-version = "1.95"`),
+> `rust-toolchain.toml` (`channel = "1.95"`), and `policy/clippy-lints.toml`
+> (`msrv = "1.95"`). The "Current MSRV: 1.92" field below reflects the
+> workspace state *at the time of this audit*, not today.
+
 **Date:** 2026-05-08  
 **Auditor:** Claude (automated)  
 **Branch:** `probe/rust-1.95-compat`  


### PR DESCRIPTION
## Summary

`docs/audits/rust-1.95-compatibility.md` still leads with **Current MSRV: 1.92** and **Target MSRV: 1.95 (proposed)**, which was accurate when the audit was run on 2026-05-08 but is misleading now that the bump has landed. Add a top-of-doc callout that:

- Marks the document as a pre-bump historical record.
- Points readers to the live policy files: `Cargo.toml` (\`rust-version = \"1.95\"\`), `rust-toolchain.toml` (\`channel = \"1.95\"\`), `policy/clippy-lints.toml` (\`msrv = \"1.95\"\`).
- Notes that the "Current MSRV: 1.92" line below reflects the workspace state at the time of audit, not today.

Pure docs change — 7 lines added, audit body untouched.

## Validation

- \`cargo xtask typos\` — passed
- \`git diff --check\` — clean

## Test plan

- [ ] CI green (docs-sync should be unaffected; doc isn't in the docs-sync inventory)