### PR TITLE
docs: capture v0.7.0 publish-lane lessons learned

### DIFF
--- a/docs/release/v0.7.0-lessons-learned.md
+++ b/docs/release/v0.7.0-lessons-learned.md
@@ -1,0 +1,167 @@
+# v0.7.0 Publish Lane — Lessons Learned
+
+## Summary
+
+The v0.7.0 release ("Rust 1.95 scanner-safe fixture platform release") published
+successfully, but the release lane took four publish attempts before all crates
+landed on crates.io. Three of the four failures came from publish-order and
+manifest-shape bugs in `uselesskey` itself; the fourth came from an upstream
+defect in `shipper 0.3.0-rc.2`. None of the failures reflected a fixture-promise
+regression — the release content was correct from the first attempt — but the
+publish tooling assumptions were not. This note captures the failure shapes,
+the fix PRs, and the guardrails the release governance milestone should grow
+before v0.8.0.
+
+## What broke
+
+### 1. PUBLISH_CRATES had compatibility shims before owner crates (#565)
+
+**Symptom.** The first publish (tag `v0.7.0` after #562 merged) failed packaging
+`uselesskey-core-seed v0.7.0`. The shim requires `uselesskey-core ^0.7.0`, but
+only `uselesskey-core 0.6.0` was on crates.io at that moment.
+
+**Root cause.** The hand-maintained `PUBLISH_CRATES` array in
+`xtask/src/main.rs:842` listed the compatibility shims (the renamed shards from
+the v0.7.0 "fold into `srp::*`" refactor) BEFORE their owner crates. A
+topo-sort over `cargo metadata` against that list found 14 inversions — 9 core
+shims listed before `uselesskey-core`, 5 X.509 shims listed before
+`uselesskey-x509`.
+
+**Fix.** #565 reordered `PUBLISH_CRATES` to match a topo-sort of the workspace
+DAG. After the fix the same inversion check reports 0 inversions.
+
+**Takeaway.** Hand-maintained publish orders rot silently. The check that
+catches this belongs in CI on every PR that touches `PUBLISH_CRATES` or adds a
+new crate, not at publish time.
+
+### 2. workspace.dependencies version constraints on `publish = false` crates blocked cargo publish (#569)
+
+**Symptom.** The retagged publish (after #565) failed packaging
+`uselesskey-core v0.7.0`. cargo refused because the dev-dependency
+`uselesskey-test-support = { workspace = true }` resolved to a `version` that
+crates.io did not have.
+
+**Root cause.** The `[workspace.dependencies]` entry was
+`{ path = "...", version = "0.7.0" }`. Even though `uselesskey-test-support` is
+itself `publish = false`, the `version` field made `cargo package` verify the
+constraint against crates.io. The same shape applied to
+`uselesskey-test-grid` and `uselesskey-feature-grid`.
+
+**Fix.** #569 stripped the `version` field from all three
+`workspace.dependencies` entries, leaving them path-only. `cargo publish`
+strips path-only dev-deps from the published manifest, so downstream
+consumers see no test-helper references.
+
+**Takeaway.** For `publish = false` test-helper crates, the
+`workspace.dependencies` entry MUST be path-only. Adding a `version` makes the
+helper effectively required-on-crates.io for any dependent's publish.
+
+### 3. shipper 0.3.0-rc.2 emits a non-topological plan (shipper#173; reverted via #570)
+
+**Symptom.** After migrating the publish workflows to shipper (#566), the next
+publish attempt failed: shipper put `uselesskey-aws-lc-rs` at plan position #1
+even though it depends on `uselesskey-core` (#2 in the plan),
+`uselesskey-rsa` (#29), `uselesskey-ecdsa` (#22), and `uselesskey-ed25519`,
+none of which were on crates.io at 0.7.0 yet. The plan looked
+alphabetical-by-name, not topological.
+
+**Root cause.** Upstream defect in shipper 0.3.0-rc.2 plan generation.
+
+**Fix.** Filed `shipper#173`. #570 reverted both `release.yml` and
+`publish-retry.yml` back to `cargo xtask publish`, where the fixed
+`PUBLISH_CRATES` order from #565 was already correct. Shipper re-adoption is
+deferred to a later release.
+
+**Takeaway.** Always cross-check a shipper plan against `cargo metadata`
+topo-order before live publish. Treat the plan as a candidate, not a contract.
+
+### 4. shipper-as-tooling required dirty-tree handling (#567, #568)
+
+**Symptom.** During shipper adoption, `shipper preflight` failed because
+`.shipper/plan.txt` dirtied the working tree. After fixing preflight,
+`shipper publish` and `shipper resume` also failed the same cleanliness check.
+
+**Root cause.** Shipper writes a plan file to the worktree and refuses to
+operate from a dirty tree unless told otherwise.
+
+**Fix.** #567 added `.shipper/` to `.gitignore` and passed `--allow-dirty` to
+`shipper preflight`. #568 added `--allow-dirty` to `shipper publish` and
+`shipper resume`.
+
+**Takeaway.** Any tooling that materializes state into the worktree needs an
+explicit gitignore entry plus a `--allow-dirty` (or equivalent) escape hatch
+in every invocation site. Cover all invocations together, not one at a time.
+
+## What we fixed
+
+- #562 — backfilled the v0.7.0 CHANGELOG, made the scanner-safe bundle workflow
+  visible in README, and added the GitHub-release-body draft in
+  `docs/release/v0.7.0-category-notes.md`.
+- #563 — marked `docs/audits/rust-1.95-compatibility.md` as historical; the
+  pre-bump "Current MSRV: 1.92" line was misleading after the 1.95 bump.
+- #564 — added a `policy/non-rust-allowlist.toml` entry for
+  `examples/scanner-safe-bundle/expected/**/*` (5 unmatched reference files).
+- #565 — reordered `PUBLISH_CRATES` so compatibility shims publish after their
+  owner crates (topo-sort over cargo metadata; 0 inversions).
+- #566 — migrated the release publish workflows to shipper 0.3.0-rc.2.
+  Superseded by #570 for v0.7.0.
+- #567 — gitignored `.shipper/` and passed `--allow-dirty` to
+  `shipper preflight`.
+- #568 — passed `--allow-dirty` to `shipper publish` and `shipper resume`.
+- #569 — made `uselesskey-test-support`, `uselesskey-test-grid`, and
+  `uselesskey-feature-grid` path-only in `workspace.dependencies` so dependent
+  crates can package without those helpers existing on crates.io.
+- #570 — reverted `release.yml` and `publish-retry.yml` back to
+  `cargo xtask publish` because shipper 0.3.0-rc.2 emits a non-topological plan
+  (tracked upstream as `shipper#173`).
+
+## What we learned
+
+### Hand-maintained publish orders need a topo-sort guard at PR time
+
+The PUBLISH_CRATES inversion bug was invisible until the release tag fired the
+workflow. A small xtask check — "verify PUBLISH_CRATES is a topo-sort of the
+workspace dependency DAG" — would have caught #565 during the PR that
+introduced the shim crates. The check should run on every PR that touches the
+list or adds a crate.
+
+### workspace.dependencies for publish=false crates must be path-only
+
+`publish = false` on the helper crate is not enough. As long as the
+`workspace.dependencies` entry carries a `version`, every dependent's
+`cargo package` validates that version against crates.io. The rule is
+mechanical: if the dep is `publish = false`, the workspace entry is
+path-only. A lint over `Cargo.toml` would enforce this.
+
+### Treat crates.io as source of truth during recovery; don't retag if partial publishes have landed
+
+When the first publish died mid-DAG, several owner crates were already on
+crates.io at 0.7.0. The recovery path is "publish what's left," not "retag and
+republish from zero," because crates.io versions are immutable. The workflows
+were already idempotent enough for this — `cargo publish` skips already-published
+versions — but the mental model needs to be explicit in the runbook.
+
+### Always cross-check shipper plan order against cargo metadata before live publish
+
+Shipper produced a plan that looked plausible (53 crates, every crate present)
+but was non-topological. The diff against
+`cargo metadata --format-version 1 | jq` toposort would have been a one-liner
+that flagged `uselesskey-aws-lc-rs` at position #1. Treat the shipper plan as
+a candidate to verify, not a contract to execute.
+
+## Deferred to v0.8.0
+
+### Re-migrate publish to shipper once shipper#173 lands
+
+The shipper migration goal (compute the publish DAG from cargo metadata instead
+of from a hand-maintained list) is still right. It depends on shipper emitting
+a topological plan. Once `shipper#173` is fixed and a patched release is out,
+re-do the migration on a non-release branch first and dry-run-verify the plan
+against `cargo metadata` before opening the swap PR.
+
+### Compatibility-shim removal (out of scope for 0.7.x)
+
+The 9 core shims and 5 X.509 shims that triggered the PUBLISH_CRATES inversion
+exist for v0.7.x compatibility and will stay published as shims for this
+release line. Their removal is a v0.8.0 topology change, not a publish-lane
+fix. Track removal under the v0.8.0 public-surface milestone.


### PR DESCRIPTION
Pure docs PR — captures the v0.7.0 publish lane retrospective.

## Summary

Adds `docs/release/v0.7.0-lessons-learned.md` as the narrative record of the four publish failures the v0.7.0 release lane hit before the live publish completed. The doc covers symptom, root cause, fix PR, and takeaway for each failure, plus the carryover work deferred to v0.8.0.

## Files added

- `docs/release/v0.7.0-lessons-learned.md` (167 lines)

## PRs referenced

- #562 — v0.7.0 changelog backfill + README bundle visibility + release-body draft
- #563 — rust-1.95 audit historical-record callout
- #564 — scanner-safe-bundle example reference allowlist
- #565 — PUBLISH_CRATES topo-sort fix (compat shims after owners)
- #566 — release publish migrated to shipper (later reverted by #570)
- #567 — gitignore `.shipper/` + `--allow-dirty` on shipper preflight
- #568 — `--allow-dirty` on shipper publish/resume
- #569 — workspace dev-deps for `publish = false` helpers made path-only
- #570 — reverted release/publish-retry workflows to `cargo xtask publish`

External: `shipper#173` (non-topological plan in shipper 0.3.0-rc.2).

## Test plan

- [ ] CI green on the docs-only diff
- [ ] `cargo xtask typos` passes (verified locally)
- [ ] `git diff --check` clean (verified locally)