### PR TITLE
refactor(pgp): fold uselesskey-pgp-native content into uselesskey-pgp::native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `uselesskey-rustls::srp::pki`. `uselesskey-core-rustls-pki` remains
   as a published-internal re-export shim for v0.7.x compat; scheduled
   for removal in a later v0.8.x PR.
+- Moved `PgpNativeExt` and its impls from `uselesskey-pgp-native` into
+  `uselesskey-pgp::native` (gated behind the new `native` Cargo feature).
+  `uselesskey-pgp-native` remains as a published-internal re-export
+  shim for v0.7.x compat; scheduled for removal in a later v0.8.0 PR.
 
 ## [0.7.1] - 2026-05-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pgp"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "insta",
  "pgp",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pgp-native"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "pgp",
  "uselesskey-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,8 @@ uselesskey-ecdsa = { path = "crates/uselesskey-ecdsa", version = "0.7.1" }
 uselesskey-ed25519 = { path = "crates/uselesskey-ed25519", version = "0.7.1" }
 uselesskey-hmac = { path = "crates/uselesskey-hmac", version = "0.7.2" }
 uselesskey-token = { path = "crates/uselesskey-token", version = "0.7.1" }
+uselesskey-pgp = { path = "crates/uselesskey-pgp", version = "0.7.2" }
+uselesskey-pgp-native = { path = "crates/uselesskey-pgp-native", version = "0.7.2" }
 uselesskey-x509 = { path = "crates/uselesskey-x509", version = "0.7.1" }
 uselesskey-core-base62 = { path = "crates/uselesskey-core-base62", version = "0.7.1" }
 uselesskey-core-cache = { path = "crates/uselesskey-core-cache", version = "0.7.1", default-features = false }
@@ -178,6 +180,9 @@ sha2 = "0.11.0"
 
 # JWT
 jsonwebtoken = { version = "10.3.0", features = ["use_pem", "rust_crypto"] }
