### PR TITLE
Refactor X.509 chain generation into SRP modules

### DIFF
--- a/crates/uselesskey-x509/src/chain.rs
+++ b/crates/uselesskey-x509/src/chain.rs
@@ -3,25 +3,10 @@
 use std::fmt;
 use std::sync::Arc;
 
-use rand_chacha::ChaCha20Rng;
-use rand_core::RngCore;
-use rand_core::SeedableRng;
-use rcgen::{
-    BasicConstraints, CertificateParams, CertificateRevocationListParams, DnType,
-    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, PKCS_RSA_SHA256,
-    RevocationReason, RevokedCertParams,
-};
-use rustls_pki_types::PrivatePkcs8KeyDer;
-use time::Duration as TimeDuration;
-use time::OffsetDateTime;
+use crate::srp::chain::load_chain_inner;
+use crate::srp::spec::ChainSpec;
 use uselesskey_core::sink::TempArtifact;
 use uselesskey_core::{Error, Factory};
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
-
-use crate::srp::derive::{
-    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
-};
-use crate::srp::spec::{ChainSpec, KeyUsage, NotBeforeOffset};
 
 /// Cache domain for X.509 certificate chain fixtures.
 ///
@@ -37,24 +22,24 @@ pub struct X509Chain {
     inner: Arc<ChainInner>,
 }
 
-struct ChainInner {
-    root_cert_der: Arc<[u8]>,
-    root_cert_pem: String,
-    root_key_pkcs8_der: Arc<[u8]>,
-    root_key_pkcs8_pem: String,
+pub(crate) struct ChainInner {
+    pub(crate) root_cert_der: Arc<[u8]>,
+    pub(crate) root_cert_pem: String,
+    pub(crate) root_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) root_key_pkcs8_pem: String,
 
-    intermediate_cert_der: Arc<[u8]>,
-    intermediate_cert_pem: String,
-    intermediate_key_pkcs8_der: Arc<[u8]>,
-    intermediate_key_pkcs8_pem: String,
+    pub(crate) intermediate_cert_der: Arc<[u8]>,
+    pub(crate) intermediate_cert_pem: String,
+    pub(crate) intermediate_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) intermediate_key_pkcs8_pem: String,
 
-    leaf_cert_der: Arc<[u8]>,
-    leaf_cert_pem: String,
-    leaf_key_pkcs8_der: Arc<[u8]>,
-    leaf_key_pkcs8_pem: String,
+    pub(crate) leaf_cert_der: Arc<[u8]>,
+    pub(crate) leaf_cert_pem: String,
+    pub(crate) leaf_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) leaf_key_pkcs8_pem: String,
 
