### PR TITLE
ci: add ripr review guidance, xtask ripr-pr/ ripr-review checks, and PR annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,15 @@ jobs:
         with:
           tool: cargo-fuzz,cargo-mutants,typos-cli,cargo-deny
 
+      - name: Install ripr
+        run: cargo install ripr --locked
+
       - name: Toolchain diagnostics
         run: |
           rustc -vV
           cargo +nightly -vV
           cargo fuzz --version || true
+          ripr --version || true
 
       - name: Fetch base branch
         if: github.base_ref != ''
@@ -82,6 +86,32 @@ jobs:
       - name: ripr PR evidence
         id: ripr_pr
         run: cargo xtask ripr-pr
+
+      - name: ripr review guidance
+        id: ripr_review
+        run: cargo xtask ripr-review-comments
+
+      - name: ripr PR contract
+        if: always()
+        run: cargo xtask ripr-pr --check
+
+      - name: ripr review summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## RIPR Review Guidance"
+            echo
+            if [ -f target/ripr/review/comments.md ]; then
+              cat target/ripr/review/comments.md
+            else
+              echo "No RIPR review guidance was produced."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: ripr annotations
+        if: always()
+        run: python scripts/ripr-annotations.py
 
       - name: impacted evidence
         id: impacted_evidence
@@ -142,6 +172,7 @@ jobs:
         shell: bash
         env:
           RIPR_STEP: ${{ steps.ripr_pr.conclusion }}
+          RIPR_REVIEW_STEP: ${{ steps.ripr_review.conclusion }}
           XTASK_PR_STEP: ${{ steps.xtask_pr.conclusion }}
           DOCS_SYNC_STEP: ${{ steps.docs_sync.conclusion }}
           PUBLISH_PREFLIGHT_STEP: ${{ steps.publish_preflight.conclusion }}
