### PR TITLE
ci: pass --allow-dirty to shipper publish/resume too

### DIFF
--- a/.github/workflows/publish-retry.yml
+++ b/.github/workflows/publish-retry.yml
@@ -74,13 +74,15 @@ jobs:
             --policy safe \
             --readiness-method both \
             --max-attempts 12 \
-            --max-delay 15m
+            --max-delay 15m \
+            --allow-dirty
 
       - name: Resume from specific crate
         if: ${{ !inputs.dry_run && inputs.resume_from != '' }}
         run: |
           shipper resume \
-            --resume-from "${{ inputs.resume_from }}"
+            --resume-from "${{ inputs.resume_from }}" \
+            --allow-dirty
 
       - name: Publish dry-run
         if: ${{ inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,8 @@ jobs:
             --policy safe \
             --readiness-method both \
             --max-attempts 12 \
-            --max-delay 15m
+            --max-delay 15m \
+            --allow-dirty
 
       - name: Upload final state
         if: always()


### PR DESCRIPTION
## Summary

#567 added \`--allow-dirty\` to \`shipper preflight\` but the live v0.7.0 publish run still failed at the publish step:

\`\`\`
[1/53] Publishing uselesskey-aws-lc-rs@0.7.0... (1.533µs)
Error: git working tree is not clean; commit/stash changes or use --allow-dirty
\`\`\`

\`shipper publish\` and \`shipper resume\` each do their own up-front git-cleanliness check. Add \`--allow-dirty\` to both in \`release.yml\` and \`publish-retry.yml\`.

The long-term hygiene fix (\`.shipper/\` in \`.gitignore\` via #567, or writing the plan to a path outside the workspace) already applies for v0.8.0+. This PR is the in-flight unblock for v0.7.0.

## Test plan

- [ ] CI green
- [ ] Dispatch \`publish-retry.yml\` on v0.7.0 after merge — shipper publishes the remaining ~50 crates