### PR TITLE
ci: add RIPR review guidance, xtask check commands, CI summary & annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,32 @@ jobs:
         id: ripr_pr
         run: cargo xtask ripr-pr
 
+      - name: ripr review guidance
+        id: ripr_review
+        run: cargo xtask ripr-review-comments
+
+      - name: ripr PR contract
+        if: always()
+        run: cargo xtask ripr-pr --check
+
+      - name: ripr review summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## RIPR Review Guidance"
+            echo
+            if [ -f target/ripr/review/comments.md ]; then
+              cat target/ripr/review/comments.md
+            else
+              echo "No RIPR review guidance was produced."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: ripr annotations
+        if: always()
+        run: python scripts/ripr-annotations.py
+
       - name: impacted evidence
         id: impacted_evidence
         shell: bash
@@ -142,6 +168,7 @@ jobs:
         shell: bash
         env:
           RIPR_STEP: ${{ steps.ripr_pr.conclusion }}
+          RIPR_REVIEW_STEP: ${{ steps.ripr_review.conclusion }}
           XTASK_PR_STEP: ${{ steps.xtask_pr.conclusion }}
           DOCS_SYNC_STEP: ${{ steps.docs_sync.conclusion }}
           PUBLISH_PREFLIGHT_STEP: ${{ steps.publish_preflight.conclusion }}
