### PR TITLE
Refactor X.509 chain generation into SRP modules

### DIFF
--- a/crates/uselesskey-x509/src/chain.rs
+++ b/crates/uselesskey-x509/src/chain.rs
@@ -3,25 +3,12 @@
 use std::fmt;
 use std::sync::Arc;
 
-use rand_chacha::ChaCha20Rng;
-use rand_core::RngCore;
-use rand_core::SeedableRng;
-use rcgen::{
-    BasicConstraints, CertificateParams, CertificateRevocationListParams, DnType,
-    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, PKCS_RSA_SHA256,
-    RevocationReason, RevokedCertParams,
-};
-use rustls_pki_types::PrivatePkcs8KeyDer;
-use time::Duration as TimeDuration;
-use time::OffsetDateTime;
+use crate::srp::chain_artifacts::{ChainArtifacts, build_chain_artifacts};
+use crate::srp::chain_keys::load_chain_key_material;
 use uselesskey_core::sink::TempArtifact;
 use uselesskey_core::{Error, Factory};
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
 
-use crate::srp::derive::{
-    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
-};
-use crate::srp::spec::{ChainSpec, KeyUsage, NotBeforeOffset};
+use crate::srp::spec::ChainSpec;
 
 /// Cache domain for X.509 certificate chain fixtures.
 ///
@@ -548,30 +535,6 @@ impl X509Chain {
     }
 }
 
