### PR TITLE
xtask: add tls contract-pack proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   negative-class leaves (expired, not-yet-valid, hostname mismatch,
   untrusted root). Per-fixture rejection expectations in
   `docs/release/v0.8.0-tls-profile-design.md`.
+- `cargo xtask bundle-proof --profile tls` generates a release-evidence
+  proof artifact for the TLS contract pack, mirroring the OIDC pattern.
+  Included in the minor-release `release-evidence` step list.
 
 ## [0.7.1] - 2026-05-11
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -153,7 +153,7 @@ enum Cmd {
     },
     /// Generate, verify, inspect, and export a bundle proof artifact for release evidence.
     BundleProof {
-        /// Bundle profile to prove. Supports `scanner-safe` and `oidc`.
+        /// Bundle profile to prove. Supports `scanner-safe`, `oidc`, and `tls`.
         #[arg(long, default_value = "scanner-safe")]
         profile: String,
         /// Output directory for proof artifacts.
@@ -2860,6 +2860,22 @@ fn release_evidence_steps_minor() -> Vec<ReleaseEvidenceStep> {
             ],
         },
         ReleaseEvidenceStep {
+            name: "tls-contract-pack-proof",
+            command: &[
+                "cargo",
+                "xtask",
+                "bundle-proof",
+                "--profile",
+                "tls",
+                "--out",
+                "target/release-evidence/tls",
+            ],
+            artifacts: &[
+                "target/release-evidence/tls/tls-contract-pack-proof.json",
+                "target/release-evidence/tls/tls-contract-pack-proof.md",
+            ],
+        },
+        ReleaseEvidenceStep {
             name: "economics",
             command: &["cargo", "xtask", "economics"],
             artifacts: &[
@@ -3279,6 +3295,7 @@ fn render_release_evidence_summary_markdown(receipt: &ReleaseEvidenceReceipt) ->
                 "OIDC contract-pack proof",
                 &["oidc-contract-pack-proof"][..],
             ),
+            ("TLS contract-pack proof", &["tls-contract-pack-proof"][..]),
             ("RIPR exposure", &["ripr-pr", "impacted-evidence"][..]),
             ("Nightly mutation scope", &["mutants-nightly-public"][..]),
             ("Performance evidence", &["perf"][..]),
@@ -3425,6 +3442,14 @@ const OIDC_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY: &[&str] = &[
     "OIDC contract-pack proof covers the generated release-candidate OIDC profile, not every downstream validator",
     "OIDC proof verifies pack shape and fixture presence, not downstream validator correctness",
     "OIDC profile artifacts remain scanner-safe and do not include usable private or symmetric fixture material",
+    "bundle proof is fixture-platform evidence, not production key management or scanner evasion",
+];
+
+const TLS_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY: &[&str] = &[
+    "TLS contract-pack proof covers the generated release-candidate TLS profile, not every downstream TLS verifier",
+    "TLS proof verifies pack shape and fixture presence (valid chain + four negative-class leaves), not downstream verifier correctness",
+    "TLS proof does not cover revocation (CRL/OCSP), certificate transparency, mTLS client chains, browser trust stores, or production CA custody",
+    "TLS profile artifacts remain scanner-safe and do not include usable private or symmetric fixture material",
     "bundle proof is fixture-platform evidence, not production key management or scanner evasion",
 ];
 
@@ -3592,6 +3617,32 @@ fn bundle_proof(profile: &str, out_dir: Option<&Path>) -> Result<()> {
         )?);
     }
 
