### PR TITLE
docs: define TLS contract-pack profile

### DIFF
--- a/docs/release/v0.8.0-tls-profile-design.md
+++ b/docs/release/v0.8.0-tls-profile-design.md
@@ -1,0 +1,286 @@
+# TLS contract-pack profile (design)
+
+> **Status:** design — accepted scope for v0.8.0. No code in this doc.
+> See PR-A of the v0.8.0 lane.
+
+## Why
+
+Certificate-chain validation is one of the most common test workflows in
+TLS-touching services: rustls/tonic/hyper-rustls callers need to assert
+that their verifier accepts a good chain and rejects each well-known
+failure class. Committing real CA material is scanner-hostile, and
+hand-rolling per-test certs leaks CA-shaped code into test crates. The
+v0.7.0 OIDC contract pack proved the model — a deterministic bundle of
+valid plus protocol-shaped negative fixtures that downstream validators
+can run against. TLS is the next obvious user surface for the same
+recipe.
+
+## Scope
+
+This pack proves that a downstream TLS verifier:
+
+- accepts a valid leaf served from a valid chain,
+- rejects an expired leaf,
+- rejects a not-yet-valid leaf,
+- rejects a leaf with a wrong-hostname SAN,
+- rejects a leaf signed by a CA outside the configured trust anchors.
+
+This pack does NOT prove:
+
+- revocation handling (CRL, OCSP, OCSP stapling),
+- certificate transparency log presence,
+- mTLS client-cert chains,
+- browser-trust-store simulation,
+- production CA custody, key escrow, or any production crypto guarantee,
+- adapter-internal verifier heuristics beyond the five failure classes
+  above.
+
+The claim boundary is the same as for the scanner-safe and OIDC packs:
+`uselesskey` is a test-fixture layer, not production key management or
+cryptographic assurance.
+
+## User-facing surface
+
+### Command
+
+```bash
+uselesskey bundle --profile tls --out target/tls-fixtures
+```
+
+The command is deterministic from the bundle seed (re-using the v0.7.0
+`uselesskey-core` derivation chain), matches the dispatch shape of
+`--profile scanner-safe` and `--profile oidc`, and writes under
+`--out`. As with the OIDC pack, the recommended pattern is to regenerate
+the bundle under `target/` in CI rather than commit the generated
+payloads.
+
+### Bundle contents
+
+| Path | Role | Failure class |
+|---|---|---|
+| `certs/valid-leaf.pem` | A valid leaf signed by the bundle's CA | (none — happy path) |
+| `certs/valid-chain.pem` | Full chain (leaf + intermediate + root) | (none — happy path) |
+| `certs/negative-expired-leaf.pem` | Leaf with `notAfter` in the past | expired |
+| `certs/negative-not-yet-valid.pem` | Leaf with `notBefore` in the future | not yet valid |
+| `certs/negative-wrong-hostname.pem` | Valid signature, wrong SAN/CN | hostname mismatch |
+| `certs/negative-untrusted-root.pem` | Signed by a CA not in the chain | unknown CA |
+| `receipts/materialization.json` | Bundle generation receipt | (evidence) |
+| `receipts/audit-surface.json` | Audit-surface receipt | (evidence) |
+| `evidence/tls-profile.md` | Per-fixture rejection expectations | (evidence) |
+
+Six certificate fixtures, two receipts, one evidence doc. The receipt
+shape mirrors the OIDC pack so the same `verify-bundle` and
+`inspect-bundle` commands work without a new code path.
+
+## Per-fixture spec
+
+### `certs/valid-leaf.pem`
+
+- **Encodes:** a leaf certificate with a deterministic SAN, signed by
+  the bundle's intermediate, which is in turn signed by the bundle's
+  root. `notBefore` and `notAfter` derived from
+  `deterministic_base_time()` such that the leaf is valid for the full
+  CI window.
+- **What this proves:** verifiers configured with the bundle's root as
+  a trust anchor accept this leaf as the happy-path case.
+- **What this does NOT prove:** cipher suite negotiation, ALPN, SNI
+  routing, or any verifier behavior beyond chain construction and
+  date-bounds checking.
+- **Expected verifier behavior:** rustls / webpki / tonic accept the
+  leaf when the bundle's root is installed as a trust anchor and the
+  expected SAN matches the connection target.
+- **Adapter expectation:** see "Adapter contracts" below.
+
+### `certs/valid-chain.pem`
+
+- **Encodes:** the full chain (leaf, intermediate, root) concatenated
+  in standard PEM order. Re-uses the same leaf as `valid-leaf.pem`.
+- **What this proves:** verifiers that accept a server-presented chain
+  blob construct a valid path to the bundle's root.
+- **What this does NOT prove:** cross-signing handling, chain
+  reordering tolerance, or AIA-fetching behavior.
+- **Expected verifier behavior:** chain validation succeeds; the
+  verifier reaches the bundle's root as the terminating trust anchor.
+- **Adapter expectation:** see "Adapter contracts" below.
+
+### `certs/negative-expired-leaf.pem`
+
+- **Encodes:** leaf certificate whose `notAfter` is fixed in the past
+  using the existing `ChainNegative::ExpiredLeaf` / `X509Negative::Expired`
+  derivation in `uselesskey-x509`.
+- **What this proves:** verifiers that perform date-bounds checking
+  reject this leaf with an "expired" error path.
+- **What this does NOT prove:** revocation handling, OCSP behavior, CT
+  log presence, or any verifier-internal heuristic beyond date bounds.
+- **Expected verifier behavior:** rustls returns a date-related
+  certificate error (the rustls error family that surfaces expired
+  certificates); tonic propagates the same.
+- **Adapter expectation:** see "Adapter contracts" below.
+
+### `certs/negative-not-yet-valid.pem`
+
+- **Encodes:** leaf certificate whose `notBefore` is fixed in the
+  future using the existing `ChainNegative::NotYetValidLeaf` /
+  `X509Negative::NotYetValid` derivation in `uselesskey-x509`.
+- **What this proves:** verifiers that perform date-bounds checking
+  reject this leaf with a "not yet valid" error path.
+- **What this does NOT prove:** clock-skew tolerance configuration or
+  any verifier-internal grace window beyond exact date-bounds.
+- **Expected verifier behavior:** rustls returns a date-related
+  certificate error distinct from the expired case where the verifier
+  exposes that distinction; tonic propagates the same.
+- **Adapter expectation:** see "Adapter contracts" below.
+
+### `certs/negative-wrong-hostname.pem`
+
+- **Encodes:** leaf certificate with a valid signature from the bundle's
+  intermediate, but whose SAN/CN intentionally does not match the
+  bundle's documented expected hostname. Derived from
+  `ChainNegative::HostnameMismatch { wrong_hostname }` with a fixed
+  hostname value baked into the bundle's evidence doc.
+- **What this proves:** verifiers that perform hostname checking
+  reject this leaf with a hostname-mismatch error path.
+- **What this does NOT prove:** wildcard SAN evaluation, IP-SAN
+  handling, IDN normalization, or alternative-name precedence rules
+  beyond the single wrong-hostname case.
+- **Expected verifier behavior:** rustls returns a hostname-related
+  certificate error when the client requests the bundle's documented
+  expected hostname; tonic propagates the same.
+- **Adapter expectation:** see "Adapter contracts" below.
+
+### `certs/negative-untrusted-root.pem`
+
+- **Encodes:** leaf certificate plus its chain signed by an alternate
+  root CA that is intentionally NOT in the bundle's `valid-chain.pem`.
+  Derived from `ChainNegative::UnknownCa`.
+- **What this proves:** verifiers that anchor only to the bundle's
+  primary root reject this leaf with an unknown-CA error path.
+- **What this does NOT prove:** trust-store merging, system-trust
+  fallback behavior, or cross-signed chain handling.
+- **Expected verifier behavior:** rustls returns an unknown-issuer /
+  untrusted-root certificate error; tonic propagates the same.
+- **Adapter expectation:** see "Adapter contracts" below.
+
+## Adapter contracts
+
+The adapter behavior below is the **contract** for PR-B. No adapter code
+ships in this PR.
+
+- `uselesskey-rustls`: expected to expose helpers that turn the bundle
+  into rustls trust-store and per-leaf material, plus accessors for
+  each negative fixture so downstream tests can assert on the
+  rejection path without re-parsing PEM. The exact API surface (type
+  names, function signatures) lands in PR-B; this doc fixes the
+  contract that (a) every fixture in the bundle has a typed accessor,
+  (b) the valid path produces a usable rustls trust anchor plus a
+  matching server key/leaf pair, and (c) every negative fixture is
+  documented with the rustls error family the test should assert on.
+- `uselesskey-tonic`: expected to expose helpers building on the
+  rustls adapter for TLS-protected gRPC tests. The contract is that
+  tonic helpers re-export the same negative-fixture accessors so a
+  tonic-using test crate does not need to depend on
+  `uselesskey-rustls` directly.
+
+Neither adapter is expected to add new verifier behavior. The adapters
+are wrappers that convert bundle bytes into adapter-typed values; the
+rejection paths are the verifier's own.
+
+## Scanner-safety boundary
+
+- All certificate material is generated deterministically from the
+  bundle seed (re-uses the v0.7.0 `uselesskey-core` derivation chain).
+- The bundle-internal keypairs are scanner-safe placeholders by
+  construction: derived deterministically from the bundle seed, never
+  rotated, never published, and never claim to be production key
+  material.
+- PEM payloads of the bundle remain shape-realistic so downstream
+  parsers exercise their real parsing paths. As with the scanner-safe
+  and OIDC packs, the recommended pattern is to regenerate cert exports
+  under `target/`, NOT commit them — see
+  `docs/release/publish-recovery.md` for the registry-truth analogue
+  and `examples/scanner-safe-bundle/README.md` for the
+  committed-vs-generated split.
+- The TLS profile inherits the same scanner-safe stance as the OIDC
+  profile: `bundle_artifact_is_scanner_safe(_, BundleProfile::Tls)`
+  is expected to return `true` for all artifacts in the bundle.
+
+## Evidence routing
+
+### PR-time (during v0.8.0 development)
+
+```bash
+cargo xtask scanner-safe-reference --check
+cargo xtask impacted-evidence --base origin/main
+cargo xtask mutants-pr --changed
+cargo xtask no-blob
+cargo test -p uselesskey-x509 --all-features
+cargo test -p uselesskey-rustls --all-features
+cargo test -p uselesskey-tonic --all-features
+cargo test -p uselesskey-cli tls_profile --all-features
+```
+
+The first four commands are the standard PR-time evidence lane shared
+with the OIDC pack. The four test invocations cover the crates that
+PR-B and PR-C touch.
+
+### Release-time (v0.8.0)
+
+A new release-evidence artifact:
+
+```bash
+cargo xtask bundle-proof --profile tls --out target/release-evidence/tls
+```
+
+This produces `tls-contract-pack-proof.json` and
+`tls-contract-pack-proof.md` mirroring the OIDC proof at
+`target/release-evidence/oidc/oidc-contract-pack-proof.md`. The proof
+artifact lands in PR-C of the v0.8.0 lane and is added to the v0.8.0
+release-evidence matrix.
+
+## Out of scope for v0.8.0
+
+- Revocation lists, OCSP responses, or CT log fixtures.
+- mTLS client-cert chains (a possible later contract pack).
+- Browser-trust-store simulation.
+- Variable hostname / SAN parameterization beyond the negative
+  wrong-hostname fixture.
+- Any non-deterministic certificate generation.
+- Cipher-suite, ALPN, or SNI fixtures.
+- New CLI subcommands beyond `bundle --profile tls`.
+
+## Out of scope for this PR
+
+- Implementation of the CLI dispatch, X.509 negative fixtures, or
+  adapter helpers.
+- Changes to `uselesskey-cli`, `uselesskey-x509`, `uselesskey-rustls`,
+  or `uselesskey-tonic` source files.
+- New examples directory.
+- New how-to guide under `docs/how-to/` (will land alongside PR-B once
+  the CLI surface is bound).
+
+Those land in PR-B and PR-C of the v0.8.0 lane.
+
+## v0.8.0 PR sequence
+
+- **PR-A (this doc):** `docs: define TLS contract-pack profile`. Pure
+  design — establishes the contract before code.
+- **PR-B:** `feat(cli): add tls bundle profile`. Adds
+  `BundleProfile::Tls` dispatch, wires the six cert fixtures, writes
+  the receipts and evidence markdown, and adds adapter helpers in
+  `uselesskey-rustls` and `uselesskey-tonic`.
+- **PR-C:** `xtask: add tls contract-pack proof`. Adds the
+  `bundle-proof --profile tls` runner and folds the artifact into the
+  release-evidence matrix for v0.8.0.
+
+## References
+
+- OIDC contract pack (v0.7.0): `docs/how-to/test-oidc-jwks-validation.md`
+- Existing X.509 negative fixtures: `uselesskey-core-x509-negative`,
+  `uselesskey-core-x509-chain-negative` (canonical implementation lives
+  in `uselesskey-x509::srp::negative` and
+  `uselesskey-x509::srp::chain_negative`)
+- Scanner-safe lessons: `docs/release/v0.7.0-lessons-learned.md`
+- Scanner-safe reference workflow: `examples/scanner-safe-bundle/README.md`
+- Publish recovery: `docs/release/publish-recovery.md`
+- Category notes for v0.7.0 (release-doc style template):
+  `docs/release/v0.7.0-category-notes.md`


