### PR TITLE
docs: document partial publish recovery and registry-truth rules

### DIFF
--- a/docs/how-to/recover-partial-publish.md
+++ b/docs/how-to/recover-partial-publish.md
@@ -1,0 +1,100 @@
+# How to: recover from a partial publish
+
+Use this when `cargo xtask publish` or the `release.yml` workflow has
+failed *after* one or more crates landed on crates.io. The operating
+rule is simple: **crates.io is the source of truth**. Once a crate is
+published at a version, it cannot be unpublished — only yanked. Plan
+around that fact.
+
+## Recognize a partial publish
+
+You are in a partial-publish state when:
+
+- The release workflow exited with `publish` job failure (not preflight).
+- `cargo info <crate>` shows the new version live for at least one
+  workspace crate but not the facade `uselesskey`.
+- `target/xtask/publish-state.json` lists at least one crate with
+  `status = "published"`.
+
+## Inspect registry truth
+
+For each PUBLISH_CRATES entry, query crates.io:
+
+```bash
+for c in $(jq -r '.crates[].name' target/xtask/publish-state.json); do
+  v=$(curl -s "https://crates.io/api/v1/crates/$c" \
+      | python -c "import sys,json; print(json.load(sys.stdin)['crate']['max_version'])")
+  echo "$c: $v"
+done
+```
+
+Cross-reference with `target/xtask/publish-state.json` to confirm what
+shipper or `cargo xtask publish` thought it did.
+
+## Choose the recovery path
+
+### Recovery path A: resume from the failed crate
+
+When the cause is transient (crates.io indexing race, network blip, a
+single crate metadata error) and all earlier crates published cleanly:
+
+```bash
+gh workflow run publish-retry.yml \
+  -f tag=<tag> \
+  -f resume_from=<failed-crate-name>
+```
+
+`cargo xtask publish --from <crate>` walks PUBLISH_CRATES from that
+index forward. Already-published crates are detected via
+`cargo publish`'s `crate version already uploaded` error and recorded
+as `already_published` in `publish-state.json`.
+
+### Recovery path B: patch the workspace, then resume
+
+When the cause is structural (incorrect dep order, manifest issue,
+missing dep on crates.io):
+
+1. Land the fix on `main` via a PR. Do not retag yet.
+2. Once main is updated:
+   - If the tag commit was the source of truth and `release.yml` is
+     what dispatches publish: delete `<tag>` locally and on origin,
+     retag main HEAD, push.
+   - If you can recover via `publish-retry.yml` against main HEAD
+     (no tag needed for that workflow's checkout), use that without
+     retagging.
+3. Treat partial-publish crates as fixed points. Do not try to
+   republish the same version that already landed.
+
+## Anti-patterns
+
+- **Do not retag blindly** when crates have already landed at the
+  target version. The retag does not unpublish, and re-running the
+  workflow against a still-broken graph just re-attempts the same
+  failures.
+- **Do not yank** unless you have actively deployed broken artifacts.
+  Yanked versions stay queryable; they only suppress new resolution.
+- **Do not republish under a new version** (`0.7.0 → 0.7.0-fix`) when
+  only some crates landed. The split history makes downstream
+  resolution worse, not better.
+- **Do not use retries to solve order failures.** Retries only help
+  with crates.io indexing/readiness lag. Dependency-order failures are
+  deterministic and will fail every attempt.
+
+## Tooling that helps you avoid this
+
+- `cargo xtask publish-check` — runs every PR and now (post-#572)
+  verifies PUBLISH_CRATES is dependency-topological.
+- `cargo xtask publish-preflight` — runs every PR and (post-PR 2 of
+  the v0.7.1 series) rejects versioned `workspace.dependencies`
+  entries that point at `publish = false` crates.
+- `cargo xtask publish --dry-run --from <crate>` — dry-run a resume
+  before live publish.
+
+## Why shipper is parked
+
+`shipper 0.3.0-rc.2` was migrated in #566 then reverted in #570
+because its publish plan was not dependency-topological for this
+workspace (tracked in EffortlessMetrics/shipper#173). The
+`release.yml` / `publish-retry.yml` workflows use `cargo xtask publish`
+for v0.7.x patch releases. Re-migration happens after shipper's next
+patch resolves #173.

--- a/docs/release/publish-recovery.md
+++ b/docs/release/publish-recovery.md
@@ -1,0 +1,75 @@
+# Publish recovery and registry-truth rules
+
+This document defines the release-process posture for partial-publish
+incidents. Operational steps live in
+[`docs/how-to/recover-partial-publish.md`](../how-to/recover-partial-publish.md);
+this is the policy/why side.
+
+## Registry truth
+
+crates.io is the immutable source of truth. Once `<crate>@<version>`
+is uploaded, the release process treats that as the final state of
+that crate at that version. The local `publish-state.json` is a
+record of intent; crates.io is the record of fact.
+
+When the two disagree, prefer crates.io.
+
+## Recovery posture by failure class
+
+| Failure class | Recovery | Retag? | Restart? |
+| --- | --- | --- | --- |
+| Indexing race / readiness lag | retry with backoff | no | no |
+| Single-crate metadata error | patch + `--from <crate>` | no | no |
+| Dependency-order error | patch PUBLISH_CRATES + `--from <crate>` | no | no |
+| Workspace verification error (versioned publish-false dep, etc.) | patch workspace.dependencies + `--from <crate>` | no | no |
+| Tag points at wrong commit | delete tag, retag, push | yes (rare) | yes |
+| Shipper plan defect | revert to cargo xtask publish, `--from <crate>` | no | no |
+| Auth/token issue | rotate token, retry | no | no |
+
+## Tag-touching is the exception
+
+The release tag (e.g. `v0.7.0`) should be deleted+recreated only when
+the tag commit itself was the wrong commit. If `main` has been
+patched after the partial publish and the new commits are the
+intended release content, retagging to that new HEAD is correct.
+
+If `main` is unchanged and only the workspace state needs to be
+reinspected, do NOT retag — dispatch the publish-retry workflow
+instead.
+
+## When to yank
+
+Yank a published version only when:
+
+- the artifact has a critical defect that would mislead downstream
+  consumers, and
+- a fixed version is being prepared on a higher patch number.
+
+Yanks suppress new resolution but keep the artifact queryable. Do not
+yank to "clean up" a partial publish; that leaves a half-yanked
+history that downstream consumers must navigate.
+
+## Publish-system hardening
+
+The v0.7.0 release lane exposed three publish-system gaps that are
+being closed in v0.7.1:
+
+1. **Publish graph topology** — #572: PUBLISH_CRATES must be
+   dependency-topological; verified at PR time.
+2. **Versioned publish-false workspace deps** — (PR 2 of v0.7.1):
+   `workspace.dependencies` entries pointing at `publish = false`
+   crates must be path-only.
+3. **Scanner-safe reference drift** — (PR 3 of v0.7.1):
+   `examples/scanner-safe-bundle/expected/*` is verified against
+   regenerated outputs at PR time.
+
+See [`v0.7.0-lessons-learned.md`](v0.7.0-lessons-learned.md) for the
+incident retrospective.
+
+## Shipper status
+
+Migration to `shipper` for publish is parked behind
+EffortlessMetrics/shipper#173 (non-topological plan ordering). The
+current path is `cargo xtask publish` via `release.yml` and
+`publish-retry.yml`. Re-migration happens after shipper's next patch
+ships and the plan ordering is verified against this workspace's DAG.


### PR DESCRIPTION
## Summary

Pure docs PR. Captures publish-recovery operational procedure and registry-truth rules as durable institutional knowledge after the v0.7.0 publish lane.

This is "PR 6" of the v0.7.1 publish-system hardening series:

- PR 1 (#572): xtask publish-check topological-order guard
- PR 2 (#578): xtask reject versioned publish=false workspace deps
- PR 3 (#577): xtask scanner-safe-reference --check
- PR 6 (this PR): publish-recovery docs

## Files added

- `docs/how-to/recover-partial-publish.md` — operator-facing procedure: when to retry vs patch vs retag, what counts as a partial publish, anti-patterns.
- `docs/release/publish-recovery.md` — release-process posture: registry truth, recovery posture by failure class, when to yank, current shipper status.

Complementary to #571 (v0.7.0 lessons-learned retrospective). #571 = what happened in v0.7.0; these docs = what to do during any future partial publish.

## References

- #565 — first publish failure (PUBLISH_CRATES inversions)
- #569 — second publish failure (versioned publish=false workspace deps)
- #566/#567/#568 — shipper migration + dirty-tree fixes
- #570 — reverted publish back to cargo xtask publish
- #571 — v0.7.0 lessons-learned retrospective (open)
- shipper#173 — external blocker for shipper re-migration

## Test plan

- [ ] CI green (docs only; no source changes)