-    crl_der: Option<Arc<[u8]>>,
-    crl_pem: Option<String>,
+    pub(crate) crl_der: Option<Arc<[u8]>>,
+    pub(crate) crl_pem: Option<String>,
 }
 
 impl fmt::Debug for X509Chain {
@@ -546,221 +531,6 @@ impl X509Chain {
     pub(crate) fn factory(&self) -> &Factory {
         &self.factory
     }
-}
-
-fn apply_not_before(base_time: OffsetDateTime, offset: Option<NotBeforeOffset>) -> OffsetDateTime {
-    match offset.unwrap_or(NotBeforeOffset::DaysAgo(1)) {
-        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
-        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
-    }
-}
-
-fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
-    let mut purposes = Vec::new();
-    if key_usage.key_cert_sign {
-        purposes.push(KeyUsagePurpose::KeyCertSign);
-    }
-    if key_usage.crl_sign {
-        purposes.push(KeyUsagePurpose::CrlSign);
-    }
-    if key_usage.digital_signature {
-        purposes.push(KeyUsagePurpose::DigitalSignature);
-    }
-    if key_usage.key_encipherment {
-        purposes.push(KeyUsagePurpose::KeyEncipherment);
-    }
-    purposes
-}
-
-fn load_chain_inner(
-    factory: &Factory,
-    label: &str,
-    spec: &ChainSpec,
-    variant: &str,
-) -> Arc<ChainInner> {
-    let spec_bytes = spec.stable_bytes();
-
-    factory.get_or_init(DOMAIN_X509_CHAIN, label, &spec_bytes, variant, |seed| {
-        let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
-        let rsa_spec = RsaSpec::new(spec.rsa_bits);
-
-        // Generate 3 RSA keypairs with role-tagged labels
-        let root_key_label = format!("{}-chain-root", label);
-        let int_key_label = format!("{}-chain-intermediate", label);
-        let leaf_key_label = format!("{}-chain-leaf", label);
-
-        let root_rsa = factory.rsa(&root_key_label, rsa_spec);
-        let int_rsa = factory.rsa(&int_key_label, rsa_spec);
-        let leaf_rsa = factory.rsa(&leaf_key_label, rsa_spec);
-
-        // Convert to rcgen KeyPairs
-        let root_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(root_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("root key parse");
-
-        let int_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(int_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("intermediate key parse");
-
-        let leaf_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(leaf_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("leaf key parse");
-
-        // Deterministic base time for the chain
-        let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
-        let base_time = deterministic_base_time_from_parts(&[
-            label.as_bytes(),
-            spec.leaf_cn.as_bytes(),
-            spec.root_cn.as_bytes(),
-            &rsa_bits,
-        ]);
-
-        // --- Root CA ---
-        let mut root_params = CertificateParams::default();
-        root_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.root_cn.clone());
-        root_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(1));
-        root_params.key_usages = vec![
-            KeyUsagePurpose::KeyCertSign,
-            KeyUsagePurpose::CrlSign,
-            KeyUsagePurpose::DigitalSignature,
-        ];
-        root_params.not_before = base_time - TimeDuration::days(1);
-        root_params.not_after =
-            root_params.not_before + TimeDuration::days(spec.root_validity_days as i64);
-        root_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let root_cert = root_params.self_signed(&root_kp).expect("root cert gen");
-
-        // --- Intermediate CA ---
-        let mut int_params = CertificateParams::default();
-        int_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.intermediate_cn.clone());
-        let intermediate_is_ca = spec.intermediate_is_ca.unwrap_or(true);
-        int_params.is_ca = if intermediate_is_ca {
-            IsCa::Ca(BasicConstraints::Constrained(0))
-        } else {
-            IsCa::NoCa
-        };
-        int_params.key_usages =
-            key_usage_purposes(spec.intermediate_key_usage.unwrap_or_else(KeyUsage::ca));
-        int_params.not_before = apply_not_before(base_time, spec.intermediate_not_before);
-        int_params.not_after =
-            int_params.not_before + TimeDuration::days(spec.intermediate_validity_days as i64);
-        int_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let root_issuer = Issuer::from_params(&root_params, &root_kp);
-        let int_cert = int_params
-            .signed_by(&int_kp, &root_issuer)
-            .expect("intermediate cert gen");
-
-        // --- Leaf ---
-        let mut leaf_params = CertificateParams::default();
-        leaf_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.leaf_cn.clone());
-        leaf_params.is_ca = IsCa::NoCa;
-        leaf_params.key_usages = vec![
-            KeyUsagePurpose::DigitalSignature,
-            KeyUsagePurpose::KeyEncipherment,
-        ];
-        leaf_params.extended_key_usages = vec![
-            ExtendedKeyUsagePurpose::ServerAuth,
-            ExtendedKeyUsagePurpose::ClientAuth,
-        ];
-
-        // Add SANs (sorted and deduplicated to match stable_bytes)
-        let mut sorted_sans = spec.leaf_sans.clone();
-        sorted_sans.sort();
-        sorted_sans.dedup();
-        for san in &sorted_sans {
-            leaf_params.subject_alt_names.push(rcgen::SanType::DnsName(
-                san.clone().try_into().expect("valid DNS name"),
-            ));
-        }
-
-        leaf_params.not_before = apply_not_before(base_time, spec.leaf_not_before);
-        leaf_params.not_after =
-            leaf_params.not_before + TimeDuration::days(spec.leaf_validity_days as i64);
-        leaf_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let leaf_serial = leaf_params
-            .serial_number
-            .clone()
-            .expect("leaf serial number");
-
-        let int_issuer = Issuer::from_params(&int_params, &int_kp);
-        let leaf_cert = leaf_params
-            .signed_by(&leaf_kp, &int_issuer)
-            .expect("leaf cert gen");
-
-        // --- CRL (only for revoked_leaf variant) ---
-        let (crl_der, crl_pem) = if variant == "revoked_leaf" {
-            let crl_number = deterministic_serial_number_with_rng(|bytes| {
-                rng.fill_bytes(bytes);
-            });
-
-            let revoked = RevokedCertParams {
-                serial_number: leaf_serial,
-                revocation_time: base_time,
-                reason_code: Some(RevocationReason::KeyCompromise),
-                invalidity_date: None,
-            };
-
-            let crl_params = CertificateRevocationListParams {
-                this_update: base_time,
-                next_update: base_time + TimeDuration::days(30),
-                crl_number,
-                issuing_distribution_point: None,
-                revoked_certs: vec![revoked],
-                key_identifier_method: rcgen::KeyIdMethod::Sha256,
-            };
-
-            let int_issuer = Issuer::from_params(&int_params, &int_kp);
-            let crl = crl_params.signed_by(&int_issuer).expect("CRL gen");
-
-            (
-                Some(Arc::from(crl.der().as_ref())),
-                Some(crl.pem().expect("CRL PEM")),
-            )
-        } else {
-            (None, None)
-        };
-
-        ChainInner {
-            root_cert_der: Arc::from(root_cert.der().as_ref()),
-            root_cert_pem: root_cert.pem(),
-            root_key_pkcs8_der: Arc::from(root_rsa.private_key_pkcs8_der()),
-            root_key_pkcs8_pem: root_rsa.private_key_pkcs8_pem().to_string(),
-
-            intermediate_cert_der: Arc::from(int_cert.der().as_ref()),
-            intermediate_cert_pem: int_cert.pem(),
-            intermediate_key_pkcs8_der: Arc::from(int_rsa.private_key_pkcs8_der()),
-            intermediate_key_pkcs8_pem: int_rsa.private_key_pkcs8_pem().to_string(),
-
-            leaf_cert_der: Arc::from(leaf_cert.der().as_ref()),
-            leaf_cert_pem: leaf_cert.pem(),
-            leaf_key_pkcs8_der: Arc::from(leaf_rsa.private_key_pkcs8_der()),
-            leaf_key_pkcs8_pem: leaf_rsa.private_key_pkcs8_pem().to_string(),
-
-            crl_der,
-            crl_pem,
-        }
-    })
 }
 
 #[cfg(test)]

