### PR TITLE
SRP: extract X.509 chain generation into srp::chain_generation submodules

### DIFF
--- a/crates/uselesskey-x509/src/chain.rs
+++ b/crates/uselesskey-x509/src/chain.rs
@@ -3,25 +3,9 @@
 use std::fmt;
 use std::sync::Arc;
 
-use rand_chacha::ChaCha20Rng;
-use rand_core::RngCore;
-use rand_core::SeedableRng;
-use rcgen::{
-    BasicConstraints, CertificateParams, CertificateRevocationListParams, DnType,
-    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, PKCS_RSA_SHA256,
-    RevocationReason, RevokedCertParams,
-};
-use rustls_pki_types::PrivatePkcs8KeyDer;
-use time::Duration as TimeDuration;
-use time::OffsetDateTime;
+use crate::srp::spec::ChainSpec;
 use uselesskey_core::sink::TempArtifact;
 use uselesskey_core::{Error, Factory};
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
-
-use crate::srp::derive::{
-    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
-};
-use crate::srp::spec::{ChainSpec, KeyUsage, NotBeforeOffset};
 
 /// Cache domain for X.509 certificate chain fixtures.
 ///
@@ -37,24 +21,24 @@ pub struct X509Chain {
     inner: Arc<ChainInner>,
 }
 
-struct ChainInner {
-    root_cert_der: Arc<[u8]>,
-    root_cert_pem: String,
-    root_key_pkcs8_der: Arc<[u8]>,
-    root_key_pkcs8_pem: String,
+pub(crate) struct ChainInner {
+    pub(crate) root_cert_der: Arc<[u8]>,
+    pub(crate) root_cert_pem: String,
+    pub(crate) root_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) root_key_pkcs8_pem: String,
 
-    intermediate_cert_der: Arc<[u8]>,
-    intermediate_cert_pem: String,
-    intermediate_key_pkcs8_der: Arc<[u8]>,
-    intermediate_key_pkcs8_pem: String,
+    pub(crate) intermediate_cert_der: Arc<[u8]>,
+    pub(crate) intermediate_cert_pem: String,
+    pub(crate) intermediate_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) intermediate_key_pkcs8_pem: String,
 
-    leaf_cert_der: Arc<[u8]>,
-    leaf_cert_pem: String,
-    leaf_key_pkcs8_der: Arc<[u8]>,
-    leaf_key_pkcs8_pem: String,
+    pub(crate) leaf_cert_der: Arc<[u8]>,
+    pub(crate) leaf_cert_pem: String,
+    pub(crate) leaf_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) leaf_key_pkcs8_pem: String,
 
-    crl_der: Option<Arc<[u8]>>,
-    crl_pem: Option<String>,
+    pub(crate) crl_der: Option<Arc<[u8]>>,
+    pub(crate) crl_pem: Option<String>,
 }
 
 impl fmt::Debug for X509Chain {
@@ -548,219 +532,13 @@ impl X509Chain {
     }
 }
 