-fn apply_not_before(base_time: OffsetDateTime, offset: Option<NotBeforeOffset>) -> OffsetDateTime {
-    match offset.unwrap_or(NotBeforeOffset::DaysAgo(1)) {
-        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
-        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
-    }
-}
-
-fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
-    let mut purposes = Vec::new();
-    if key_usage.key_cert_sign {
-        purposes.push(KeyUsagePurpose::KeyCertSign);
-    }
-    if key_usage.crl_sign {
-        purposes.push(KeyUsagePurpose::CrlSign);
-    }
-    if key_usage.digital_signature {
-        purposes.push(KeyUsagePurpose::DigitalSignature);
-    }
-    if key_usage.key_encipherment {
-        purposes.push(KeyUsagePurpose::KeyEncipherment);
-    }
-    purposes
-}
-
 fn load_chain_inner(
     factory: &Factory,
     label: &str,
@@ -581,186 +544,34 @@ fn load_chain_inner(
     let spec_bytes = spec.stable_bytes();
 
     factory.get_or_init(DOMAIN_X509_CHAIN, label, &spec_bytes, variant, |seed| {
-        let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
-        let rsa_spec = RsaSpec::new(spec.rsa_bits);
-
-        // Generate 3 RSA keypairs with role-tagged labels
-        let root_key_label = format!("{}-chain-root", label);
-        let int_key_label = format!("{}-chain-intermediate", label);
-        let leaf_key_label = format!("{}-chain-leaf", label);
-
-        let root_rsa = factory.rsa(&root_key_label, rsa_spec);
-        let int_rsa = factory.rsa(&int_key_label, rsa_spec);
-        let leaf_rsa = factory.rsa(&leaf_key_label, rsa_spec);
-
-        // Convert to rcgen KeyPairs
-        let root_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(root_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("root key parse");
-
-        let int_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(int_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("intermediate key parse");
-
-        let leaf_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(leaf_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("leaf key parse");
-
-        // Deterministic base time for the chain
-        let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
-        let base_time = deterministic_base_time_from_parts(&[
-            label.as_bytes(),
-            spec.leaf_cn.as_bytes(),
-            spec.root_cn.as_bytes(),
-            &rsa_bits,
-        ]);
-
-        // --- Root CA ---
-        let mut root_params = CertificateParams::default();
-        root_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.root_cn.clone());
-        root_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(1));
-        root_params.key_usages = vec![
-            KeyUsagePurpose::KeyCertSign,
-            KeyUsagePurpose::CrlSign,
-            KeyUsagePurpose::DigitalSignature,
-        ];
-        root_params.not_before = base_time - TimeDuration::days(1);
-        root_params.not_after =
-            root_params.not_before + TimeDuration::days(spec.root_validity_days as i64);
-        root_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let root_cert = root_params.self_signed(&root_kp).expect("root cert gen");
-
-        // --- Intermediate CA ---
-        let mut int_params = CertificateParams::default();
-        int_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.intermediate_cn.clone());
-        let intermediate_is_ca = spec.intermediate_is_ca.unwrap_or(true);
-        int_params.is_ca = if intermediate_is_ca {
-            IsCa::Ca(BasicConstraints::Constrained(0))
-        } else {
-            IsCa::NoCa
-        };
-        int_params.key_usages =
-            key_usage_purposes(spec.intermediate_key_usage.unwrap_or_else(KeyUsage::ca));
-        int_params.not_before = apply_not_before(base_time, spec.intermediate_not_before);
-        int_params.not_after =
-            int_params.not_before + TimeDuration::days(spec.intermediate_validity_days as i64);
-        int_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let root_issuer = Issuer::from_params(&root_params, &root_kp);
-        let int_cert = int_params
-            .signed_by(&int_kp, &root_issuer)
-            .expect("intermediate cert gen");
-
-        // --- Leaf ---
-        let mut leaf_params = CertificateParams::default();
-        leaf_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.leaf_cn.clone());
-        leaf_params.is_ca = IsCa::NoCa;
-        leaf_params.key_usages = vec![
-            KeyUsagePurpose::DigitalSignature,
-            KeyUsagePurpose::KeyEncipherment,
-        ];
-        leaf_params.extended_key_usages = vec![
-            ExtendedKeyUsagePurpose::ServerAuth,
-            ExtendedKeyUsagePurpose::ClientAuth,
-        ];
-
-        // Add SANs (sorted and deduplicated to match stable_bytes)
-        let mut sorted_sans = spec.leaf_sans.clone();
-        sorted_sans.sort();
-        sorted_sans.dedup();
-        for san in &sorted_sans {
-            leaf_params.subject_alt_names.push(rcgen::SanType::DnsName(
-                san.clone().try_into().expect("valid DNS name"),
-            ));
-        }
-
-        leaf_params.not_before = apply_not_before(base_time, spec.leaf_not_before);
-        leaf_params.not_after =
-            leaf_params.not_before + TimeDuration::days(spec.leaf_validity_days as i64);
-        leaf_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let leaf_serial = leaf_params
-            .serial_number
-            .clone()
-            .expect("leaf serial number");
-
-        let int_issuer = Issuer::from_params(&int_params, &int_kp);
-        let leaf_cert = leaf_params
-            .signed_by(&leaf_kp, &int_issuer)
-            .expect("leaf cert gen");
-
-        // --- CRL (only for revoked_leaf variant) ---
-        let (crl_der, crl_pem) = if variant == "revoked_leaf" {
-            let crl_number = deterministic_serial_number_with_rng(|bytes| {
-                rng.fill_bytes(bytes);
-            });
-
-            let revoked = RevokedCertParams {
-                serial_number: leaf_serial,
-                revocation_time: base_time,
-                reason_code: Some(RevocationReason::KeyCompromise),
-                invalidity_date: None,
-            };
-
-            let crl_params = CertificateRevocationListParams {
-                this_update: base_time,
-                next_update: base_time + TimeDuration::days(30),
-                crl_number,
-                issuing_distribution_point: None,
-                revoked_certs: vec![revoked],
-                key_identifier_method: rcgen::KeyIdMethod::Sha256,
-            };
-
-            let int_issuer = Issuer::from_params(&int_params, &int_kp);
-            let crl = crl_params.signed_by(&int_issuer).expect("CRL gen");
-
-            (
-                Some(Arc::from(crl.der().as_ref())),
-                Some(crl.pem().expect("CRL PEM")),
-            )
-        } else {
-            (None, None)
-        };
-
-        ChainInner {
-            root_cert_der: Arc::from(root_cert.der().as_ref()),
-            root_cert_pem: root_cert.pem(),
-            root_key_pkcs8_der: Arc::from(root_rsa.private_key_pkcs8_der()),
-            root_key_pkcs8_pem: root_rsa.private_key_pkcs8_pem().to_string(),
-
-            intermediate_cert_der: Arc::from(int_cert.der().as_ref()),
-            intermediate_cert_pem: int_cert.pem(),
-            intermediate_key_pkcs8_der: Arc::from(int_rsa.private_key_pkcs8_der()),
-            intermediate_key_pkcs8_pem: int_rsa.private_key_pkcs8_pem().to_string(),
-
-            leaf_cert_der: Arc::from(leaf_cert.der().as_ref()),
-            leaf_cert_pem: leaf_cert.pem(),
-            leaf_key_pkcs8_der: Arc::from(leaf_rsa.private_key_pkcs8_der()),
-            leaf_key_pkcs8_pem: leaf_rsa.private_key_pkcs8_pem().to_string(),
-
-            crl_der,
-            crl_pem,
-        }
+        let keys = load_chain_key_material(factory, label, spec.rsa_bits);
+        let artifacts = build_chain_artifacts(label, spec, variant, seed, &keys);
+        ChainInner::from_artifacts(artifacts)
     })
+}
+
+impl ChainInner {
+    fn from_artifacts(artifacts: ChainArtifacts) -> Self {
+        Self {
+            root_cert_der: artifacts.root_cert_der,
+            root_cert_pem: artifacts.root_cert_pem,
+            root_key_pkcs8_der: artifacts.root_key_pkcs8_der,
+            root_key_pkcs8_pem: artifacts.root_key_pkcs8_pem,
+
+            intermediate_cert_der: artifacts.intermediate_cert_der,
+            intermediate_cert_pem: artifacts.intermediate_cert_pem,
+            intermediate_key_pkcs8_der: artifacts.intermediate_key_pkcs8_der,
+            intermediate_key_pkcs8_pem: artifacts.intermediate_key_pkcs8_pem,
+
+            leaf_cert_der: artifacts.leaf_cert_der,
+            leaf_cert_pem: artifacts.leaf_cert_pem,
+            leaf_key_pkcs8_der: artifacts.leaf_key_pkcs8_der,
+            leaf_key_pkcs8_pem: artifacts.leaf_key_pkcs8_pem,
+
+            crl_der: artifacts.crl_der,
+            crl_pem: artifacts.crl_pem,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/uselesskey-x509/src/srp/chain_artifacts.rs
+++ b/crates/uselesskey-x509/src/srp/chain_artifacts.rs
@@ -1,0 +1,260 @@
+//! X.509 chain certificate and CRL assembly helpers.
+//!
+//! This module is responsible for turning prepared chain key material and a
+//! [`ChainSpec`](super::spec::ChainSpec) into serialized root, intermediate,
+//! leaf, and optional CRL artifacts.
+
+use std::sync::Arc;
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::{RngCore, SeedableRng};
+use rcgen::{
+    BasicConstraints, CertificateParams, CertificateRevocationListParams, DnType,
+    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyUsagePurpose, RevocationReason, RevokedCertParams,
+};
+use time::{Duration as TimeDuration, OffsetDateTime};
+use uselesskey_core::Seed;
+
+use super::chain_keys::ChainKeyMaterial;
+use super::derive::{deterministic_base_time_from_parts, deterministic_serial_number_with_rng};
+use super::spec::{ChainSpec, KeyUsage, NotBeforeOffset};
+
+/// Serialized chain outputs ready for the public `X509Chain` facade.
+pub(crate) struct ChainArtifacts {
+    pub(crate) root_cert_der: Arc<[u8]>,
+    pub(crate) root_cert_pem: String,
+    pub(crate) root_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) root_key_pkcs8_pem: String,
+
+    pub(crate) intermediate_cert_der: Arc<[u8]>,
+    pub(crate) intermediate_cert_pem: String,
+    pub(crate) intermediate_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) intermediate_key_pkcs8_pem: String,
+
+    pub(crate) leaf_cert_der: Arc<[u8]>,
+    pub(crate) leaf_cert_pem: String,
+    pub(crate) leaf_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) leaf_key_pkcs8_pem: String,
+
+    pub(crate) crl_der: Option<Arc<[u8]>>,
+    pub(crate) crl_pem: Option<String>,
+}
+
+/// Build a deterministic three-level certificate chain and optional CRL.
+pub(crate) fn build_chain_artifacts(
+    label: &str,
+    spec: &ChainSpec,
+    variant: &str,
+    seed: Seed,
+    keys: &ChainKeyMaterial,
+) -> ChainArtifacts {
+    let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
+    let base_time = chain_base_time(label, spec);
+
+    let root_params = root_params(spec, base_time, &mut rng);
+    let root_cert = root_params
+        .self_signed(&keys.root_kp)
+        .expect("root cert gen");
+
+    let intermediate_params = intermediate_params(spec, base_time, &mut rng);
+    let root_issuer = Issuer::from_params(&root_params, &keys.root_kp);
+    let intermediate_cert = intermediate_params
+        .signed_by(&keys.intermediate_kp, &root_issuer)
+        .expect("intermediate cert gen");
+
+    let leaf_params = leaf_params(spec, base_time, &mut rng);
+    let leaf_serial = leaf_params
+        .serial_number
+        .clone()
+        .expect("leaf serial number");
+    let intermediate_issuer = Issuer::from_params(&intermediate_params, &keys.intermediate_kp);
+    let leaf_cert = leaf_params
+        .signed_by(&keys.leaf_kp, &intermediate_issuer)
+        .expect("leaf cert gen");
+
+    let (crl_der, crl_pem) = revoked_leaf_crl(
+        variant,
+        base_time,
+        leaf_serial,
+        &intermediate_params,
+        &keys.intermediate_kp,
+        &mut rng,
+    );
+
+    ChainArtifacts {
+        root_cert_der: Arc::from(root_cert.der().as_ref()),
+        root_cert_pem: root_cert.pem(),
+        root_key_pkcs8_der: Arc::from(keys.root_rsa.private_key_pkcs8_der()),
+        root_key_pkcs8_pem: keys.root_rsa.private_key_pkcs8_pem().to_string(),
+
+        intermediate_cert_der: Arc::from(intermediate_cert.der().as_ref()),
+        intermediate_cert_pem: intermediate_cert.pem(),
+        intermediate_key_pkcs8_der: Arc::from(keys.intermediate_rsa.private_key_pkcs8_der()),
+        intermediate_key_pkcs8_pem: keys.intermediate_rsa.private_key_pkcs8_pem().to_string(),
+
+        leaf_cert_der: Arc::from(leaf_cert.der().as_ref()),
+        leaf_cert_pem: leaf_cert.pem(),
+        leaf_key_pkcs8_der: Arc::from(keys.leaf_rsa.private_key_pkcs8_der()),
+        leaf_key_pkcs8_pem: keys.leaf_rsa.private_key_pkcs8_pem().to_string(),
+
+        crl_der,
+        crl_pem,
+    }
+}
+
+fn chain_base_time(label: &str, spec: &ChainSpec) -> OffsetDateTime {
+    let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
+    deterministic_base_time_from_parts(&[
+        label.as_bytes(),
+        spec.leaf_cn.as_bytes(),
+        spec.root_cn.as_bytes(),
+        &rsa_bits,
+    ])
+}
+
+fn root_params(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut ChaCha20Rng,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.root_cn.clone());
+    params.is_ca = IsCa::Ca(BasicConstraints::Constrained(1));
+    params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+    params.not_before = base_time - TimeDuration::days(1);
+    params.not_after = params.not_before + TimeDuration::days(spec.root_validity_days as i64);
+    params.serial_number = Some(next_serial(rng));
+    params
+}
+
+fn intermediate_params(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut ChaCha20Rng,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.intermediate_cn.clone());
+    params.is_ca = if spec.intermediate_is_ca.unwrap_or(true) {
+        IsCa::Ca(BasicConstraints::Constrained(0))
+    } else {
+        IsCa::NoCa
+    };
+    params.key_usages =
+        key_usage_purposes(spec.intermediate_key_usage.unwrap_or_else(KeyUsage::ca));
+    params.not_before = apply_not_before(base_time, spec.intermediate_not_before);
+    params.not_after =
+        params.not_before + TimeDuration::days(spec.intermediate_validity_days as i64);
+    params.serial_number = Some(next_serial(rng));
+    params
+}
+
+fn leaf_params(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut ChaCha20Rng,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.leaf_cn.clone());
+    params.is_ca = IsCa::NoCa;
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+    params.extended_key_usages = vec![
+        ExtendedKeyUsagePurpose::ServerAuth,
+        ExtendedKeyUsagePurpose::ClientAuth,
+    ];
+
+    for san in sorted_leaf_sans(spec) {
+        params.subject_alt_names.push(rcgen::SanType::DnsName(
+            san.try_into().expect("valid DNS name"),
+        ));
+    }
+
+    params.not_before = apply_not_before(base_time, spec.leaf_not_before);
+    params.not_after = params.not_before + TimeDuration::days(spec.leaf_validity_days as i64);
+    params.serial_number = Some(next_serial(rng));
+    params
+}
+
+fn sorted_leaf_sans(spec: &ChainSpec) -> Vec<String> {
+    let mut sorted_sans = spec.leaf_sans.clone();
+    sorted_sans.sort();
+    sorted_sans.dedup();
+    sorted_sans
+}
+
+fn revoked_leaf_crl(
+    variant: &str,
+    base_time: OffsetDateTime,
+    leaf_serial: rcgen::SerialNumber,
+    intermediate_params: &CertificateParams,
+    intermediate_kp: &rcgen::KeyPair,
+    rng: &mut ChaCha20Rng,
+) -> (Option<Arc<[u8]>>, Option<String>) {
+    if variant != "revoked_leaf" {
+        return (None, None);
+    }
+
+    let revoked = RevokedCertParams {
+        serial_number: leaf_serial,
+        revocation_time: base_time,
+        reason_code: Some(RevocationReason::KeyCompromise),
+        invalidity_date: None,
+    };
+
+    let crl_params = CertificateRevocationListParams {
+        this_update: base_time,
+        next_update: base_time + TimeDuration::days(30),
+        crl_number: next_serial(rng),
+        issuing_distribution_point: None,
+        revoked_certs: vec![revoked],
+        key_identifier_method: rcgen::KeyIdMethod::Sha256,
+    };
+
+    let intermediate_issuer = Issuer::from_params(intermediate_params, intermediate_kp);
+    let crl = crl_params.signed_by(&intermediate_issuer).expect("CRL gen");
+
+    (
+        Some(Arc::from(crl.der().as_ref())),
+        Some(crl.pem().expect("CRL PEM")),
+    )
+}
+
+fn next_serial(rng: &mut ChaCha20Rng) -> rcgen::SerialNumber {
+    deterministic_serial_number_with_rng(|bytes| rng.fill_bytes(bytes))
+}
+
+fn apply_not_before(base_time: OffsetDateTime, offset: Option<NotBeforeOffset>) -> OffsetDateTime {
+    match offset.unwrap_or(NotBeforeOffset::DaysAgo(1)) {
+        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
+        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
+    }
+}
+
+fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
+    let mut purposes = Vec::new();
+    if key_usage.key_cert_sign {
+        purposes.push(KeyUsagePurpose::KeyCertSign);
+    }
+    if key_usage.crl_sign {
+        purposes.push(KeyUsagePurpose::CrlSign);
+    }
+    if key_usage.digital_signature {
+        purposes.push(KeyUsagePurpose::DigitalSignature);
+    }
+    if key_usage.key_encipherment {
+        purposes.push(KeyUsagePurpose::KeyEncipherment);
+    }
+    purposes
+}