--- a/crates/uselesskey-x509/src/srp/chain/crl.rs
+++ b/crates/uselesskey-x509/src/srp/chain/crl.rs
@@ -1,0 +1,69 @@
+//! Certificate revocation list generation for X.509 chain negatives.
+
+use std::sync::Arc;
+
+use rand_core::RngCore;
+use rcgen::{
+    CertificateParams, CertificateRevocationListParams, Issuer, KeyPair, RevocationReason,
+    RevokedCertParams, SerialNumber,
+};
+use time::{Duration as TimeDuration, OffsetDateTime};
+
+use crate::srp::derive::deterministic_serial_number_with_rng;
+
+pub(crate) struct RevocationListBytes {
+    pub(crate) der: Arc<[u8]>,
+    pub(crate) pem: String,
+}
+
+pub(crate) fn maybe_revoked_leaf_crl<R: RngCore>(
+    variant: &str,
+    leaf_serial: SerialNumber,
+    base_time: OffsetDateTime,
+    intermediate_params: &CertificateParams,
+    intermediate_key: &KeyPair,
+    rng: &mut R,
+) -> Option<RevocationListBytes> {
+    (variant == "revoked_leaf").then(|| {
+        revoked_leaf_crl(
+            leaf_serial,
+            base_time,
+            intermediate_params,
+            intermediate_key,
+            rng,
+        )
+    })
+}
+
+fn revoked_leaf_crl<R: RngCore>(
+    leaf_serial: SerialNumber,
+    base_time: OffsetDateTime,
+    intermediate_params: &CertificateParams,
+    intermediate_key: &KeyPair,
+    rng: &mut R,
+) -> RevocationListBytes {
+    let crl_number = deterministic_serial_number_with_rng(|bytes| rng.fill_bytes(bytes));
+    let revoked = RevokedCertParams {
+        serial_number: leaf_serial,
+        revocation_time: base_time,
+        reason_code: Some(RevocationReason::KeyCompromise),
+        invalidity_date: None,
+    };
+
+    let crl_params = CertificateRevocationListParams {
+        this_update: base_time,
+        next_update: base_time + TimeDuration::days(30),
+        crl_number,
+        issuing_distribution_point: None,
+        revoked_certs: vec![revoked],
+        key_identifier_method: rcgen::KeyIdMethod::Sha256,
+    };
+
+    let issuer = Issuer::from_params(intermediate_params, intermediate_key);
+    let crl = crl_params.signed_by(&issuer).expect("CRL gen");
+
+    RevocationListBytes {
+        der: Arc::from(crl.der().as_ref()),
+        pem: crl.pem().expect("CRL PEM"),
+    }
+}

