### PR TITLE
policy: allowlist scanner-safe-bundle example reference outputs

### DIFF
--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -231,3 +231,14 @@ classification = "generated"
 reason = "Generated workspace docs / perf-baseline metadata."
 generated_by = "cargo xtask docs-sync"
 covered_by = ["cargo xtask docs-sync --check"]
+
+# === Example reference outputs =============================================
+
+[[allow]]
+glob = "examples/scanner-safe-bundle/expected/**/*"
+kind = "scanner_safe_bundle_reference"
+owner = "cli"
+surface = "examples"
+classification = "test"
+reason = "Scanner-safe bundle reference outputs (manifest, payload shapes, receipts) used by examples/scanner-safe-bundle/README.md to demonstrate deterministic generator stability. Shape-only — never real secret material."
+covered_by = ["examples/scanner-safe-bundle/README.md", "manual review"]


### PR DESCRIPTION
## Summary

`cargo xtask check-file-policy` was failing with **5 unmatched files**, all under `examples/scanner-safe-bundle/expected/`:

- \`examples/scanner-safe-bundle/expected/kv-v2.shape.json\`
- \`examples/scanner-safe-bundle/expected/manifest.json\`
- \`examples/scanner-safe-bundle/expected/receipts/audit-surface.json\`
- \`examples/scanner-safe-bundle/expected/receipts/materialization.json\`
- \`examples/scanner-safe-bundle/expected/secret.shape.yaml\`

These are reference outputs (manifest, payload shapes, receipts) that the \`examples/scanner-safe-bundle/README.md\` walkthrough uses to demonstrate the deterministic generator. Per the scanner-safe lesson, all values are shape-only — never real secret material — so committing them is correct, they just needed an explicit allowlist entry.

Add one entry covering \`examples/scanner-safe-bundle/expected/**/*\` with:

- \`kind = \"scanner_safe_bundle_reference\"\`
- \`owner = \"cli\"\`
- \`surface = \"examples\"\`
- \`classification = \"test\"\`
- \`covered_by = [\"examples/scanner-safe-bundle/README.md\", \"manual review\"]\`

## Validation

- \`cargo xtask check-file-policy\` — **1214 files; 1214 matched; 0 unmatched; 0 unused; 0 expired** (was 5 unmatched before)
- \`git diff --check\` — clean

## Test plan

- [ ] CI green