### PR TITLE
fix: make internal test-helper deps path-only in workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,12 @@ authors = ["Effortless Metrics <opensource@effortlessmetrics.com>"]
 # error handling
 thiserror = "2.0.18"
 
-uselesskey-test-grid = { path = "crates/uselesskey-test-grid", version = "0.7.0" }
-uselesskey-test-support = { path = "crates/uselesskey-test-support", version = "0.7.0" }
-uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid", version = "0.7.0" }
+# Internal test helpers, never published (publish = false in their Cargo.toml).
+# Path-only — no version constraint — so cargo publish of dependents strips
+# them from the published manifest rather than requiring them on crates.io.
+uselesskey-test-grid = { path = "crates/uselesskey-test-grid" }
+uselesskey-test-support = { path = "crates/uselesskey-test-support" }
+uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid" }
 uselesskey = { path = "crates/uselesskey", version = "0.7.0", default-features = false }
 uselesskey-cli = { path = "crates/uselesskey-cli", version = "0.7.0" }
 uselesskey-entropy = { path = "crates/uselesskey-entropy", version = "0.7.0" }


### PR DESCRIPTION
## Summary

**v0.7.0 publish blocker.** Every \`cargo publish\` of a workspace crate that consumes a test-helper via \`[dev-dependencies] foo = { workspace = true }\` was failing:

\`\`\`
error: failed to prepare local package for uploading
Caused by: no matching package named \`uselesskey-test-support\` found
  location searched: crates.io index
\`\`\`

The \`workspace.dependencies\` entries for the three internal test-helper crates carried \`version = "0.7.0"\`:

\`\`\`toml
uselesskey-test-grid    = { path = \"crates/uselesskey-test-grid\",    version = \"0.7.0\" }
uselesskey-test-support = { path = \"crates/uselesskey-test-support\", version = \"0.7.0\" }
uselesskey-feature-grid = { path = \"crates/uselesskey-feature-grid\", version = \"0.7.0\" }
\`\`\`

Even for dev-deps, cargo requires the workspace version constraint to resolve against crates.io during publish — but all three crates are \`publish = false\` and never reach crates.io.

## Fix

Strip \`version\` from those three entries — keep them path-only. Cargo strips path-only dev-deps from the published manifest, which is the correct behavior for workspace-internal test helpers.

## Validation

Before:

\`\`\`
$ cargo publish --dry-run -p uselesskey-core --allow-dirty
error: failed to prepare local package for uploading
Caused by:
  no matching package named \`uselesskey-test-support\` found
\`\`\`

After:

\`\`\`
$ cargo publish --dry-run -p uselesskey-core --allow-dirty
   Packaging uselesskey-core v0.7.0 (...)
   ... (clean) ...
warning: aborting upload due to dry run
\`\`\`

## Why this only surfaced now

The three crates were given workspace versions during the v0.7.0 fold-into-srp work so they could be referenced consistently via \`{ workspace = true }\`. Pre-v0.7.0 they were only referenced via direct paths and the version mismatch never bit. The shipper migration in #566 made the failure visible because shipper actually runs \`cargo package\` per crate at preflight.

## Recovery sequence

After this PR merges, delete + retag \`v0.7.0\` on the new main HEAD and re-trigger publish-retry. The 3 crates already on crates.io at 0.7.0 (\`uselesskey-core-hmac-spec\`, \`uselesskey-jwk\`, \`uselesskey-core-jwk\`) stay where they are; shipper reconciles.

## Test plan

- [ ] CI green
- [ ] After merge: dry-run \`publish-retry.yml\` on retagged v0.7.0 — plan should not show test-helper publish requirements
- [ ] Live shipper publish completes the remaining ~50 crates