### PR TITLE
docs: bump migration guide install snippets to 0.7.0

### DIFF
--- a/docs/how-to/migration.md
+++ b/docs/how-to/migration.md
@@ -1,6 +1,6 @@
-# Migrating to `uselesskey` 0.6.0: deterministic crypto fixtures without committed blobs
+# Migrating to `uselesskey` 0.7.0: deterministic crypto fixtures without committed blobs
 
-This guide shows how to replace committed PEM/DER/JWK/token blobs with runtime-generated fixtures using `uselesskey` **0.6.0**.
+This guide shows how to replace committed PEM/DER/JWK/token blobs with runtime-generated fixtures using `uselesskey` **0.7.0**.
 
 ## What this repo is for
 
@@ -18,7 +18,7 @@ Use `uselesskey` as a `dev-dependency`, then opt into only the fixture families 
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.6.0", default-features = false, features = ["rsa", "jwk"] }
+uselesskey = { version = "0.7.0", default-features = false, features = ["rsa", "jwk"] }
 ```
 
 ### Minimal feature examples
@@ -26,22 +26,22 @@ uselesskey = { version = "0.6.0", default-features = false, features = ["rsa", "
 ```toml
 # token-only tests
 [dev-dependencies]
-uselesskey = { version = "0.6.0", default-features = false, features = ["token"] }
+uselesskey = { version = "0.7.0", default-features = false, features = ["token"] }
 ```
 
 ```toml
 # TLS chain + rustls adapter
 [dev-dependencies]
-uselesskey = { version = "0.6.0", default-features = false, features = ["x509"] }
-uselesskey-rustls = { version = "0.6.0" }
+uselesskey = { version = "0.7.0", default-features = false, features = ["x509"] }
+uselesskey-rustls = { version = "0.7.0" }
 ```
 
 ```toml
 # JWT + JOSE/OpenID style conversions
 [dev-dependencies]
-uselesskey = { version = "0.6.0", default-features = false, features = ["rsa", "hmac", "jwk"] }
-uselesskey-jsonwebtoken = { version = "0.6.0" }
-uselesskey-jose-openid = { version = "0.6.0" }
+uselesskey = { version = "0.7.0", default-features = false, features = ["rsa", "hmac", "jwk"] }
+uselesskey-jsonwebtoken = { version = "0.7.0" }
+uselesskey-jose-openid = { version = "0.7.0" }
 ```
 
 > Prefer adapter crates (`uselesskey-rustls`, `uselesskey-jsonwebtoken`, etc.) over broad feature bundles to keep compile and dependency surface small.
@@ -173,7 +173,7 @@ Use `Factory::random()` when fixture values should vary across runs (e.g., explo
 
 ## Migration checklist
 
-1. Add `uselesskey` 0.6.0 to `[dev-dependencies]`
+1. Add `uselesskey` 0.7.0 to `[dev-dependencies]`
 2. Enable only needed features (`rsa`, `ecdsa`, `ed25519`, `hmac`, `token`, `x509`, `pgp`, `jwk`)
 3. Replace committed PEM/DER/JWK/token fixtures with `Factory` calls
 4. Centralize seed strategy (`USELESSKEY_SEED` in CI)


### PR DESCRIPTION
## Why

`docs/how-to/migration.md` install snippets still pointed at `uselesskey 0.6.0` even though v0.7.0 is published on crates.io. New users following the migration guide were pinning an outdated minor. Closes #574.

## What

Bumped 9 install/version references in `docs/how-to/migration.md` from `0.6.0` to `0.7.0`:

- Line 1 (title): `# Migrating to ` + "`uselesskey`" + ` 0.6.0` -> `0.7.0`
- Line 3 (lead): `using ` + "`uselesskey`" + ` **0.6.0**` -> `**0.7.0**`
- Line 21: `uselesskey = { version = "0.6.0", ... features = ["rsa", "jwk"] }` -> `"0.7.0"`
- Line 29: `uselesskey = { version = "0.6.0", ... features = ["token"] }` -> `"0.7.0"`
- Line 35: `uselesskey = { version = "0.6.0", ... features = ["x509"] }` -> `"0.7.0"`
- Line 36: `uselesskey-rustls = { version = "0.6.0" }` -> `"0.7.0"`
- Line 42: `uselesskey = { version = "0.6.0", ... features = ["rsa", "hmac", "jwk"] }` -> `"0.7.0"`
- Line 43: `uselesskey-jsonwebtoken = { version = "0.6.0" }` -> `"0.7.0"`
- Line 44: `uselesskey-jose-openid = { version = "0.6.0" }` -> `"0.7.0"`
- Line 176 (checklist): `Add ` + "`uselesskey`" + ` 0.6.0 to [dev-dependencies]` -> `0.7.0`

## Preserved

No "from 0.6.0" historical references existed in this file, so nothing to preserve there. Out-of-scope (intentionally untouched) per issue #574: `CHANGELOG.md`, `docs/explanation/roadmap.md`, `docs/release/v0.7.0-category-notes.md`, `docs/release/evidence-matrix-v0.7.0.md`, `docs/explanation/roadmap-followups-0251.md` — all legitimate historical / baseline references.

## Test plan

- [x] `grep -n "0\.6\.0" docs/how-to/migration.md` -> no matches
- [x] `cargo xtask docs-sync --check` -> exit 0 (migration.md is not part of docs-sync inventory)
- [x] `cargo xtask typos` -> exit 0
- [x] `git diff --check` -> clean