-fn apply_not_before(base_time: OffsetDateTime, offset: Option<NotBeforeOffset>) -> OffsetDateTime {
-    match offset.unwrap_or(NotBeforeOffset::DaysAgo(1)) {
-        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
-        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
-    }
-}
-
-fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
-    let mut purposes = Vec::new();
-    if key_usage.key_cert_sign {
-        purposes.push(KeyUsagePurpose::KeyCertSign);
-    }
-    if key_usage.crl_sign {
-        purposes.push(KeyUsagePurpose::CrlSign);
-    }
-    if key_usage.digital_signature {
-        purposes.push(KeyUsagePurpose::DigitalSignature);
-    }
-    if key_usage.key_encipherment {
-        purposes.push(KeyUsagePurpose::KeyEncipherment);
-    }
-    purposes
-}
-
 fn load_chain_inner(
     factory: &Factory,
     label: &str,
     spec: &ChainSpec,
     variant: &str,
 ) -> Arc<ChainInner> {
-    let spec_bytes = spec.stable_bytes();
-
-    factory.get_or_init(DOMAIN_X509_CHAIN, label, &spec_bytes, variant, |seed| {
-        let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
-        let rsa_spec = RsaSpec::new(spec.rsa_bits);
-
-        // Generate 3 RSA keypairs with role-tagged labels
-        let root_key_label = format!("{}-chain-root", label);
-        let int_key_label = format!("{}-chain-intermediate", label);
-        let leaf_key_label = format!("{}-chain-leaf", label);
-
-        let root_rsa = factory.rsa(&root_key_label, rsa_spec);
-        let int_rsa = factory.rsa(&int_key_label, rsa_spec);
-        let leaf_rsa = factory.rsa(&leaf_key_label, rsa_spec);
-
-        // Convert to rcgen KeyPairs
-        let root_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(root_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("root key parse");
-
-        let int_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(int_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("intermediate key parse");
-
-        let leaf_kp = KeyPair::from_pkcs8_der_and_sign_algo(
-            &PrivatePkcs8KeyDer::from(leaf_rsa.private_key_pkcs8_der().to_vec()),
-            &PKCS_RSA_SHA256,
-        )
-        .expect("leaf key parse");
-
-        // Deterministic base time for the chain
-        let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
-        let base_time = deterministic_base_time_from_parts(&[
-            label.as_bytes(),
-            spec.leaf_cn.as_bytes(),
-            spec.root_cn.as_bytes(),
-            &rsa_bits,
-        ]);
-
-        // --- Root CA ---
-        let mut root_params = CertificateParams::default();
-        root_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.root_cn.clone());
-        root_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(1));
-        root_params.key_usages = vec![
-            KeyUsagePurpose::KeyCertSign,
-            KeyUsagePurpose::CrlSign,
-            KeyUsagePurpose::DigitalSignature,
-        ];
-        root_params.not_before = base_time - TimeDuration::days(1);
-        root_params.not_after =
-            root_params.not_before + TimeDuration::days(spec.root_validity_days as i64);
-        root_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let root_cert = root_params.self_signed(&root_kp).expect("root cert gen");
-
-        // --- Intermediate CA ---
-        let mut int_params = CertificateParams::default();
-        int_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.intermediate_cn.clone());
-        let intermediate_is_ca = spec.intermediate_is_ca.unwrap_or(true);
-        int_params.is_ca = if intermediate_is_ca {
-            IsCa::Ca(BasicConstraints::Constrained(0))
-        } else {
-            IsCa::NoCa
-        };
-        int_params.key_usages =
-            key_usage_purposes(spec.intermediate_key_usage.unwrap_or_else(KeyUsage::ca));
-        int_params.not_before = apply_not_before(base_time, spec.intermediate_not_before);
-        int_params.not_after =
-            int_params.not_before + TimeDuration::days(spec.intermediate_validity_days as i64);
-        int_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let root_issuer = Issuer::from_params(&root_params, &root_kp);
-        let int_cert = int_params
-            .signed_by(&int_kp, &root_issuer)
-            .expect("intermediate cert gen");
-
-        // --- Leaf ---
-        let mut leaf_params = CertificateParams::default();
-        leaf_params
-            .distinguished_name
-            .push(DnType::CommonName, spec.leaf_cn.clone());
-        leaf_params.is_ca = IsCa::NoCa;
-        leaf_params.key_usages = vec![
-            KeyUsagePurpose::DigitalSignature,
-            KeyUsagePurpose::KeyEncipherment,
-        ];
-        leaf_params.extended_key_usages = vec![
-            ExtendedKeyUsagePurpose::ServerAuth,
-            ExtendedKeyUsagePurpose::ClientAuth,
-        ];
-
-        // Add SANs (sorted and deduplicated to match stable_bytes)
-        let mut sorted_sans = spec.leaf_sans.clone();
-        sorted_sans.sort();
-        sorted_sans.dedup();
-        for san in &sorted_sans {
-            leaf_params.subject_alt_names.push(rcgen::SanType::DnsName(
-                san.clone().try_into().expect("valid DNS name"),
-            ));
-        }
-
-        leaf_params.not_before = apply_not_before(base_time, spec.leaf_not_before);
-        leaf_params.not_after =
-            leaf_params.not_before + TimeDuration::days(spec.leaf_validity_days as i64);
-        leaf_params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        let leaf_serial = leaf_params
-            .serial_number
-            .clone()
-            .expect("leaf serial number");
-
-        let int_issuer = Issuer::from_params(&int_params, &int_kp);
-        let leaf_cert = leaf_params
-            .signed_by(&leaf_kp, &int_issuer)
-            .expect("leaf cert gen");
-
-        // --- CRL (only for revoked_leaf variant) ---
-        let (crl_der, crl_pem) = if variant == "revoked_leaf" {
-            let crl_number = deterministic_serial_number_with_rng(|bytes| {
-                rng.fill_bytes(bytes);
-            });
-
-            let revoked = RevokedCertParams {
-                serial_number: leaf_serial,
-                revocation_time: base_time,
-                reason_code: Some(RevocationReason::KeyCompromise),
-                invalidity_date: None,
-            };
-
-            let crl_params = CertificateRevocationListParams {
-                this_update: base_time,
-                next_update: base_time + TimeDuration::days(30),
-                crl_number,
-                issuing_distribution_point: None,
-                revoked_certs: vec![revoked],
-                key_identifier_method: rcgen::KeyIdMethod::Sha256,
-            };
-
-            let int_issuer = Issuer::from_params(&int_params, &int_kp);
-            let crl = crl_params.signed_by(&int_issuer).expect("CRL gen");
-
-            (
-                Some(Arc::from(crl.der().as_ref())),
-                Some(crl.pem().expect("CRL PEM")),
-            )
-        } else {
-            (None, None)
-        };
-
-        ChainInner {
-            root_cert_der: Arc::from(root_cert.der().as_ref()),
-            root_cert_pem: root_cert.pem(),
-            root_key_pkcs8_der: Arc::from(root_rsa.private_key_pkcs8_der()),
-            root_key_pkcs8_pem: root_rsa.private_key_pkcs8_pem().to_string(),
-
-            intermediate_cert_der: Arc::from(int_cert.der().as_ref()),
-            intermediate_cert_pem: int_cert.pem(),
-            intermediate_key_pkcs8_der: Arc::from(int_rsa.private_key_pkcs8_der()),
-            intermediate_key_pkcs8_pem: int_rsa.private_key_pkcs8_pem().to_string(),
-
-            leaf_cert_der: Arc::from(leaf_cert.der().as_ref()),
-            leaf_cert_pem: leaf_cert.pem(),
-            leaf_key_pkcs8_der: Arc::from(leaf_rsa.private_key_pkcs8_der()),
-            leaf_key_pkcs8_pem: leaf_rsa.private_key_pkcs8_pem().to_string(),
-
-            crl_der,
-            crl_pem,
-        }
-    })
+    crate::srp::chain_generation::load_inner(factory, label, spec, variant)
 }
 
 #[cfg(test)]