--- a/crates/uselesskey-x509/src/srp/chain/keys.rs
+++ b/crates/uselesskey-x509/src/srp/chain/keys.rs
@@ -1,0 +1,46 @@
+//! RSA key material loading for X.509 chains.
+
+use rcgen::{KeyPair, PKCS_RSA_SHA256};
+use rustls_pki_types::PrivatePkcs8KeyDer;
+use uselesskey_core::Factory;
+use uselesskey_rsa::{RsaFactoryExt, RsaKeyPair, RsaSpec};
+
+use crate::srp::spec::ChainSpec;
+
+pub(crate) struct ChainKeys {
+    pub(crate) root_rsa: RsaKeyPair,
+    pub(crate) intermediate_rsa: RsaKeyPair,
+    pub(crate) leaf_rsa: RsaKeyPair,
+    pub(crate) root_kp: KeyPair,
+    pub(crate) intermediate_kp: KeyPair,
+    pub(crate) leaf_kp: KeyPair,
+}
+
+pub(crate) fn load_chain_keys(factory: &Factory, label: &str, spec: &ChainSpec) -> ChainKeys {
+    let rsa_spec = RsaSpec::new(spec.rsa_bits);
+
+    let root_rsa = factory.rsa(format!("{label}-chain-root"), rsa_spec);
+    let intermediate_rsa = factory.rsa(format!("{label}-chain-intermediate"), rsa_spec);
+    let leaf_rsa = factory.rsa(format!("{label}-chain-leaf"), rsa_spec);
+
+    let root_kp = key_pair_from_rsa(&root_rsa, "root");
+    let intermediate_kp = key_pair_from_rsa(&intermediate_rsa, "intermediate");
+    let leaf_kp = key_pair_from_rsa(&leaf_rsa, "leaf");
+
+    ChainKeys {
+        root_rsa,
+        intermediate_rsa,
+        leaf_rsa,
+        root_kp,
+        intermediate_kp,
+        leaf_kp,
+    }
+}
+
+fn key_pair_from_rsa(rsa: &RsaKeyPair, role: &str) -> KeyPair {
+    KeyPair::from_pkcs8_der_and_sign_algo(
+        &PrivatePkcs8KeyDer::from(rsa.private_key_pkcs8_der().to_vec()),
+        &PKCS_RSA_SHA256,
+    )
+    .unwrap_or_else(|_| panic!("{role} key parse"))
+}

