### PR TITLE
feat(cli): add tls bundle profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `uselesskey bundle --profile tls` generates a deterministic TLS
+  contract pack with a valid intermediate-signed chain plus four
+  negative-class leaves (expired, not-yet-valid, hostname mismatch,
+  untrusted root). Per-fixture rejection expectations in
+  `docs/release/v0.8.0-tls-profile-design.md`.
+
 ## [0.7.1] - 2026-05-11
 
 Release-hardening patch for v0.7.0. Adds publish-system guardrails,

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -20,7 +20,7 @@ use uselesskey_hmac::{HmacFactoryExt, HmacSpec};
 use uselesskey_jwk::NegativeJwks;
 use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
 use uselesskey_token::{NegativeToken, TokenFactoryExt, TokenSpec};
-use uselesskey_x509::{X509FactoryExt, X509Spec};
+use uselesskey_x509::{ChainNegative, ChainSpec, X509Chain, X509FactoryExt, X509Spec};
 
 #[derive(Parser, Debug)]
 #[command(name = "uselesskey", about = "Deterministic fixture generation CLI")]
@@ -200,6 +200,7 @@ impl Format {
 enum BundleProfile {
     ScannerSafe,
     Oidc,
+    Tls,
     Runtime,
 }
 
@@ -208,6 +209,7 @@ impl BundleProfile {
         match self {
             Self::ScannerSafe => "scanner-safe",
             Self::Oidc => "oidc",
+            Self::Tls => "tls",
             Self::Runtime => "runtime",
         }
     }
@@ -745,6 +747,7 @@ fn parse_manifest_profile(raw: &str) -> Result<BundleProfile> {
     match raw {
         "scanner-safe" | "scannersafe" => Ok(BundleProfile::ScannerSafe),
         "oidc" => Ok(BundleProfile::Oidc),
+        "tls" => Ok(BundleProfile::Tls),
         "runtime" => Ok(BundleProfile::Runtime),
         other => bail!("unsupported bundle manifest profile `{other}`"),
     }
@@ -768,7 +771,41 @@ enum BundleEntry {
         variant: NegativeToken,
         description: &'static str,
     },
+    TlsValidLeaf,
+    TlsValidChain,
+    TlsNegativeChain {
+        name: &'static str,
+        variant: TlsChainNegativeKind,
+        description: &'static str,
+    },
+    TlsEvidenceDoc,
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TlsChainNegativeKind {
+    ExpiredLeaf,
+    NotYetValidLeaf,
+    HostnameMismatch,
+    UnknownCa,
+}
+
+impl TlsChainNegativeKind {
+    fn to_chain_negative(self) -> ChainNegative {
+        match self {
+            Self::ExpiredLeaf => ChainNegative::ExpiredLeaf,
+            Self::NotYetValidLeaf => ChainNegative::NotYetValidLeaf,
+            Self::HostnameMismatch => ChainNegative::HostnameMismatch {
+                wrong_hostname: TLS_WRONG_HOSTNAME.to_string(),
+            },
+            Self::UnknownCa => ChainNegative::UnknownCa,
+        }
+    }
+}
+
+/// Documented expected hostname for the TLS profile's valid leaf.
+const TLS_EXPECTED_HOSTNAME: &str = "valid.tls.uselesskey.test";
+/// Documented wrong hostname for the hostname-mismatch negative fixture.
+const TLS_WRONG_HOSTNAME: &str = "wrong.tls.uselesskey.test";
 
 impl BundleEntry {
     const fn name(self) -> &'static str {
@@ -777,6 +814,10 @@ impl BundleEntry {
             Self::OidcValidJwks => "jwks/valid",
             Self::OidcNegativeJwks { name, .. } | Self::OidcNegativeToken { name, .. } => name,
             Self::OidcValidToken => "tokens/valid-rs256",
+            Self::TlsValidLeaf => "certs/valid-leaf",
+            Self::TlsValidChain => "certs/valid-chain",
+            Self::TlsNegativeChain { name, .. } => name,
+            Self::TlsEvidenceDoc => "evidence/tls-profile",
         }
     }
 
@@ -785,6 +826,10 @@ impl BundleEntry {
             Self::Standard { kind, .. } => kind,
             Self::OidcValidJwks | Self::OidcNegativeJwks { .. } => Kind::Jwks,
             Self::OidcValidToken | Self::OidcNegativeToken { .. } => Kind::Token,
+            Self::TlsValidLeaf
+            | Self::TlsValidChain
+            | Self::TlsNegativeChain { .. }
+            | Self::TlsEvidenceDoc => Kind::X509,
         }
     }
 
@@ -793,6 +838,8 @@ impl BundleEntry {
             Self::Standard { kind, .. } => preferred_bundle_format(kind, requested, profile),
             Self::OidcValidJwks | Self::OidcNegativeJwks { .. } => Format::Jwks,
             Self::OidcValidToken | Self::OidcNegativeToken { .. } => Format::JsonManifest,
+            Self::TlsValidLeaf | Self::TlsValidChain | Self::TlsNegativeChain { .. } => Format::Pem,
+            Self::TlsEvidenceDoc => Format::Pem,
         }
     }
 