@@ -226,6 +253,7 @@ jobs:
           lines.append("| --- | --- |")
           for name, env_name in [
               ("ripr-pr", "RIPR_STEP"),
+              ("ripr-review", "RIPR_REVIEW_STEP"),
               ("xtask pr", "XTASK_PR_STEP"),
               ("docs-sync", "DOCS_SYNC_STEP"),
               ("publish-preflight", "PUBLISH_PREFLIGHT_STEP"),
@@ -270,6 +298,7 @@ jobs:
           lines.append("## Artifacts")
           lines.append("")
           lines.append("- `ripr-pr`: `target/ripr/pr/`")
+          lines.append("- `ripr-review`: `target/ripr/review/`")
           lines.append("- `impacted-evidence`: `target/xtask/impacted-evidence/`")
           lines.append("- `receipt-pr`: `target/xtask/receipt.json`")
           lines.append("- `lane-receipts-pr`: economics and audit-surface receipts")
@@ -306,6 +335,14 @@ jobs:
         with:
           name: ripr-pr
           path: target/ripr/pr
+          if-no-files-found: warn
+        if: always()
+
+      - name: Upload ripr review guidance
+        uses: actions/upload-artifact@v7
+        with:
+          name: ripr-review
+          path: target/ripr/review
           if-no-files-found: warn
         if: always()
 

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -83,6 +83,15 @@ classification = "tooling"
 reason = "Repo-managed pre-push hook script."
 covered_by = ["cargo xtask gate"]
 
+[[allow]]
+glob = "scripts/*.py"
+kind = "tooling_script"
+owner = "release/ci"
+surface = "ci"
+classification = "tooling"
+reason = "Repository-maintained helper scripts for CI annotations and evidence projection."
+covered_by = ["cargo xtask check-file-policy", "python scripts/ripr-annotations.py"]
+
 # === Cargo / lock / manifests ==============================================
 
 [[allow]]

--- a/scripts/ripr-annotations.py
+++ b/scripts/ripr-annotations.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Emit non-blocking GitHub Actions annotations for line-placeable RIPR comments."""
+
+import json
+from pathlib import Path
+
+path = Path("target/ripr/review/comments.json")
+if not path.exists():
+    raise SystemExit(0)
+
+data = json.loads(path.read_text(encoding="utf-8"))
+
+for item in data.get("comments", []):
+    file = item.get("path") or item.get("file")
+    line = item.get("line")
+    title = item.get("title") or "RIPR"
+    body = item.get("body") or item.get("message") or ""
+
+    if not file or not line:
+        continue
+
+    body = str(body).replace("\n", "%0A")
+    print(f"::warning file={file},line={line},title={title}::{body}")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -100,7 +100,17 @@ enum Cmd {
         with_mutants: bool,
     },
     /// Run advisory ripr PR exposure evidence (requires external `ripr`).
-    RiprPr,
+    RiprPr {
+        /// Verify required PR evidence artifacts instead of generating them.
+        #[arg(long)]
+        check: bool,
+    },
+    /// Run advisory ripr review guidance (requires external `ripr`).
+    RiprReviewComments {
+        /// Verify required review guidance artifacts instead of generating them.
+        #[arg(long)]
+        check: bool,
+    },
     /// Generate the repo-scoped RIPR test-efficiency report used by ripr+ badge output.
     TestEfficiencyReport,
     /// Run PR-scoped mutation testing explicitly.
@@ -421,7 +431,8 @@ fn main() -> Result<()> {
         Cmd::ExamplesSmoke { run } => docs_sync::examples_smoke_cmd(run),
         Cmd::PublishCheck => publish_check(),
         Cmd::Pr { with_mutants } => pr(with_mutants),
-        Cmd::RiprPr => ripr_pr(),
+        Cmd::RiprPr { check } => ripr_pr(check),
+        Cmd::RiprReviewComments { check } => ripr_review_comments(check),
         Cmd::TestEfficiencyReport => test_efficiency::test_efficiency_report_cmd(),
         Cmd::MutantsPr {
             changed,
@@ -5123,14 +5134,22 @@ const RIPR_CLAIM_BOUNDARY: &[&str] = &[
     "advisory PR evidence should route targeted mutation, not suppress it",
 ];
 
-fn ripr_pr() -> Result<()> {
+fn ripr_pr(check: bool) -> Result<()> {
+    let workspace_root = workspace_root_path();
     let base_ref = resolve_base_ref();
-    let out_dir = PathBuf::from(RIPR_PR_DIR);
+    let out_dir = workspace_root.join(RIPR_PR_DIR);
+    if check {
+        return check_ripr_pr_artifacts(&out_dir);
+    }
     fs::create_dir_all(&out_dir)
         .with_context(|| format!("failed to create {}", out_dir.display()))?;
 
-    let output = match Command::new("ripr")
-        .args(["check", "--base", &base_ref, "--format", "json"])
+    let ripr_bin = env::var("RIPR_BIN").unwrap_or_else(|_| "ripr".to_string());
+    let output = match Command::new(&ripr_bin)
+        .args(["check", "--root"])
+        .arg(&workspace_root)
+        .args(["--base", &base_ref, "--head", "HEAD", "--format", "json"])
+        .current_dir(&workspace_root)
         .output()
     {
         Ok(output) => output,
@@ -5141,18 +5160,18 @@ fn ripr_pr() -> Result<()> {
             println!(
                 "ripr-pr: wrote {}, {}, and {}",
                 out_dir.join("repo-exposure.json").display(),
-                out_dir.join("summary.md").display(),
+                out_dir.join("repo-exposure.md").display(),
                 out_dir.join("review.md").display()
             );
             return Ok(());
         }
-        Err(err) => return Err(err).context("failed to spawn ripr"),
+        Err(err) => return Err(err).with_context(|| format!("failed to spawn {ripr_bin}")),
     };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         bail!(
-            "ripr check failed with status {}: {}",
+            "{ripr_bin} check failed with status {}: {}",
             output.status,
             stderr
         );
@@ -5167,6 +5186,9 @@ fn ripr_pr() -> Result<()> {
         .with_context(|| format!("failed to write {}", json_path.display()))?;
 
     let markdown = render_ripr_markdown(&base_ref, &json);
+    let markdown_path = out_dir.join("repo-exposure.md");
+    fs::write(&markdown_path, &markdown)
+        .with_context(|| format!("failed to write {}", markdown_path.display()))?;
     let summary_path = out_dir.join("summary.md");
     fs::write(&summary_path, &markdown)
         .with_context(|| format!("failed to write {}", summary_path.display()))?;
@@ -5184,9 +5206,132 @@ fn ripr_pr() -> Result<()> {
     println!(
         "ripr-pr: wrote {}, {}, and {}",
         json_path.display(),
-        summary_path.display(),
+        markdown_path.display(),
         review_path.display()
     );
+    Ok(())
+}
+
+
+fn check_ripr_pr_artifacts(out_dir: &Path) -> Result<()> {
+    let json_path = out_dir.join("repo-exposure.json");
+    let markdown_path = out_dir.join("repo-exposure.md");
+    let json: serde_json::Value = read_json_file(&json_path)?;
+    if !json.is_object() {
+        bail!("{} must contain a JSON object", json_path.display());
+    }
+    let markdown = fs::read_to_string(&markdown_path)
+        .with_context(|| format!("failed to read {}", markdown_path.display()))?;
+    if markdown.trim().is_empty() {
+        bail!("{} is empty", markdown_path.display());
+    }
+    println!("ripr-pr: artifact contract is current");
+    Ok(())
+}
+
+const RIPR_REVIEW_DIR: &str = "target/ripr/review";
+
+fn ripr_review_comments(check: bool) -> Result<()> {
+    let workspace_root = workspace_root_path();
+    let out_dir = workspace_root.join(RIPR_REVIEW_DIR);
+    let json_path = out_dir.join("comments.json");
+    let markdown_path = out_dir.join("comments.md");
+    if check {
+        return check_ripr_review_artifacts(&json_path, &markdown_path);
+    }
+
+    fs::create_dir_all(&out_dir)
+        .with_context(|| format!("failed to create {}", out_dir.display()))?;
+    let base_ref = resolve_base_ref();
+    let ripr_bin = env::var("RIPR_BIN").unwrap_or_else(|_| "ripr".to_string());
+    let output = match Command::new(&ripr_bin)
+        .arg("review-comments")
+        .arg("--root")
+        .arg(&workspace_root)
+        .arg("--base")
+        .arg(&base_ref)
+        .arg("--head")
+        .arg("HEAD")
+        .arg("--out")
+        .arg(&json_path)
+        .current_dir(&workspace_root)
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            write_ripr_review_skipped_artifacts(&json_path, &markdown_path, &base_ref)?;
+            println!("ripr-review-comments: skipped (ripr is not installed or not on PATH)");
+            return Ok(());
+        }
+        Err(err) => return Err(err).with_context(|| format!("failed to spawn {ripr_bin}")),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "{ripr_bin} review-comments failed with status {}: {}",
+            output.status,
+            stderr
+        );
+    }
+
+    check_ripr_review_artifacts(&json_path, &markdown_path)?;
+    println!(
+        "ripr-review-comments: wrote {} and {}",
+        json_path.display(),
+        markdown_path.display()
+    );
+    Ok(())
+}
+
+fn check_ripr_review_artifacts(json_path: &Path, markdown_path: &Path) -> Result<()> {
+    let json: serde_json::Value = read_json_file(json_path)?;
+    if !json.is_object() {
+        bail!("{} must contain a JSON object", json_path.display());
+    }
+    for field in ["comments", "summary_only", "suppressed", "warnings"] {
+        if let Some(value) = json.get(field)
+            && !value.is_array()
+        {
+            bail!("{} field `{field}` must be an array", json_path.display());
+        }
+    }
+    let markdown = fs::read_to_string(markdown_path)
+        .with_context(|| format!("failed to read {}", markdown_path.display()))?;
+    if markdown.trim().is_empty() {
+        bail!("{} is empty", markdown_path.display());
+    }
+    println!("ripr-review-comments: artifact contract is current");
+    Ok(())
+}
+
+fn write_ripr_review_skipped_artifacts(
+    json_path: &Path,
+    markdown_path: &Path,
+    base_ref: &str,
+) -> Result<()> {
+    let json = serde_json::json!({
+        "schema_version": 1,
+        "tool": "ripr",
+        "lane": "review-comments",
+        "status": "skipped",
+        "base": base_ref,
+        "comments": [],
+        "summary_only": [{
+            "title": "RIPR review guidance skipped",
+            "body": "ripr is not installed or not on PATH"
+        }],
+        "suppressed": [],
+        "warnings": ["ripr is not installed or not on PATH"]
+    });
+    write_json_pretty(json_path, &json)?;
+    fs::write(
+        markdown_path,
+        format!(
+            "# RIPR Review Guidance\n\nStatus: skipped\n\nBase: `{base_ref}`\n\nReason: ripr is not installed or not on PATH.\n"
+        ),
+    )
+    .with_context(|| format!("failed to write {}", markdown_path.display()))?;
     Ok(())
 }
 
@@ -5200,7 +5345,7 @@ fn write_ripr_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) ->
         "reason": reason,
         "artifacts": [
             "target/ripr/pr/repo-exposure.json",
-            "target/ripr/pr/summary.md",
+            "target/ripr/pr/repo-exposure.md",
             "target/ripr/pr/review.md"
         ],
         "claim_boundary": RIPR_CLAIM_BOUNDARY,
@@ -5208,6 +5353,12 @@ fn write_ripr_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) ->
     write_json_pretty(&out_dir.join("repo-exposure.json"), &json)?;
 
     let markdown = render_ripr_skipped_markdown(base_ref, reason);
+    fs::write(out_dir.join("repo-exposure.md"), &markdown).with_context(|| {
+        format!(
+            "failed to write {}",
+            out_dir.join("repo-exposure.md").display()
+        )
+    })?;
     fs::write(out_dir.join("summary.md"), &markdown)
         .with_context(|| format!("failed to write {}", out_dir.join("summary.md").display()))?;
     fs::write(out_dir.join("review.md"), &markdown)


### PR DESCRIPTION
### Motivation

- Provide PR-scoped RIPR review guidance and non-blocking changed-line annotations so reviewers get diff-scoped advisory evidence without polluting repo-scoped README badges.  
- Add `--check` modes to validate PR artifacts contract (JSON/Markdown) so CI can assert that required RIPR outputs are present and well-formed even when `ripr` is unavailable.  

### Description

- Add `ripr-pr --check` and new `ripr-review-comments` (`--check`) to `xtask` with workspace-root anchoring, `RIPR_BIN` override, explicit `--base`/`--head` invocation, and skipped-artifact output when `ripr` is missing (`xtask/src/main.rs`).  
- Produce and validate additional PR artifacts: `target/ripr/pr/repo-exposure.md` and `target/ripr/review/comments.json|.md`, and add artifact validation helpers `check_ripr_pr_artifacts` and `check_ripr_review_artifacts` (`xtask/src/main.rs`).  
- Extend PR CI (`.github/workflows/ci.yml`) to run `cargo xtask ripr-review-comments`, append review guidance to `GITHUB_STEP_SUMMARY`, run `cargo xtask ripr-pr --check`, upload `target/ripr/review` as `ripr-review` artifact, and include non-blocking annotations step.  
- Add `scripts/ripr-annotations.py` which emits non-blocking GitHub Actions `::warning` annotations for line-placeable `comments[]` from `target/ripr/review/comments.json`.  
- Add file-policy allowlist entry for `scripts/*.py` and minor xtask/CI wiring and message-shape updates.  

### Testing

- Ran unit tests: `cargo test -p xtask badge` (passed) and `cargo test -p xtask ripr` (passed).  
- Exercised xtask commands: `cargo xtask ripr-pr` (skipped path recorded when `ripr` not found), `cargo xtask ripr-pr --check` (artifact contract check passed), `cargo xtask ripr-review-comments` (skipped path when `ripr` not found) and `cargo xtask ripr-review-comments --check` (artifact contract check passed).  
- Verified badges generation flows: `RIPR_BIN=<stub> cargo xtask badges` and `RIPR_BIN=<stub> cargo xtask badges --check` (both succeeded using a stubbed `ripr`), and `cargo xtask badges --check` initially failed when `ripr` was absent (expected behavior; verified with stub).  
- Ran policy/docs gates: `cargo xtask docs-sync --check` (ok) and `cargo xtask check-file-policy` (ok after adding the `scripts/*.py` allowlist).  

Note: `ripr` and `actionlint` were not installed in the test environment; behavior requiring those external tools was validated via xtask's skipped-artifact path or via a stubbed `RIPR_BIN`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0401d0a1d083338124578180608d98)