--- a/crates/uselesskey-x509/src/srp/chain_generation/crl.rs
+++ b/crates/uselesskey-x509/src/srp/chain_generation/crl.rs
@@ -1,0 +1,50 @@
+//! Certificate revocation list generation for X.509 chain negative fixtures.
+
+use std::sync::Arc;
+
+use rand_core::RngCore;
+use rcgen::{
+    CertificateParams, CertificateRevocationListParams, Issuer, KeyPair, RevocationReason,
+    RevokedCertParams, SerialNumber,
+};
+use time::Duration as TimeDuration;
+use time::OffsetDateTime;
+
+use super::params;
+
+pub(crate) fn revoked_leaf<R: RngCore>(
+    variant: &str,
+    rng: &mut R,
+    base_time: OffsetDateTime,
+    leaf_serial: SerialNumber,
+    intermediate_params: &CertificateParams,
+    intermediate_key_pair: &KeyPair,
+) -> (Option<Arc<[u8]>>, Option<String>) {
+    if variant != "revoked_leaf" {
+        return (None, None);
+    }
+
+    let revoked = RevokedCertParams {
+        serial_number: leaf_serial,
+        revocation_time: base_time,
+        reason_code: Some(RevocationReason::KeyCompromise),
+        invalidity_date: None,
+    };
+
+    let crl_params = CertificateRevocationListParams {
+        this_update: base_time,
+        next_update: base_time + TimeDuration::days(30),
+        crl_number: params::serial_number(rng),
+        issuing_distribution_point: None,
+        revoked_certs: vec![revoked],
+        key_identifier_method: rcgen::KeyIdMethod::Sha256,
+    };
+
+    let int_issuer = Issuer::from_params(intermediate_params, intermediate_key_pair);
+    let crl = crl_params.signed_by(&int_issuer).expect("CRL gen");
+
+    (
+        Some(Arc::from(crl.der().as_ref())),
+        Some(crl.pem().expect("CRL PEM")),
+    )
+}