--- a/crates/uselesskey-x509/src/srp/chain/mod.rs
+++ b/crates/uselesskey-x509/src/srp/chain/mod.rs
@@ -1,0 +1,105 @@
+//! SRP components for X.509 certificate chain generation.
+
+use std::sync::Arc;
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use rcgen::{Certificate, Issuer};
+use uselesskey_core::Factory;
+
+use crate::chain::{ChainInner, DOMAIN_X509_CHAIN};
+use crate::srp::chain::crl::maybe_revoked_leaf_crl;
+use crate::srp::chain::keys::load_chain_keys;
+use crate::srp::chain::params::build_chain_params;
+use crate::srp::derive::deterministic_base_time_from_parts;
+use crate::srp::spec::ChainSpec;
+
+mod crl;
+mod keys;
+mod params;
+
+pub(crate) fn load_chain_inner(
+    factory: &Factory,
+    label: &str,
+    spec: &ChainSpec,
+    variant: &str,
+) -> Arc<ChainInner> {
+    let spec_bytes = spec.stable_bytes();
+
+    factory.get_or_init(DOMAIN_X509_CHAIN, label, &spec_bytes, variant, |seed| {
+        generate_chain_inner(factory, label, spec, variant, seed.bytes())
+    })
+}
+
+fn generate_chain_inner(
+    factory: &Factory,
+    label: &str,
+    spec: &ChainSpec,
+    variant: &str,
+    seed: &[u8; 32],
+) -> ChainInner {
+    let mut rng = ChaCha20Rng::from_seed(*seed);
+    let keys = load_chain_keys(factory, label, spec);
+    let base_time = chain_base_time(label, spec);
+    let params = build_chain_params(spec, base_time, &mut rng);
+
+    let root_cert = params
+        .root
+        .self_signed(&keys.root_kp)
+        .expect("root cert gen");
+
+    let root_issuer = Issuer::from_params(&params.root, &keys.root_kp);
+    let intermediate_cert = params
+        .intermediate
+        .signed_by(&keys.intermediate_kp, &root_issuer)
+        .expect("intermediate cert gen");
+
+    let intermediate_issuer = Issuer::from_params(&params.intermediate, &keys.intermediate_kp);
+    let leaf_cert = params
+        .leaf
+        .signed_by(&keys.leaf_kp, &intermediate_issuer)
+        .expect("leaf cert gen");
+
+    let crl = maybe_revoked_leaf_crl(
+        variant,
+        params.leaf_serial,
+        base_time,
+        &params.intermediate,
+        &keys.intermediate_kp,
+        &mut rng,
+    );
+
+    ChainInner {
+        root_cert_der: cert_der(&root_cert),
+        root_cert_pem: root_cert.pem(),
+        root_key_pkcs8_der: Arc::from(keys.root_rsa.private_key_pkcs8_der()),
+        root_key_pkcs8_pem: keys.root_rsa.private_key_pkcs8_pem().to_string(),
+
+        intermediate_cert_der: cert_der(&intermediate_cert),
+        intermediate_cert_pem: intermediate_cert.pem(),
+        intermediate_key_pkcs8_der: Arc::from(keys.intermediate_rsa.private_key_pkcs8_der()),
+        intermediate_key_pkcs8_pem: keys.intermediate_rsa.private_key_pkcs8_pem().to_string(),
+
+        leaf_cert_der: cert_der(&leaf_cert),
+        leaf_cert_pem: leaf_cert.pem(),
+        leaf_key_pkcs8_der: Arc::from(keys.leaf_rsa.private_key_pkcs8_der()),
+        leaf_key_pkcs8_pem: keys.leaf_rsa.private_key_pkcs8_pem().to_string(),
+
+        crl_der: crl.as_ref().map(|crl| crl.der.clone()),
+        crl_pem: crl.map(|crl| crl.pem),
+    }
+}
+
+fn chain_base_time(label: &str, spec: &ChainSpec) -> time::OffsetDateTime {
+    let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
+    deterministic_base_time_from_parts(&[
+        label.as_bytes(),
+        spec.leaf_cn.as_bytes(),
+        spec.root_cn.as_bytes(),
+        &rsa_bits,
+    ])
+}
+
+fn cert_der(cert: &Certificate) -> Arc<[u8]> {
+    Arc::from(cert.der().as_ref())
+}

--- a/crates/uselesskey-x509/src/srp/chain/params.rs
+++ b/crates/uselesskey-x509/src/srp/chain/params.rs
@@ -1,0 +1,143 @@
+//! Certificate parameter construction for X.509 chains.
+
+use rand_core::RngCore;
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+    SerialNumber,
+};
+use time::{Duration as TimeDuration, OffsetDateTime};
+
+use crate::srp::derive::deterministic_serial_number_with_rng;
+use crate::srp::spec::{ChainSpec, KeyUsage, NotBeforeOffset};
+
+pub(crate) struct ChainParams {
+    pub(crate) root: CertificateParams,
+    pub(crate) intermediate: CertificateParams,
+    pub(crate) leaf: CertificateParams,
+    pub(crate) leaf_serial: SerialNumber,
+}
+
+pub(crate) fn build_chain_params<R: RngCore>(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut R,
+) -> ChainParams {
+    let root = build_root_params(spec, base_time, rng);
+    let intermediate = build_intermediate_params(spec, base_time, rng);
+    let leaf = build_leaf_params(spec, base_time, rng);
+    let leaf_serial = leaf.serial_number.clone().expect("leaf serial number");
+
+    ChainParams {
+        root,
+        intermediate,
+        leaf,
+        leaf_serial,
+    }
+}
+
+fn build_root_params<R: RngCore>(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut R,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.root_cn.clone());
+    params.is_ca = IsCa::Ca(BasicConstraints::Constrained(1));
+    params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+    params.not_before = base_time - TimeDuration::days(1);
+    params.not_after = params.not_before + TimeDuration::days(spec.root_validity_days as i64);
+    params.serial_number = Some(next_serial_number(rng));
+    params
+}
+
+fn build_intermediate_params<R: RngCore>(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut R,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.intermediate_cn.clone());
+    params.is_ca = if spec.intermediate_is_ca.unwrap_or(true) {
+        IsCa::Ca(BasicConstraints::Constrained(0))
+    } else {
+        IsCa::NoCa
+    };
+    params.key_usages =
+        key_usage_purposes(spec.intermediate_key_usage.unwrap_or_else(KeyUsage::ca));
+    params.not_before = apply_not_before(base_time, spec.intermediate_not_before);
+    params.not_after =
+        params.not_before + TimeDuration::days(spec.intermediate_validity_days as i64);
+    params.serial_number = Some(next_serial_number(rng));
+    params
+}
+
+fn build_leaf_params<R: RngCore>(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut R,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.leaf_cn.clone());
+    params.is_ca = IsCa::NoCa;
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+    params.extended_key_usages = vec![
+        ExtendedKeyUsagePurpose::ServerAuth,
+        ExtendedKeyUsagePurpose::ClientAuth,
+    ];
+    params.subject_alt_names = sorted_leaf_sans(spec);
+    params.not_before = apply_not_before(base_time, spec.leaf_not_before);
+    params.not_after = params.not_before + TimeDuration::days(spec.leaf_validity_days as i64);
+    params.serial_number = Some(next_serial_number(rng));
+    params
+}
+
+fn sorted_leaf_sans(spec: &ChainSpec) -> Vec<rcgen::SanType> {
+    let mut sorted_sans = spec.leaf_sans.clone();
+    sorted_sans.sort();
+    sorted_sans.dedup();
+    sorted_sans
+        .into_iter()
+        .map(|san| rcgen::SanType::DnsName(san.try_into().expect("valid DNS name")))
+        .collect()
+}
+
+fn apply_not_before(base_time: OffsetDateTime, offset: Option<NotBeforeOffset>) -> OffsetDateTime {
+    match offset.unwrap_or(NotBeforeOffset::DaysAgo(1)) {
+        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
+        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
+    }
+}
+
+fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
+    let mut purposes = Vec::new();
+    if key_usage.key_cert_sign {
+        purposes.push(KeyUsagePurpose::KeyCertSign);
+    }
+    if key_usage.crl_sign {
+        purposes.push(KeyUsagePurpose::CrlSign);
+    }
+    if key_usage.digital_signature {
+        purposes.push(KeyUsagePurpose::DigitalSignature);
+    }
+    if key_usage.key_encipherment {
+        purposes.push(KeyUsagePurpose::KeyEncipherment);
+    }
+    purposes
+}
+
+fn next_serial_number<R: RngCore>(rng: &mut R) -> SerialNumber {
+    deterministic_serial_number_with_rng(|bytes| rng.fill_bytes(bytes))
+}