### PR DESCRIPTION
Pure design doc for the v0.8.0 TLS contract-pack profile. No code.

## Summary

Establishes the contract for `uselesskey bundle --profile tls` before any
implementation lands. Models the v0.7.0 OIDC contract pack — a
deterministic bundle of valid plus protocol-shaped negative fixtures that
downstream TLS verifiers can run against — for cert-chain validation
tests.

Bundle shape:
- `certs/valid-leaf.pem`, `certs/valid-chain.pem` (happy path)
- `certs/negative-expired-leaf.pem` (expired)
- `certs/negative-not-yet-valid.pem` (not yet valid)
- `certs/negative-wrong-hostname.pem` (hostname mismatch)
- `certs/negative-untrusted-root.pem` (unknown CA)
- `receipts/materialization.json`, `receipts/audit-surface.json`
- `evidence/tls-profile.md`

The doc records per-fixture expected verifier behavior, rustls / tonic
adapter contracts (behavior only — no typed API claims yet), the
scanner-safety boundary, PR-time and release-time evidence routing, and
an explicit out-of-scope list.

## v0.8.0 PR sequence

- **PR-A (this PR):** `docs: define TLS contract-pack profile` —
  pure design.
- **PR-B:** `feat(cli): add tls bundle profile` — `BundleProfile::Tls`
  dispatch, six cert fixtures, receipts, evidence markdown, rustls/tonic
  adapter helpers.
