### PR TITLE
xtask: fix PUBLISH_CRATES order so compat shims publish after their owners

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -840,54 +840,57 @@ fn feature_matrix_cmd() -> Result<()> {
 }
 
 const PUBLISH_CRATES: &[&str] = &[
-    // Leaf crates (no workspace deps)
-    "uselesskey-core-seed",
-    "uselesskey-core-hash",
+    // True leaf crates (no workspace deps)
     "uselesskey-core-hmac-spec",
-    "uselesskey-core-id",
-    "uselesskey-core-cache",
-    "uselesskey-core-factory",
     "uselesskey-jwk",
-    // JWK compatibility shims
     "uselesskey-core-kid",
-    // Negative fixture crates
-    "uselesskey-core-negative-der",
-    "uselesskey-core-negative-pem",
-    "uselesskey-core-negative",
-    // Sinks and shapes
-    "uselesskey-core-sink",
     "uselesskey-core-jwk-shape",
     "uselesskey-core-jwks-order",
     "uselesskey-core-jwk-builder",
+    // JWK aggregate (depends on the JWK shards above)
     "uselesskey-core-jwk",
-    // X.509 crates (in dep order)
-    "uselesskey-core-x509-spec",
-    "uselesskey-core-x509-derive",
-    "uselesskey-core-x509-chain-negative",
-    "uselesskey-core-x509-negative",
-    "uselesskey-core-x509",
-    // Core aggregate
+    // Core (depends on the JWK lane above)
     "uselesskey-core",
+    // Core compatibility shims (depend on uselesskey-core)
+    "uselesskey-core-seed",
+    "uselesskey-core-hash",
+    "uselesskey-core-id",
+    "uselesskey-core-cache",
+    "uselesskey-core-factory",
+    "uselesskey-core-negative-der",
+    "uselesskey-core-negative-pem",
+    "uselesskey-core-negative",
+    "uselesskey-core-sink",
+    // Keypair material
     "uselesskey-core-keypair-material",
     "uselesskey-core-keypair",
-    // Mid-level crates
+    // Mid-level fixture crates
     "uselesskey-entropy",
     "uselesskey-rsa",
     "uselesskey-ecdsa",
     "uselesskey-ed25519",
     "uselesskey-hmac",
     "uselesskey-token",
-    // Token compatibility shims
+    // Token compatibility shims (depend on uselesskey-token)
     "uselesskey-token-spec",
     "uselesskey-core-base62",
     "uselesskey-core-token-shape",
     "uselesskey-core-token",
+    // Higher-level fixture crates
     "uselesskey-webhook",
     "uselesskey-pkcs11-mock",
     "uselesskey-webauthn",
     "uselesskey-ssh",
     "uselesskey-pgp",
+    // X.509 (depends on core and downstream)
     "uselesskey-x509",
+    // X.509 compatibility shims (depend on uselesskey-x509)
+    "uselesskey-core-x509-spec",
+    "uselesskey-core-x509-derive",
+    "uselesskey-core-x509-chain-negative",
+    "uselesskey-core-x509-negative",
+    "uselesskey-core-x509",
+    // Servers and CLI
     "uselesskey-test-server",
     "uselesskey-axum",
     "uselesskey-cli",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7286,7 +7286,8 @@ end_of_record
 
     #[test]
     fn resolve_start_index_from_first_crate() {
-        let idx = resolve_start_index(Some("uselesskey-core-seed"), false).unwrap();
+        let first = PUBLISH_CRATES[0];
+        let idx = resolve_start_index(Some(first), false).unwrap();
         assert_eq!(idx, 0);
     }
 


### PR DESCRIPTION
## Summary

**v0.7.0 release blocker.** The release workflow for tag \`v0.7.0\` failed on \`cargo xtask publish\` with:

\`\`\`
error: failed to prepare local package for uploading
Caused by: failed to select a version for the requirement \`uselesskey-core = \"^0.7.0\"\`
  candidate versions found which didn't match: 0.6.0, 0.5.1, ...
  required by package \`uselesskey-core-seed v0.7.0\`
\`\`\`

The v0.7.0 fold-into-\`srp::*\` refactor turned the former \`uselesskey-core-*\` and \`uselesskey-core-x509*\` shards into compatibility shims that depend on their owner crates. But \`PUBLISH_CRATES\` still listed them at the top under "Leaf crates", which walked them before \`uselesskey-core\` / \`uselesskey-x509\` could land on crates.io.

## Inversions before this PR

Topo-sort over \`cargo metadata\` deps found **14 inversions**:

- 9 core shims (\`core-seed\`, \`core-hash\`, \`core-id\`, \`core-cache\`, \`core-factory\`, \`core-negative-der\`, \`core-negative-pem\`, \`core-negative\`, \`core-sink\`) listed before \`uselesskey-core\`
- 5 x509 shims (\`core-x509-spec\`, \`core-x509-derive\`, \`core-x509-chain-negative\`, \`core-x509-negative\`, \`core-x509\`) listed before \`uselesskey-x509\`

## Fix

Reorder \`PUBLISH_CRATES\` so:

- core JWK shards publish first (the only true workspace-dep-free leaves)
- \`uselesskey-core\` follows
- the 9 core compat shims publish after \`uselesskey-core\`
- mid-level fixture and token crates follow
- \`uselesskey-x509\` publishes before its 5 x509 compat shims
- facade \`uselesskey\` stays last

## Validation

- Topo-sort over \`cargo metadata --no-deps\` dependencies: **53 crates, 0 inversions** (was 14)
- \`cargo check -p xtask\` — passes

## Recovery plan for v0.7.0

After this PR merges:

1. \`git tag -d v0.7.0 && git push --delete origin v0.7.0\`
2. Re-tag the new \`main\` HEAD (which includes this fix) as \`v0.7.0\`
3. Push the new tag; \`release.yml\` runs end-to-end with correct ordering

Nothing v0.7.0 reached crates.io on the first attempt (verified: all crates still default to 0.6.0 on crates.io), so retag is safe.

## Follow-up

\`cargo xtask publish-check\` did not catch this because its dry-run resolves workspace deps against local paths. A follow-up PR will add a topo-sort verification to publish-check so future ordering bugs fail loudly before tag push.

## Test plan

- [ ] CI green (fmt, check, clippy, test-compile, public-surface, docs-sync, publish-preflight, publish-check)