--- a/crates/uselesskey-x509/src/srp/mod.rs
+++ b/crates/uselesskey-x509/src/srp/mod.rs
@@ -1,5 +1,6 @@
 //! Single-responsibility internals for X.509 fixture generation.
 
+pub(crate) mod chain;
 pub mod chain_negative;
 pub mod derive;
 pub mod negative;


### PR DESCRIPTION
### Motivation

- Break a large, complex chain-generation routine into single-responsibility (SRP) submodules to improve readability and testability.
- Isolate RSA key loading, certificate-parameter construction, and CRL generation so deterministic derivation and cache identity remain stable.
- Preserve the public `X509Chain` API surface while moving orchestration details into crate-private SRP internals.

### Description

- Delegated chain construction from `crates/uselesskey-x509/src/chain.rs` to a new SRP namespace by adding `pub(crate) mod chain` in `crates/uselesskey-x509/src/srp/mod.rs` and calling `srp::chain::load_chain_inner` from `chain.rs`.
- Introduced `crates/uselesskey-x509/src/srp/chain/mod.rs` to orchestrate deterministic RNG seeding, certificate signing, and materialization into a `ChainInner` struct.
- Split responsibilities into focused SRP files: `srp/chain/keys.rs` (RSA fixture loading and `rcgen` key-pair conversion), `srp/chain/params.rs` (root/intermediate/leaf `CertificateParams`, SAN sorting, `not_before` handling, key-usage mapping), and `srp/chain/crl.rs` (revoked-leaf CRL generation).
- Made `ChainInner` crate-private (`pub(crate)`) and exposed only the unchanged `X509Chain` public API; small lints/formatting adjustments applied (e.g. string construction passed directly to `factory.rsa` to satisfy Clippy).

### Testing

- Ran `cargo test -p uselesskey-x509` and all x509 unit/integration/doctests completed successfully (all tests passed).
- Ran linting/formatting checks with `cargo xtask lint-fix --check` and fixed formatting differences with `cargo xtask lint-fix --no-clippy` where needed.
- Ran Clippy with `cargo clippy -p uselesskey-x509 --all-targets -- -D warnings` and resolved warnings; `cargo check -p uselesskey-x509` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04463621648333a7cec26b05ad258e)