- **PR-C:** `xtask: add tls contract-pack proof` —
  `bundle-proof --profile tls` runner, fold into v0.8.0 release-evidence
  matrix.

## Precedent

The OIDC contract pack (v0.7.0, `bundle --profile oidc`) proved the
contract-pack model and is referenced throughout this doc:

- How-to: `docs/how-to/test-oidc-jwks-validation.md`
- Release-evidence proof: `target/release-evidence/oidc/oidc-contract-pack-proof.md`

The TLS pack reuses the same dispatch shape, scanner-safe stance, and
receipt schema.

## Claim boundary

`uselesskey` is a test-fixture layer. The TLS pack proves verifier
rejection paths for five failure classes; it does NOT prove revocation
handling, CT log behavior, mTLS, browser-trust-store simulation, or
production CA custody.

## Test plan

- [x] `cargo xtask docs-sync --check` passes
- [x] `cargo xtask typos` passes
- [x] `git diff --check` clean
- [x] Doc placed under `docs/release/` (release-scope design), not
      `docs/how-to/`
- [x] No changes outside the new doc file (no `crates/`, `xtask/`,
      `examples/`, or other code-path edits)
- [x] All six certificate fixtures specified with expected-behavior /
      not-proven boundaries
- [x] Claim boundary explicit in Scope section