+    if profile == "tls" {
+        commands.push(run_bundle_proof_command(
+            "cli-tls-contract-pack-test",
+            vec![
+                "cargo".to_string(),
+                "test".to_string(),
+                "-p".to_string(),
+                "uselesskey-cli".to_string(),
+                "tls".to_string(),
+                "--all-features".to_string(),
+            ],
+            Vec::new(),
+        )?);
+        commands.push(run_bundle_proof_command(
+            "x509-owner-tests",
+            vec![
+                "cargo".to_string(),
+                "test".to_string(),
+                "-p".to_string(),
+                "uselesskey-x509".to_string(),
+                "--all-features".to_string(),
+            ],
+            Vec::new(),
+        )?);
+    }
+
     commands.push(run_bundle_proof_command(
         "no-blob",
         vec![
@@ -3630,11 +3681,24 @@ fn bundle_proof(profile: &str, out_dir: Option<&Path>) -> Result<()> {
 }
 
 fn ensure_supported_bundle_proof_profile(profile: &str) -> Result<()> {
-    if matches!(profile, "scanner-safe" | "oidc") {
+    if BUNDLE_PROOF_SUPPORTED_PROFILES.contains(&profile) {
         Ok(())
     } else {
-        bail!("bundle-proof currently supports --profile scanner-safe and --profile oidc");
+        bail!("{}", unsupported_bundle_proof_profile_message());
     }
+}
+
+/// Profiles supported by `cargo xtask bundle-proof --profile <name>`.
+///
+/// Order matches the v0.7.0 -> v0.8.0 release lane introduction order:
+/// scanner-safe (v0.7.0), oidc (v0.7.0), tls (v0.8.0 PR-C).
+const BUNDLE_PROOF_SUPPORTED_PROFILES: &[&str] = &["scanner-safe", "oidc", "tls"];
+
+fn unsupported_bundle_proof_profile_message() -> String {
+    format!(
+        "bundle-proof currently supports --profile {}",
+        BUNDLE_PROOF_SUPPORTED_PROFILES.join(", "),
+    )
 }
 
 const SCANNER_SAFE_REFERENCE_EXPECTED_DIR: &str = "examples/scanner-safe-bundle/expected";
@@ -4040,7 +4104,8 @@ fn default_bundle_proof_out_dir(profile: &str) -> Result<PathBuf> {
     Ok(PathBuf::from(match profile {
         "scanner-safe" => "target/release-evidence/scanner-safe",
         "oidc" => "target/release-evidence/oidc",
-        _ => bail!("bundle-proof currently supports --profile scanner-safe and --profile oidc"),
+        "tls" => "target/release-evidence/tls",
+        _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     }))
 }
 
@@ -4048,7 +4113,8 @@ fn bundle_proof_json_filename(profile: &str) -> Result<&'static str> {
     Ok(match profile {
         "scanner-safe" => "scanner-safe-bundle-proof.json",
         "oidc" => "oidc-contract-pack-proof.json",
-        _ => bail!("bundle-proof currently supports --profile scanner-safe and --profile oidc"),
+        "tls" => "tls-contract-pack-proof.json",
+        _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
 
@@ -4056,7 +4122,8 @@ fn bundle_proof_markdown_filename(profile: &str) -> Result<&'static str> {
     Ok(match profile {
         "scanner-safe" => "scanner-safe-bundle-proof.md",
         "oidc" => "oidc-contract-pack-proof.md",
-        _ => bail!("bundle-proof currently supports --profile scanner-safe and --profile oidc"),
+        "tls" => "tls-contract-pack-proof.md",
+        _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
 
@@ -4064,7 +4131,8 @@ fn bundle_proof_markdown_title(profile: &str) -> Result<&'static str> {
     Ok(match profile {
         "scanner-safe" => "Scanner-Safe Bundle Proof",
         "oidc" => "OIDC Contract-Pack Proof",
-        _ => bail!("bundle-proof currently supports --profile scanner-safe and --profile oidc"),
+        "tls" => "TLS Contract-Pack Proof",
+        _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
 
@@ -4072,7 +4140,8 @@ fn bundle_proof_claim_boundary(profile: &str) -> Result<Vec<&'static str>> {
     Ok(match profile {
         "scanner-safe" => SCANNER_SAFE_BUNDLE_PROOF_CLAIM_BOUNDARY.to_vec(),
         "oidc" => OIDC_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY.to_vec(),
-        _ => bail!("bundle-proof currently supports --profile scanner-safe and --profile oidc"),
+        "tls" => TLS_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY.to_vec(),
+        _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
 
@@ -4111,7 +4180,44 @@ fn bundle_proof_expected_artifacts(profile: &str) -> Result<Vec<BundleProofExpec
                 description: "OIDC negative token with bad audience",
             },
         ],
-        _ => bail!("bundle-proof currently supports --profile scanner-safe and --profile oidc"),
+        "tls" => vec![
+            BundleProofExpectedArtifact {
+                name: "valid_leaf",
+                path: "certs/valid-leaf.pem",
+                description: "TLS valid leaf certificate (PEM)",
+            },
+            BundleProofExpectedArtifact {
+                name: "valid_chain",
+                path: "certs/valid-chain.pem",
+                description: "TLS valid full chain: leaf + intermediate + root (PEM)",
+            },
+            BundleProofExpectedArtifact {
+                name: "negative_expired_leaf",
+                path: "certs/negative-expired-leaf.pem",
+                description: "TLS negative chain with expired leaf (notAfter in past)",
+            },
+            BundleProofExpectedArtifact {
+                name: "negative_not_yet_valid",
+                path: "certs/negative-not-yet-valid.pem",
+                description: "TLS negative chain with not-yet-valid leaf (notBefore in future)",
+            },
+            BundleProofExpectedArtifact {
+                name: "negative_wrong_hostname",
+                path: "certs/negative-wrong-hostname.pem",
+                description: "TLS negative chain with leaf SAN/CN mismatch against expected hostname",
+            },
+            BundleProofExpectedArtifact {
+                name: "negative_untrusted_root",
+                path: "certs/negative-untrusted-root.pem",
+                description: "TLS negative chain anchored to an untrusted root CA",
+            },
+            BundleProofExpectedArtifact {
+                name: "tls_evidence_doc",
+                path: "evidence/tls-profile.md",
+                description: "TLS profile per-fixture rejection-expectation evidence",
+            },
+        ],
+        _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
 
@@ -7487,6 +7593,7 @@ index 1111111..2222222 100644
             "examples-smoke",
             "scanner-safe-bundle-proof",
             "oidc-contract-pack-proof",
+            "tls-contract-pack-proof",
             "economics",
             "audit-surface",
             "perf",
@@ -7512,6 +7619,11 @@ index 1111111..2222222 100644
             receipt
                 .artifacts
                 .contains(&"target/release-evidence/oidc/oidc-contract-pack-proof.md".to_string())
+        );
+        assert!(
+            receipt
+                .artifacts
+                .contains(&"target/release-evidence/tls/tls-contract-pack-proof.md".to_string())
         );
         assert!(
             receipt
@@ -7545,6 +7657,7 @@ index 1111111..2222222 100644
         assert!(markdown.contains("Package and publish proof"));
         assert!(markdown.contains("Scanner-safe bundle proof"));
         assert!(markdown.contains("OIDC contract-pack proof"));
+        assert!(markdown.contains("TLS contract-pack proof"));
         assert!(markdown.contains("Nightly mutation scope"));
         assert!(markdown.contains("Pending RC execution"));
         assert!(markdown.contains("not production key management"));
@@ -7642,6 +7755,87 @@ index 1111111..2222222 100644
         assert!(markdown.contains("Crates.io install smoke"));
         assert!(markdown.contains("Scanner-safe reference"));
         assert!(!markdown.contains("Nightly mutation scope"));
+    }
+
+    #[test]
+    fn release_evidence_patch_step_list_excludes_tls_contract_pack_proof() {
+        let steps = release_evidence_steps_patch();
+        let names = steps.iter().map(|step| step.name).collect::<BTreeSet<_>>();
+        assert!(
+            !names.contains("tls-contract-pack-proof"),
+            "patch lane must not include tls-contract-pack-proof (full pack proofs are minor-only)",
+        );
+    }
+
+    #[test]
+    fn release_evidence_minor_step_list_includes_tls_contract_pack_proof() {
+        let steps = release_evidence_steps_minor();
+        let step = steps
+            .iter()
+            .find(|step| step.name == "tls-contract-pack-proof")
+            .expect("minor lane must wire tls-contract-pack-proof");
+        assert_eq!(
+            step.command,
+            &[
+                "cargo",
+                "xtask",
+                "bundle-proof",
+                "--profile",
+                "tls",
+                "--out",
+                "target/release-evidence/tls",
+            ],
+        );
+        assert!(
+            step.artifacts
+                .contains(&"target/release-evidence/tls/tls-contract-pack-proof.json"),
+        );
+        assert!(
+            step.artifacts
+                .contains(&"target/release-evidence/tls/tls-contract-pack-proof.md"),
+        );
+    }
+
+    #[test]
+    fn bundle_proof_tls_profile_constant_includes_tls() {
+        assert!(
+            BUNDLE_PROOF_SUPPORTED_PROFILES.contains(&"tls"),
+            "tls must be a supported bundle-proof profile",
+        );
+        ensure_supported_bundle_proof_profile("tls")
+            .expect("tls profile must pass ensure_supported_bundle_proof_profile");
+        assert_eq!(
+            bundle_proof_json_filename("tls").unwrap(),
+            "tls-contract-pack-proof.json",
+        );
+        assert_eq!(
+            bundle_proof_markdown_filename("tls").unwrap(),
+            "tls-contract-pack-proof.md",
+        );
+        assert_eq!(
+            bundle_proof_markdown_title("tls").unwrap(),
+            "TLS Contract-Pack Proof",
+        );
+        assert_eq!(
+            default_bundle_proof_out_dir("tls").unwrap(),
+            PathBuf::from("target/release-evidence/tls"),
+        );
+        let expected = bundle_proof_expected_artifacts("tls").expect("tls expected artifacts");
+        let paths = expected.iter().map(|e| e.path).collect::<Vec<_>>();
+        for required in [
+            "certs/valid-leaf.pem",
+            "certs/valid-chain.pem",
+            "certs/negative-expired-leaf.pem",
+            "certs/negative-not-yet-valid.pem",
+            "certs/negative-wrong-hostname.pem",
+            "certs/negative-untrusted-root.pem",
+            "evidence/tls-profile.md",
+        ] {
+            assert!(
+                paths.contains(&required),
+                "tls expected artifacts missing {required}",
+            );
+        }
     }
 
     #[test]
@@ -7862,6 +8056,102 @@ index 1111111..2222222 100644
         assert!(markdown.contains("downstream validator correctness"));
     }
 
+    #[test]
+    fn bundle_proof_receipt_enforces_tls_contract_pack_contents() {
+        let manifest = tls_bundle_proof_manifest();
+        let audit_surface = serde_json::json!({
+            "scanner_safe": true,
+            "runtime_material_count": 0,
+        });
+        let receipt = bundle_proof_receipt(BundleProofReceiptInput {
+            profile: "tls",
+            bundle_dir: Path::new("target/release-evidence/tls/bundle"),
+            manifest_path: Path::new("target/release-evidence/tls/bundle/manifest.json"),
+            inspect_summary_path: Path::new("target/release-evidence/tls/inspect-bundle.txt"),
+            manifest: &manifest,
+            audit_surface: &audit_surface,
+            expected_artifacts: bundle_proof_expected_artifacts("tls")
+                .expect("tls expected artifacts"),
+            commands: Vec::new(),
+            exports_generated: Vec::new(),
+        })
+        .expect("tls proof receipt");
+
+        assert_eq!(receipt.profile, "tls");
+        assert_eq!(receipt.artifact_count, 7);
+        assert_eq!(receipt.contract_pack_checks.len(), 7);
+        assert!(
+            receipt
+                .contract_pack_checks
+                .iter()
+                .all(|check| check.present)
+        );
+        assert!(!receipt.private_key_material);
+        assert!(!receipt.symmetric_secret_material);
+    }
+
+    #[test]
+    fn bundle_proof_receipt_rejects_incomplete_tls_contract_pack() {
+        let mut manifest = tls_bundle_proof_manifest();
+        manifest
+            .files
+            .retain(|path| path != "certs/negative-wrong-hostname.pem");
+        manifest
+            .artifacts
+            .retain(|artifact| artifact.path != "certs/negative-wrong-hostname.pem");
+        let audit_surface = serde_json::json!({
+            "scanner_safe": true,
+            "runtime_material_count": 0,
+        });
+        let error = bundle_proof_receipt(BundleProofReceiptInput {
+            profile: "tls",
+            bundle_dir: Path::new("target/release-evidence/tls/bundle"),
+            manifest_path: Path::new("target/release-evidence/tls/bundle/manifest.json"),
+            inspect_summary_path: Path::new("target/release-evidence/tls/inspect-bundle.txt"),
+            manifest: &manifest,
+            audit_surface: &audit_surface,
+            expected_artifacts: bundle_proof_expected_artifacts("tls")
+                .expect("tls expected artifacts"),
+            commands: Vec::new(),
+            exports_generated: Vec::new(),
+        })
+        .expect_err("missing TLS artifact should fail proof");
+
+        assert!(
+            error.to_string().contains("negative_wrong_hostname"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn bundle_proof_markdown_summarizes_tls_contract_checks() {
+        let manifest = tls_bundle_proof_manifest();
+        let audit_surface = serde_json::json!({
+            "scanner_safe": true,
+            "runtime_material_count": 0,
+        });
+        let receipt = bundle_proof_receipt(BundleProofReceiptInput {
+            profile: "tls",
+            bundle_dir: Path::new("target/release-evidence/tls/bundle"),
+            manifest_path: Path::new("target/release-evidence/tls/bundle/manifest.json"),
+            inspect_summary_path: Path::new("target/release-evidence/tls/inspect-bundle.txt"),
+            manifest: &manifest,
+            audit_surface: &audit_surface,
+            expected_artifacts: bundle_proof_expected_artifacts("tls")
+                .expect("tls expected artifacts"),
+            commands: Vec::new(),
+            exports_generated: Vec::new(),
+        })
+        .expect("tls proof receipt");
+        let markdown = render_bundle_proof_markdown(&receipt).expect("render proof markdown");
+
+        assert!(markdown.contains("# TLS Contract-Pack Proof"));
+        assert!(markdown.contains("negative_expired_leaf"));
+        assert!(markdown.contains("certs/negative-untrusted-root.pem"));
+        assert!(markdown.contains("evidence/tls-profile.md"));
+        assert!(markdown.contains("downstream TLS verifier"));
+    }
+
     fn scanner_safe_bundle_proof_manifest() -> BundleProofManifest {
         BundleProofManifest {
             profile: "scanner-safe".to_string(),
@@ -7981,6 +8271,101 @@ index 1111111..2222222 100644
                     path: "receipts/audit-surface.json".to_string(),
                     kind: "audit-surface".to_string(),
                     profile: "oidc".to_string(),
+                    description: "scanner-safety and lane metadata receipt".to_string(),
+                },
+            ],
+        }
+    }
+
+    fn tls_bundle_proof_manifest() -> BundleProofManifest {
+        BundleProofManifest {
+            profile: "tls".to_string(),
+            files: vec![
+                "certs/valid-leaf.pem".to_string(),
+                "certs/valid-chain.pem".to_string(),
+                "certs/negative-expired-leaf.pem".to_string(),
+                "certs/negative-not-yet-valid.pem".to_string(),
+                "certs/negative-wrong-hostname.pem".to_string(),
+                "certs/negative-untrusted-root.pem".to_string(),
+                "evidence/tls-profile.md".to_string(),
+                "receipts/materialization.json".to_string(),
+                "receipts/audit-surface.json".to_string(),
+            ],
+            artifacts: vec![
+                BundleProofArtifactRecord {
+                    path: "certs/valid-leaf.pem".to_string(),
+                    kind: "x509".to_string(),
+                    format: "pem".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: true,
+                    description: "TLS valid leaf certificate (PEM)".to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "certs/valid-chain.pem".to_string(),
+                    kind: "x509".to_string(),
+                    format: "pem".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: true,
+                    description: "TLS valid full chain: leaf + intermediate + root (PEM)"
+                        .to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "certs/negative-expired-leaf.pem".to_string(),
+                    kind: "x509".to_string(),
+                    format: "pem".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: true,
+                    description: "TLS negative chain with expired leaf (notAfter in past)"
+                        .to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "certs/negative-not-yet-valid.pem".to_string(),
+                    kind: "x509".to_string(),
+                    format: "pem".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: true,
+                    description: "TLS negative chain with not-yet-valid leaf (notBefore in future)"
+                        .to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "certs/negative-wrong-hostname.pem".to_string(),
+                    kind: "x509".to_string(),
+                    format: "pem".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: true,
+                    description:
+                        "TLS negative chain with leaf SAN/CN mismatch against expected hostname"
+                            .to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "certs/negative-untrusted-root.pem".to_string(),
+                    kind: "x509".to_string(),
+                    format: "pem".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: true,
+                    description: "TLS negative chain anchored to an untrusted root CA".to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "evidence/tls-profile.md".to_string(),
+                    kind: "x509".to_string(),
+                    format: "pem".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: true,
+                    description: "TLS profile per-fixture rejection-expectation evidence"
+                        .to_string(),
+                },
+            ],
+            receipts: vec![
+                BundleProofReceiptRecord {
+                    path: "receipts/materialization.json".to_string(),
+                    kind: "materialization".to_string(),
+                    profile: "tls".to_string(),
+                    description: "deterministic bundle materialization receipt".to_string(),
+                },
+                BundleProofReceiptRecord {
+                    path: "receipts/audit-surface.json".to_string(),
+                    kind: "audit-surface".to_string(),
+                    profile: "tls".to_string(),
                     description: "scanner-safety and lane metadata receipt".to_string(),
                 },
             ],


### PR DESCRIPTION
## Why

Completes the v0.8.0 TLS contract-pack lane:

- **PR-A (#585, merged):** design doc at `docs/release/v0.8.0-tls-profile-design.md`.
- **PR-B (#587, merged):** `feat(cli): add tls bundle profile`.
- **PR-C (this PR):** xtask runner that produces the release-evidence proof artifact for the TLS profile, mirroring the OIDC proof shipped in v0.7.0.

The TLS profile design (PR-A) calls out PR-C explicitly: a new `cargo xtask bundle-proof --profile tls` invocation, folded into the v0.8.0 release-evidence matrix. This is that PR.

## What

- Adds `tls` to `BUNDLE_PROOF_SUPPORTED_PROFILES`. Extends `default_bundle_proof_out_dir`, `bundle_proof_json_filename`, `bundle_proof_markdown_filename`, `bundle_proof_markdown_title`, `bundle_proof_claim_boundary`, and `bundle_proof_expected_artifacts` to cover `tls`.
- Adds `TLS_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY` (matches the design-doc scope: pack shape, not downstream verifier correctness; no revocation, no mTLS, no production CA custody).
- Adds a TLS-specific arm to `bundle_proof()` that runs the CLI tls contract-pack tests and `uselesskey-x509` owner tests alongside the standard `bundle`, `verify-bundle`, `inspect-bundle`, and `no-blob` commands.
- The TLS proof validates 7 expected artifacts: `certs/{valid-leaf, valid-chain, negative-expired-leaf, negative-not-yet-valid, negative-wrong-hostname, negative-untrusted-root}.pem` plus `evidence/tls-profile.md`. Both materialization and audit-surface receipts are required as for OIDC.
- Wires `tls-contract-pack-proof` into `release_evidence_steps_minor()` after the OIDC step. Adds the corresponding row to the minor release-summary table.
- **Does not** add TLS to `release_evidence_steps_patch()` — full contract-pack proofs are minor-only, matching the OIDC precedent.
- CHANGELOG: new `[Unreleased]` `### Added` entry under the existing v0.8.0 TLS PR-B entry.

Tests added:

- `bundle_proof_tls_profile_constant_includes_tls` (the requested sanity test) covers the supported-profile list, every helper, and the 7 expected artifact paths.
- `bundle_proof_receipt_enforces_tls_contract_pack_contents` / `bundle_proof_receipt_rejects_incomplete_tls_contract_pack` mirror the OIDC receipt tests against a new `tls_bundle_proof_manifest()` helper.
- `bundle_proof_markdown_summarizes_tls_contract_checks` covers the rendered markdown.
- `release_evidence_minor_step_list_includes_tls_contract_pack_proof` and `release_evidence_patch_step_list_excludes_tls_contract_pack_proof` pin step-list wiring on both lanes.
- Updates the existing minor-lane dry-run / summary tests to also assert the new TLS step.

## Validation

- `cargo build -p xtask` — clean.
- `cargo xtask bundle-proof --profile tls --out target/release-evidence/tls` — succeeds end-to-end. Generated bundle has all 9 files (6 cert PEMs + evidence markdown + 2 receipts); `tls-contract-pack-proof.{json,md}` written with all 7 contract-pack checks `present: true`, `scanner_safe: true`, `private_key_material: false`, `symmetric_secret_material: false`, `runtime_material_count: 0`.
- `cargo xtask bundle-proof --profile scanner-safe` and `--profile oidc` still succeed (regression-clean).
- `cargo xtask release-evidence --version 0.8.0-dev --dry-run --summary` plans 16 commands including `tls-contract-pack-proof` and lists the TLS proof artifacts in the receipt.
- `cargo xtask release-evidence --version 0.8.0-dev --patch --dry-run --summary` plans 10 commands with `tls-contract-pack-proof` correctly absent.
- `cargo test -p xtask` (single-threaded) — 273 passed. (Parallel runs hit the existing `publish_order_is_topological` `cargo metadata` race; isolated reruns pass. Unrelated to these changes.)
- `cargo fmt --check -p xtask` — clean.
- `cargo clippy -p xtask --all-targets -- -D warnings` — clean.

## Out of scope

- `crates/uselesskey-cli/` — the TLS profile already exists post-#587; this PR is xtask-only.
- Task-first TLS how-to docs (planned for PR-D).
- `uselesskey-rustls` / `uselesskey-tonic` adapter helpers (future release; design doc fixes the contract, not the API).

## Test plan

- [x] `cargo build -p xtask`
- [x] `cargo test -p xtask bundle_proof_tls` (the requested unit test)
- [x] `cargo test -p xtask -- --test-threads=1` (273 passed)
- [x] `cargo fmt --check -p xtask`
- [x] `cargo clippy -p xtask --all-targets -- -D warnings`
- [x] `cargo xtask bundle-proof --profile tls --out target/release-evidence/tls` end-to-end
- [x] Regression: `cargo xtask bundle-proof --profile scanner-safe` succeeds
- [x] Regression: `cargo xtask bundle-proof --profile oidc` succeeds
- [x] `cargo xtask release-evidence --version 0.8.0-dev --dry-run --summary` includes tls step
- [x] `cargo xtask release-evidence --version 0.8.0-dev --patch --dry-run --summary` excludes tls step