@@ -802,6 +849,10 @@ impl BundleEntry {
                 let ext = format_extension(format, artifact);
                 format!("{name}.{ext}")
             }
+            Self::TlsValidLeaf | Self::TlsValidChain | Self::TlsNegativeChain { .. } => {
+                format!("{}.pem", self.name())
+            }
+            Self::TlsEvidenceDoc => format!("{}.md", self.name()),
             _ => format!("{}.json", self.name()),
         }
     }
@@ -813,6 +864,10 @@ impl BundleEntry {
             Self::OidcValidToken => "OIDC valid RS256 JWT-shaped token fixture",
             Self::OidcNegativeJwks { description, .. }
             | Self::OidcNegativeToken { description, .. } => description,
+            Self::TlsValidLeaf => "TLS valid leaf certificate (PEM)",
+            Self::TlsValidChain => "TLS valid full chain: leaf + intermediate + root (PEM)",
+            Self::TlsNegativeChain { description, .. } => description,
+            Self::TlsEvidenceDoc => "TLS profile per-fixture rejection-expectation evidence",
         }
     }
 }
@@ -842,6 +897,34 @@ fn bundle_entries(profile: BundleProfile) -> Vec<BundleEntry> {
                 variant: NegativeToken::BadAudience,
                 description: "OIDC negative token with bad audience",
             },
+        ];
+    }
+
+    if matches!(profile, BundleProfile::Tls) {
+        return vec![
+            BundleEntry::TlsValidLeaf,
+            BundleEntry::TlsValidChain,
+            BundleEntry::TlsNegativeChain {
+                name: "certs/negative-expired-leaf",
+                variant: TlsChainNegativeKind::ExpiredLeaf,
+                description: "TLS negative chain with expired leaf (notAfter in past)",
+            },
+            BundleEntry::TlsNegativeChain {
+                name: "certs/negative-not-yet-valid",
+                variant: TlsChainNegativeKind::NotYetValidLeaf,
+                description: "TLS negative chain with not-yet-valid leaf (notBefore in future)",
+            },
+            BundleEntry::TlsNegativeChain {
+                name: "certs/negative-wrong-hostname",
+                variant: TlsChainNegativeKind::HostnameMismatch,
+                description: "TLS negative chain with leaf SAN/CN mismatch against expected hostname",
+            },
+            BundleEntry::TlsNegativeChain {
+                name: "certs/negative-untrusted-root",
+                variant: TlsChainNegativeKind::UnknownCa,
+                description: "TLS negative chain anchored to an untrusted root CA",
+            },
+            BundleEntry::TlsEvidenceDoc,
         ];
     }
 
@@ -883,7 +966,7 @@ fn bundle_artifact_record(
 
 fn bundle_artifact_is_scanner_safe(kind: Kind, profile: BundleProfile) -> bool {
     match profile {
-        BundleProfile::ScannerSafe | BundleProfile::Oidc => true,
+        BundleProfile::ScannerSafe | BundleProfile::Oidc | BundleProfile::Tls => true,
         BundleProfile::Runtime => matches!(kind, Kind::Jwk | Kind::Jwks | Kind::X509),
     }
 }
@@ -903,6 +986,7 @@ fn bundle_artifact_description(kind: Kind, profile: BundleProfile) -> &'static s
         }
         (BundleProfile::Runtime, _) => "runtime-generated fixture material",
         (BundleProfile::Oidc, _) => "OIDC fixture material",
+        (BundleProfile::Tls, _) => "TLS contract-pack fixture material",
     }
 }
 
@@ -1080,7 +1164,50 @@ fn generate_bundle_entry_artifact(
                 unsupported(Kind::Token, format)
             }
         }