--- a/crates/uselesskey-x509/src/srp/chain_generation/keys.rs
+++ b/crates/uselesskey-x509/src/srp/chain_generation/keys.rs
@@ -1,0 +1,44 @@
+//! Key generation and rcgen key parsing for X.509 chains.
+
+use rcgen::{KeyPair, PKCS_RSA_SHA256};
+use rustls_pki_types::PrivatePkcs8KeyDer;
+use uselesskey_core::Factory;
+use uselesskey_rsa::{RsaFactoryExt, RsaKeyPair, RsaSpec};
+
+pub(crate) struct ChainKeys {
+    pub(crate) root_rsa: RsaKeyPair,
+    pub(crate) intermediate_rsa: RsaKeyPair,
+    pub(crate) leaf_rsa: RsaKeyPair,
+    pub(crate) root_key_pair: KeyPair,
+    pub(crate) intermediate_key_pair: KeyPair,
+    pub(crate) leaf_key_pair: KeyPair,
+}
+
+pub(crate) fn generate(factory: &Factory, label: &str, rsa_bits: usize) -> ChainKeys {
+    let rsa_spec = RsaSpec::new(rsa_bits);
+
+    let root_rsa = factory.rsa(format!("{label}-chain-root"), rsa_spec);
+    let intermediate_rsa = factory.rsa(format!("{label}-chain-intermediate"), rsa_spec);
+    let leaf_rsa = factory.rsa(format!("{label}-chain-leaf"), rsa_spec);
+
+    let root_key_pair = parse_pkcs8_key(&root_rsa, "root");
+    let intermediate_key_pair = parse_pkcs8_key(&intermediate_rsa, "intermediate");
+    let leaf_key_pair = parse_pkcs8_key(&leaf_rsa, "leaf");
+
+    ChainKeys {
+        root_rsa,
+        intermediate_rsa,
+        leaf_rsa,
+        root_key_pair,
+        intermediate_key_pair,
+        leaf_key_pair,
+    }
+}
+
+fn parse_pkcs8_key(key: &RsaKeyPair, role: &str) -> KeyPair {
+    KeyPair::from_pkcs8_der_and_sign_algo(
+        &PrivatePkcs8KeyDer::from(key.private_key_pkcs8_der().to_vec()),
+        &PKCS_RSA_SHA256,
+    )
+    .unwrap_or_else(|_| panic!("{role} key parse"))
+}