--- a/crates/uselesskey-x509/src/srp/chain_keys.rs
+++ b/crates/uselesskey-x509/src/srp/chain_keys.rs
@@ -1,0 +1,53 @@
+//! X.509 chain key-material helpers.
+//!
+//! This module owns the RSA fixture labels used by chain generation and the
+//! conversion from reusable `uselesskey-rsa` fixtures into `rcgen` signing keys.
+
+use rcgen::{KeyPair, PKCS_RSA_SHA256};
+use rustls_pki_types::PrivatePkcs8KeyDer;
+use uselesskey_core::Factory;
+use uselesskey_rsa::{RsaFactoryExt, RsaKeyPair, RsaSpec};
+
+/// RSA fixture material and parsed `rcgen` signers for a root/intermediate/leaf chain.
+pub(crate) struct ChainKeyMaterial {
+    pub(crate) root_rsa: RsaKeyPair,
+    pub(crate) root_kp: KeyPair,
+    pub(crate) intermediate_rsa: RsaKeyPair,
+    pub(crate) intermediate_kp: KeyPair,
+    pub(crate) leaf_rsa: RsaKeyPair,
+    pub(crate) leaf_kp: KeyPair,
+}
+
+/// Generate role-tagged RSA key fixtures and parse them for X.509 signing.
+pub(crate) fn load_chain_key_material(
+    factory: &Factory,
+    label: &str,
+    rsa_bits: usize,
+) -> ChainKeyMaterial {
+    let rsa_spec = RsaSpec::new(rsa_bits);
+
+    let root_rsa = factory.rsa(format!("{label}-chain-root"), rsa_spec);
+    let intermediate_rsa = factory.rsa(format!("{label}-chain-intermediate"), rsa_spec);
+    let leaf_rsa = factory.rsa(format!("{label}-chain-leaf"), rsa_spec);
+
+    let root_kp = parse_rsa_signing_key(&root_rsa, "root");
+    let intermediate_kp = parse_rsa_signing_key(&intermediate_rsa, "intermediate");
+    let leaf_kp = parse_rsa_signing_key(&leaf_rsa, "leaf");
+
+    ChainKeyMaterial {
+        root_rsa,
+        root_kp,
+        intermediate_rsa,
+        intermediate_kp,
+        leaf_rsa,
+        leaf_kp,
+    }
+}
+
+fn parse_rsa_signing_key(rsa: &RsaKeyPair, role: &str) -> KeyPair {
+    KeyPair::from_pkcs8_der_and_sign_algo(
+        &PrivatePkcs8KeyDer::from(rsa.private_key_pkcs8_der().to_vec()),
+        &PKCS_RSA_SHA256,
+    )
+    .unwrap_or_else(|_| panic!("{role} key parse"))
+}