@@ -226,6 +257,7 @@ jobs:
           lines.append("| --- | --- |")
           for name, env_name in [
               ("ripr-pr", "RIPR_STEP"),
+              ("ripr-review", "RIPR_REVIEW_STEP"),
               ("xtask pr", "XTASK_PR_STEP"),
               ("docs-sync", "DOCS_SYNC_STEP"),
               ("publish-preflight", "PUBLISH_PREFLIGHT_STEP"),
@@ -270,6 +302,7 @@ jobs:
           lines.append("## Artifacts")
           lines.append("")
           lines.append("- `ripr-pr`: `target/ripr/pr/`")
+          lines.append("- `ripr-review`: `target/ripr/review/`")
           lines.append("- `impacted-evidence`: `target/xtask/impacted-evidence/`")
           lines.append("- `receipt-pr`: `target/xtask/receipt.json`")
           lines.append("- `lane-receipts-pr`: economics and audit-surface receipts")
@@ -306,6 +339,14 @@ jobs:
         with:
           name: ripr-pr
           path: target/ripr/pr
+          if-no-files-found: warn
+        if: always()
+
+      - name: Upload ripr review guidance
+        uses: actions/upload-artifact@v7
+        with:
+          name: ripr-review
+          path: target/ripr/review
           if-no-files-found: warn
         if: always()
 

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -213,7 +213,7 @@ The v0.7.0 release-candidate checklist starts in
 For an ordinary PR:
 
 1. Run the fast local gates for the touched surface.
-2. Run `cargo xtask ripr-pr` and read `target/ripr/pr/summary.md`.
+2. Run `cargo xtask ripr-pr` and read `target/ripr/pr/repo-exposure.md`.
 3. Add focused tests when changed behavior is weakly exposed.
 4. Use targeted mutation only when the routing rules call for it.
 
@@ -232,10 +232,15 @@ For a high-risk PR:
 artifacts under `target/ripr/pr/`:
 
 - `repo-exposure.json`;
-- `summary.md`;
-- `review.md`.
+- `repo-exposure.md`;
+- `summary.md` (compatibility alias);
+- `review.md` (compatibility alias).
 
-Pull request CI uploads that directory as the `ripr-pr` artifact.
+`cargo xtask ripr-pr --check` validates that required JSON and Markdown
+contract. `cargo xtask ripr-review-comments` writes line-placeable review
+guidance under `target/ripr/review/`, and `cargo xtask ripr-review-comments
+--check` validates `comments.json` and `comments.md`. Pull request CI uploads
+those directories as the `ripr-pr` and `ripr-review` artifacts.
 
 If `ripr` is not installed, the command writes skipped artifacts with a clear
 reason and exits successfully. Other `ripr` runtime failures should fail the
@@ -255,8 +260,9 @@ When no high-risk owner surface changed, it exits successfully without running
 mutation and prints that targeted mutation was not required. When a high-risk
 surface changed, it runs mutation for the mapped owner crate(s).
 
-Pull request CI runs `cargo xtask impacted-evidence` after `ripr-pr`, uploads
-`target/xtask/impacted-evidence/` as the `impacted-evidence` artifact, and runs
+Pull request CI runs `cargo xtask impacted-evidence` after `ripr-pr` and
+`ripr-review-comments`, uploads `target/xtask/impacted-evidence/` as the
+`impacted-evidence` artifact, and runs
 `cargo xtask mutants-pr --changed` when any of these are true:
 
 - the PR has a `mutation` label;

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -83,6 +83,15 @@ classification = "tooling"
 reason = "Repo-managed pre-push hook script."
 covered_by = ["cargo xtask gate"]
 
+[[allow]]
+glob = "scripts/*.py"
+kind = "ci_helper_script"
+owner = "release/ci"
+surface = "ci"
+classification = "tooling"
+reason = "Small CI helper scripts for advisory report projection and annotations."
+covered_by = ["python scripts/ripr-annotations.py", "cargo xtask pr"]
+
 # === Cargo / lock / manifests ==============================================
 
 [[allow]]

--- a/scripts/ripr-annotations.py
+++ b/scripts/ripr-annotations.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Emit non-blocking GitHub annotations for line-placeable RIPR comments."""
+
+import json
+from pathlib import Path
+
+path = Path("target/ripr/review/comments.json")
+if not path.exists():
+    raise SystemExit(0)
+
+data = json.loads(path.read_text(encoding="utf-8"))
+
+for item in data.get("comments", []):
+    file = item.get("path") or item.get("file")
+    line = item.get("line")
+    title = item.get("title") or "RIPR"
+    body = item.get("body") or item.get("message") or ""
+
+    if not file or not line:
+        continue
+
+    body = str(body).replace("\n", "%0A")
+    print(f"::warning file={file},line={line},title={title}::{body}")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -100,7 +100,17 @@ enum Cmd {
         with_mutants: bool,
     },
     /// Run advisory ripr PR exposure evidence (requires external `ripr`).
-    RiprPr,
+    RiprPr {
+        /// Verify the existing PR evidence output contract without regenerating.
+        #[arg(long)]
+        check: bool,
+    },
+    /// Run advisory RIPR review guidance for changed lines (requires external `ripr`).
+    RiprReviewComments {
+        /// Verify the existing review guidance output contract without regenerating.
+        #[arg(long)]
+        check: bool,
+    },
     /// Generate the repo-scoped RIPR test-efficiency report used by ripr+ badge output.
     TestEfficiencyReport,
     /// Run PR-scoped mutation testing explicitly.
@@ -421,7 +431,8 @@ fn main() -> Result<()> {
         Cmd::ExamplesSmoke { run } => docs_sync::examples_smoke_cmd(run),
         Cmd::PublishCheck => publish_check(),
         Cmd::Pr { with_mutants } => pr(with_mutants),
-        Cmd::RiprPr => ripr_pr(),
+        Cmd::RiprPr { check } => ripr_pr(check),
+        Cmd::RiprReviewComments { check } => ripr_review_comments(check),
         Cmd::TestEfficiencyReport => test_efficiency::test_efficiency_report_cmd(),
         Cmd::MutantsPr {
             changed,
@@ -2778,6 +2789,7 @@ fn release_evidence_steps_minor() -> Vec<ReleaseEvidenceStep> {
             command: &["cargo", "xtask", "ripr-pr"],
             artifacts: &[
                 "target/ripr/pr/repo-exposure.json",
+                "target/ripr/pr/repo-exposure.md",
                 "target/ripr/pr/summary.md",
                 "target/ripr/pr/review.md",
             ],
@@ -5123,24 +5135,33 @@ const RIPR_CLAIM_BOUNDARY: &[&str] = &[
     "advisory PR evidence should route targeted mutation, not suppress it",
 ];
 
-fn ripr_pr() -> Result<()> {
-    let base_ref = resolve_base_ref();
+fn ripr_pr(check: bool) -> Result<()> {
     let out_dir = PathBuf::from(RIPR_PR_DIR);
+    if check {
+        check_ripr_pr_contract(&out_dir)?;
+        println!("ripr-pr: output contract is intact");
+        return Ok(());
+    }
+
+    let base_ref = resolve_base_ref();
     fs::create_dir_all(&out_dir)
         .with_context(|| format!("failed to create {}", out_dir.display()))?;
 
-    let output = match Command::new("ripr")
+    let ripr_bin = env::var("RIPR_BIN").unwrap_or_else(|_| "ripr".to_string());
+    let output = match Command::new(&ripr_bin)
         .args(["check", "--base", &base_ref, "--format", "json"])
+        .current_dir(workspace_root_path())
         .output()
     {
         Ok(output) => output,
         Err(err) if err.kind() == ErrorKind::NotFound => {
-            let reason = "ripr is not installed or not on PATH";
-            write_ripr_skipped_artifacts(&out_dir, &base_ref, reason)?;
+            let reason = format!("{ripr_bin} is not installed or not on PATH");
+            write_ripr_skipped_artifacts(&out_dir, &base_ref, &reason)?;
             println!("ripr-pr: skipped ({reason})");
             println!(
-                "ripr-pr: wrote {}, {}, and {}",
+                "ripr-pr: wrote {}, {}, {}, and {}",
                 out_dir.join("repo-exposure.json").display(),
+                out_dir.join("repo-exposure.md").display(),
                 out_dir.join("summary.md").display(),
                 out_dir.join("review.md").display()
             );
@@ -5167,6 +5188,9 @@ fn ripr_pr() -> Result<()> {
         .with_context(|| format!("failed to write {}", json_path.display()))?;
 
     let markdown = render_ripr_markdown(&base_ref, &json);
+    let exposure_md_path = out_dir.join("repo-exposure.md");
+    fs::write(&exposure_md_path, &markdown)
+        .with_context(|| format!("failed to write {}", exposure_md_path.display()))?;
     let summary_path = out_dir.join("summary.md");
     fs::write(&summary_path, &markdown)
         .with_context(|| format!("failed to write {}", summary_path.display()))?;
@@ -5182,8 +5206,9 @@ fn ripr_pr() -> Result<()> {
         json_u64(summary, "weakly_exposed")
     );
     println!(
-        "ripr-pr: wrote {}, {}, and {}",
+        "ripr-pr: wrote {}, {}, {}, and {}",
         json_path.display(),
+        exposure_md_path.display(),
         summary_path.display(),
         review_path.display()
     );
@@ -5200,6 +5225,7 @@ fn write_ripr_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) ->
         "reason": reason,
         "artifacts": [
             "target/ripr/pr/repo-exposure.json",
+            "target/ripr/pr/repo-exposure.md",
             "target/ripr/pr/summary.md",
             "target/ripr/pr/review.md"
         ],
@@ -5208,10 +5234,143 @@ fn write_ripr_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) ->
     write_json_pretty(&out_dir.join("repo-exposure.json"), &json)?;
 
     let markdown = render_ripr_skipped_markdown(base_ref, reason);
+    fs::write(out_dir.join("repo-exposure.md"), &markdown).with_context(|| {
+        format!(
+            "failed to write {}",
+            out_dir.join("repo-exposure.md").display()
+        )
+    })?;
     fs::write(out_dir.join("summary.md"), &markdown)
         .with_context(|| format!("failed to write {}", out_dir.join("summary.md").display()))?;
     fs::write(out_dir.join("review.md"), &markdown)
         .with_context(|| format!("failed to write {}", out_dir.join("review.md").display()))?;
+    Ok(())
+}
+
+fn check_ripr_pr_contract(out_dir: &Path) -> Result<()> {
+    let json_path = out_dir.join("repo-exposure.json");
+    let markdown_path = out_dir.join("repo-exposure.md");
+    let json: serde_json::Value = read_json_file(&json_path)
+        .with_context(|| format!("missing or invalid {}", json_path.display()))?;
+
+    let schema_version = json.get("schema_version").and_then(serde_json::Value::as_u64);
+    if matches!(schema_version, Some(version) if version > 1) {
+        bail!(
+            "ripr-pr schema drift: unsupported schema_version {} in {}",
+            schema_version.unwrap_or_default(),
+            json_path.display()
+        );
+    }
+
+    let markdown = fs::read_to_string(&markdown_path)
+        .with_context(|| format!("missing {}", markdown_path.display()))?;
+    if markdown.trim().is_empty() {
+        bail!("{} is empty", markdown_path.display());
+    }
+
+    Ok(())
+}
+
+fn ripr_review_comments(check: bool) -> Result<()> {
+    let workspace_root = workspace_root_path();
+    let out_dir = workspace_root.join("target/ripr/review");
+    if check {
+        check_ripr_review_contract(&out_dir)?;
+        println!("ripr-review-comments: output contract is intact");
+        return Ok(());
+    }
+
+    fs::create_dir_all(&out_dir)
+        .with_context(|| format!("failed to create {}", out_dir.display()))?;
+    let json_path = out_dir.join("comments.json");
+    let base_ref = resolve_base_ref();
+    let ripr_bin = env::var("RIPR_BIN").unwrap_or_else(|_| "ripr".to_string());
+
+    let output = match Command::new(&ripr_bin)
+        .arg("review-comments")
+        .arg("--root")
+        .arg(&workspace_root)
+        .arg("--base")
+        .arg(&base_ref)
+        .arg("--head")
+        .arg("HEAD")
+        .arg("--out")
+        .arg(&json_path)
+        .current_dir(&workspace_root)
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            let reason = format!("{ripr_bin} is not installed or not on PATH");
+            write_ripr_review_skipped_artifacts(&out_dir, &base_ref, &reason)?;
+            println!("ripr-review-comments: skipped ({reason})");
+            return Ok(());
+        }
+        Err(err) => return Err(err).context("failed to spawn ripr review-comments"),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "ripr review-comments failed with status {}: {}",
+            output.status,
+            stderr
+        );
+    }
+
+    check_ripr_review_contract(&out_dir)?;
+    println!(
+        "ripr-review-comments: wrote {} and {}",
+        out_dir.join("comments.json").display(),
+        out_dir.join("comments.md").display()
+    );
+    Ok(())
+}
+
+fn write_ripr_review_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) -> Result<()> {
+    let json = serde_json::json!({
+        "schema_version": 1,
+        "tool": "ripr",
+        "lane": "review-comments",
+        "status": "skipped",
+        "base": base_ref,
+        "head": "HEAD",
+        "reason": reason,
+        "comments": [],
+        "summary_only": [],
+        "suppressed": [],
+        "warnings": [reason],
+        "claim_boundary": RIPR_CLAIM_BOUNDARY,
+    });
+    write_json_pretty(&out_dir.join("comments.json"), &json)?;
+    fs::write(
+        out_dir.join("comments.md"),
+        format!(
+            "# RIPR Review Guidance\n\nStatus: skipped\n\nBase: `{base_ref}`\n\nReason: {reason}.\n"
+        ),
+    )
+    .with_context(|| format!("failed to write {}", out_dir.join("comments.md").display()))?;
+    Ok(())
+}
+
+fn check_ripr_review_contract(out_dir: &Path) -> Result<()> {
+    let json_path = out_dir.join("comments.json");
+    let markdown_path = out_dir.join("comments.md");
+    let json: serde_json::Value = read_json_file(&json_path)
+        .with_context(|| format!("missing or invalid {}", json_path.display()))?;
+    for key in ["comments", "summary_only", "suppressed", "warnings"] {
+        if !json.get(key).is_some_and(serde_json::Value::is_array) {
+            bail!(
+                "ripr-review-comments contract drift: `{key}` is missing or is not an array in {}",
+                json_path.display()
+            );
+        }
+    }
+    let markdown = fs::read_to_string(&markdown_path)
+        .with_context(|| format!("missing {}", markdown_path.display()))?;
+    if markdown.trim().is_empty() {
+        bail!("{} is empty", markdown_path.display());
+    }
     Ok(())
 }
 
@@ -7823,6 +7982,48 @@ index 1111111..2222222 100644
         assert!(json.contains(r#""label": "fixtures""#));
         assert!(json.contains(r#""message": "scanner-safe""#));
         assert!(json.contains(r#""color": "brightgreen""#));
+    }
+
+    #[test]
+    fn ripr_pr_contract_accepts_required_artifacts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out_dir = dir.path().join("pr");
+        fs::create_dir_all(&out_dir).expect("create pr dir");
+        write_json_pretty(
+            &out_dir.join("repo-exposure.json"),
+            &serde_json::json!({
+                "schema_version": 1,
+                "tool": "ripr",
+                "summary": {}
+            }),
+        )
+        .expect("write json");
+        fs::write(out_dir.join("repo-exposure.md"), "# RIPR PR Evidence\n")
+            .expect("write markdown");
+
+        check_ripr_pr_contract(&out_dir).expect("valid pr contract");
+    }
+
+    #[test]
+    fn ripr_review_comments_contract_accepts_required_artifacts() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out_dir = dir.path().join("review");
+        fs::create_dir_all(&out_dir).expect("create review dir");
+        write_json_pretty(
+            &out_dir.join("comments.json"),
+            &serde_json::json!({
+                "schema_version": 1,
+                "comments": [],
+                "summary_only": [],
+                "suppressed": [],
+                "warnings": []
+            }),
+        )
+        .expect("write json");
+        fs::write(out_dir.join("comments.md"), "# RIPR Review Guidance\n")
+            .expect("write markdown");
+
+        check_ripr_review_contract(&out_dir).expect("valid review contract");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Make `ripr` PR evidence more actionable by producing line-placeable review guidance and a stable output contract for PR artifacts.
- Ensure README badge generation and PR evidence remain repo- vs diff-scoped by validating artifacts and adding `--check` contract surfaces to `xtask`.
- Surface review guidance non-blockingly in CI so reviewers get human-readable summaries plus optional changed-line annotations.

### Description

- Add `RiprPr { --check }` and `RiprReviewComments { --check }` xtask commands that either generate advisory `ripr` artifacts (`target/ripr/pr/` and `target/ripr/review/`) or validate the expected JSON/Markdown output contract. (`xtask/src/main.rs`).
- Emit `repo-exposure.md` alongside `repo-exposure.json` and write skipped-artifact compatibility outputs when `ripr` is not installed, and add contract validation helpers `check_ripr_pr_contract` and `check_ripr_review_contract`.
- Add `scripts/ripr-annotations.py` to translate `comments[]` entries from `target/ripr/review/comments.json` into non-blocking GitHub warning annotations and add the script to the non-Rust file policy allowlist.
- Wire CI (`.github/workflows/ci.yml`) to install `ripr`, run `cargo xtask ripr-pr`, `cargo xtask ripr-review-comments`, append `target/ripr/review/comments.md` to `GITHUB_STEP_SUMMARY`, emit annotations via the helper, and upload both `ripr-pr` and `ripr-review` artifacts.
- Update docs in `docs/ci/test-evidence-lanes.md` to document the new artifact layout (`repo-exposure.md`) and the `ripr-review` artifact contract, and update release evidence artifact lists accordingly.

### Testing

- Ran unit tests: `cargo test -p xtask ripr` (7 passed) and `cargo test -p xtask badge` (2 passed). These succeeded.
- Exercised new xtask commands: `cargo xtask ripr-pr` and `cargo xtask ripr-review-comments` ran but emitted skipped artifacts because `ripr` is not installed in this environment, while `cargo xtask ripr-pr --check` and `cargo xtask ripr-review-comments --check` reported the output contract intact.
- Ran integration/validation flows: `python scripts/ripr-annotations.py` (succeeded), `RIPR_BIN="$PWD/target/xtask-tools/fake-ripr-badge" cargo xtask badges --check` (succeeded), `cargo xtask docs-sync --check` (succeeded), `cargo xtask check-file-policy` (succeeded after adding allowlist), and `XTASK_BASE_REF=HEAD cargo xtask pr` (fast gates executed and completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0401d0a1d083338124578180608d98)