### PR TITLE
ci: revert publish workflow to cargo xtask publish (shipper#173 blocker)

### DIFF
--- a/.github/workflows/publish-retry.yml
+++ b/.github/workflows/publish-retry.yml
@@ -46,53 +46,23 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Install shipper
-        run: cargo install shipper --locked --version "0.3.0-rc.2"
-
-      - name: Plan
-        run: |
-          mkdir -p .shipper
-          shipper plan --format json | tee .shipper/plan.txt
-
-      - name: Upload plan state
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: shipper-state-plan
-          path: .shipper/
-          include-hidden-files: true
-          retention-days: 30
-
-      - name: Preflight
+      - name: Publish crates
         if: ${{ !inputs.dry_run }}
-        run: shipper preflight --policy safe --allow-dirty
-
-      - name: Publish (shipper reconciles against registry truth)
-        if: ${{ !inputs.dry_run && inputs.resume_from == '' }}
         run: |
-          shipper publish \
-            --policy safe \
-            --readiness-method both \
-            --max-attempts 12 \
-            --max-delay 15m \
-            --allow-dirty
-
-      - name: Resume from specific crate
-        if: ${{ !inputs.dry_run && inputs.resume_from != '' }}
-        run: |
-          shipper resume \
-            --resume-from "${{ inputs.resume_from }}" \
-            --allow-dirty
+          if [ -n "${{ inputs.resume_from }}" ]; then
+            cargo xtask publish --from "${{ inputs.resume_from }}"
+          else
+            cargo xtask publish
+          fi
 
       - name: Publish dry-run
         if: ${{ inputs.dry_run }}
-        run: shipper plan --format text
+        run: cargo xtask publish-check
 
-      - name: Upload final state
+      - name: Upload publish state
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: shipper-state-final
-          path: .shipper/
-          include-hidden-files: true
-          retention-days: 90
+          name: publish-state
+          path: target/xtask/publish-state.json
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,43 +60,16 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Install shipper
-        run: cargo install shipper --locked --version "0.3.0-rc.2"
+      - name: Publish all crates
+        run: cargo xtask publish
 
-      - name: Plan
-        run: |
-          mkdir -p .shipper
-          shipper plan --format json | tee .shipper/plan.txt
-
-      - name: Upload plan state
+      - name: Upload publish state
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: shipper-state-plan
-          path: .shipper/
-          include-hidden-files: true
-          retention-days: 30
-
-      - name: Preflight
-        run: shipper preflight --policy safe --allow-dirty
-
-      - name: Publish
-        run: |
-          shipper publish \
-            --policy safe \
-            --readiness-method both \
-            --max-attempts 12 \
-            --max-delay 15m \
-            --allow-dirty
-
-      - name: Upload final state
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: shipper-state-final
-          path: .shipper/
-          include-hidden-files: true
-          retention-days: 90
+          name: publish-state
+          path: target/xtask/publish-state.json
+          if-no-files-found: ignore
 
   release:
     needs: publish


### PR DESCRIPTION
## Summary

shipper 0.3.0-rc.2 emits the publish plan in alphabetical-looking order rather than topological order. With \`uselesskey-aws-lc-rs\` at position 1 and \`uselesskey-core\` at #2, shipper's linear walk fails immediately because \`cargo publish\` of aws-lc-rs requires \`uselesskey-ecdsa\` (#22) and other deps to already be on crates.io.

Filed against shipper: **effortlessmetrics/shipper#173** (to be fixed in shipper's next patch). Reverting publish flow to \`cargo xtask publish\` for v0.7.0; we'll re-migrate to shipper once #173 is resolved.

## Why this works now

The two reasons \`cargo xtask publish\` failed earlier are both addressed:

- **#565** corrected \`PUBLISH_CRATES\` so owner crates publish before their compatibility shims (\`uselesskey-core\` before \`uselesskey-core-seed\`, etc.). 14 inversions → 0 verified by topo-sort over \`cargo metadata\`.
- **#569** removed the \`version\` constraint from \`workspace.dependencies\` for the three \`publish = false\` test-helper crates (\`uselesskey-test-support\`, \`uselesskey-test-grid\`, \`uselesskey-feature-grid\`), so \`cargo publish\` no longer fails verification looking for them on crates.io. Confirmed locally with \`cargo publish --dry-run -p uselesskey-core --allow-dirty\`.

## Changes

- \`release.yml\` \`publish\` job: shipper plan/preflight/publish steps → single \`cargo xtask publish\` step + \`publish-state.json\` artifact upload (the pre-shipper-migration shape).
- \`publish-retry.yml\`: shipper paths → \`cargo xtask publish\` (or \`--from <crate>\` when \`resume_from\` input is set) and \`cargo xtask publish-check\` for dry-run.
- Keep \`.shipper/\` in \`.gitignore\` (harmless future-proofing for the eventual re-migration).
- Keep the existing \`Quality gate\` / \`Publish preflight\` / \`Publish dry-run\` steps in the \`preflight\` job — unaffected.

## Recovery for v0.7.0

After this PR merges, delete + retag \`v0.7.0\` on the new main HEAD and push. \`release.yml\` runs end-to-end with cargo xtask publish. Three crates already at 0.7.0 (\`uselesskey-core-hmac-spec\`, \`uselesskey-jwk\`, \`uselesskey-core-jwk\`) stay where they are; cargo xtask publish skips them on \"version already published\" via \`already_published\` state in \`publish-state.json\`.

## Test plan

- [ ] CI green
- [ ] After merge, retag v0.7.0 and tag push fires release.yml end-to-end
- [ ] All ~53 publishable crates reach 0.7.0 on crates.io
- [ ] release job creates the GitHub release (we'll overwrite the body with the custom one post-publish)