--- a/crates/uselesskey-x509/src/srp/mod.rs
+++ b/crates/uselesskey-x509/src/srp/mod.rs
@@ -1,5 +1,7 @@
 //! Single-responsibility internals for X.509 fixture generation.
 
+pub mod chain_artifacts;
+pub mod chain_keys;
 pub mod chain_negative;
 pub mod derive;
 pub mod negative;


### PR DESCRIPTION
### Motivation

- Reduce complexity and improve single-responsibility of the X.509 chain generation path by breaking a large, multi-purpose function into focused SRP submodules. 
- Isolate RSA key-material labeling/parsing and certificate/CRL assembly so deterministic derivation, SAN sorting, serial generation, and CRL logic are easier to review and maintain.

### Description

- Split chain key handling into a new `srp::chain_keys` module with `load_chain_key_material` and `ChainKeyMaterial` to produce role-tagged `uselesskey-rsa` fixtures and parsed `rcgen::KeyPair` signers. 
- Moved certificate/CRL assembly and related helpers into `srp::chain_artifacts` which exposes `build_chain_artifacts` and `ChainArtifacts` and contains deterministic base-time derivation, `root_params`/`intermediate_params`/`leaf_params`, SAN sorting, serial generation, and revoked-leaf CRL generation. 
- Simplified `load_chain_inner` in `crates/uselesskey-x509/src/chain.rs` to call `load_chain_key_material` + `build_chain_artifacts` and map `ChainArtifacts` into the public `ChainInner` via `ChainInner::from_artifacts`, removing the previous large inline implementation. 
- Registered the new submodules in `crates/uselesskey-x509/src/srp/mod.rs` and removed now-duplicated imports from the public `chain.rs` file.

### Testing

- Ran `cargo check -p uselesskey-x509` which completed successfully. 
- Ran `cargo test -p uselesskey-x509` and the crate tests passed (all unit/doctests and integration tests for `uselesskey-x509` completed with no failures). 
- Ran `cargo xtask lint-fix --check` (format and clippy check) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04463621648333a7cec26b05ad258e)