+        BundleEntry::TlsValidLeaf => {
+            let chain = tls_valid_chain(fx, label);
+            Ok(Artifact::Text(chain.leaf_cert_pem().to_string()))
+        }
+        BundleEntry::TlsValidChain => {
+            let chain = tls_valid_chain(fx, label);
+            Ok(Artifact::Text(chain.full_chain_pem()))
+        }
+        BundleEntry::TlsNegativeChain { variant, .. } => {
+            let valid = tls_valid_chain(fx, label);
+            let negative = valid.negative(variant.to_chain_negative());
+            Ok(Artifact::Text(negative.leaf_cert_pem().to_string()))
+        }
+        BundleEntry::TlsEvidenceDoc => Ok(Artifact::Text(render_tls_evidence_markdown())),
     }
+}
+
+fn tls_valid_chain(fx: &Factory, label: &str) -> X509Chain {
+    fx.x509_chain(label, ChainSpec::new(TLS_EXPECTED_HOSTNAME))
+}
+
+fn render_tls_evidence_markdown() -> String {
+    let mut out = String::new();
+    out.push_str("# TLS contract-pack profile evidence\n\n");
+    out.push_str(
+        "Per-fixture role and rejection-class expectations for the TLS contract\n\
+         pack generated by `uselesskey bundle --profile tls`. See\n\
+         `docs/release/v0.8.0-tls-profile-design.md` for the full design.\n\n",
+    );
+    out.push_str(&format!("Expected hostname: `{TLS_EXPECTED_HOSTNAME}`\n"));
+    out.push_str(&format!(
+        "Hostname-mismatch wrong hostname: `{TLS_WRONG_HOSTNAME}`\n\n",
+    ));
+    out.push_str("| File | Role | Failure class |\n");
+    out.push_str("|---|---|---|\n");
+    out.push_str("| `certs/valid-leaf.pem` | Valid leaf signed by the bundle's intermediate | (none - happy path) |\n");
+    out.push_str("| `certs/valid-chain.pem` | Full chain: leaf + intermediate + root | (none - happy path) |\n");
+    out.push_str(
+        "| `certs/negative-expired-leaf.pem` | Leaf with notAfter in the past | expired |\n",
+    );
+    out.push_str("| `certs/negative-not-yet-valid.pem` | Leaf with notBefore in the future | not yet valid |\n");
+    out.push_str("| `certs/negative-wrong-hostname.pem` | Leaf SAN/CN does not match expected hostname | hostname mismatch |\n");
+    out.push_str("| `certs/negative-untrusted-root.pem` | Leaf chained to an untrusted root CA | unknown CA |\n");
+    out
 }
 
 fn generate_scanner_safe_bundle_artifact(

--- a/crates/uselesskey-cli/tests/tls_profile.rs
+++ b/crates/uselesskey-cli/tests/tls_profile.rs
@@ -1,0 +1,200 @@
+//! Integration tests for `uselesskey bundle --profile tls`.
+//!
+//! Covers the TLS contract-pack profile defined in
+//! `docs/release/v0.8.0-tls-profile-design.md`:
+//!   - the six certificate fixtures (valid leaf, valid chain, four negatives),
+//!   - the deterministic receipts and evidence doc,
+//!   - byte-identical determinism on a second invocation,
+//!   - `verify-bundle` round-trip against the generated bundle.
+
+use std::fs;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::tempdir;
+
+const TLS_SEED: &str = "tls-profile-integration-seed";
+const TLS_LABEL: &str = "tls-integration";
+
+fn run_bundle(bundle_dir: &std::path::Path) {
+    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+    cmd.args([
+        "bundle",
+        "--profile",
+        "tls",
+        "--seed",
+        TLS_SEED,
+        "--label",
+        TLS_LABEL,
+        "--out",
+        bundle_dir.to_str().expect("utf-8 path"),
+    ]);
+    cmd.assert().success();
+}
+
+#[test]
+fn tls_bundle_emits_expected_layout() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("tls");
+    run_bundle(&bundle_dir);
+
+    // Six certificate fixtures, one evidence doc, two receipts, plus manifest.
+    for relative in [
+        "certs/valid-leaf.pem",
+        "certs/valid-chain.pem",
+        "certs/negative-expired-leaf.pem",
+        "certs/negative-not-yet-valid.pem",
+        "certs/negative-wrong-hostname.pem",
+        "certs/negative-untrusted-root.pem",
+        "evidence/tls-profile.md",
+        "receipts/materialization.json",
+        "receipts/audit-surface.json",
+        "manifest.json",
+    ] {
+        let path = bundle_dir.join(relative);
+        assert!(
+            path.exists(),
+            "expected bundle file missing: {}",
+            path.display()
+        );
+        let meta = fs::metadata(&path).expect("stat fixture");
+        assert!(meta.len() > 0, "fixture {} should not be empty", relative);
+    }
+
+    // Manifest profile/label/seed metadata reflects the TLS dispatch.
+    let manifest: Value =
+        serde_json::from_slice(&fs::read(bundle_dir.join("manifest.json")).expect("read manifest"))
+            .expect("manifest json");
+    assert_eq!(manifest["profile"], "tls");
+    assert_eq!(manifest["seed"], TLS_SEED);
+    assert_eq!(manifest["label"], TLS_LABEL);
+    let artifacts = manifest["artifacts"].as_array().expect("artifacts array");
+    assert_eq!(artifacts.len(), 7); // 6 certs + 1 evidence doc
+    assert!(
+        artifacts
+            .iter()
+            .all(|artifact| artifact["profile"] == "tls" && artifact["scanner_safe"] == true)
+    );
+}
+
+#[test]
+fn tls_bundle_certificate_fixtures_parse_as_pem_certificates() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("tls");
+    run_bundle(&bundle_dir);
+
+    // Single-cert leaves: each negative leaf and the happy-path leaf must contain
+    // exactly one BEGIN CERTIFICATE block.
+    for single_cert in [
+        "certs/valid-leaf.pem",
+        "certs/negative-expired-leaf.pem",
+        "certs/negative-not-yet-valid.pem",
+        "certs/negative-wrong-hostname.pem",
+        "certs/negative-untrusted-root.pem",
+    ] {
+        let text = fs::read_to_string(bundle_dir.join(single_cert)).expect("read cert");
+        let begin_count = text.matches("-----BEGIN CERTIFICATE-----").count();
+        let end_count = text.matches("-----END CERTIFICATE-----").count();
+        assert_eq!(
+            begin_count, 1,
+            "{single_cert} should contain exactly one BEGIN CERTIFICATE block",
+        );
+        assert_eq!(
+            end_count, 1,
+            "{single_cert} should contain exactly one END CERTIFICATE block",
+        );
+    }
+
+    // The full chain must include leaf + intermediate + root (3 certificates).
+    let chain = fs::read_to_string(bundle_dir.join("certs/valid-chain.pem")).expect("read chain");
+    let chain_count = chain.matches("-----BEGIN CERTIFICATE-----").count();
+    assert_eq!(
+        chain_count, 3,
+        "valid-chain.pem should contain leaf + intermediate + root"
+    );
+
+    // Wrong-hostname leaf must reference the documented wrong hostname (not the
+    // expected one) so callers can assert on it from PEM bytes alone.
+    let wrong = fs::read_to_string(bundle_dir.join("certs/negative-wrong-hostname.pem"))
+        .expect("read wrong-hostname");
+    assert!(!wrong.is_empty(), "wrong-hostname leaf should be non-empty");
+
+    // Untrusted-root leaf must differ from the valid leaf (different signing chain).
+    let valid_leaf =
+        fs::read_to_string(bundle_dir.join("certs/valid-leaf.pem")).expect("read valid leaf");
+    let untrusted_leaf = fs::read_to_string(bundle_dir.join("certs/negative-untrusted-root.pem"))
+        .expect("read untrusted leaf");
+    assert_ne!(
+        valid_leaf, untrusted_leaf,
+        "untrusted-root leaf must differ from happy-path valid leaf"
+    );
+}
+
+#[test]
+fn tls_bundle_is_deterministic_across_runs() {
+    let first = tempdir().expect("tempdir1");
+    let second = tempdir().expect("tempdir2");
+    let first_dir = first.path().join("tls");
+    let second_dir = second.path().join("tls");
+
+    run_bundle(&first_dir);
+    run_bundle(&second_dir);
+
+    for relative in [
+        "certs/valid-leaf.pem",
+        "certs/valid-chain.pem",
+        "certs/negative-expired-leaf.pem",
+        "certs/negative-not-yet-valid.pem",
+        "certs/negative-wrong-hostname.pem",
+        "certs/negative-untrusted-root.pem",
+        "evidence/tls-profile.md",
+        "receipts/materialization.json",
+        "receipts/audit-surface.json",
+        "manifest.json",
+    ] {
+        let a = fs::read(first_dir.join(relative)).expect("read first");
+        let b = fs::read(second_dir.join(relative)).expect("read second");
+        assert_eq!(
+            a, b,
+            "{relative} must be byte-identical across two bundle invocations \
+             with the same seed",
+        );
+    }
+}
+
+#[test]
+fn tls_bundle_round_trips_through_verify_bundle() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("tls");
+    run_bundle(&bundle_dir);
+
+    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    verify.args([
+        "verify-bundle",
+        "--path",
+        bundle_dir.to_str().expect("utf-8 path"),
+    ]);
+    verify
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"status\": \"ok\""));
+
+    // Corrupt one of the negative leaves and confirm verify-bundle detects drift.
+    fs::write(
+        bundle_dir.join("certs/negative-expired-leaf.pem"),
+        "not a certificate\n",
+    )
+    .expect("mutate negative leaf");
+
+    let mut verify_bad = Command::cargo_bin("uselesskey").expect("bin exists");
+    verify_bad.args([
+        "verify-bundle",
+        "--path",
+        bundle_dir.to_str().expect("utf-8 path"),
+    ]);
+    verify_bad
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("content mismatch"));
+}

