### PR TITLE
Refactor X.509 chain generation into SRP chain submodules

### DIFF
--- a/crates/uselesskey-x509/src/chain.rs
+++ b/crates/uselesskey-x509/src/chain.rs
@@ -4,24 +4,16 @@ use std::fmt;
 use std::sync::Arc;
 
 use rand_chacha::ChaCha20Rng;
-use rand_core::RngCore;
 use rand_core::SeedableRng;
-use rcgen::{
-    BasicConstraints, CertificateParams, CertificateRevocationListParams, DnType,
-    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, PKCS_RSA_SHA256,
-    RevocationReason, RevokedCertParams,
-};
-use rustls_pki_types::PrivatePkcs8KeyDer;
-use time::Duration as TimeDuration;
-use time::OffsetDateTime;
+use rcgen::Issuer;
 use uselesskey_core::sink::TempArtifact;
 use uselesskey_core::{Error, Factory};
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+use uselesskey_rsa::RsaSpec;
 
-use crate::srp::derive::{
-    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
-};
-use crate::srp::spec::{ChainSpec, KeyUsage, NotBeforeOffset};
+use crate::srp::chain::crl::revoked_leaf_crl;
+use crate::srp::chain::keys::ChainKeys;
+use crate::srp::chain::params::{chain_base_time, intermediate_params, leaf_params, root_params};
+use crate::srp::spec::ChainSpec;
 
 /// Cache domain for X.509 certificate chain fixtures.
 ///
@@ -548,30 +540,6 @@ impl X509Chain {
     }
 }
 