+
+# OpenPGP — legacy upstream island (rsa 0.9 / rand_core 0.6).
+pgp = { version = "0.19.0", default-features = false }
 
 # TLS
 rustls = { version = "0.23.40", default-features = false, features = ["std", "tls12", "ring"] }

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Dependency snippets:
   ```toml
   [dev-dependencies]
   uselesskey = { version = "0.7.1", features = ["pgp"] }
-  uselesskey-pgp-native = { version = "0.7.1" }
+  uselesskey-pgp-native = { version = "0.7.2" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 

--- a/crates/uselesskey-pgp-native/Cargo.toml
+++ b/crates/uselesskey-pgp-native/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "uselesskey-pgp-native"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 repository.workspace = true
-description = "Native OpenPGP key type adapters for uselesskey fixtures."
+description = "Deprecated compatibility shim re-exporting PgpNativeExt from uselesskey-pgp."
 categories.workspace = true
 keywords = ["openpgp", "pgp", "fixtures", "testing", "adapter"]
 readme = "README.md"
@@ -15,19 +15,18 @@ documentation = "https://docs.rs/uselesskey-pgp-native"
 authors.workspace = true
 
 [dependencies]
-uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.7.1", optional = true }
-pgp = { version = "0.19.0", default-features = false }
+uselesskey-pgp = { workspace = true, features = ["native"] }
 
 [package.metadata.docs.rs]
 features = ["pgp-native"]
 
 [features]
 default = ["pgp-native"]
-pgp-native = ["dep:uselesskey-pgp"]
+pgp-native = []
 
 [dev-dependencies]
-uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.7.1" }
 uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+pgp = { workspace = true }
 
 
 [lints]

--- a/crates/uselesskey-pgp-native/src/lib.rs
+++ b/crates/uselesskey-pgp-native/src/lib.rs
@@ -1,81 +1,8 @@
 #![forbid(unsafe_code)]
 
-//! OpenPGP native adapters for uselesskey fixtures.
+//! Deprecated compatibility shim.
 //!
-//! Provides conversions to native `pgp` crate key types from
-//! `uselesskey-pgp` generated fixtures.
+//! Prefer `uselesskey-pgp` with the `native` feature for the supported
+//! `PgpNativeExt` surface.
 
-use std::io::Cursor;
-
-use pgp::composed::{Deserializable, SignedPublicKey, SignedSecretKey};
-
-/// Conversion surface for OpenPGP native key types.
-pub trait PgpNativeExt {
-    /// Parse and return a native `SignedSecretKey`.
-    fn secret_key(&self) -> SignedSecretKey;
-
-    /// Parse and return a native `SignedPublicKey`.
-    fn public_key(&self) -> SignedPublicKey;
-
-    /// Parse and return an armored native secret key.
-    fn secret_key_armor(&self) -> SignedSecretKey;
-
-    /// Parse and return an armored native public key.
-    fn public_key_armor(&self) -> SignedPublicKey;
-}
-
-impl PgpNativeExt for uselesskey_pgp::PgpKeyPair {
-    fn secret_key(&self) -> SignedSecretKey {
-        SignedSecretKey::from_bytes(Cursor::new(self.private_key_binary()))
-            .expect("failed to parse uselesskey PGP private key bytes")
-    }
-
-    fn public_key(&self) -> SignedPublicKey {
-        SignedPublicKey::from_bytes(Cursor::new(self.public_key_binary()))
-            .expect("failed to parse uselesskey PGP public key bytes")
-    }
-
-    fn secret_key_armor(&self) -> SignedSecretKey {
-        let (key, _) = SignedSecretKey::from_armor_single(Cursor::new(self.private_key_armored()))
-            .expect("failed to parse armored uselesskey PGP private key");
-        key
-    }
-
-    fn public_key_armor(&self) -> SignedPublicKey {
-        let (key, _) = SignedPublicKey::from_armor_single(Cursor::new(self.public_key_armored()))
-            .expect("failed to parse armored uselesskey PGP public key");
-        key
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use pgp::types::KeyDetails;
-    use uselesskey_core::Factory;
-    use uselesskey_pgp::{PgpFactoryExt, PgpSpec};
-
-    use super::PgpNativeExt;
-
-    #[test]
-    fn parse_round_trip_binary_and_armor() {
-        let fx = Factory::random();
-        let keypair = fx.pgp("fixture", PgpSpec::ed25519());
-
-        assert_eq!(
-            keypair.fingerprint(),
-            keypair.secret_key().fingerprint().to_string()
-        );
-        assert_eq!(
-            keypair.fingerprint(),
-            keypair.secret_key_armor().fingerprint().to_string()
-        );
-        assert_eq!(
-            keypair.fingerprint(),
-            keypair.public_key().fingerprint().to_string()
-        );
-        assert_eq!(
-            keypair.fingerprint(),
-            keypair.public_key_armor().fingerprint().to_string()
-        );
-    }
-}
+pub use uselesskey_pgp::native::*;

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-pgp"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ authors.workspace = true
 
 [dependencies]
 uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
-pgp = { version = "0.19.0", default-features = false }
+pgp = { workspace = true }
 rand_chacha = { version = "0.3.1", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 
@@ -24,6 +24,13 @@ rand_core = { version = "0.6.4", default-features = false }
 proptest.workspace = true
 serde.workspace = true
 insta.workspace = true
+
+[features]
+# Re-export the native `pgp` crate adapter surface
+# (`PgpNativeExt` and impls). Off by default to keep the legacy `pgp` 0.19
+# / `rsa` 0.9 island from being forced on consumers that only want the
+# armored/binary byte surface owned by this crate.
+native = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-pgp/src/lib.rs
+++ b/crates/uselesskey-pgp/src/lib.rs
@@ -49,5 +49,11 @@
 mod keypair;
 mod spec;
 
+#[cfg(feature = "native")]
+pub mod native;
+
 pub use keypair::{DOMAIN_PGP_KEYPAIR, PgpFactoryExt, PgpKeyPair};
 pub use spec::PgpSpec;
+
+#[cfg(feature = "native")]
+pub use native::PgpNativeExt;

--- a/crates/uselesskey-pgp/src/native.rs
+++ b/crates/uselesskey-pgp/src/native.rs
@@ -1,0 +1,83 @@
+//! OpenPGP native adapters for uselesskey fixtures.
+//!
+//! Provides conversions to native [`pgp`] crate key types from
+//! [`PgpKeyPair`](crate::PgpKeyPair) generated fixtures.
+//!
+//! Gated behind the `native` Cargo feature so consumers that only want
+//! the armored/binary byte surface owned by this crate are not pulled
+//! into the native parser surface.
+
+use std::io::Cursor;
+
+use pgp::composed::{Deserializable, SignedPublicKey, SignedSecretKey};
+
+/// Conversion surface for OpenPGP native key types.
+pub trait PgpNativeExt {
+    /// Parse and return a native `SignedSecretKey`.
+    fn secret_key(&self) -> SignedSecretKey;
+
+    /// Parse and return a native `SignedPublicKey`.
+    fn public_key(&self) -> SignedPublicKey;
+
+    /// Parse and return an armored native secret key.
+    fn secret_key_armor(&self) -> SignedSecretKey;
+
+    /// Parse and return an armored native public key.
+    fn public_key_armor(&self) -> SignedPublicKey;
+}
+
+impl PgpNativeExt for crate::PgpKeyPair {
+    fn secret_key(&self) -> SignedSecretKey {
+        SignedSecretKey::from_bytes(Cursor::new(self.private_key_binary()))
+            .expect("failed to parse uselesskey PGP private key bytes")
+    }
+
+    fn public_key(&self) -> SignedPublicKey {
+        SignedPublicKey::from_bytes(Cursor::new(self.public_key_binary()))
+            .expect("failed to parse uselesskey PGP public key bytes")
+    }
+
+    fn secret_key_armor(&self) -> SignedSecretKey {
+        let (key, _) = SignedSecretKey::from_armor_single(Cursor::new(self.private_key_armored()))
+            .expect("failed to parse armored uselesskey PGP private key");
+        key
+    }
+
+    fn public_key_armor(&self) -> SignedPublicKey {
+        let (key, _) = SignedPublicKey::from_armor_single(Cursor::new(self.public_key_armored()))
+            .expect("failed to parse armored uselesskey PGP public key");
+        key
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pgp::types::KeyDetails;
+    use uselesskey_core::Factory;
+
+    use super::PgpNativeExt;
+    use crate::{PgpFactoryExt, PgpSpec};
+
+    #[test]
+    fn parse_round_trip_binary_and_armor() {
+        let fx = Factory::random();
+        let keypair = fx.pgp("fixture", PgpSpec::ed25519());
+
+        assert_eq!(
+            keypair.fingerprint(),
+            keypair.secret_key().fingerprint().to_string()
+        );
+        assert_eq!(
+            keypair.fingerprint(),
+            keypair.secret_key_armor().fingerprint().to_string()
+        );
+        assert_eq!(
+            keypair.fingerprint(),
+            keypair.public_key().fingerprint().to_string()
+        );
+        assert_eq!(
+            keypair.fingerprint(),
+            keypair.public_key_armor().fingerprint().to_string()
+        );
+    }
+}

--- a/crates/uselesskey/README.md
+++ b/crates/uselesskey/README.md
@@ -96,7 +96,7 @@ Dependency snippets:
   ```toml
   [dev-dependencies]
   uselesskey = { version = "0.7.1", features = ["pgp"] }
