### PR TITLE
ci: add ripr review-guidance surface and xtask contract checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           tool: cargo-fuzz,cargo-mutants,typos-cli,cargo-deny
 
+      - name: Install ripr
+        run: cargo install ripr --locked
+
       - name: Toolchain diagnostics
         run: |
           rustc -vV
@@ -82,6 +85,36 @@ jobs:
       - name: ripr PR evidence
         id: ripr_pr
         run: cargo xtask ripr-pr
+
+      - name: ripr review guidance
+        id: ripr_review
+        run: cargo xtask ripr-review-comments
+
+      - name: ripr PR contract
+        if: always()
+        run: cargo xtask ripr-pr --check
+
+      - name: ripr review contract
+        if: always()
+        run: cargo xtask ripr-review-comments --check
+
+      - name: ripr annotations
+        if: always()
+        run: python scripts/ripr-annotations.py
+
+      - name: ripr review summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## RIPR Review Guidance"
+            echo
+            if [ -f target/ripr/review/comments.md ]; then
+              cat target/ripr/review/comments.md
+            else
+              echo "No RIPR review guidance was produced."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: impacted evidence
         id: impacted_evidence
@@ -142,6 +175,7 @@ jobs:
         shell: bash
         env:
           RIPR_STEP: ${{ steps.ripr_pr.conclusion }}
+          RIPR_REVIEW_STEP: ${{ steps.ripr_review.conclusion }}
           XTASK_PR_STEP: ${{ steps.xtask_pr.conclusion }}
           DOCS_SYNC_STEP: ${{ steps.docs_sync.conclusion }}
           PUBLISH_PREFLIGHT_STEP: ${{ steps.publish_preflight.conclusion }}