-fn apply_not_before(base_time: OffsetDateTime, offset: Option<NotBeforeOffset>) -> OffsetDateTime {
-    match offset.unwrap_or(NotBeforeOffset::DaysAgo(1)) {
-        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
-        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
-    }
-}
-
-fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
-    let mut purposes = Vec::new();
-    if key_usage.key_cert_sign {
-        purposes.push(KeyUsagePurpose::KeyCertSign);
-    }
-    if key_usage.crl_sign {
-        purposes.push(KeyUsagePurpose::CrlSign);
-    }
-    if key_usage.digital_signature {
-        purposes.push(KeyUsagePurpose::DigitalSignature);
-    }
-    if key_usage.key_encipherment {
-        purposes.push(KeyUsagePurpose::KeyEncipherment);
-    }
-    purposes
-}
-
 fn load_chain_inner(
     factory: &Factory,
     label: &str,
@@ -582,183 +550,57 @@ fn load_chain_inner(
 
     factory.get_or_init(DOMAIN_X509_CHAIN, label, &spec_bytes, variant, |seed| {
         let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
-        let rsa_spec = RsaSpec::new(spec.rsa_bits);
+        let keys = ChainKeys::load(factory, label, RsaSpec::new(spec.rsa_bits));
+        let base_time = chain_base_time(label, spec);
 
-        // Generate 3 RSA keypairs with role-tagged labels
-        let root_key_label = format!("{}-chain-root", label);
-        let int_key_label = format!("{}-chain-intermediate", label);
-        let leaf_key_label = format!("{}-chain-leaf", label);
+        let root_params = root_params(spec, base_time, &mut rng);
+        let root_cert = root_params
+            .self_signed(&keys.root_kp)
+            .expect("root cert gen");
 
-        let root_rsa = factory.rsa(&root_key_label, rsa_spec);
-        let int_rsa = factory.rsa(&int_key_label, rsa_spec);
-        let leaf_rsa = factory.rsa(&leaf_key_label, rsa_spec);
-
-        // Convert to rcgen KeyPairs
-        let root_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(root_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("root key parse");
-
-        let int_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(int_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("intermediate key parse");
-
-        let leaf_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(leaf_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("leaf key parse");
-
-        // Deterministic base time for the chain
-        let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
-        let base_time = deterministic_base_time_from_parts(&[
-            label.as_bytes(),
-            spec.leaf_cn.as_bytes(),
-            spec.root_cn.as_bytes(),
-            &rsa_bits,
-        ]);
-
-        // --- Root CA ---
-        let mut root_params = CertificateParams::default();
-        root_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.root_cn.clone());
-        root_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(1));
-        root_params.key_usages = vec![
-            KeyUsagePurpose::KeyCertSign,
-            KeyUsagePurpose::CrlSign,
-            KeyUsagePurpose::DigitalSignature,
-        ];
-        root_params.not_before = base_time - TimeDuration::days(1);
-        root_params.not_after =
-            root_params.not_before + TimeDuration::days(spec.root_validity_days as i64);
-        root_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let root_cert = root_params.self_signed(&root_kp).expect("root cert gen");
-
-        // --- Intermediate CA ---
-        let mut int_params = CertificateParams::default();
-        int_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.intermediate_cn.clone());
-        let intermediate_is_ca = spec.intermediate_is_ca.unwrap_or(true);
-        int_params.is_ca = if intermediate_is_ca {
-            IsCa::Ca(BasicConstraints::Constrained(0))
-        } else {
-            IsCa::NoCa
-        };
-        int_params.key_usages =
-            key_usage_purposes(spec.intermediate_key_usage.unwrap_or_else(KeyUsage::ca));
-        int_params.not_before = apply_not_before(base_time, spec.intermediate_not_before);
-        int_params.not_after =
-            int_params.not_before + TimeDuration::days(spec.intermediate_validity_days as i64);
-        int_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let root_issuer = Issuer::from_params(&root_params, &root_kp);
-        let int_cert = int_params
-            .signed_by(&int_kp, &root_issuer)
+        let intermediate_params = intermediate_params(spec, base_time, &mut rng);
+        let root_issuer = Issuer::from_params(&root_params, &keys.root_kp);
+        let intermediate_cert = intermediate_params
+            .signed_by(&keys.intermediate_kp, &root_issuer)
             .expect("intermediate cert gen");
 
-        // --- Leaf ---
-        let mut leaf_params = CertificateParams::default();
-        leaf_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.leaf_cn.clone());
-        leaf_params.is_ca = IsCa::NoCa;
-        leaf_params.key_usages = vec![
-            KeyUsagePurpose::DigitalSignature,
-            KeyUsagePurpose::KeyEncipherment,
-        ];
-        leaf_params.extended_key_usages = vec![
-            ExtendedKeyUsagePurpose::ServerAuth,
-            ExtendedKeyUsagePurpose::ClientAuth,
-        ];
-
-        // Add SANs (sorted and deduplicated to match stable_bytes)
-        let mut sorted_sans = spec.leaf_sans.clone();
-        sorted_sans.sort();
-        sorted_sans.dedup();
-        for san in &sorted_sans {
-            leaf_params.subject_alt_names.push(rcgen::SanType::DnsName(
-                san.clone().try_into().expect("valid DNS name"),
-            ));
-        }
-
-        leaf_params.not_before = apply_not_before(base_time, spec.leaf_not_before);
-        leaf_params.not_after =
-            leaf_params.not_before + TimeDuration::days(spec.leaf_validity_days as i64);
-        leaf_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
+        let leaf_params = leaf_params(spec, base_time, &mut rng);
         let leaf_serial = leaf_params
             .serial_number
             .clone()
             .expect("leaf serial number");
-
-        let int_issuer = Issuer::from_params(&int_params, &int_kp);
+        let intermediate_issuer = Issuer::from_params(&intermediate_params, &keys.intermediate_kp);
         let leaf_cert = leaf_params
-            .signed_by(&leaf_kp, &int_issuer)
+            .signed_by(&keys.leaf_kp, &intermediate_issuer)
             .expect("leaf cert gen");
 
-        // --- CRL (only for revoked_leaf variant) ---
-        let (crl_der, crl_pem) = if variant == "revoked_leaf" {
-            let crl_number = deterministic_serial_number_with_rng(|bytes| {
-                rng.fill_bytes(bytes);
-            });
-
-            let revoked = RevokedCertParams {
-                serial_number: leaf_serial,
-                revocation_time: base_time,
-                reason_code: Some(RevocationReason::KeyCompromise),
-                invalidity_date: None,
-            };
-
-            let crl_params = CertificateRevocationListParams {
-                this_update: base_time,
-                next_update: base_time + TimeDuration::days(30),
-                crl_number,
-                issuing_distribution_point: None,
-                revoked_certs: vec![revoked],
-                key_identifier_method: rcgen::KeyIdMethod::Sha256,
-            };
-
-            let int_issuer = Issuer::from_params(&int_params, &int_kp);
-            let crl = crl_params.signed_by(&int_issuer).expect("CRL gen");
-
-            (
-                Some(Arc::from(crl.der().as_ref())),
-                Some(crl.pem().expect("CRL PEM")),
-            )
-        } else {
-            (None, None)
-        };
+        let crl = revoked_leaf_crl(
+            variant,
+            leaf_serial,
+            &intermediate_params,
+            &keys.intermediate_kp,
+            base_time,
+            &mut rng,
+        );
 
         ChainInner {
             root_cert_der: Arc::from(root_cert.der().as_ref()),
             root_cert_pem: root_cert.pem(),
-            root_key_pkcs8_der: Arc::from(root_rsa.private_key_pkcs8_der()),
-            root_key_pkcs8_pem: root_rsa.private_key_pkcs8_pem().to_string(),
+            root_key_pkcs8_der: Arc::from(keys.root_rsa.private_key_pkcs8_der()),
+            root_key_pkcs8_pem: keys.root_rsa.private_key_pkcs8_pem().to_string(),
 
-            intermediate_cert_der: Arc::from(int_cert.der().as_ref()),
-            intermediate_cert_pem: int_cert.pem(),
-            intermediate_key_pkcs8_der: Arc::from(int_rsa.private_key_pkcs8_der()),
-            intermediate_key_pkcs8_pem: int_rsa.private_key_pkcs8_pem().to_string(),
+            intermediate_cert_der: Arc::from(intermediate_cert.der().as_ref()),
+            intermediate_cert_pem: intermediate_cert.pem(),
+            intermediate_key_pkcs8_der: Arc::from(keys.intermediate_rsa.private_key_pkcs8_der()),
+            intermediate_key_pkcs8_pem: keys.intermediate_rsa.private_key_pkcs8_pem().to_string(),
 
             leaf_cert_der: Arc::from(leaf_cert.der().as_ref()),
             leaf_cert_pem: leaf_cert.pem(),
-            leaf_key_pkcs8_der: Arc::from(leaf_rsa.private_key_pkcs8_der()),
-            leaf_key_pkcs8_pem: leaf_rsa.private_key_pkcs8_pem().to_string(),
+            leaf_key_pkcs8_der: Arc::from(keys.leaf_rsa.private_key_pkcs8_der()),
+            leaf_key_pkcs8_pem: keys.leaf_rsa.private_key_pkcs8_pem().to_string(),
 
-            crl_der,
-            crl_pem,
+            crl_der: crl.der,
+            crl_pem: crl.pem,
         }
     })
 }