--- a/crates/uselesskey-x509/src/srp/chain_generation/mod.rs
+++ b/crates/uselesskey-x509/src/srp/chain_generation/mod.rs
@@ -1,0 +1,77 @@
+//! Single-responsibility chain generation orchestration.
+
+mod crl;
+mod keys;
+mod params;
+
+use std::sync::Arc;
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use rcgen::Issuer;
+use uselesskey_core::Factory;
+
+use crate::chain::{ChainInner, DOMAIN_X509_CHAIN};
+use crate::srp::spec::ChainSpec;
+
+pub(crate) fn load_inner(
+    factory: &Factory,
+    label: &str,
+    spec: &ChainSpec,
+    variant: &str,
+) -> Arc<ChainInner> {
+    let spec_bytes = spec.stable_bytes();
+
+    factory.get_or_init(DOMAIN_X509_CHAIN, label, &spec_bytes, variant, |seed| {
+        let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
+        let keys = keys::generate(factory, label, spec.rsa_bits);
+        let base_time = params::base_time(label, spec);
+
+        let root_params = params::root(spec, base_time, &mut rng);
+        let root_cert = root_params
+            .self_signed(&keys.root_key_pair)
+            .expect("root cert gen");
+
+        let intermediate_params = params::intermediate(spec, base_time, &mut rng);
+        let root_issuer = Issuer::from_params(&root_params, &keys.root_key_pair);
+        let intermediate_cert = intermediate_params
+            .signed_by(&keys.intermediate_key_pair, &root_issuer)
+            .expect("intermediate cert gen");
+
+        let (leaf_params, leaf_serial) = params::leaf(spec, base_time, &mut rng);
+        let intermediate_issuer =
+            Issuer::from_params(&intermediate_params, &keys.intermediate_key_pair);
+        let leaf_cert = leaf_params
+            .signed_by(&keys.leaf_key_pair, &intermediate_issuer)
+            .expect("leaf cert gen");
+
+        let (crl_der, crl_pem) = crl::revoked_leaf(
+            variant,
+            &mut rng,
+            base_time,
+            leaf_serial,
+            &intermediate_params,
+            &keys.intermediate_key_pair,
+        );
+
+        ChainInner {
+            root_cert_der: Arc::from(root_cert.der().as_ref()),
+            root_cert_pem: root_cert.pem(),
+            root_key_pkcs8_der: Arc::from(keys.root_rsa.private_key_pkcs8_der()),
+            root_key_pkcs8_pem: keys.root_rsa.private_key_pkcs8_pem().to_string(),
+
+            intermediate_cert_der: Arc::from(intermediate_cert.der().as_ref()),
+            intermediate_cert_pem: intermediate_cert.pem(),
+            intermediate_key_pkcs8_der: Arc::from(keys.intermediate_rsa.private_key_pkcs8_der()),
+            intermediate_key_pkcs8_pem: keys.intermediate_rsa.private_key_pkcs8_pem().to_string(),
+
+            leaf_cert_der: Arc::from(leaf_cert.der().as_ref()),
+            leaf_cert_pem: leaf_cert.pem(),
+            leaf_key_pkcs8_der: Arc::from(keys.leaf_rsa.private_key_pkcs8_der()),
+            leaf_key_pkcs8_pem: keys.leaf_rsa.private_key_pkcs8_pem().to_string(),
+
+            crl_der,
+            crl_pem,
+        }
+    })
+}

