### PR TITLE
release: publish v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,83 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-12
+
+TLS contract-pack and public crate-surface cleanup release. v0.8.0 adds
+a deterministic TLS contract pack (valid chain plus four negative
+classes) with a matching release-evidence proof, lands a task-first
+how-to sweep across the public docs, completes the v0.7.x SRP fold by
+moving HMAC/rustls/PGP content into their owner crates, and removes the
+v0.7.0-vintage published-internal shim crates from the workspace.
+
+`uselesskey` is a test-fixture layer. It is not production key
+management, scanner evasion, or cryptographic assurance.
+
 ### Added
 
 - `uselesskey bundle --profile tls` generates a deterministic TLS
   contract pack with a valid intermediate-signed chain plus four
   negative-class leaves (expired, not-yet-valid, hostname mismatch,
   untrusted root). Per-fixture rejection expectations in
-  `docs/release/v0.8.0-tls-profile-design.md`.
+  `docs/release/v0.8.0-tls-profile-design.md`. (#585, #587)
 - `cargo xtask bundle-proof --profile tls` generates a release-evidence
-  proof artifact for the TLS contract pack, mirroring the OIDC pattern.
-  Included in the minor-release `release-evidence` step list.
+  proof artifact for the TLS contract pack, mirroring the OIDC
+  pattern, and is included in the minor-release `release-evidence`
+  step list. (#588)
+- Task-first how-to docs sweep across the public surface: TLS chain
+  validation, Vault KV export, build.rs materialize, WebAuthn
+  ceremony validation, PKCS#11 mock fixtures, and webhook signature
+  validation. (#589, #590, #591, #592, #593, #594)
+- `docs/how-to/migrate-to-v0.8.md` documents the v0.7.x to v0.8.0
+  crate-surface migration. Most users do not need to migrate. (#603)
 
 ### Changed
 
 - Moved `HmacSpec` and its helpers from `uselesskey-core-hmac-spec`
-  into `uselesskey-hmac::srp::spec`.
+  into `uselesskey-hmac::srp::spec`. The former crate becomes a thin
+  re-export shim while it remains in the workspace. (#595)
 - Moved `RustlsPrivateKeyExt`, `RustlsCertExt`, and `RustlsChainExt`
-  traits from `uselesskey-core-rustls-pki` into
-  `uselesskey-rustls::srp::pki`.
-- Moved `PgpNativeExt` and its impls from `uselesskey-pgp-native` into
-  `uselesskey-pgp::native` (gated behind the new `native` Cargo feature).
+  traits and their impls from `uselesskey-core-rustls-pki` into
+  `uselesskey-rustls::srp::pki`. The former crate becomes a thin
+  re-export shim while it remains in the workspace. (#598)
+- Moved `PgpNativeExt` and its impls from `uselesskey-pgp-native`
+  into `uselesskey-pgp::native`, gated behind the new `native` Cargo
+  feature on `uselesskey-pgp`. The former crate becomes a thin
+  re-export shim while it remains in the workspace. (#599)
+- Activated the Rust 1.94/1.95 Clippy ratchets workspace-wide under
+  `-D warnings`. (#505)
+- Refreshed dependency floors via the standard maintenance lane:
+  `blake3`, `tokio`, `clap`, `tonic`, `cucumber`, `rustls-pki-types`,
+  `signature`, and `codecov/codecov-action`. (#484-#491)
 
 ### Removed
 
-**Breaking.** Removed the 29 fully-folded published-internal compatibility
-shim crates introduced in v0.7.x. The content they re-exported now lives
-exclusively as `srp::*` modules under the owner public crates. Downstream
-consumers should depend on the owner crates and the facade; the shim
-crate names are no longer published. See `docs/how-to/migrate-from-v0.7.md`
-for the full mapping.
-
-Core internals (canonical home: `uselesskey_core::srp::*`):
-
-- `uselesskey-core-cache` -> `uselesskey_core::srp::cache`
-- `uselesskey-core-factory` -> `uselesskey_core::srp::factory`
-- `uselesskey-core-hash` -> `uselesskey_core::srp::hash`
-- `uselesskey-core-id` -> `uselesskey_core::srp::identity`
-- `uselesskey-core-seed` -> `uselesskey_core::srp::seed`
-- `uselesskey-core-sink` -> `uselesskey_core::srp::sink`
-- `uselesskey-core-keypair` -> `uselesskey_core::srp::keypair`
-- `uselesskey-core-keypair-material` -> `uselesskey_core::srp::keypair_material`
-- `uselesskey-core-negative` -> `uselesskey_core::srp::negative`
-- `uselesskey-core-negative-der` -> `uselesskey_core::srp::negative::der`
-- `uselesskey-core-negative-pem` -> `uselesskey_core::srp::negative::pem`
-
-JWK internals (canonical home: `uselesskey_jwk::srp::*`):
-
-- `uselesskey-core-kid` -> `uselesskey_jwk::srp::kid`
-- `uselesskey-core-jwk` -> `uselesskey_jwk`
-- `uselesskey-core-jwk-builder` -> `uselesskey_jwk::JwksBuilder`
-- `uselesskey-core-jwk-shape` -> `uselesskey_jwk::srp::shape`
-- `uselesskey-core-jwks-order` -> `uselesskey_jwk::srp::ordering`
-
-Token internals (canonical home: `uselesskey_token::srp::*`):
-
-- `uselesskey-core-base62` -> `uselesskey_token::srp::base62`
-- `uselesskey-core-token` -> `uselesskey_token::srp::shape`
-- `uselesskey-core-token-shape` -> `uselesskey_token::srp::shape`
-- `uselesskey-token-spec` -> `uselesskey_token::srp::spec`
-
-X.509 internals (canonical home: `uselesskey_x509::srp::*`):
-
-- `uselesskey-core-x509` -> `uselesskey_x509::srp::policy`
-- `uselesskey-core-x509-spec` -> `uselesskey_x509::srp::spec`
-- `uselesskey-core-x509-derive` -> `uselesskey_x509::srp::derive`
-- `uselesskey-core-x509-negative` -> `uselesskey_x509::srp::negative`
-- `uselesskey-core-x509-chain-negative` -> `uselesskey_x509::srp::chain_negative`
-
-Folded standalones (content moved in v0.7.2 by #595, #598, #599; shim
-crates removed in v0.8.0):
-
-- `uselesskey-core-hmac-spec` -> `uselesskey_hmac::srp::spec` (#595)
-- `uselesskey-core-rustls-pki` -> `uselesskey_rustls::srp::pki` (#598)
-- `uselesskey-pgp-native` -> `uselesskey_pgp::native` (feature = "native") (#599)
-
-Conditional duplicate (byte-equal to `JwtKeyExt`):
-
-- `uselesskey-jose-openid` -> `uselesskey_jsonwebtoken::JwtKeyExt`
+- Removed the 29 v0.7.0-vintage published-internal shim crates from the
+  workspace. v0.7.0 folded their content into owner-crate `srp::*`
+  modules; v0.7.x kept the shims as compatibility re-exports; v0.8.0
+  removes them entirely. The v0.7.x crate versions remain on
+  crates.io as historical records. Downstreams that pinned a shim
+  directly should follow `docs/how-to/migrate-to-v0.8.md`. (#602)
 
 ## [0.7.1] - 2026-05-11
 
@@ -599,7 +579,8 @@ Repository organised into four layers:
 - **Determinism regression** — hardcoded expected-value snapshots ensure
   derivation stability across releases
 
-[Unreleased]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.5.1...v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "insta",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-aws-lc-rs"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "aws-lc-rs",
  "hex",
@@ -4612,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-axum"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "axum",
  "http",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-bdd-steps"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-cli"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "blake3",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ecdsa"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "elliptic-curve 0.14.0-rc.29",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ed25519"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-entropy"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "proptest",
  "uselesskey-core",
@@ -4770,14 +4770,14 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-feature-grid"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "uselesskey-test-support",
 ]
 
 [[package]]
 name = "uselesskey-hmac"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "base64",
  "insta",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jsonwebtoken"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "insta",
  "jsonwebtoken",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jwk"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "blake3",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pgp"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "insta",
  "pgp",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pkcs11-mock"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "sha2 0.11.0",
  "uselesskey-core",
@@ -4907,7 +4907,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ring"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "hex",
  "insta",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rsa"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "insta",
@@ -4942,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustcrypto"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustls"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "hex",
  "insta",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ssh"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "proptest",
  "rand_chacha 0.3.1",
@@ -4991,14 +4991,14 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-test-grid"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "uselesskey-feature-grid",
 ]
 
 [[package]]
 name = "uselesskey-test-server"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "axum",
  "blake3",
@@ -5017,11 +5017,11 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-test-support"
-version = "0.7.1"
+version = "0.8.0"
 
 [[package]]
 name = "uselesskey-token"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "insta",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-tonic"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "insta",
  "proptest",
@@ -5047,7 +5047,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-webauthn"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "ciborium",
  "serde_json",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-webhook"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "hex",
@@ -5072,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-x509"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,20 +58,20 @@ thiserror = "2.0.18"
 uselesskey-test-grid = { path = "crates/uselesskey-test-grid" }
 uselesskey-test-support = { path = "crates/uselesskey-test-support" }
 uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid" }
-uselesskey = { path = "crates/uselesskey", version = "0.7.1", default-features = false }
-uselesskey-cli = { path = "crates/uselesskey-cli", version = "0.7.1" }
-uselesskey-entropy = { path = "crates/uselesskey-entropy", version = "0.7.1" }
-uselesskey-core = { path = "crates/uselesskey-core", version = "0.7.1" }
-uselesskey-rsa = { path = "crates/uselesskey-rsa", version = "0.7.1" }
-uselesskey-ecdsa = { path = "crates/uselesskey-ecdsa", version = "0.7.1" }
-uselesskey-ed25519 = { path = "crates/uselesskey-ed25519", version = "0.7.1" }
-uselesskey-hmac = { path = "crates/uselesskey-hmac", version = "0.7.2" }
-uselesskey-token = { path = "crates/uselesskey-token", version = "0.7.1" }
-uselesskey-pgp = { path = "crates/uselesskey-pgp", version = "0.7.2" }
-uselesskey-x509 = { path = "crates/uselesskey-x509", version = "0.7.1" }
-uselesskey-webhook = { path = "crates/uselesskey-webhook", version = "0.7.1" }
-uselesskey-ssh = { path = "crates/uselesskey-ssh", version = "0.7.1" }
-uselesskey-rustls = { path = "crates/uselesskey-rustls", version = "0.7.2" }
+uselesskey = { path = "crates/uselesskey", version = "0.8.0", default-features = false }
+uselesskey-cli = { path = "crates/uselesskey-cli", version = "0.8.0" }
+uselesskey-entropy = { path = "crates/uselesskey-entropy", version = "0.8.0" }
+uselesskey-core = { path = "crates/uselesskey-core", version = "0.8.0" }
+uselesskey-rsa = { path = "crates/uselesskey-rsa", version = "0.8.0" }
+uselesskey-ecdsa = { path = "crates/uselesskey-ecdsa", version = "0.8.0" }
+uselesskey-ed25519 = { path = "crates/uselesskey-ed25519", version = "0.8.0" }
+uselesskey-hmac = { path = "crates/uselesskey-hmac", version = "0.8.0" }
+uselesskey-token = { path = "crates/uselesskey-token", version = "0.8.0" }
+uselesskey-pgp = { path = "crates/uselesskey-pgp", version = "0.8.0" }
+uselesskey-x509 = { path = "crates/uselesskey-x509", version = "0.8.0" }
+uselesskey-webhook = { path = "crates/uselesskey-webhook", version = "0.8.0" }
+uselesskey-ssh = { path = "crates/uselesskey-ssh", version = "0.8.0" }
+uselesskey-rustls = { path = "crates/uselesskey-rustls", version = "0.8.0" }
 
 # determinism / hashing
 blake3 = "1.8.5"

--- a/README.md
+++ b/README.md
@@ -93,31 +93,31 @@ Common starting points:
 ```toml
 # Entropy-only fixtures
 [dev-dependencies]
-uselesskey = { version = "0.7.1", default-features = false, features = ["entropy"] }
+uselesskey = { version = "0.8.0", default-features = false, features = ["entropy"] }
 ```
 
 ```toml
 # RSA fixtures
 [dev-dependencies]
-uselesskey = { version = "0.7.1", features = ["rsa"] }
+uselesskey = { version = "0.8.0", features = ["rsa"] }
 ```
 
 ```toml
 # Token-only fixtures, no RSA/X.509 pull-in
 [dev-dependencies]
-uselesskey = { version = "0.7.1", default-features = false, features = ["token"] }
+uselesskey = { version = "0.8.0", default-features = false, features = ["token"] }
 ```
 
 ```toml
 # RSA + JWK/JWKS
 [dev-dependencies]
-uselesskey = { version = "0.7.1", features = ["rsa", "jwk"] }
+uselesskey = { version = "0.8.0", features = ["rsa", "jwk"] }
 ```
 
 ```toml
 # X.509 fixtures
 [dev-dependencies]
-uselesskey = { version = "0.7.1", features = ["x509"] }
+uselesskey = { version = "0.8.0", features = ["x509"] }
 ```
 
 ```bash
@@ -131,13 +131,13 @@ For `build.rs` consumers:
 ```toml
 # Common shape-only build-time path
 [build-dependencies]
-uselesskey-cli = { version = "0.7.1", default-features = false }
+uselesskey-cli = { version = "0.8.0", default-features = false }
 ```
 
 ```toml
 # Specialized RSA PKCS#8 build-time path
 [build-dependencies]
-uselesskey-cli = { version = "0.7.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.8.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 Use the facade for convenience. Depend on leaf crates only when compile-time minimization matters enough to justify the sharper API.
@@ -190,37 +190,37 @@ Dependency snippets:
 - **Quick start (RSA)**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["rsa"] }
+  uselesskey = { version = "0.8.0", features = ["rsa"] }
   ```
 
 
 - **Token-only**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", default-features = false, features = ["token"] }
+  uselesskey = { version = "0.8.0", default-features = false, features = ["token"] }
   ```
 
 
 - **JWT/JWK**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["rsa", "jwk"] }
+  uselesskey = { version = "0.8.0", features = ["rsa", "jwk"] }
   ```
 
 
 - **X.509 + rustls**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["x509"] }
-  uselesskey-rustls = { version = "0.7.2", features = ["tls-config", "rustls-ring"] }
+  uselesskey = { version = "0.8.0", features = ["x509"] }
+  uselesskey-rustls = { version = "0.8.0", features = ["tls-config", "rustls-ring"] }
   ```
 
 
 - **jsonwebtoken adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jsonwebtoken = { version = "0.7.1" }
+  uselesskey = { version = "0.8.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jsonwebtoken = { version = "0.8.0" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 
@@ -383,8 +383,8 @@ With the `tls-config` feature, build rustls configs in one step:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7.1", features = ["x509"] }
-uselesskey-rustls = { version = "0.7.2", features = ["tls-config", "rustls-ring"] }
+uselesskey = { version = "0.8.0", features = ["x509"] }
+uselesskey-rustls = { version = "0.8.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```rust
@@ -402,8 +402,8 @@ let client_config = chain.client_config_rustls();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7.1", features = ["rsa"] }
-uselesskey-ring = { version = "0.7.1", features = ["all"] }
+uselesskey = { version = "0.8.0", features = ["rsa"] }
+uselesskey-ring = { version = "0.8.0", features = ["all"] }
 ```
 
 ```rust
@@ -419,8 +419,8 @@ let ring_kp = rsa.rsa_key_pair_ring();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7.1", features = ["rsa"] }
-uselesskey-rustcrypto = { version = "0.7.1", features = ["all"] }
+uselesskey = { version = "0.8.0", features = ["rsa"] }
+uselesskey-rustcrypto = { version = "0.8.0", features = ["all"] }
 ```
 
 ```rust
@@ -436,8 +436,8 @@ let rsa_pk = rsa.rsa_private_key();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7.1", features = ["rsa"] }
-uselesskey-aws-lc-rs = { version = "0.7.1", features = ["native", "all"] }
+uselesskey = { version = "0.8.0", features = ["rsa"] }
+uselesskey-aws-lc-rs = { version = "0.8.0", features = ["native", "all"] }
 ```
 
 ```rust
@@ -453,8 +453,8 @@ let lc_kp = rsa.rsa_key_pair_aws_lc_rs();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7.1", features = ["x509"] }
-uselesskey-tonic = "0.7.1"
+uselesskey = { version = "0.8.0", features = ["x509"] }
+uselesskey-tonic = "0.8.0"
 ```
 
 ```rust

--- a/crates/materialize-buildrs-example/Cargo.toml
+++ b/crates/materialize-buildrs-example/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 description = "Build-time materialization example for uselesskey fixtures."
 
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.7.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.8.0", default-features = false, features = ["rsa-materialize"] }
 
 [lints]
 workspace = true

--- a/crates/materialize-shape-buildrs-example/Cargo.toml
+++ b/crates/materialize-shape-buildrs-example/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 description = "Build-time shape-only materialization example for uselesskey fixtures."
 
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.7.1", default-features = false }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.8.0", default-features = false }
 
 
 [lints]

--- a/crates/uselesskey-aws-lc-rs/Cargo.toml
+++ b/crates/uselesskey-aws-lc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-aws-lc-rs"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,9 +18,9 @@ authors.workspace = true
 aws-lc-rs = { version = "1", optional = true }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -38,10 +38,10 @@ ed25519 = ["dep:uselesskey-ed25519"]
 all = ["native", "rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0" }
 aws-lc-rs = "1"
 hex = "0.4"
 serde.workspace = true

--- a/crates/uselesskey-aws-lc-rs/README.md
+++ b/crates/uselesskey-aws-lc-rs/README.md
@@ -20,7 +20,7 @@ When `native` is disabled, this crate builds as a no-op and exports no adapter t
 
 ```toml
 [dev-dependencies]
-uselesskey-aws-lc-rs = { version = "0.7.1", features = ["native", "rsa"] }
+uselesskey-aws-lc-rs = { version = "0.8.0", features = ["native", "rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-axum/Cargo.toml
+++ b/crates/uselesskey-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-axum"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -21,8 +21,8 @@ jsonwebtoken.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tower = { version = "0.5.2", features = ["util"] }
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1", features = ["jwk"] }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0", features = ["jwk"] }
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/uselesskey-bdd-steps/Cargo.toml
+++ b/crates/uselesskey-bdd-steps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-bdd-steps"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -29,11 +29,11 @@ x509-parser = "0.18.1"
 serde_json.workspace = true
 base64.workspace = true
 pgp = { version = "0.19.0", default-features = false }
-uselesskey-aws-lc-rs = { path = "../uselesskey-aws-lc-rs", version = "0.7.1", optional = true, default-features = false, features = ["all"] }
-uselesskey-ring = { path = "../uselesskey-ring", version = "0.7.1", optional = true, default-features = false, features = ["all"] }
-uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", version = "0.7.1", optional = true, default-features = false, features = ["all"] }
-uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.7.1", optional = true, default-features = false, features = ["x509", "tls-config", "rustls-ring"] }
-uselesskey-tonic = { path = "../uselesskey-tonic", version = "0.7.1", optional = true, default-features = false, features = ["x509"] }
+uselesskey-aws-lc-rs = { path = "../uselesskey-aws-lc-rs", version = "0.8.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-ring = { path = "../uselesskey-ring", version = "0.8.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", version = "0.8.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.8.0", optional = true, default-features = false, features = ["x509", "tls-config", "rustls-ring"] }
+uselesskey-tonic = { path = "../uselesskey-tonic", version = "0.8.0", optional = true, default-features = false, features = ["x509"] }
 hmac = { version = "0.13.0-rc.6", optional = true }
 aws-lc-rs = { version = "1", optional = true }
 ring = { workspace = true, optional = true }

--- a/crates/uselesskey-bench/Cargo.toml
+++ b/crates/uselesskey-bench/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 tempfile.workspace = true
 uselesskey = { path = "../uselesskey", features = ["full"] }
 uselesskey-cli.workspace = true
-uselesskey-pkcs11-mock = { path = "../uselesskey-pkcs11-mock", version = "0.7.1" }
-uselesskey-webauthn = { path = "../uselesskey-webauthn", version = "0.7.1" }
+uselesskey-pkcs11-mock = { path = "../uselesskey-pkcs11-mock", version = "0.8.0" }
+uselesskey-webauthn = { path = "../uselesskey-webauthn", version = "0.8.0" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/uselesskey-cli/Cargo.toml
+++ b/crates/uselesskey-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-cli"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -41,7 +41,7 @@ uselesskey-core.workspace = true
 uselesskey-ecdsa = { workspace = true, features = ["jwk"], optional = true }
 uselesskey-ed25519 = { workspace = true, features = ["jwk"], optional = true }
 uselesskey-hmac = { workspace = true, features = ["jwk"], optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.1" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.8.0" }
 uselesskey-rsa = { workspace = true, features = ["jwk"], optional = true }
 uselesskey-token.workspace = true
 uselesskey-x509 = { workspace = true, optional = true }

--- a/crates/uselesskey-cli/README.md
+++ b/crates/uselesskey-cli/README.md
@@ -27,14 +27,14 @@ cargo run -p uselesskey-cli -- verify \
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.7.1", default-features = false }
+uselesskey-cli = { version = "0.8.0", default-features = false }
 ```
 
 Specialized RSA PKCS#8 build-time lane:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.7.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.8.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 The workspace ships both compiled build-time examples:

--- a/crates/uselesskey-core/Cargo.toml
+++ b/crates/uselesskey-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-ecdsa/Cargo.toml
+++ b/crates/uselesskey-ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ecdsa"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-ecdsa"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 
 # Elliptic curve support from RustCrypto's current RC line
 p256 = { version = "0.14.0-rc.8", features = ["ecdsa", "pkcs8", "pem"] }
@@ -27,7 +27,7 @@ rand_core10.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.8.0", optional = true }
 
 [features]
 default = []

--- a/crates/uselesskey-ed25519/Cargo.toml
+++ b/crates/uselesskey-ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ed25519"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,14 +15,14 @@ documentation = "https://docs.rs/uselesskey-ed25519"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 ed25519-dalek.workspace = true
 pkcs8.workspace = true
 
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.8.0", optional = true }
 
 [features]
 default = []

--- a/crates/uselesskey-entropy/Cargo.toml
+++ b/crates/uselesskey-entropy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-entropy"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-entropy"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/uselesskey-feature-grid/Cargo.toml
+++ b/crates/uselesskey-feature-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-feature-grid"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-hmac/Cargo.toml
+++ b/crates/uselesskey-hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-hmac"
-version = "0.7.2"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,12 +15,12 @@ documentation = "https://docs.rs/uselesskey-hmac"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 
 # Optional JWK/JWKS support
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.8.0", optional = true }
 base64 = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-jsonwebtoken/Cargo.toml
+++ b/crates/uselesskey-jsonwebtoken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-jsonwebtoken"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -20,10 +20,10 @@ authors.workspace = true
 jsonwebtoken = { version = "10", features = ["use_pem"] }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.1", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.8.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -37,11 +37,11 @@ hmac = ["dep:uselesskey-hmac"]
 all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1" }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.8.0" }
 serde.workspace = true
 insta.workspace = true
 proptest.workspace = true

--- a/crates/uselesskey-jsonwebtoken/README.md
+++ b/crates/uselesskey-jsonwebtoken/README.md
@@ -24,7 +24,7 @@ Implements `JwtKeyExt` so fixture types return `jsonwebtoken::EncodingKey` and
 
 ```toml
 [dev-dependencies]
-uselesskey-jsonwebtoken = { version = "0.7.1", features = ["rsa"] }
+uselesskey-jsonwebtoken = { version = "0.8.0", features = ["rsa"] }
 jsonwebtoken = { version = "10", features = ["use_pem", "rust_crypto"] }
 ```
 

--- a/crates/uselesskey-jwk/Cargo.toml
+++ b/crates/uselesskey-jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-jwk"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-pgp"
-version = "0.7.2"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-pgp"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 pgp = { workspace = true }
 rand_chacha = { version = "0.3.1", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }

--- a/crates/uselesskey-pkcs11-mock/Cargo.toml
+++ b/crates/uselesskey-pkcs11-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-pkcs11-mock"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,11 +15,11 @@ documentation = "https://docs.rs/uselesskey-pkcs11-mock"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 sha2.workspace = true
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 
 [lints]
 workspace = true

--- a/crates/uselesskey-ring/Cargo.toml
+++ b/crates/uselesskey-ring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ring"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,9 +18,9 @@ authors.workspace = true
 ring = "0.17"
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -33,7 +33,7 @@ ed25519 = ["dep:uselesskey-ed25519"]
 all = ["rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-ring/README.md
+++ b/crates/uselesskey-ring/README.md
@@ -17,7 +17,7 @@ Converts fixture keypairs into native ring signing key types for tests that call
 
 ```toml
 [dev-dependencies]
-uselesskey-ring = { version = "0.7.1", features = ["rsa"] }
+uselesskey-ring = { version = "0.8.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-rsa/Cargo.toml
+++ b/crates/uselesskey-rsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rsa"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-rsa"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 rsa.workspace = true
 rsa09 = { package = "rsa", version = "0.9.10", features = ["pem"], optional = true }
 rand_chacha = { version = "0.3.1", default-features = false, optional = true }
@@ -26,7 +26,7 @@ rand_chacha10.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.8.0", optional = true }
 
 [features]
 default = ["legacy-rsa09"]

--- a/crates/uselesskey-rustcrypto/Cargo.toml
+++ b/crates/uselesskey-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rustcrypto"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -23,10 +23,10 @@ hmac = { version = "0.13.0-rc.6", optional = true }
 sha2 = { version = "0.11", optional = true }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1", optional = true, default-features = false }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.1", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0", optional = true, default-features = false }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.8.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -40,11 +40,11 @@ hmac = ["dep:hmac", "dep:sha2", "dep:uselesskey-hmac"]
 all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1", default-features = false }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1" }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0", default-features = false }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.8.0" }
 rand_chacha10.workspace = true
 proptest.workspace = true
 rsa = { workspace = true, features = ["sha2"] }

--- a/crates/uselesskey-rustcrypto/README.md
+++ b/crates/uselesskey-rustcrypto/README.md
@@ -18,7 +18,7 @@ Converts fixture key material into native RustCrypto types (`rsa`, `p256`/`p384`
 
 ```toml
 [dev-dependencies]
-uselesskey-rustcrypto = { version = "0.7.1", features = ["rsa"] }
+uselesskey-rustcrypto = { version = "0.8.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rustls"
-version = "0.7.2"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -19,10 +19,10 @@ rustls-pki-types = "1"
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"], optional = true }
 
 # Key type crates (all optional)
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.1", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.8.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all", "tls-config", "rustls-ring"]
@@ -42,11 +42,11 @@ rustls-aws-lc-rs = ["rustls?/aws_lc_rs"]
 
 [dev-dependencies]
 rustls-pki-types = "1"
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.8.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0" }
 rustls = { version = "0.23", features = ["ring"] }
 hex = "0.4"
 serde.workspace = true

--- a/crates/uselesskey-rustls/README.md
+++ b/crates/uselesskey-rustls/README.md
@@ -30,7 +30,7 @@ optional `ServerConfig` / `ClientConfig` builders (including mTLS support).
 
 ```toml
 [dev-dependencies]
-uselesskey-rustls = { version = "0.7.2", features = ["tls-config", "rustls-ring"] }
+uselesskey-rustls = { version = "0.8.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```rust

--- a/crates/uselesskey-ssh/Cargo.toml
+++ b/crates/uselesskey-ssh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ssh"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-ssh"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 ssh-key = { version = "0.6.7", default-features = false, features = ["std", "ed25519", "rsa", "rand_core"] }
 rand_chacha = { version = "0.3.1", default-features = false }
 

--- a/crates/uselesskey-test-grid/Cargo.toml
+++ b/crates/uselesskey-test-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-grid"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-test-server/Cargo.toml
+++ b/crates/uselesskey-test-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-server"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -23,11 +23,11 @@ blake3.workspace = true
 axum = { version = "0.8.6", default-features = false, features = ["tokio", "http1", "json"] }
 http = "1.3.1"
 
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.1" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1", features = ["jwk"] }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1", features = ["jwk"] }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1", features = ["jwk"] }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.8.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0", features = ["jwk"] }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0", features = ["jwk"] }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0", features = ["jwk"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/uselesskey-test-support/Cargo.toml
+++ b/crates/uselesskey-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-support"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-token"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -19,7 +19,7 @@ base64.workspace = true
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 serde_json.workspace = true
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-tonic/Cargo.toml
+++ b/crates/uselesskey-tonic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-tonic"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ authors.workspace = true
 
 [dependencies]
 tonic = { version = "0.14.6", default-features = false, features = ["transport", "tls-ring"] }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.1", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.8.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["x509"]
@@ -26,8 +26,8 @@ default = ["x509"]
 x509 = ["dep:uselesskey-x509"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.8.0" }
 proptest.workspace = true
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-tonic/README.md
+++ b/crates/uselesskey-tonic/README.md
@@ -19,9 +19,9 @@ Converts fixture certs and chains into `tonic::transport` TLS types:
 
 ```toml
 [dev-dependencies]
-uselesskey-tonic = "0.7.1"
-uselesskey-core = "0.7.1"
-uselesskey-x509 = "0.7.1"
+uselesskey-tonic = "0.8.0"
+uselesskey-core = "0.8.0"
+uselesskey-x509 = "0.8.0"
 ```
 
 ```rust

--- a/crates/uselesskey-webauthn/Cargo.toml
+++ b/crates/uselesskey-webauthn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-webauthn"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,13 +15,13 @@ documentation = "https://docs.rs/uselesskey-webauthn"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 serde_json.workspace = true
 ciborium.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 serde_json.workspace = true
 
 [lints]

--- a/crates/uselesskey-webhook/Cargo.toml
+++ b/crates/uselesskey-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-webhook"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-webhook"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 base64.workspace = true

--- a/crates/uselesskey-x509/Cargo.toml
+++ b/crates/uselesskey-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-x509"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,9 +15,9 @@ documentation = "https://docs.rs/uselesskey-x509"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1" }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.1", optional = true }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.8.0", optional = true }
 rcgen = "0.14.7"
 rustls-pki-types = "1"
 x509-parser = "0.18"

--- a/crates/uselesskey/Cargo.toml
+++ b/crates/uselesskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey"
-version = "0.7.1"
+version = "0.8.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -22,20 +22,20 @@ maintenance = { status = "actively-developed" }
 features = ["full"]
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.8.0" }
 
 # Key type crates - all optional
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.7.1", optional = true }
-uselesskey-entropy = { path = "../uselesskey-entropy", version = "0.7.1", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.7.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.7.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.7.1", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.7.1", optional = true }
-uselesskey-token = { path = "../uselesskey-token", version = "0.7.1", optional = true }
-uselesskey-ssh = { path = "../uselesskey-ssh", version = "0.7.1", optional = true }
-uselesskey-webhook = { path = "../uselesskey-webhook", version = "0.7.1", optional = true }
-uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.7.1", optional = true }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.7.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.8.0", optional = true }
+uselesskey-entropy = { path = "../uselesskey-entropy", version = "0.8.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.8.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.8.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.8.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.8.0", optional = true }
+uselesskey-token = { path = "../uselesskey-token", version = "0.8.0", optional = true }
+uselesskey-ssh = { path = "../uselesskey-ssh", version = "0.8.0", optional = true }
+uselesskey-webhook = { path = "../uselesskey-webhook", version = "0.8.0", optional = true }
+uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.8.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.8.0", optional = true }
 
 [features]
 default = []
@@ -77,8 +77,8 @@ x509-parser = "0.18"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 jsonwebtoken = { workspace = true, features = ["rust_crypto"] }
-uselesskey-jsonwebtoken = { path = "../uselesskey-jsonwebtoken", version = "0.7.1", features = ["all"] }
-uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.7.1", features = ["all", "tls-config", "rustls-ring"] }
+uselesskey-jsonwebtoken = { path = "../uselesskey-jsonwebtoken", version = "0.8.0", features = ["all"] }
+uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.8.0", features = ["all", "tls-config", "rustls-ring"] }
 rustls-pki-types.workspace = true
 
 [[bench]]

--- a/crates/uselesskey/README.md
+++ b/crates/uselesskey/README.md
@@ -50,37 +50,37 @@ Dependency snippets:
 - **Quick start (RSA)**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["rsa"] }
+  uselesskey = { version = "0.8.0", features = ["rsa"] }
   ```
 
 
 - **Token-only**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", default-features = false, features = ["token"] }
+  uselesskey = { version = "0.8.0", default-features = false, features = ["token"] }
   ```
 
 
 - **JWT/JWK**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["rsa", "jwk"] }
+  uselesskey = { version = "0.8.0", features = ["rsa", "jwk"] }
   ```
 
 
 - **X.509 + rustls**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["x509"] }
-  uselesskey-rustls = { version = "0.7.2", features = ["tls-config", "rustls-ring"] }
+  uselesskey = { version = "0.8.0", features = ["x509"] }
+  uselesskey-rustls = { version = "0.8.0", features = ["tls-config", "rustls-ring"] }
   ```
 
 
 - **jsonwebtoken adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jsonwebtoken = { version = "0.7.1" }
+  uselesskey = { version = "0.8.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jsonwebtoken = { version = "0.8.0" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 
@@ -97,7 +97,7 @@ Entropy-only consumers can stay lighter still:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7.1", default-features = false, features = ["entropy"] }
+uselesskey = { version = "0.8.0", default-features = false, features = ["entropy"] }
 ```
 
 ```rust
@@ -119,7 +119,7 @@ If you want RSA fixtures, enable `rsa` explicitly:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7.1", features = ["rsa"] }
+uselesskey = { version = "0.8.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey/src/lib.rs
+++ b/crates/uselesskey/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! uselesskey = { version = "0.7.1", default-features = false, features = ["token"] }
+//! uselesskey = { version = "0.8.0", default-features = false, features = ["token"] }
 //! ```
 //!
 //! ```
@@ -42,7 +42,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! uselesskey = { version = "0.7.1", default-features = false, features = ["entropy"] }
+//! uselesskey = { version = "0.8.0", default-features = false, features = ["entropy"] }
 //! ```
 //!
 //! ```

--- a/docs/how-to/choose-features.md
+++ b/docs/how-to/choose-features.md
@@ -35,37 +35,37 @@ Dependency snippets:
 - **Quick start (RSA)**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["rsa"] }
+  uselesskey = { version = "0.8.0", features = ["rsa"] }
   ```
 
 
 - **Token-only**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", default-features = false, features = ["token"] }
+  uselesskey = { version = "0.8.0", default-features = false, features = ["token"] }
   ```
 
 
 - **JWT/JWK**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["rsa", "jwk"] }
+  uselesskey = { version = "0.8.0", features = ["rsa", "jwk"] }
   ```
 
 
 - **X.509 + rustls**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["x509"] }
-  uselesskey-rustls = { version = "0.7.2", features = ["tls-config", "rustls-ring"] }
+  uselesskey = { version = "0.8.0", features = ["x509"] }
+  uselesskey-rustls = { version = "0.8.0", features = ["tls-config", "rustls-ring"] }
   ```
 
 
 - **jsonwebtoken adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.7.1", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jsonwebtoken = { version = "0.7.1" }
+  uselesskey = { version = "0.8.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jsonwebtoken = { version = "0.8.0" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 

--- a/docs/how-to/materialize-fixtures-in-build-rs.md
+++ b/docs/how-to/materialize-fixtures-in-build-rs.md
@@ -146,7 +146,7 @@ Shape-only — `crates/materialize-shape-buildrs-example/Cargo.toml`:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.7.1", default-features = false }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.8.0", default-features = false }
 ```
 
 Shape-only manifests use kinds like `entropy.bytes`, `token.jwt_shape`,
@@ -158,7 +158,7 @@ Runtime RSA — `crates/materialize-buildrs-example/Cargo.toml`:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.7.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.8.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 The `rsa-materialize` feature is what unlocks `rsa.pkcs8_der` and

--- a/docs/metadata/workspace-docs.json
+++ b/docs/metadata/workspace-docs.json
@@ -754,8 +754,7 @@
           "features": [
             "tls-config",
             "rustls-ring"
-          ],
-          "version": "0.7.2"
+          ]
         }
       ],
       "minimal_example_command": "cargo run -p uselesskey --example adapter_rustls --no-default-features --features x509"
@@ -782,7 +781,7 @@
       "minimal_example_command": "cargo run -p uselesskey --example adapter_jsonwebtoken --no-default-features --features rsa,ecdsa,ed25519,hmac"
     }
   ],
-  "release_version": "0.7.1",
+  "release_version": "0.8.0",
   "public_features": [
     "rsa",
     "ecdsa",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,28 +14,28 @@ keywords = ["testing", "integration", "fixtures", "crypto", "deterministic"]
 
 [dependencies]
 # Core
-uselesskey-core = { path = "../crates/uselesskey-core", version = "0.7.1" }
+uselesskey-core = { path = "../crates/uselesskey-core", version = "0.8.0" }
 blake3.workspace = true
 
 # Key types (all optional features)
-uselesskey-rsa = { path = "../crates/uselesskey-rsa", version = "0.7.1", optional = true, features = ["jwk"] }
-uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa", version = "0.7.1", optional = true, features = ["jwk"] }
-uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519", version = "0.7.1", optional = true, features = ["jwk"] }
-uselesskey-hmac = { path = "../crates/uselesskey-hmac", version = "0.7.1", optional = true, features = ["jwk"] }
-uselesskey-x509 = { path = "../crates/uselesskey-x509", version = "0.7.1", optional = true }
-uselesskey-token = { path = "../crates/uselesskey-token", version = "0.7.1", optional = true }
+uselesskey-rsa = { path = "../crates/uselesskey-rsa", version = "0.8.0", optional = true, features = ["jwk"] }
+uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa", version = "0.8.0", optional = true, features = ["jwk"] }
+uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519", version = "0.8.0", optional = true, features = ["jwk"] }
+uselesskey-hmac = { path = "../crates/uselesskey-hmac", version = "0.8.0", optional = true, features = ["jwk"] }
+uselesskey-x509 = { path = "../crates/uselesskey-x509", version = "0.8.0", optional = true }
+uselesskey-token = { path = "../crates/uselesskey-token", version = "0.8.0", optional = true }
 
 # JWK/JWKS
-uselesskey-jwk = { path = "../crates/uselesskey-jwk", version = "0.7.1", optional = true }
+uselesskey-jwk = { path = "../crates/uselesskey-jwk", version = "0.8.0", optional = true }
 
 # Adapters
-uselesskey-jsonwebtoken = { path = "../crates/uselesskey-jsonwebtoken", version = "0.7.1", optional = true, features = ["all"] }
-uselesskey-rustls = { path = "../crates/uselesskey-rustls", version = "0.7.1", optional = true, features = ["server-config", "client-config"] }
-uselesskey-ring = { path = "../crates/uselesskey-ring", version = "0.7.1", optional = true, features = ["all"] }
-uselesskey-rustcrypto = { path = "../crates/uselesskey-rustcrypto", version = "0.7.1", optional = true, features = ["all"] }
+uselesskey-jsonwebtoken = { path = "../crates/uselesskey-jsonwebtoken", version = "0.8.0", optional = true, features = ["all"] }
+uselesskey-rustls = { path = "../crates/uselesskey-rustls", version = "0.8.0", optional = true, features = ["server-config", "client-config"] }
+uselesskey-ring = { path = "../crates/uselesskey-ring", version = "0.8.0", optional = true, features = ["all"] }
+uselesskey-rustcrypto = { path = "../crates/uselesskey-rustcrypto", version = "0.8.0", optional = true, features = ["all"] }
 
 # Facade crate (for determinism tests)
-uselesskey = { path = "../crates/uselesskey", version = "0.7.1", optional = true, features = ["full"] }
+uselesskey = { path = "../crates/uselesskey", version = "0.8.0", optional = true, features = ["full"] }
 
 # External dependencies
 jsonwebtoken = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary

TLS contract-pack and public crate-surface cleanup release. Bumps workspace from v0.7.x to v0.8.0.

## What's new

### TLS contract pack
- \`uselesskey bundle --profile tls\` produces a deterministic chain fixture with 4 negative classes (expired leaf, not-yet-valid, hostname mismatch, untrusted root). Per-fixture rejection expectations: \`docs/release/v0.8.0-tls-profile-design.md\`. (#585, #587)
- \`cargo xtask bundle-proof --profile tls\` produces the release-evidence proof artifact mirroring the OIDC pack. (#588)
- Task-first how-to: \`docs/how-to/test-tls-chain-validation.md\`. (#589)

### Task-first user docs sweep
Five new how-to pages: Vault KV export (#590), build.rs materialize (#591), WebAuthn ceremony validation (#592), PKCS#11 mock fixtures (#593), webhook signature validation (#594).

### Public crate-surface cleanup
29 published-internal shim crates removed. v0.7.0 folded their content into owner crate \`srp::*\` modules; v0.7.x kept the shims as compatibility re-exports; v0.8.0 removes them entirely. The v0.7.x crate versions remain on crates.io as historical records.

- HMAC fold: \`uselesskey-core-hmac-spec\` -> \`uselesskey-hmac::srp::spec\` (#595)
- rustls fold: \`uselesskey-core-rustls-pki\` -> \`uselesskey-rustls::srp::pki\` (#598)
- PGP fold: \`uselesskey-pgp-native\` -> \`uselesskey-pgp::native\` (feature \`native\`) (#599)
- Shim deletion: 29 crates removed in #602
- Migration guide: \`docs/how-to/migrate-to-v0.8.md\` (#603)

### Publish-system hardening
- Clippy 1.94/1.95 ratchets activated workspace-wide (8 lints). (#505)
- 8 dependabot bumps: blake3, tokio, clap, tonic, cucumber, rustls-pki-types, signature, codecov-action.

## Toolchain

No MSRV change. v0.8.0 stays on Rust 1.95.

## Claim boundary

\`uselesskey\` is a test-fixture layer. It is not production key management, scanner evasion, or cryptographic assurance.

## Validation

Local validation (worktree):
- \`cargo xtask public-surface\` — ok
- \`cargo xtask docs-sync --check\` — ok
- \`cargo xtask publish-preflight\` — ok
- \`cargo xtask publish-check\` — ok

CI will run the full \`xtask pr\` lane (bdd, full test matrix, fuzz build, clippy, etc.) plus the rest of \`release-evidence --version 0.8.0 --summary\` (TLS contract-pack proof, scanner-safe proof, OIDC proof, economics, audit-surface, perf, mutants-nightly --scope public). The local lane couldn't complete the fuzz build because the agent ran from a worktree where \`cargo fuzz\` resolves \`fuzz/Cargo.toml\` against the main-checkout workspace root.

## Post-merge

1. Tag v0.8.0 on the merge commit and push the tag.
2. \`release.yml\` runs end-to-end with \`cargo xtask publish\`.
3. Verify all 22 publishable crates land at 0.8.0 on crates.io.
4. \`gh release edit v0.8.0 --notes-file <\$TEMP/v0.8.0-release-body.md>\` to swap in the hand-written body.
5. Run \`cargo xtask cratesio-smoke --version 0.8.0\` post-publish to prove the registry user path.
6. Complete the v0.8.0 post-release audit per \`docs/release/post-release-audit.md\`.

## References

- v0.7.0 retrospective: \`docs/release/v0.7.0-lessons-learned.md\`
- Publish recovery procedures: \`docs/release/publish-recovery.md\`
- v0.7.x -> v0.8.0 migration guide: \`docs/how-to/migrate-to-v0.8.md\`

## Test plan

- [ ] CI green (preflight + pr full lane)
- [ ] No publish=false dep regression (#578 guard catches it)
- [ ] All 22 publishable crates show at 0.8.0 post-publish
- [ ] docs.rs builds queued/complete for the facade