--- a/crates/uselesskey-x509/src/srp/chain/crl.rs
+++ b/crates/uselesskey-x509/src/srp/chain/crl.rs
@@ -1,0 +1,64 @@
+//! Revocation-list generation for certificate-chain negative fixtures.
+
+use std::sync::Arc;
+
+use rand_core::RngCore;
+use rcgen::{
+    CertificateParams, CertificateRevocationListParams, Issuer, KeyPair, RevocationReason,
+    RevokedCertParams, SerialNumber,
+};
+use time::Duration as TimeDuration;
+use time::OffsetDateTime;
+
+use crate::srp::chain::params::next_serial;
+
+pub(crate) struct CrlMaterial {
+    pub(crate) der: Option<Arc<[u8]>>,
+    pub(crate) pem: Option<String>,
+}
+
+impl CrlMaterial {
+    pub(crate) fn none() -> Self {
+        Self {
+            der: None,
+            pem: None,
+        }
+    }
+}
+
+pub(crate) fn revoked_leaf_crl(
+    variant: &str,
+    leaf_serial: SerialNumber,
+    issuer_params: &CertificateParams,
+    issuer_key: &KeyPair,
+    base_time: OffsetDateTime,
+    rng: &mut impl RngCore,
+) -> CrlMaterial {
+    if variant != "revoked_leaf" {
+        return CrlMaterial::none();
+    }
+
+    let revoked = RevokedCertParams {
+        serial_number: leaf_serial,
+        revocation_time: base_time,
+        reason_code: Some(RevocationReason::KeyCompromise),
+        invalidity_date: None,
+    };
+
+    let crl_params = CertificateRevocationListParams {
+        this_update: base_time,
+        next_update: base_time + TimeDuration::days(30),
+        crl_number: next_serial(rng),
+        issuing_distribution_point: None,
+        revoked_certs: vec![revoked],
+        key_identifier_method: rcgen::KeyIdMethod::Sha256,
+    };
+
+    let issuer = Issuer::from_params(issuer_params, issuer_key);
+    let crl = crl_params.signed_by(&issuer).expect("CRL gen");
+
+    CrlMaterial {
+        der: Some(Arc::from(crl.der().as_ref())),
+        pem: Some(crl.pem().expect("CRL PEM")),
+    }
+}