--- a/crates/uselesskey-x509/src/srp/chain_generation/params.rs
+++ b/crates/uselesskey-x509/src/srp/chain_generation/params.rs
@@ -1,0 +1,133 @@
+//! Certificate parameter builders for the chain roles.
+
+use rand_core::RngCore;
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+    SerialNumber,
+};
+use time::Duration as TimeDuration;
+use time::OffsetDateTime;
+
+use crate::srp::derive::{
+    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
+};
+use crate::srp::spec::{ChainSpec, KeyUsage, NotBeforeOffset};
+
+pub(crate) fn base_time(label: &str, spec: &ChainSpec) -> OffsetDateTime {
+    let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
+    deterministic_base_time_from_parts(&[
+        label.as_bytes(),
+        spec.leaf_cn.as_bytes(),
+        spec.root_cn.as_bytes(),
+        &rsa_bits,
+    ])
+}
+
+pub(crate) fn root<R: RngCore>(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut R,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.root_cn.clone());
+    params.is_ca = IsCa::Ca(BasicConstraints::Constrained(1));
+    params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+    params.not_before = base_time - TimeDuration::days(1);
+    params.not_after = params.not_before + TimeDuration::days(spec.root_validity_days as i64);
+    params.serial_number = Some(serial_number(rng));
+    params
+}
+
+pub(crate) fn intermediate<R: RngCore>(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut R,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.intermediate_cn.clone());
+
+    params.is_ca = if spec.intermediate_is_ca.unwrap_or(true) {
+        IsCa::Ca(BasicConstraints::Constrained(0))
+    } else {
+        IsCa::NoCa
+    };
+    params.key_usages =
+        key_usage_purposes(spec.intermediate_key_usage.unwrap_or_else(KeyUsage::ca));
+    params.not_before = apply_not_before(base_time, spec.intermediate_not_before);
+    params.not_after =
+        params.not_before + TimeDuration::days(spec.intermediate_validity_days as i64);
+    params.serial_number = Some(serial_number(rng));
+    params
+}
+
+pub(crate) fn leaf<R: RngCore>(
+    spec: &ChainSpec,
+    base_time: OffsetDateTime,
+    rng: &mut R,
+) -> (CertificateParams, SerialNumber) {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.leaf_cn.clone());
+    params.is_ca = IsCa::NoCa;
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+    params.extended_key_usages = vec![
+        ExtendedKeyUsagePurpose::ServerAuth,
+        ExtendedKeyUsagePurpose::ClientAuth,
+    ];
+
+    let mut sorted_sans = spec.leaf_sans.clone();
+    sorted_sans.sort();
+    sorted_sans.dedup();
+    for san in &sorted_sans {
+        params.subject_alt_names.push(rcgen::SanType::DnsName(
+            san.clone().try_into().expect("valid DNS name"),
+        ));
+    }
+
+    params.not_before = apply_not_before(base_time, spec.leaf_not_before);
+    params.not_after = params.not_before + TimeDuration::days(spec.leaf_validity_days as i64);
+    params.serial_number = Some(serial_number(rng));
+
+    let serial = params.serial_number.clone().expect("leaf serial number");
+    (params, serial)
+}
+
+pub(crate) fn serial_number<R: RngCore>(rng: &mut R) -> SerialNumber {
+    deterministic_serial_number_with_rng(|bytes| rng.fill_bytes(bytes))
+}
+
+fn apply_not_before(base_time: OffsetDateTime, offset: Option<NotBeforeOffset>) -> OffsetDateTime {
+    match offset.unwrap_or(NotBeforeOffset::DaysAgo(1)) {
+        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
+        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
+    }
+}
+
+fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
+    let mut purposes = Vec::new();
+    if key_usage.key_cert_sign {
+        purposes.push(KeyUsagePurpose::KeyCertSign);
+    }
+    if key_usage.crl_sign {
+        purposes.push(KeyUsagePurpose::CrlSign);
+    }
+    if key_usage.digital_signature {
+        purposes.push(KeyUsagePurpose::DigitalSignature);
+    }
+    if key_usage.key_encipherment {
+        purposes.push(KeyUsagePurpose::KeyEncipherment);
+    }
+    purposes
+}

--- a/crates/uselesskey-x509/src/srp/mod.rs
+++ b/crates/uselesskey-x509/src/srp/mod.rs
@@ -1,5 +1,6 @@
 //! Single-responsibility internals for X.509 fixture generation.
 
+pub mod chain_generation;
 pub mod chain_negative;
 pub mod derive;
 pub mod negative;


### PR DESCRIPTION
### Motivation

- Reduce complexity in `crates/uselesskey-x509/src/chain.rs` by moving a large, multi-responsibility generation routine into focused single-responsibility (SRP) submodules. 
- Make key generation/parsing, certificate-parameter construction, and CRL creation easier to reason about, test, and maintain while preserving deterministic derivation and cache identity.

### Description

- Added a new SRP module `crate::srp::chain_generation` with `mod.rs`, `keys.rs`, `params.rs`, and `crl.rs` to handle orchestration, RSA key parsing, certificate parameter builders, and revoked-CRL generation respectively, and wired it into `chain.rs` via `srp::chain_generation::load_inner`.
- Simplified `crates/uselesskey-x509/src/chain.rs` so `X509Chain` retains the public data/accessor surface and delegates cache-backed generation to the new SRP module, and made `ChainInner` fields `pub(crate)` so the generator can populate them.
- Preserved deterministic behavior: RNG seeding, `DOMAIN_X509_CHAIN` cache identity, SAN sorting/deduplication, and negative-variant support (e.g. `revoked_leaf`) remain unchanged.
- Small dependency/version updates landed in `fuzz/Cargo.lock` as part of the workspace resolution (blake3/cpufeatures/uselesskey version bumps seen in the diff).

### Testing

- Ran `cargo check -p uselesskey-x509` and it completed successfully.
- Ran `cargo test -p uselesskey-x509` and all unit/integration tests passed for the x509 crate.
- Ran `cargo xtask lint-fix --check` (format + clippy) and the lint/format checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04463621648333a7cec26b05ad258e)