### PR TITLE
ci: gitignore .shipper/ and pass --allow-dirty to shipper preflight

### DIFF
--- a/.github/workflows/publish-retry.yml
+++ b/.github/workflows/publish-retry.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Preflight
         if: ${{ !inputs.dry_run }}
-        run: shipper preflight --policy safe
+        run: shipper preflight --policy safe --allow-dirty
 
       - name: Publish (shipper reconciles against registry truth)
         if: ${{ !inputs.dry_run && inputs.resume_from == '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           retention-days: 30
 
       - name: Preflight
-        run: shipper preflight --policy safe
+        run: shipper preflight --policy safe --allow-dirty
 
       - name: Publish
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ output.txt
 
 .gemini/
 gha-creds-*.json
+
+# shipper publish state (plan, receipts, etc.)
+.shipper/


### PR DESCRIPTION
## Summary

Unblock the v0.7.0 shipper publish. After #566 migrated to shipper, the live publish failed at preflight:

\`\`\`
[info] checking git cleanliness...
Error: git working tree is not clean; commit/stash changes or use --allow-dirty
\`\`\`

Our \`Plan\` step writes \`.shipper/plan.txt\` via \`tee\` (per shipper's GitHub Actions how-to). That dirties the working tree, so \`shipper preflight --policy safe\` rejects the run.

## Fix

Belt-and-suspenders:

1. **\`.gitignore\`** — add \`.shipper/\` so shipper's state directory is never tracked and doesn't dirty the tree from git's point of view.
2. **\`release.yml\`** + **\`publish-retry.yml\`** — pass \`--allow-dirty\` to \`shipper preflight\`, so even if shipper writes other state at runtime, preflight proceeds.

## After this PR merges

Dispatch \`publish-retry.yml\` on \`v0.7.0\` again. 3 of 53 crates are already on crates.io at 0.7.0; shipper will reconcile against the registry and continue from the rest.

## Test plan

- [ ] CI green
- [ ] Subsequent shipper publish run on v0.7.0 reaches \`Publish\` step