--- a/crates/uselesskey-x509/src/srp/chain/keys.rs
+++ b/crates/uselesskey-x509/src/srp/chain/keys.rs
@@ -1,0 +1,48 @@
+//! RSA key material and rcgen key-pair conversion for chain generation.
+
+use rcgen::{KeyPair, PKCS_RSA_SHA256};
+use rustls_pki_types::PrivatePkcs8KeyDer;
+use uselesskey_core::Factory;
+use uselesskey_rsa::{RsaFactoryExt, RsaKeyPair, RsaSpec};
+
+pub(crate) struct ChainKeys {
+    pub(crate) root_rsa: RsaKeyPair,
+    pub(crate) intermediate_rsa: RsaKeyPair,
+    pub(crate) leaf_rsa: RsaKeyPair,
+    pub(crate) root_kp: KeyPair,
+    pub(crate) intermediate_kp: KeyPair,
+    pub(crate) leaf_kp: KeyPair,
+}
+
+impl ChainKeys {
+    pub(crate) fn load(factory: &Factory, label: &str, rsa_spec: RsaSpec) -> Self {
+        let root_key_label = format!("{}-chain-root", label);
+        let intermediate_key_label = format!("{}-chain-intermediate", label);
+        let leaf_key_label = format!("{}-chain-leaf", label);
+
+        let root_rsa = factory.rsa(&root_key_label, rsa_spec);
+        let intermediate_rsa = factory.rsa(&intermediate_key_label, rsa_spec);
+        let leaf_rsa = factory.rsa(&leaf_key_label, rsa_spec);
+
+        let root_kp = key_pair_from_rsa(&root_rsa, "root key parse");
+        let intermediate_kp = key_pair_from_rsa(&intermediate_rsa, "intermediate key parse");
+        let leaf_kp = key_pair_from_rsa(&leaf_rsa, "leaf key parse");
+
+        Self {
+            root_rsa,
+            intermediate_rsa,
+            leaf_rsa,
+            root_kp,
+            intermediate_kp,
+            leaf_kp,
+        }
+    }
+}
+
+fn key_pair_from_rsa(rsa: &RsaKeyPair, context: &str) -> KeyPair {
+    KeyPair::from_pkcs8_der_and_sign_algo(
+        &PrivatePkcs8KeyDer::from(rsa.private_key_pkcs8_der().to_vec()),
+        &PKCS_RSA_SHA256,
+    )
+    .expect(context)
+}

--- a/crates/uselesskey-x509/src/srp/chain/mod.rs
+++ b/crates/uselesskey-x509/src/srp/chain/mod.rs
@@ -1,0 +1,5 @@
+//! Single-responsibility helpers for X.509 chain generation.
+
+pub(crate) mod crl;
+pub(crate) mod keys;
+pub(crate) mod params;