-  uselesskey-pgp-native = { version = "0.7.1" }
+  uselesskey-pgp-native = { version = "0.7.2" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -120,6 +120,9 @@ set of focused microcrates that each own a single concern:
 
 - `uselesskey-core-rustls-pki` — compatibility shim re-exporting the
   rustls-pki adapter traits now owned by `uselesskey-rustls`
+- `uselesskey-pgp-native` — compatibility shim re-exporting the native
+  `pgp` crate adapter (`PgpNativeExt`) now owned by `uselesskey-pgp`
+  under the `native` feature
 
 ### Adapter crates
 

--- a/docs/how-to/choose-features.md
+++ b/docs/how-to/choose-features.md
@@ -81,7 +81,7 @@ Dependency snippets:
   ```toml
   [dev-dependencies]
   uselesskey = { version = "0.7.1", features = ["pgp"] }
-  uselesskey-pgp-native = { version = "0.7.1" }
+  uselesskey-pgp-native = { version = "0.7.2" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 

--- a/docs/metadata/workspace-docs.json
+++ b/docs/metadata/workspace-docs.json
@@ -559,12 +559,13 @@
     },
     {
       "name": "uselesskey-pgp-native",
-      "support_tier": "incubating",
+      "support_tier": "experimental",
       "publish_status": "published",
       "facade_exposed": false,
-      "semver_expectation": "Minor releases may refine APIs before 1.0.",
+      "semver_expectation": "Published-internal compatibility shim; `PgpNativeExt` is owned by `uselesskey-pgp` (under the `native` feature).",
       "msrv_policy": "Tracks workspace MSRV (Rust 1.95).",
-      "intended_audience": "adapter-users"
+      "intended_audience": "repo-internal",
+      "deprecation_note": "Prefer `uselesskey-pgp` with `features = [\"native\"]`; this crate is retained only as a compatibility shim."
     },
     {
       "name": "uselesskey-pkcs11-mock",
@@ -1129,7 +1130,8 @@
         {
           "crate_name": "uselesskey-pgp-native",
           "default_features": null,
-          "features": []
+          "features": [],
+          "version": "0.7.2"
         }
       ],
       "minimal_example_command": "cargo test -p uselesskey-pgp-native --no-default-features --features rsa"

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -52,7 +52,7 @@
 | `uselesskey-jsonwebtoken` | `stable` | `published` | — | `adapter-users` | Stable adapter API; follows upstream compatibility windows. | Tracks workspace MSRV (Rust 1.95). | — |
 | `uselesskey-jwk` | `stable` | `published` | ✓ | `most-users` | Normal semver guarantees for public APIs. | Tracks workspace MSRV (Rust 1.95). | — |
 | `uselesskey-pgp` | `stable` | `published` | ✓ | `most-users` | Normal semver guarantees for public APIs. | Tracks workspace MSRV (Rust 1.95). | — |
-| `uselesskey-pgp-native` | `incubating` | `published` | — | `adapter-users` | Minor releases may refine APIs before 1.0. | Tracks workspace MSRV (Rust 1.95). | — |
+| `uselesskey-pgp-native` | `experimental` | `published` | — | `repo-internal` | Published-internal compatibility shim; `PgpNativeExt` is owned by `uselesskey-pgp` (under the `native` feature). | Tracks workspace MSRV (Rust 1.95). | Prefer `uselesskey-pgp` with `features = ["native"]`; this crate is retained only as a compatibility shim. |
 | `uselesskey-pkcs11-mock` | `stable` | `published` | — | `most-users` | Normal semver guarantees for public APIs. | Tracks workspace MSRV (Rust 1.95). | — |
 | `uselesskey-ring` | `stable` | `published` | — | `adapter-users` | Stable adapter API; follows upstream compatibility windows. | Tracks workspace MSRV (Rust 1.95). | — |
 | `uselesskey-rsa` | `stable` | `published` | ✓ | `most-users` | Normal semver guarantees for public APIs. | Tracks workspace MSRV (Rust 1.95). | — |

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -923,6 +923,8 @@ const PUBLISH_CRATES: &[&str] = &[
     "uselesskey-webauthn",
     "uselesskey-ssh",
     "uselesskey-pgp",
+    // PGP compatibility shim (depends on uselesskey-pgp)
+    "uselesskey-pgp-native",
     // X.509 (depends on core and downstream)
     "uselesskey-x509",
     // X.509 compatibility shims (depend on uselesskey-x509)
@@ -938,7 +940,6 @@ const PUBLISH_CRATES: &[&str] = &[
     // Adapters (depend on key crates, NOT on facade)
     "uselesskey-jsonwebtoken",
     "uselesskey-jose-openid",
-    "uselesskey-pgp-native",
     "uselesskey-rustls",
     // rustls compatibility shim (depends on uselesskey-rustls)
     "uselesskey-core-rustls-pki",

--- a/xtask/src/plan.rs
+++ b/xtask/src/plan.rs
@@ -304,7 +304,8 @@ fn dependents(crate_name: &str) -> &'static [&'static str] {
             "uselesskey-core-token",
             "uselesskey",
         ],
-        "uselesskey-pgp" => &["uselesskey"],
+        "uselesskey-pgp" => &["uselesskey", "uselesskey-pgp-native"],
+        "uselesskey-pgp-native" => &[],
         "uselesskey" => &[],
         "uselesskey-jsonwebtoken" => &[],
         "uselesskey-rustls" => &["uselesskey-core-rustls-pki"],
@@ -886,6 +887,18 @@ mod tests {
         let impacted = &plan.impacted_crates;
         assert!(impacted.contains("uselesskey-core-hmac-spec"));
         assert!(!impacted.contains("uselesskey-hmac"));
+    }
+
+    #[test]
+    fn pgp_native_change_is_isolated_to_shim() {
+        // After v0.8.0 fold, `uselesskey-pgp-native` is a leaf shim that
+        // re-exports from `uselesskey-pgp`. Changes to it no longer ripple
+        // into the PGP stack.
+        let paths = vec!["crates/uselesskey-pgp-native/src/lib.rs".to_string()];
+        let plan = build_plan(&paths);
+        let impacted = &plan.impacted_crates;
+        assert!(impacted.contains("uselesskey-pgp-native"));
+        assert!(!impacted.contains("uselesskey-pgp"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

PR-3 of the v0.8.0 SRP collapse lane (after #595 hmac-spec, #598 rustls-pki). `uselesskey-pgp-native` is in the per-crate survey's "conditional" bucket — content (~50 LoC of `PgpNativeExt` impls) is valuable, but doesn't justify a separately published adapter crate carrying its own `pgp` 0.19 public-dep surface. Folding it into `uselesskey-pgp::native` (under a new `native` Cargo feature) collapses the publish graph and keeps the supported `PgpNativeExt` surface co-located with the `PgpKeyPair` it adapts.

The shim crate stays published as a v0.7.x compat re-export; deletion is PR-4 of this lane.

## What

- New `crates/uselesskey-pgp/src/native.rs` carries `PgpNativeExt`, the impl block on `PgpKeyPair`, and the inline `#[cfg(test)] mod tests`.
- `crates/uselesskey-pgp/src/lib.rs` declares `#[cfg(feature = "native")] pub mod native;` and re-exports `PgpNativeExt` at the top level under the same gate.
- `uselesskey-pgp/Cargo.toml` adds the `native = []` feature (off by default). The `pgp` 0.19 pin moves into `[workspace.dependencies]` so the two crates share one version line.
- `uselesskey-pgp-native/Cargo.toml` drops its direct `pgp = ...` dep, adds `uselesskey-pgp.workspace = true` with `features = ["native"]`, and routes its `pgp-native` feature to a no-op marker.
- `uselesskey-pgp-native/src/lib.rs` is now `pub use uselesskey_pgp::native::*;`.
- `xtask::PUBLISH_CRATES` moves `uselesskey-pgp-native` to a post-`uselesskey-pgp` slot under a "PGP compatibility shim" comment, matching `uselesskey-core-hmac-spec` after #595.
- `xtask::plan::dependents()` makes `uselesskey-pgp-native` a leaf and adds it as a `uselesskey-pgp` dependent. New `pgp_native_change_is_isolated_to_shim` test mirrors the `core_hmac_spec_change_is_isolated_to_shim` shape.
- `uselesskey-pgp` and `uselesskey-pgp-native` bump to 0.7.2 so the shim's `pub use uselesskey_pgp::native::*;` resolves against a registry version that ships the new path (otherwise dry-run resolves to v0.7.1 and fails `E0432: unresolved imports`).
- `docs/explanation/architecture.md`, `docs/metadata/workspace-docs.json`, and `docs/reference/support-matrix.md` describe the crate as a compatibility shim.
- CHANGELOG `[Unreleased] / Changed` entry added.

### Doc-versions plumbing

The shim bumps to 0.7.2 while the rest of the workspace stays at 0.7.1. This breaks the existing `publish-preflight doc-versions` check, which expects every workspace-crate mention in a README snippet to match `cargo metadata`. Followup commit adds an opt-in `version_override: Option<String>` field to `DependencySnippet::dependencies[]` in `workspace-docs.json`, threaded through `xtask::docs_sync::render_single_dependency_snippet`. The `pgp-native adapter` snippet entry sets the override to 0.7.2; the rest of the snippet continues to render against `release_version` (0.7.1). README.md, crates/uselesskey/README.md, and docs/how-to/choose-features.md regenerated via `cargo xtask docs-sync`.

## Out of scope

- Shim crate deletion. Tracked for PR-4 of the v0.8.0 SRP collapse lane.
- Public API of `PgpNativeExt` (unchanged — same 4 methods, same return types).

## Test plan

- [x] `cargo build --workspace --all-targets --all-features --locked`
- [x] `cargo test -p uselesskey-pgp --all-features` (native test runs; round-trip fingerprint check passes)
- [x] `cargo test -p uselesskey-pgp --no-default-features` (verifies `native` feature is off-by-default and the keygen surface stands alone)
- [x] `cargo test -p uselesskey-pgp-native --all-features` (shim integration test still resolves through the re-export)
- [x] `cargo xtask publish-check` (clean; `uselesskey-pgp-native` skipped per usual `workspace dep not yet on crates.io` pattern matching #595)
- [x] `cargo xtask publish-preflight` (57 passed, 0 failed; `doc-versions` clean after the `version_override` plumbing)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- [x] `cargo xtask scanner-safe-reference --check`
- [x] `cargo xtask docs-sync --check` (clean)
- [x] `cargo xtask typos`
- [x] `cargo test -p xtask docs_sync` (new `dependency_snippet_version_override_wins` test covers the override path)