### PR TITLE
docs: define source-of-truth model

### DIFF
--- a/.uselesskey/goals/README.md
+++ b/.uselesskey/goals/README.md
@@ -1,0 +1,16 @@
+# Active Goals
+
+This directory stores machine-readable lane state for agents working in
+`uselesskey`.
+
+The active goal manifest is the current execution source. Handoffs and learnings
+record history; they should not be treated as active instructions.
+
+## Files
+
+- `active.toml` - Current agent lane, once a lane is active.
+- `archive/` - Completed or superseded active-goal manifests.
+- `templates/active.toml` - Template for new active goals.
+
+Do not create `active.toml` until the lane has an accepted proposal or spec to
+link to.

--- a/.uselesskey/goals/templates/active.toml
+++ b/.uselesskey/goals/templates/active.toml
@@ -1,0 +1,36 @@
+id = "uselesskey-example-lane"
+title = "Short active goal title"
+status = "active"
+owner = "EffortlessMetrics"
+created = "YYYY-MM-DD"
+
+objective = """
+Describe the current lane in one durable paragraph.
+"""
+
+end_state = [
+  "Concrete end-state item.",
+  "Another concrete end-state item.",
+]
+
+[[work_item]]
+id = "first-work-item"
+status = "ready"
+proposal = "USELESSKEY-PROP-0000"
+spec = "USELESSKEY-SPEC-0000"
+plan = "plans/example/implementation-plan.md"
+commands = [
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "future-work-item"
+status = "planned"
+proposal = "USELESSKEY-PROP-0000"
+spec = "USELESSKEY-SPEC-0000"
+plan = "plans/example/implementation-plan.md"
+commands = [
+  "cargo xtask spec-check",
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,19 @@ Architecture Decision Records (ADRs) capture significant design choices and thei
 - [0003-order-independent-determinism.md](adr/0003-order-independent-determinism.md) — Order-independent derivation design
 - [0004-microcrate-architecture.md](adr/0004-microcrate-architecture.md) — Microcrate decomposition strategy
 
+## Source of Truth
+
+Repository operating artifacts are split by job so public claims, proof, and
+agent state do not drift into one document.
+
+- [proposals](proposals/README.md) - Why a lane exists, who benefits, and what alternatives were considered
+- [specs](specs/README.md) - What behavior is promised, not promised, and how it is proven
+- [status](status/README.md) - Public claim, support tier, and proof mapping indexes
+- [handoffs](handoffs/README.md) - Closeout notes and operator handoffs after a lane changes state
+- [learnings](learnings/README.md) - Durable lessons from releases, incidents, and proof lanes
+- [plans](../plans/README.md) - PR sequencing and rollback plans
+- [active goals](../.uselesskey/goals/README.md) - Machine-readable current agent lane state
+
 ## How-to Guides
 
 Task-oriented instructions for common workflows.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,10 @@ Each ADR follows this structure:
 - **Consequences**: What are the positive and negative outcomes?
 - **Alternatives Considered**: What other options were evaluated?
 
+New source-of-truth ADRs should also include TOML front matter with a stable
+`USELESSKEY-ADR-XXXX` ID. Existing numbered ADRs remain valid historical
+records; do not renumber them only to adopt the newer template.
+
 ## Creating a New ADR
 
 1. Copy `0001-use-adr-template.md` to a new file
@@ -27,6 +31,9 @@ Each ADR follows this structure:
 3. Create a short, kebab-case title (e.g., `0005-add-new-feature.md`)
 4. Fill in all sections
 5. Submit with your pull request
+
+For spec-system work, start from [the ADR template](../templates/adr.md) and
+use a stable `USELESSKEY-ADR-XXXX` ID in the front matter.
 
 ### Naming Convention
 

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,19 @@
+# Handoffs
+
+Handoffs record what changed, what proof exists, and what the next operator
+should do after a lane changes state.
+
+Use handoffs for release gates, PR queue transitions, failed external
+dependencies, and lane closeout. Do not use handoffs as the active task source;
+current agent state belongs under `.uselesskey/goals/`.
+
+## Required Shape
+
+Use [the handoff template](../templates/handoff.md). A handoff should include:
+
+- Current state
+- Relevant PRs, issues, commits, or releases
+- Proof already run
+- Known blockers
+- Next safe action
+- Explicit non-goals

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -1,0 +1,18 @@
+# Learnings
+
+Learning records capture durable lessons from releases, incidents, proof lanes,
+and product boundary changes.
+
+They should explain what changed in the operating model, not restate every step
+from a PR or release log.
+
+## Required Shape
+
+Use [the learning template](../templates/learning.md). A learning record should
+include:
+
+- Trigger
+- What changed
+- Evidence that made the lesson visible
+- Repository rule or habit to keep
+- Follow-up specs, ADRs, plans, or policy entries

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,32 @@
+# Proposals
+
+Proposals explain why a lane exists before the repo accepts a behavior
+contract. They are the place for users, motivation, alternatives, risk, and
+success criteria.
+
+Proposals do not own implementation sequencing. Link to a plan for PR order and
+rollback details.
+
+## Required Shape
+
+Use [the proposal template](../templates/proposal.md). Each proposal should
+define:
+
+- Problem and affected users
+- Success criteria
+- Proposed shape
+- Alternatives considered
+- Specs or ADRs expected from the lane
+- Evidence plan
+- Non-goals
+- Exit criteria
+
+## Status Values
+
+Use these status values in TOML front matter:
+
+- `proposed`
+- `accepted`
+- `implemented`
+- `superseded`
+- `archived`

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,34 @@
+# Specs
+
+Specs define what `uselesskey` promises and how that promise is proven. They are
+behavior contracts, not implementation journals.
+
+A spec should make a public claim auditable:
+
+```text
+claim -> behavior -> non-goals -> proof command -> receipt -> user doc
+```
+
+## Required Shape
+
+Use [the spec template](../templates/spec.md). Each accepted spec should include:
+
+- Problem
+- Behavior
+- Non-goals
+- Required evidence
+- Acceptance
+- Acceptance examples
+- Test mapping
+- Implementation mapping
+- CI proof
+- Metrics or promotion rule
+
+Do not claim enforcement until `cargo xtask spec-check` exists and is wired into
+the relevant evidence lane.
+
+## Examples To Keep Concrete
+
+Good examples for this repo are scanner-safe fixtures, TLS contract packs,
+OIDC/JWKS validation fixtures, `ripr+` badge endpoints, crates.io smoke, and
+public crate-surface cleanup.

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -1,0 +1,19 @@
+# Status
+
+Status docs map public claims to support tiers, proof commands, receipts, and
+user-facing docs.
+
+This directory is for compact indexes and ledgers. Put long rationale in a
+proposal, behavior contract in a spec, and historical lessons in `docs/learnings/`.
+
+## Expected Surfaces
+
+Future status docs should cover:
+
+- Public README claims and their proof commands
+- Support tiers for contract packs and adapter surfaces
+- Release evidence rows for stable claims
+- Claim boundaries for scanner-safe, cryptographic, and registry-facing signals
+
+No status page should imply enforcement before the matching spec and `xtask`
+check exist.

--- a/docs/templates/adr.md
+++ b/docs/templates/adr.md
@@ -1,0 +1,32 @@
++++
+id = "USELESSKEY-ADR-0000"
+kind = "adr"
+title = "Short ADR title"
+status = "proposed"
+owner = "EffortlessMetrics"
+created = "YYYY-MM-DD"
+linked_proposal = "USELESSKEY-PROP-0000"
+linked_specs = []
++++
+
+# USELESSKEY-ADR-0000: Short ADR Title
+
+## Decision
+
+State the durable architecture decision.
+
+## Context
+
+Why this decision exists.
+
+## Consequences
+
+What this enables and constrains.
+
+## Alternatives Considered
+
+What did we reject?
+
+## Follow-up Specs / Plans
+
+What must be implemented next.

--- a/docs/templates/handoff.md
+++ b/docs/templates/handoff.md
@@ -1,0 +1,38 @@
++++
+id = "USELESSKEY-HANDOFF-YYYY-MM-DD-short-name"
+kind = "handoff"
+title = "Short handoff title"
+status = "implemented"
+owner = "EffortlessMetrics"
+created = "YYYY-MM-DD"
+linked_proposal = ""
+linked_specs = []
+linked_prs = []
+linked_releases = []
++++
+
+# Short Handoff Title
+
+## Current State
+
+What is true now?
+
+## Relevant Links
+
+PRs, issues, commits, releases, specs, plans, and receipts.
+
+## Proof Already Run
+
+Commands and results.
+
+## Known Blockers
+
+External blockers, failing checks, or unresolved decisions.
+
+## Next Safe Action
+
+The next action that does not mix lanes.
+
+## Non-goals
+
+What should not be done from this handoff.

--- a/docs/templates/learning.md
+++ b/docs/templates/learning.md
@@ -1,0 +1,34 @@
++++
+id = "USELESSKEY-LEARNING-YYYY-MM-short-name"
+kind = "learning"
+title = "Short learning title"
+status = "implemented"
+owner = "EffortlessMetrics"
+created = "YYYY-MM-DD"
+linked_proposal = ""
+linked_specs = []
+linked_adrs = []
+linked_plan = ""
++++
+
+# Short Learning Title
+
+## Trigger
+
+What event or lane made this lesson visible?
+
+## What Changed
+
+What should future maintainers or agents do differently?
+
+## Evidence
+
+Which commands, PRs, releases, or receipts support the lesson?
+
+## Rule to Keep
+
+The durable repository habit or policy.
+
+## Follow-up Artifacts
+
+Specs, ADRs, plans, policy files, or active-goal entries to create or update.

--- a/docs/templates/proposal.md
+++ b/docs/templates/proposal.md
@@ -1,0 +1,62 @@
++++
+id = "USELESSKEY-PROP-0000"
+kind = "proposal"
+title = "Short proposal title"
+status = "proposed"
+owner = "EffortlessMetrics"
+created = "YYYY-MM-DD"
+milestone = "v0.0.0"
+linked_specs = []
+linked_adrs = []
+linked_plan = "plans/example/implementation-plan.md"
++++
+
+# USELESSKEY-PROP-0000: Short Proposal Title
+
+## Problem
+
+What risk or product gap exists?
+
+## Users and Surfaces
+
+Who benefits, and where do they touch `uselesskey`?
+
+## Success Criteria
+
+What must be true when this is complete?
+
+## Proposed Shape
+
+What are we doing?
+
+## Alternatives Considered
+
+What did we reject and why?
+
+## Specs to Create or Update
+
+- `USELESSKEY-SPEC-0000`
+
+## Architecture Decisions Needed
+
+- `USELESSKEY-ADR-0000`
+
+## Implementation Campaign Shape
+
+PR-sized phases.
+
+## Evidence Plan
+
+Proof commands, fixtures, support-tier updates, CI lanes, and release receipts.
+
+## Risks
+
+What can go wrong?
+
+## Non-goals
+
+What is explicitly out of scope?
+
+## Exit Criteria
+
+When is this proposal done?

--- a/docs/templates/spec.md
+++ b/docs/templates/spec.md
@@ -1,0 +1,56 @@
++++
+id = "USELESSKEY-SPEC-0000"
+kind = "spec"
+title = "Short spec title"
+status = "proposed"
+owner = "EffortlessMetrics"
+created = "YYYY-MM-DD"
+milestone = "v0.0.0"
+linked_proposal = "USELESSKEY-PROP-0000"
+linked_adrs = []
+linked_plan = "plans/example/implementation-plan.md"
+support_tier_impact = []
+policy_impact = []
++++
+
+# USELESSKEY-SPEC-0000: Short Spec Title
+
+## Problem
+
+What behavior or contract gap exists?
+
+## Behavior
+
+What must be true?
+
+## Non-goals
+
+What is out of scope?
+
+## Required Evidence
+
+What proof is required?
+
+## Acceptance
+
+Concrete acceptance criteria.
+
+## Acceptance Examples
+
+Examples that make the contract unambiguous.
+
+## Test Mapping
+
+Which tests, fixtures, proofs, or receipts cover this?
+
+## Implementation Mapping
+
+Which crates, modules, docs, or policies own this?
+
+## CI Proof
+
+Which commands and lanes prove it?
+
+## Metrics / Promotion Rule
+
+What moves this from proposed to accepted to implemented?

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,14 @@
+# Plans
+
+Plans define sequencing. They are where a lane becomes PR-sized work with proof
+commands, rollback notes, and stop conditions.
+
+Plans do not define product truth. Link to proposals for why and specs for what.
+
+## Current Plan Areas
+
+- [spec-system](spec-system/README.md) - Source-of-truth and spec-system rollout
+
+## Templates
+
+- [implementation-plan.md](templates/implementation-plan.md)

--- a/plans/spec-system/README.md
+++ b/plans/spec-system/README.md
@@ -1,0 +1,18 @@
+# Spec-System Plan Area
+
+This directory tracks the rollout that makes proposals, specs, ADRs, plans,
+active goal manifests, and policy ledgers the normal operating model for
+`uselesskey`.
+
+The first PR is scaffold-only. It adds navigation and templates without claiming
+automation enforcement.
+
+## Initial PR Order
+
+1. Define source-of-truth scaffold.
+2. Add the spec-governed fixture-platform proposal.
+3. Add the source-of-truth and public-claim specs.
+4. Add contract-pack and generated-evidence specs.
+5. Add ADRs and the active goal manifest.
+6. Add `cargo xtask spec-check`.
+7. Wire `spec-check` into normal evidence after the command settles.

--- a/plans/templates/implementation-plan.md
+++ b/plans/templates/implementation-plan.md
@@ -1,0 +1,47 @@
++++
+id = "USELESSKEY-PLAN-0000"
+kind = "plan"
+title = "Short implementation plan title"
+status = "proposed"
+owner = "EffortlessMetrics"
+created = "YYYY-MM-DD"
+milestone = "v0.0.0"
+linked_proposal = "USELESSKEY-PROP-0000"
+linked_specs = []
+linked_adrs = []
++++
+
+# Short Implementation Plan Title
+
+## Objective
+
+What this plan completes.
+
+## Scope
+
+What is included.
+
+## Non-goals
+
+What must not be mixed into this lane.
+
+## PR Sequence
+
+1. First PR, files, and validation.
+2. Second PR, files, and validation.
+
+## Proof Commands
+
+```bash
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+## Rollback
+
+How to back out safely if a PR or lane fails.
+
+## Stop Conditions
+
+When an agent or maintainer should pause and ask for direction.


### PR DESCRIPTION
## Summary
- add scaffold navigation for proposals, specs, status docs, handoffs, learnings, plans, and active goals
- add TOML-front-matter templates for proposals, specs, ADRs, handoffs, learnings, implementation plans, and active goal manifests
- update the existing docs and ADR indexes to point at the new source-of-truth surfaces without changing product behavior

## Files added
- docs/proposals/README.md
- docs/specs/README.md
- docs/status/README.md
- docs/handoffs/README.md
- docs/learnings/README.md
- docs/templates/{proposal,spec,adr,handoff,learning}.md
- plans/README.md
- plans/spec-system/README.md
- plans/templates/implementation-plan.md
- .uselesskey/goals/README.md
- .uselesskey/goals/templates/active.toml

## Validation
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask check-file-policy
- cargo xtask pr
- git diff --check

## Non-goals
- no product behavior changes
- no new fixture profiles or contract packs
- no spec-check implementation or CI wiring
- no claim-ledger entries yet
- no no-panic, shipper, SRP, or badge-workflow changes