--- a/crates/uselesskey-x509/src/srp/chain/params.rs
+++ b/crates/uselesskey-x509/src/srp/chain/params.rs
@@ -1,0 +1,134 @@
+//! rcgen parameter builders for root, intermediate, and leaf certificates.
+
+use rand_core::RngCore;
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+};
+use time::Duration as TimeDuration;
+use time::OffsetDateTime;
+
+use crate::srp::derive::{
+    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
+};
+use crate::srp::spec::{ChainSpec, KeyUsage, NotBeforeOffset};
+
+pub(crate) fn chain_base_time(label: &str, spec: &ChainSpec) -> OffsetDateTime {
+    let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
+    deterministic_base_time_from_parts(&[
+        label.as_bytes(),
+        spec.leaf_cn.as_bytes(),
+        spec.root_cn.as_bytes(),
+        &rsa_bits,
+    ])
+}
+
+pub(crate) fn root_params(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut impl RngCore,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.root_cn.clone());
+    params.is_ca = IsCa::Ca(BasicConstraints::Constrained(1));
+    params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+    params.not_before = base_time - TimeDuration::days(1);
+    params.not_after = params.not_before + TimeDuration::days(spec.root_validity_days as i64);
+    params.serial_number = Some(next_serial(rng));
+    params
+}
+
+pub(crate) fn intermediate_params(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut impl RngCore,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.intermediate_cn.clone());
+    let intermediate_is_ca = spec.intermediate_is_ca.unwrap_or(true);
+    params.is_ca = if intermediate_is_ca {
+        IsCa::Ca(BasicConstraints::Constrained(0))
+    } else {
+        IsCa::NoCa
+    };
+    params.key_usages =
+        key_usage_purposes(spec.intermediate_key_usage.unwrap_or_else(KeyUsage::ca));
+    params.not_before = apply_not_before(base_time, spec.intermediate_not_before);
+    params.not_after =
+        params.not_before + TimeDuration::days(spec.intermediate_validity_days as i64);
+    params.serial_number = Some(next_serial(rng));
+    params
+}
+
+pub(crate) fn leaf_params(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut impl RngCore,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.leaf_cn.clone());
+    params.is_ca = IsCa::NoCa;
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+    params.extended_key_usages = vec![
+        ExtendedKeyUsagePurpose::ServerAuth,
+        ExtendedKeyUsagePurpose::ClientAuth,
+    ];
+
+    for san in sorted_leaf_sans(spec) {
+        params.subject_alt_names.push(rcgen::SanType::DnsName(
+            san.try_into().expect("valid DNS name"),
+        ));
+    }
+
+    params.not_before = apply_not_before(base_time, spec.leaf_not_before);
+    params.not_after = params.not_before + TimeDuration::days(spec.leaf_validity_days as i64);
+    params.serial_number = Some(next_serial(rng));
+    params
+}
+
+pub(crate) fn next_serial(rng: &mut impl RngCore) -> rcgen::SerialNumber {
+    deterministic_serial_number_with_rng(|bytes| rng.fill_bytes(bytes))
+}
+
+fn apply_not_before(base_time: OffsetDateTime, offset: Option<NotBeforeOffset>) -> OffsetDateTime {
+    match offset.unwrap_or(NotBeforeOffset::DaysAgo(1)) {
+        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
+        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
+    }
+}
+
+fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
+    let mut purposes = Vec::new();
+    if key_usage.key_cert_sign {
+        purposes.push(KeyUsagePurpose::KeyCertSign);
+    }
+    if key_usage.crl_sign {
+        purposes.push(KeyUsagePurpose::CrlSign);
+    }
+    if key_usage.digital_signature {
+        purposes.push(KeyUsagePurpose::DigitalSignature);
+    }
+    if key_usage.key_encipherment {
+        purposes.push(KeyUsagePurpose::KeyEncipherment);
+    }
+    purposes
+}
+
+fn sorted_leaf_sans(spec: &ChainSpec) -> Vec<String> {
+    let mut sans = spec.leaf_sans.clone();
+    sans.sort();
+    sans.dedup();
+    sans
+}

--- a/crates/uselesskey-x509/src/srp/mod.rs
+++ b/crates/uselesskey-x509/src/srp/mod.rs
@@ -1,5 +1,6 @@
 //! Single-responsibility internals for X.509 fixture generation.
 
+pub(crate) mod chain;
 pub mod chain_negative;
 pub mod derive;
 pub mod negative;


### PR DESCRIPTION
### Motivation
- A large, complex chain-generation function was doing multiple responsibilities (key loading, rcgen conversion, param construction, CRL creation); this change splits that into single-responsibility SRP helpers to improve readability and testability.
- Preserve deterministic derivation and cache identity while making the X.509 chain loader only orchestrate the pieces it composes.

### Description
- Introduced a `srp::chain` namespace and added three SRP helpers: `crl.rs` (CRL generation), `keys.rs` (RSA fixture loading and `rcgen::KeyPair` conversion), and `params.rs` (deterministic base-time, serial allocation, SAN normalization, and certificate `CertificateParams` builders). (files: `crates/uselesskey-x509/src/srp/chain/{mod.rs,keys.rs,params.rs,crl.rs}`)
- Simplified `crates/uselesskey-x509/src/chain.rs` so `load_chain_inner` now orchestrates the flow and delegates key, params, and CRL logic to the new SRP helpers while preserving deterministic seeds/serials and cache domain `DOMAIN_X509_CHAIN`.
- Updated `crates/uselesskey-x509/src/srp/mod.rs` to expose the new `chain` submodule.
- Kept public API and deterministic outputs stable (derivation inputs, serial generation order, and cache keys remain unchanged).

### Testing
- Ran `cargo check -p uselesskey-x509` and it completed successfully.
- Ran `cargo test -p uselesskey-x509` and the X.509 crate tests completed successfully (all unit, doctest and integration tests passed).
- Ran `cargo xtask lint-fix --check --no-clippy` (format-check) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04463621648333a7cec26b05ad258e)