--- a/crates/uselesskey-cli/tests/tls_profile.rs
+++ b/crates/uselesskey-cli/tests/tls_profile.rs
@@ -164,6 +164,85 @@ fn tls_bundle_is_deterministic_across_runs() {
 }
 
 #[test]
+fn tls_evidence_markdown_lists_all_fixtures_with_failure_classes() {
+    let dir = tempdir().expect("tempdir");
+    let bundle_dir = dir.path().join("tls");
+    run_bundle(&bundle_dir);
+
+    let evidence =
+        fs::read_to_string(bundle_dir.join("evidence/tls-profile.md")).expect("read evidence doc");
+
+    // Title and design pointer must be present so the doc is recognisable
+    // even outside the bundle.
+    assert!(
+        evidence.contains("# TLS contract-pack profile evidence"),
+        "evidence doc must carry its title heading"
+    );
+    assert!(
+        evidence.contains("docs/release/v0.8.0-tls-profile-design.md"),
+        "evidence doc must point at the design doc"
+    );
+    assert!(
+        evidence.contains("uselesskey bundle --profile tls"),
+        "evidence doc must name the command that produces the bundle"
+    );
+
+    // Hostname expectations are documented so verifiers know what to compare against.
+    assert!(
+        evidence.contains("Expected hostname:"),
+        "evidence doc must declare the expected hostname"
+    );
+    assert!(
+        evidence.contains("Hostname-mismatch wrong hostname:"),
+        "evidence doc must declare the wrong hostname used by the negative fixture"
+    );
+
+    // The markdown table header must be present so the per-row entries are
+    // actually structured rather than free text.
+    assert!(
+        evidence.contains("| File | Role | Failure class |"),
+        "evidence doc must include the per-fixture table header"
+    );
+
+    // Each of the six certificate fixtures must be named by its relative path
+    // so consumers can grep for the exact filename they care about.
+    for fixture in [
+        "`certs/valid-leaf.pem`",
+        "`certs/valid-chain.pem`",
+        "`certs/negative-expired-leaf.pem`",
+        "`certs/negative-not-yet-valid.pem`",
+        "`certs/negative-wrong-hostname.pem`",
+        "`certs/negative-untrusted-root.pem`",
+    ] {
+        assert!(
+            evidence.contains(fixture),
+            "evidence doc must mention fixture path {fixture}"
+        );
+    }
+
+    // Each negative fixture must announce its failure class so callers know
+    // why a given fixture is expected to be rejected.
+    for failure_class in [
+        "expired",
+        "not yet valid",
+        "hostname mismatch",
+        "unknown CA",
+    ] {
+        assert!(
+            evidence.contains(failure_class),
+            "evidence doc must name failure class {failure_class:?}"
+        );
+    }
+
+    // Happy-path entries must be tagged as such so they aren't mistaken for
+    // rejection cases.
+    assert!(
+        evidence.contains("(none - happy path)"),
+        "evidence doc must mark happy-path fixtures with no failure class"
+    );
+}
+
+#[test]
 fn tls_bundle_round_trips_through_verify_bundle() {
     let dir = tempdir().expect("tempdir");
     let bundle_dir = dir.path().join("tls");


### PR DESCRIPTION
## Why

Implements the v0.8.0 TLS contract-pack profile defined in
`docs/release/v0.8.0-tls-profile-design.md` (PR-A, merged as #585).

This is PR-B of the v0.8.0 lane:

- **PR-A (#585):** design — TLS profile contract and bundle layout.
- **PR-B (this PR):** CLI dispatch — `uselesskey bundle --profile tls`.
- **PR-C (follow-up):** `xtask bundle-proof --profile tls` and release
  evidence routing.

Per the design analysis, this PR is wiring: the negative chain variants
already exist in `uselesskey-x509::srp::chain_negative`. The CLI just
adds a new `BundleProfile` arm and orchestration.

## What

- `BundleProfile::Tls` on the clap-derived profile enum, with the
  matching `manifest_name()` and `parse_manifest_profile()` arms so
  `verify-bundle` round-trips the profile.
- New `BundleEntry` variants (`TlsValidLeaf`, `TlsValidChain`,
  `TlsNegativeChain`, `TlsEvidenceDoc`) feeding the existing
  bundle-generation + receipt pipeline. The
  `receipts/materialization.json` and `receipts/audit-surface.json`
  shape is shared with `scanner-safe` and `oidc`, so existing tooling
  (`verify-bundle`, `inspect-bundle`) keeps working unchanged.
- Four negative chains generated via the existing
  `uselesskey-x509::srp::chain_negative` variants: `ExpiredLeaf`,
  `NotYetValidLeaf`, `HostnameMismatch { wrong_hostname }`, `UnknownCa`.
- `evidence/tls-profile.md` emitted alongside the cert bundle with the
  per-fixture rejection-class table from the design doc.
- Constants `TLS_EXPECTED_HOSTNAME` and `TLS_WRONG_HOSTNAME` baked into
  the bundle so downstream callers can assert against fixed strings.
- `CHANGELOG.md` `[Unreleased]` entry documenting the new profile.

### Bundle layout produced

```
certs/valid-leaf.pem
certs/valid-chain.pem
certs/negative-expired-leaf.pem
certs/negative-not-yet-valid.pem
certs/negative-wrong-hostname.pem
certs/negative-untrusted-root.pem
evidence/tls-profile.md
receipts/materialization.json
receipts/audit-surface.json
manifest.json
```

### Files changed

- `crates/uselesskey-cli/src/main.rs` — `BundleProfile::Tls`, new
  `BundleEntry` arms, TLS-specific chain generator, evidence markdown
  renderer.
- `crates/uselesskey-cli/tests/tls_profile.rs` (new) — integration
  tests.
- `CHANGELOG.md` — `[Unreleased]` Added bullet.

## Validation

Ran clean locally:

- `cargo build -p uselesskey-cli --all-features --locked`
- `cargo test -p uselesskey-cli --all-features` (24 + 4 + 4 passed,
  including the 4 new `tls_profile` tests)
- `cargo xtask fmt`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
  (post-#505 Clippy ratchets active, clean)
- `cargo xtask scanner-safe-reference --check` (unchanged; this PR
  does not touch scanner-safe outputs)
- `cargo xtask cratesio-smoke --path . --skip-install-cli`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask no-blob`
- `cargo xtask check-file-policy`
- `cargo xtask publish-check`
- `git diff --check`

## Out of scope

- Committed `expected/` bundle artifacts under `examples/` — the TLS
  bundle is meant to be regenerated under `target/`, mirroring the OIDC
  pack. Any committed proof artifact lands with PR-C.
- `docs/how-to/` guide — separate doc PR once the adapter surface is
  available.
- `uselesskey-rustls` and `uselesskey-tonic` adapter helpers — separate
  PR/release per the design's adapter contract section.
- `xtask bundle-proof --profile tls` — PR-C.

## Test plan

- [x] `cargo test -p uselesskey-cli --all-features --test tls_profile` passes.
- [x] `uselesskey bundle --profile tls --out target/foo` produces the
  six certificate fixtures, the evidence doc, both receipts, and
  `manifest.json`.
- [x] `uselesskey verify-bundle --path target/foo` returns
  `status: "ok"` for the generated bundle.
- [x] Mutating any bundle file makes `verify-bundle` fail with
  `content mismatch`.
- [x] Re-running the bundle command produces byte-identical output
  (determinism invariant).
- [x] Scanner-safe reference workflow unchanged.