@@ -226,6 +260,7 @@ jobs:
           lines.append("| --- | --- |")
           for name, env_name in [
               ("ripr-pr", "RIPR_STEP"),
+              ("ripr-review", "RIPR_REVIEW_STEP"),
               ("xtask pr", "XTASK_PR_STEP"),
               ("docs-sync", "DOCS_SYNC_STEP"),
               ("publish-preflight", "PUBLISH_PREFLIGHT_STEP"),
@@ -270,6 +305,7 @@ jobs:
           lines.append("## Artifacts")
           lines.append("")
           lines.append("- `ripr-pr`: `target/ripr/pr/`")
+          lines.append("- `ripr-review`: `target/ripr/review/`")
           lines.append("- `impacted-evidence`: `target/xtask/impacted-evidence/`")
           lines.append("- `receipt-pr`: `target/xtask/receipt.json`")
           lines.append("- `lane-receipts-pr`: economics and audit-surface receipts")
@@ -306,6 +342,14 @@ jobs:
         with:
           name: ripr-pr
           path: target/ripr/pr
+          if-no-files-found: warn
+        if: always()
+
+      - name: Upload ripr review guidance
+        uses: actions/upload-artifact@v7
+        with:
+          name: ripr-review
+          path: target/ripr/review
           if-no-files-found: warn
         if: always()
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -61,12 +61,16 @@ Committed endpoint files live under `badges/`. Detailed reports stay under
 
 ## Pull Request Evidence
 
-Pull requests run advisory `ripr` evidence, impacted evidence, fast gates,
-docs-sync, publish preflight, example smoke checks, and targeted mutation when
-routing rules require it.
+Pull requests run advisory `ripr` PR evidence, `ripr` review guidance, impacted
+evidence, fast gates, docs-sync, publish preflight, example smoke checks, and
+targeted mutation when routing rules require it.
 
 `ripr` may suggest focused tests or route targeted mutation. It does not edit
 code, generate tests, run mutation, or make merge decisions by default.
+
+Line-placeable `ripr` review guidance is emitted as non-blocking annotations
+from `comments[]` only. Summary-only findings stay in summaries and artifacts;
+inline PR comments are disabled by default.
 
 Pull request artifacts and summaries are diff-scoped. They must not be reused
 as repo-scope README badges.

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -45,6 +45,8 @@ Typical signals:
 - `cargo xtask examples-smoke` when examples or user recipes change;
 - `cargo xtask no-blob` when fixture, docs, bundle, or example outputs change;
 - `cargo xtask ripr-pr` for advisory `ripr` PR exposure evidence;
+- `cargo xtask ripr-review-comments` for advisory line-placeable review
+  guidance;
 - `git diff --check`.
 
 Blocking posture:
@@ -232,10 +234,23 @@ For a high-risk PR:
 artifacts under `target/ripr/pr/`:
 
 - `repo-exposure.json`;
+- `repo-exposure.md`;
 - `summary.md`;
 - `review.md`.
 
 Pull request CI uploads that directory as the `ripr-pr` artifact.
+
+`cargo xtask ripr-review-comments` runs `ripr review-comments` with explicit
+root, base, head, and output paths. It writes advisory review guidance under
+`target/ripr/review/`:
+
+- `comments.json`;
+- `comments.md`.
+
+Pull request CI uploads that directory as the `ripr-review` artifact, appends
+`comments.md` to the step summary, and emits non-blocking warning annotations
+from `comments[]` only. `summary_only[]` stays in the summary and artifact;
+inline PR comments are disabled by default.
 
 If `ripr` is not installed, the command writes skipped artifacts with a clear
 reason and exits successfully. Other `ripr` runtime failures should fail the

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -63,6 +63,17 @@ classification = "config"
 reason = "Lefthook git-hook configuration."
 covered_by = ["lefthook run pre-commit"]
 
+# === Repo automation / scripts ==============================================
+
+[[allow]]
+glob = "scripts/*.py"
+kind = "ci_helper_script"
+owner = "release/ci"
+surface = "ci"
+classification = "tooling"
+reason = "Small CI helper scripts used to project generated evidence into GitHub Actions annotations."
+covered_by = ["python scripts/ripr-annotations.py", "cargo xtask check-file-policy"]
+
 # === Repo automation / hooks ================================================
 
 [[allow]]

--- a/scripts/ripr-annotations.py
+++ b/scripts/ripr-annotations.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Emit non-blocking GitHub annotations for line-placeable RIPR guidance."""
+
+import json
+from pathlib import Path
+
+path = Path("target/ripr/review/comments.json")
+if not path.exists():
+    raise SystemExit(0)
+
+data = json.loads(path.read_text(encoding="utf-8"))
+
+for item in data.get("comments", []):
+    file = item.get("path") or item.get("file")
+    line = item.get("line")
+    title = item.get("title") or "RIPR"
+    body = item.get("body") or item.get("message") or ""
+
+    if not file or not line:
+        continue
+
+    body = str(body).replace("\n", "%0A")
+    print(f"::warning file={file},line={line},title={title}::{body}")

--- a/scripts/ripr-annotations.py
+++ b/scripts/ripr-annotations.py
@@ -4,6 +4,15 @@
 import json
 from pathlib import Path
 
+
+def escape_data(value):
+    return str(value).replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def escape_property(value):
+    return escape_data(value).replace(":", "%3A").replace(",", "%2C")
+
+
 path = Path("target/ripr/review/comments.json")
 if not path.exists():
     raise SystemExit(0)
@@ -19,5 +28,8 @@ for item in data.get("comments", []):
     if not file or not line:
         continue
 
-    body = str(body).replace("\n", "%0A")
+    file = escape_property(file)
+    line = escape_property(line)
+    title = escape_property(title)
+    body = escape_data(body)
     print(f"::warning file={file},line={line},title={title}::{body}")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -100,7 +100,17 @@ enum Cmd {
         with_mutants: bool,
     },
     /// Run advisory ripr PR exposure evidence (requires external `ripr`).
-    RiprPr,
+    RiprPr {
+        /// Verify the generated PR evidence output contract instead of running ripr.
+        #[arg(long)]
+        check: bool,
+    },
+    /// Run advisory ripr review guidance (requires external `ripr`).
+    RiprReviewComments {
+        /// Verify the generated review guidance output contract instead of running ripr.
+        #[arg(long)]
+        check: bool,
+    },
     /// Generate the repo-scoped RIPR test-efficiency report used by ripr+ badge output.
     TestEfficiencyReport,
     /// Run PR-scoped mutation testing explicitly.
@@ -421,7 +431,8 @@ fn main() -> Result<()> {
         Cmd::ExamplesSmoke { run } => docs_sync::examples_smoke_cmd(run),
         Cmd::PublishCheck => publish_check(),
         Cmd::Pr { with_mutants } => pr(with_mutants),
-        Cmd::RiprPr => ripr_pr(),
+        Cmd::RiprPr { check } => ripr_pr(check),
+        Cmd::RiprReviewComments { check } => ripr_review_comments(check),
         Cmd::TestEfficiencyReport => test_efficiency::test_efficiency_report_cmd(),
         Cmd::MutantsPr {
             changed,
@@ -5116,6 +5127,7 @@ fn resolve_base_ref() -> String {
 }
 
 const RIPR_PR_DIR: &str = "target/ripr/pr";
+const RIPR_REVIEW_DIR: &str = "target/ripr/review";
 
 const RIPR_CLAIM_BOUNDARY: &[&str] = &[
     "ripr is static oracle-exposure evidence for changed behavior",
@@ -5123,14 +5135,27 @@ const RIPR_CLAIM_BOUNDARY: &[&str] = &[
     "advisory PR evidence should route targeted mutation, not suppress it",
 ];
 
-fn ripr_pr() -> Result<()> {
+fn ripr_pr(check: bool) -> Result<()> {
+    if check {
+        return check_ripr_pr_contract(&workspace_root_path().join(RIPR_PR_DIR));
+    }
+
     let base_ref = resolve_base_ref();
-    let out_dir = PathBuf::from(RIPR_PR_DIR);
+    let workspace_root = workspace_root_path();
+    let out_dir = workspace_root.join(RIPR_PR_DIR);
     fs::create_dir_all(&out_dir)
         .with_context(|| format!("failed to create {}", out_dir.display()))?;
 
-    let output = match Command::new("ripr")
-        .args(["check", "--base", &base_ref, "--format", "json"])
+    let ripr_bin = env::var("RIPR_BIN").unwrap_or_else(|_| "ripr".to_string());
+    let output = match Command::new(&ripr_bin)
+        .arg("check")
+        .arg("--root")
+        .arg(&workspace_root)
+        .arg("--base")
+        .arg(&base_ref)
+        .arg("--format")
+        .arg("json")
+        .current_dir(&workspace_root)
         .output()
     {
         Ok(output) => output,
@@ -5139,14 +5164,15 @@ fn ripr_pr() -> Result<()> {
             write_ripr_skipped_artifacts(&out_dir, &base_ref, reason)?;
             println!("ripr-pr: skipped ({reason})");
             println!(
-                "ripr-pr: wrote {}, {}, and {}",
+                "ripr-pr: wrote {}, {}, {}, and {}",
                 out_dir.join("repo-exposure.json").display(),
+                out_dir.join("repo-exposure.md").display(),
                 out_dir.join("summary.md").display(),
                 out_dir.join("review.md").display()
             );
             return Ok(());
         }
-        Err(err) => return Err(err).context("failed to spawn ripr"),
+        Err(err) => return Err(err).with_context(|| format!("failed to spawn {ripr_bin}")),
     };
 
     if !output.status.success() {
@@ -5167,6 +5193,9 @@ fn ripr_pr() -> Result<()> {
         .with_context(|| format!("failed to write {}", json_path.display()))?;
 
     let markdown = render_ripr_markdown(&base_ref, &json);
+    let exposure_path = out_dir.join("repo-exposure.md");
+    fs::write(&exposure_path, &markdown)
+        .with_context(|| format!("failed to write {}", exposure_path.display()))?;
     let summary_path = out_dir.join("summary.md");
     fs::write(&summary_path, &markdown)
         .with_context(|| format!("failed to write {}", summary_path.display()))?;
@@ -5184,9 +5213,25 @@ fn ripr_pr() -> Result<()> {
     println!(
         "ripr-pr: wrote {}, {}, and {}",
         json_path.display(),
-        summary_path.display(),
+        exposure_path.display(),
         review_path.display()
     );
+    Ok(())
+}
+
+fn check_ripr_pr_contract(out_dir: &Path) -> Result<()> {
+    let json_path = out_dir.join("repo-exposure.json");
+    let markdown_path = out_dir.join("repo-exposure.md");
+    let json: serde_json::Value = read_json_file(&json_path)?;
+    if !json.is_object() {
+        bail!("{} must contain a JSON object", json_path.display());
+    }
+    let markdown = fs::read_to_string(&markdown_path)
+        .with_context(|| format!("failed to read {}", markdown_path.display()))?;
+    if markdown.trim().is_empty() {
+        bail!("{} must not be empty", markdown_path.display());
+    }
+    println!("ripr-pr: output contract is intact");
     Ok(())
 }
 
@@ -5200,6 +5245,7 @@ fn write_ripr_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) ->
         "reason": reason,
         "artifacts": [
             "target/ripr/pr/repo-exposure.json",
+            "target/ripr/pr/repo-exposure.md",
             "target/ripr/pr/summary.md",
             "target/ripr/pr/review.md"
         ],
@@ -5208,11 +5254,150 @@ fn write_ripr_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) ->
     write_json_pretty(&out_dir.join("repo-exposure.json"), &json)?;
 
     let markdown = render_ripr_skipped_markdown(base_ref, reason);
+    fs::write(out_dir.join("repo-exposure.md"), &markdown).with_context(|| {
+        format!(
+            "failed to write {}",
+            out_dir.join("repo-exposure.md").display()
+        )
+    })?;
     fs::write(out_dir.join("summary.md"), &markdown)
         .with_context(|| format!("failed to write {}", out_dir.join("summary.md").display()))?;
     fs::write(out_dir.join("review.md"), &markdown)
         .with_context(|| format!("failed to write {}", out_dir.join("review.md").display()))?;
     Ok(())
+}
+
+fn ripr_review_comments(check: bool) -> Result<()> {
+    let workspace_root = workspace_root_path();
+    let out_dir = workspace_root.join(RIPR_REVIEW_DIR);
+    if check {
+        return check_ripr_review_contract(&out_dir);
+    }
+
+    fs::create_dir_all(&out_dir)
+        .with_context(|| format!("failed to create {}", out_dir.display()))?;
+    let base_ref = resolve_base_ref();
+    let json_path = out_dir.join("comments.json");
+    let ripr_bin = env::var("RIPR_BIN").unwrap_or_else(|_| "ripr".to_string());
+
+    let output = match Command::new(&ripr_bin)
+        .arg("review-comments")
+        .arg("--root")
+        .arg(&workspace_root)
+        .arg("--base")
+        .arg(&base_ref)
+        .arg("--head")
+        .arg("HEAD")
+        .arg("--out")
+        .arg(&json_path)
+        .current_dir(&workspace_root)
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            let reason = "ripr is not installed or not on PATH";
+            write_ripr_review_skipped_artifacts(&out_dir, &base_ref, reason)?;
+            println!("ripr-review-comments: skipped ({reason})");
+            return Ok(());
+        }
+        Err(err) => return Err(err).with_context(|| format!("failed to spawn {ripr_bin}")),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "{ripr_bin} review-comments failed with status {}: {}",
+            output.status,
+            stderr
+        );
+    }
+
+    if !json_path.exists() {
+        fs::write(&json_path, &output.stdout)
+            .with_context(|| format!("failed to write {}", json_path.display()))?;
+    }
+    ensure_ripr_review_markdown(&out_dir, &base_ref)?;
+    println!(
+        "ripr-review-comments: wrote {} and {}",
+        json_path.display(),
+        out_dir.join("comments.md").display()
+    );
+    Ok(())
+}
+
+fn check_ripr_review_contract(out_dir: &Path) -> Result<()> {
+    let json_path = out_dir.join("comments.json");
+    let markdown_path = out_dir.join("comments.md");
+    let json: serde_json::Value = read_json_file(&json_path)?;
+    if !json.is_object() {
+        bail!("{} must contain a JSON object", json_path.display());
+    }
+    let markdown = fs::read_to_string(&markdown_path)
+        .with_context(|| format!("failed to read {}", markdown_path.display()))?;
+    if markdown.trim().is_empty() {
+        bail!("{} must not be empty", markdown_path.display());
+    }
+    println!("ripr-review-comments: output contract is intact");
+    Ok(())
+}
+
+fn write_ripr_review_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) -> Result<()> {
+    let json = serde_json::json!({
+        "schema_version": 1,
+        "tool": "ripr",
+        "lane": "review-comments",
+        "status": "skipped",
+        "base": base_ref,
+        "head": "HEAD",
+        "reason": reason,
+        "comments": [],
+        "summary_only": [],
+        "suppressed": [],
+        "warnings": [reason],
+        "claim_boundary": RIPR_CLAIM_BOUNDARY,
+    });
+    write_json_pretty(&out_dir.join("comments.json"), &json)?;
+    fs::write(
+        out_dir.join("comments.md"),
+        render_ripr_review_skipped_markdown(base_ref, reason),
+    )
+    .with_context(|| format!("failed to write {}", out_dir.join("comments.md").display()))?;
+    Ok(())
+}
+
+fn ensure_ripr_review_markdown(out_dir: &Path, base_ref: &str) -> Result<()> {
+    let markdown_path = out_dir.join("comments.md");
+    if markdown_path.exists() {
+        return Ok(());
+    }
+    let json: serde_json::Value = read_json_file(&out_dir.join("comments.json"))?;
+    fs::write(&markdown_path, render_ripr_review_markdown(base_ref, &json))
+        .with_context(|| format!("failed to write {}", markdown_path.display()))
+}
+
+fn render_ripr_review_skipped_markdown(base_ref: &str, reason: &str) -> String {
+    format!(
+        "\
+# RIPR Review Guidance\n\nStatus: skipped\n\nBase: `{base_ref}`\n\nReason: {reason}.\n\nInstall `ripr` and rerun `cargo xtask ripr-review-comments` to generate advisory review guidance.\n"
+    )
+}
+
+fn render_ripr_review_markdown(base_ref: &str, json: &serde_json::Value) -> String {
+    let comments = json_array_len(json, "comments");
+    let summary_only = json_array_len(json, "summary_only");
+    let suppressed = json_array_len(json, "suppressed");
+    let warnings = json_array_len(json, "warnings");
+    format!(
+        "\
+# RIPR Review Guidance\n\nStatus: advisory\n\nBase: `{base_ref}`\n\n| Bucket | Count |\n| --- | ---: |\n| comments | {comments} |\n| summary only | {summary_only} |\n| suppressed | {suppressed} |\n| warnings | {warnings} |\n\nLine-placeable guidance lives in `comments[]`; summary-only items remain in artifacts.\n"
+    )
+}
+
+fn json_array_len(value: &serde_json::Value, key: &str) -> usize {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len)
 }
 
 fn render_ripr_skipped_markdown(base_ref: &str, reason: &str) -> String {


### PR DESCRIPTION
### Motivation
- Provide a dedicated, repo-rooted surface for `ripr` review guidance so line-placeable advisory comments can be produced and surfaced to PR reviewers without mixing diff-scoped evidence with repo-scoped badges.
- Ensure PR evidence contracts are verifiable by adding `--check` modes that validate the expected JSON/Markdown artifacts rather than always invoking `ripr` at runtime.
- Integrate non-blocking annotations and CI upload for review guidance so `comments[]` can be surfaced as warnings while keeping `summary_only[]` in artifacts.

### Description
- Added CLI surfaces: `xtask ripr-pr --check` and `xtask ripr-review-comments [--check]`, with workspace-root anchoring and `RIPR_BIN` override support, and implemented contract-check helpers that validate required JSON/MD outputs. (files: `xtask/src/main.rs`)
- Produce `target/ripr/pr/repo-exposure.md` alongside existing `repo-exposure.json/summary.md/review.md` and write skipped artifacts with a clear reason if `ripr` is missing. (xtask changes)
- Implemented `ripr review-comments` integration that writes `target/ripr/review/comments.json` and `comments.md`, plus helpers to render review guidance Markdown and to validate that contract. (xtask changes)
- Added `scripts/ripr-annotations.py` to emit non-blocking GitHub warning annotations from `comments[]` only, and updated CI to install `ripr`, run the review guidance step, append `comments.md` to the step summary, emit annotations, and upload a `ripr-review` artifact. (.github/workflows/ci.yml, scripts/ripr-annotations.py)
- Documented the new review-guidance surface, artifact layout, and annotation boundaries in `docs/VERIFICATION.md` and `docs/ci/test-evidence-lanes.md`.

### Testing
- Unit tests: `cargo test -p xtask ripr -- --nocapture` and `cargo test -p xtask badge -- --nocapture` both passed (all relevant xtask unit tests succeeded).
- Integration/manual runs: `cargo xtask ripr-pr` (skipped with clear skipped-artifacts because `ripr` was not installed locally) and `cargo xtask ripr-pr --check` succeeded in validating the written contract artifact; `cargo xtask ripr-review-comments` (skipped similarly) and `cargo xtask ripr-review-comments --check` succeeded in contract validation.
- CI-style checks: `cargo xtask lint-fix --check`, `cargo xtask docs-sync --check`, `cargo xtask check-file-policy`, and `cargo xtask pr` completed successfully in this environment.
- Notes: `cargo xtask badges --check` failed locally because `ripr` was not present when that command was attempted, and `actionlint` was not available in the local environment when invoked; CI will install `ripr` as part of the workflow so the badge/check flow is expected to succeed in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0401d0a1d083338124578180608d98)