### PR TITLE
docs(spec): add public claim ledger

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -36,3 +36,4 @@ public crate-surface cleanup.
 ## Current Specs
 
 - [USELESSKEY-SPEC-0001: Source-of-truth model](USELESSKEY-SPEC-0001-source-of-truth-model.md)
+- [USELESSKEY-SPEC-0002: Public claim ledger](USELESSKEY-SPEC-0002-public-claim-ledger.md)

--- a/docs/specs/USELESSKEY-SPEC-0002-public-claim-ledger.md
+++ b/docs/specs/USELESSKEY-SPEC-0002-public-claim-ledger.md
@@ -1,0 +1,204 @@
++++
+id = "USELESSKEY-SPEC-0002"
+kind = "spec"
+title = "Public claim ledger"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+milestone = "v0.9.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_adrs = []
+linked_plan = "plans/spec-system/implementation-plan.md"
+support_tier_impact = ["docs/status/PUBLIC_CLAIMS.md"]
+policy_impact = ["policy/claim-ledger.toml"]
++++
+
+# USELESSKEY-SPEC-0002: Public Claim Ledger
+
+## Problem
+
+`uselesskey` public claims need to be easy to audit. The README can say
+`scanner-safe fixtures`, `ripr+`, TLS contract pack, OIDC/JWKS contract pack,
+or crates.io smoke, but users should not have to infer which command proves
+each claim.
+
+A public claim ledger gives the repo a compact source of truth:
+
+```text
+claim -> surfaces -> proof commands -> artifacts -> docs -> release lane -> boundary
+```
+
+That keeps badge and README language small while preserving enough proof mapping
+for maintainers, users, release operators, and agents.
+
+## Behavior
+
+Public claims must be represented in `policy/claim-ledger.toml` when they are
+used by README badges, top-level docs, release notes, or release evidence.
+
+Each claim entry must identify:
+
+- a stable `id`;
+- `status`;
+- public `surfaces`;
+- at least one `proof_command`;
+- generated `artifacts` or receipts, when applicable;
+- user-facing `docs`;
+- applicable `release_lanes`;
+- an explicit `boundary`.
+
+Initial claim statuses are:
+
+| Status | Meaning |
+| --- | --- |
+| `stable` | User-facing claim that should be proven in normal PR, docs, or release evidence when touched. |
+| `release-proof` | Claim whose primary proof is an external or shipped-state release lane. |
+| `advisory` | Reviewer or agent evidence that informs work but does not make a user-facing guarantee by itself. |
+
+The human index in `docs/status/PUBLIC_CLAIMS.md` must summarize the same
+claims without replacing the TOML ledger. The Markdown page is for readers; the
+TOML file is the future parser target for `cargo xtask spec-check`.
+
+The ledger is allowed to reference commands that already exist but are too
+expensive for every PR. It must still name the lane where the command belongs.
+For example, `cargo xtask cratesio-smoke --version 0.8.0` is a release-proof
+claim, not a cheap PR check.
+
+## Non-goals
+
+This spec does not make every claim blocking in every PR.
+
+This spec does not add new fixture profiles, new badge endpoints, or new
+release commands.
+
+This spec does not claim `policy/claim-ledger.toml` is enforced yet. Enforcement
+belongs to the future `cargo xtask spec-check` command.
+
+This spec does not turn advisory `ripr` PR evidence into a public product
+guarantee.
+
+## Required Evidence
+
+Current docs and generated endpoint checks:
+
+```bash
+cargo xtask badges --check
+cargo xtask scanner-safe-reference --check
+cargo xtask docs-sync --check
+git diff --check
+```
+
+When validating release-facing claims, use the claim-specific commands recorded
+in `policy/claim-ledger.toml`, such as:
+
+```bash
+cargo xtask bundle-proof --profile tls --out target/release-evidence/tls
+cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc
+cargo xtask cratesio-smoke --version 0.8.0
+```
+
+When `spec-check` exists, it must validate that every ledger entry has at least
+one proof command and a non-empty boundary.
+
+## Acceptance
+
+This spec is accepted when:
+
+- it defines the required fields for public claim entries;
+- `policy/claim-ledger.toml` seeds the current public claims;
+- `docs/status/PUBLIC_CLAIMS.md` gives readers a compact index;
+- claim boundaries separate fixture safety from production security.
+
+This spec is implemented when:
+
+- `cargo xtask spec-check` parses and validates `policy/claim-ledger.toml`;
+- release evidence can report claim-ledger coverage;
+- README claims all map to ledger entries or explicitly explain why no ledger
+  entry is needed.
+
+## Acceptance Examples
+
+Example: scanner-safe fixtures.
+
+```toml
+[[claim]]
+id = "scanner-safe-fixtures"
+status = "stable"
+proof_commands = [
+  "cargo xtask scanner-safe-reference --check",
+  "cargo xtask no-blob",
+  "cargo xtask badges --check",
+]
+boundary = "Scanner-safe fixture material does not mean every encoded export is safe to commit."
+```
+
+Example: PR review evidence.
+
+```toml
+[[claim]]
+id = "ripr-pr-review-evidence"
+status = "advisory"
+proof_commands = [
+  "cargo xtask ripr-pr --check",
+  "cargo xtask ripr-review-comments --check",
+]
+boundary = "PR evidence is diff-scoped and advisory; it is not the repo-scoped README ripr+ badge."
+```
+
+## Test Mapping
+
+Docs-only validation for this spec:
+
+```bash
+cargo xtask badges --check
+cargo xtask scanner-safe-reference --check
+cargo xtask docs-sync --check
+git diff --check
+```
+
+Future `spec-check` tests must cover:
+
+- all claim IDs are unique;
+- `status` is one of `stable`, `release-proof`, or `advisory`;
+- `proof_commands` is non-empty;
+- `boundary` is non-empty;
+- referenced specs and docs exist when listed.
+
+## Implementation Mapping
+
+The claim ledger is owned by:
+
+- `policy/claim-ledger.toml` for machine-readable claim mapping;
+- `docs/status/PUBLIC_CLAIMS.md` for human-readable claim status;
+- `docs/status/README.md` for status-surface navigation;
+- `docs/specs/USELESSKEY-SPEC-0002-public-claim-ledger.md` for the behavior
+  contract;
+- future `xtask spec-check` code for enforcement.
+
+## CI Proof
+
+Before `spec-check` exists, claim-ledger PRs should run:
+
+```bash
+cargo xtask badges --check
+cargo xtask scanner-safe-reference --check
+cargo xtask docs-sync --check
+git diff --check
+```
+
+Release operators should run the claim-specific proof commands named in the
+ledger for the claims touched by a release.
+
+After `spec-check` exists, claim-ledger PRs should also run:
+
+```bash
+cargo xtask spec-check
+cargo xtask spec-check --format json
+```
+
+## Metrics / Promotion Rule
+
+This spec remains `accepted` until `spec-check` validates the claim ledger.
+
+It can move to `implemented` when all README badge and public promise claims are
+represented in the ledger and release evidence reports ledger coverage.

--- a/docs/status/PUBLIC_CLAIMS.md
+++ b/docs/status/PUBLIC_CLAIMS.md
@@ -1,0 +1,42 @@
+# Public Claims
+
+This page summarizes public `uselesskey` claims and points to the command-backed
+ledger in [`policy/claim-ledger.toml`](../../policy/claim-ledger.toml).
+
+The Markdown page is for readers. The TOML ledger is the future parser target
+for `cargo xtask spec-check`.
+
+## Claim Statuses
+
+| Status | Meaning |
+| --- | --- |
+| `stable` | User-facing claim that should be proven in normal PR, docs, or release evidence when touched. |
+| `release-proof` | Claim whose primary proof is an external or shipped-state release lane. |
+| `advisory` | Reviewer or agent evidence that informs work but does not make a user-facing guarantee by itself. |
+
+## Current Claims
+
+| Claim | Status | Primary proof | Boundary |
+| --- | --- | --- | --- |
+| Scanner-safe fixtures | `stable` | `cargo xtask scanner-safe-reference --check`; `cargo xtask no-blob`; `cargo xtask badges --check` | Scanner-safe fixture material does not mean every encoded export is safe to commit. |
+| `ripr+` evidence endpoint | `stable` | `cargo xtask badges --check`; `cargo xtask test-efficiency-report` | `ripr+` is repo-scoped static evidence, not coverage or correctness proof. |
+| TLS contract pack | `stable` | `cargo xtask bundle-proof --profile tls --out target/release-evidence/tls` | TLS fixtures prove the documented pack paths and negatives, not mTLS, revocation, CT, browser trust stores, or production CA custody. |
+| OIDC/JWKS contract pack | `stable` | `cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc` | OIDC/JWKS fixtures prove key-set and token-shape contract paths, not production signing-key custody or full OpenID provider behavior. |
+| Public crate-surface cleanup | `stable` | `cargo xtask public-surface`; `cargo xtask publish-check` | The supported public crate surface is the current published contract; removed internal shims are not promised as v0.8.0 crates. |
+| External crates.io install smoke | `release-proof` | `cargo xtask cratesio-smoke --version 0.8.0` | Crates.io smoke proves an external install path for a published version, not every downstream feature combination. |
+| Generated badge endpoints | `stable` | `cargo xtask badges --check` | Badge JSON is a generated Shields endpoint receipt, not a hand-written slogan. |
+| `ripr` PR review evidence | `advisory` | `cargo xtask ripr-pr --check`; `cargo xtask ripr-review-comments --check` | PR evidence is diff-scoped and advisory; it is not the repo-scoped README `ripr+` badge. |
+
+## Reader Rule
+
+Public claims should answer four questions:
+
+```text
+what is promised?
+what command proves it?
+where is the generated artifact or receipt?
+what is explicitly outside the boundary?
+```
+
+If a claim cannot answer those questions, it should stay out of the README
+masthead and release headline until the proof path exists.

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -8,7 +8,7 @@ proposal, behavior contract in a spec, and historical lessons in `docs/learnings
 
 ## Expected Surfaces
 
-Future status docs should cover:
+Status docs cover:
 
 - Public README claims and their proof commands
 - Support tiers for contract packs and adapter surfaces
@@ -17,3 +17,7 @@ Future status docs should cover:
 
 No status page should imply enforcement before the matching spec and `xtask`
 check exist.
+
+## Index
+
+- [PUBLIC_CLAIMS.md](PUBLIC_CLAIMS.md) - Public claim to proof-command and boundary map

--- a/policy/claim-ledger.toml
+++ b/policy/claim-ledger.toml
@@ -1,0 +1,213 @@
+schema_version = 1
+owner = "EffortlessMetrics"
+updated = "2026-05-13"
+
+[[claim]]
+id = "scanner-safe-fixtures"
+title = "Scanner-safe fixtures"
+status = "stable"
+spec = "USELESSKEY-SPEC-0002"
+surfaces = [
+  "README badge",
+  "docs/VERIFICATION.md",
+  "docs/reference/audit-surface.md",
+  "docs/status/PUBLIC_CLAIMS.md",
+]
+proof_commands = [
+  "cargo xtask scanner-safe-reference --check",
+  "cargo xtask no-blob",
+  "cargo xtask badges --check",
+]
+artifacts = [
+  "badges/scanner-safe.json",
+  "target/release-evidence/scanner-safe/scanner-safe-bundle-proof.json",
+  "target/release-evidence/scanner-safe/scanner-safe-bundle-proof.md",
+]
+docs = [
+  "docs/VERIFICATION.md",
+  "docs/how-to/downstream-fixture-policy.md",
+  "docs/how-to/generate-scanner-safe-k8s-secret.md",
+]
+release_lanes = ["pr", "patch", "minor"]
+boundary = "Scanner-safe fixture material means repo policy found no committed secret-shaped fixture blobs; it does not mean every encoded export is safe to commit or that uselesskey provides production key management."
+
+[[claim]]
+id = "ripr-plus-evidence-endpoint"
+title = "ripr+ evidence endpoint"
+status = "stable"
+spec = "USELESSKEY-SPEC-0002"
+surfaces = [
+  "README badge",
+  "badges/ripr-plus.json",
+  "docs/VERIFICATION.md",
+  "docs/status/PUBLIC_CLAIMS.md",
+]
+proof_commands = [
+  "cargo xtask badges --check",
+  "cargo xtask test-efficiency-report",
+]
+artifacts = [
+  "badges/ripr-plus.json",
+  "target/ripr/reports/test-efficiency.json",
+  "target/ripr/reports/test-efficiency.md",
+]
+docs = [
+  "docs/VERIFICATION.md",
+]
+release_lanes = ["pr", "main", "patch", "minor"]
+boundary = "ripr+ is a repo-scoped static evidence and test-efficiency inbox-zero counter; it is not coverage, runtime mutation proof, correctness proof, or a PR-scoped review artifact."
+
+[[claim]]
+id = "tls-contract-pack"
+title = "TLS contract pack"
+status = "stable"
+spec = "USELESSKEY-SPEC-0002"
+surfaces = [
+  "README",
+  "docs/how-to/test-tls-chain-validation.md",
+  "docs/status/PUBLIC_CLAIMS.md",
+]
+proof_commands = [
+  "cargo xtask bundle-proof --profile tls --out target/release-evidence/tls",
+  "cargo xtask no-blob",
+]
+artifacts = [
+  "target/release-evidence/tls/tls-contract-pack-proof.json",
+  "target/release-evidence/tls/tls-contract-pack-proof.md",
+]
+docs = [
+  "docs/how-to/test-tls-chain-validation.md",
+  "docs/release/v0.8.0-tls-profile-design.md",
+]
+release_lanes = ["minor"]
+boundary = "The TLS contract pack proves the documented generated fixtures, receipts, and negative validation paths; it does not prove mTLS, revocation, CT, browser trust-store behavior, production CA custody, or downstream verifier correctness."
+
+[[claim]]
+id = "oidc-jwks-contract-pack"
+title = "OIDC/JWKS contract pack"
+status = "stable"
+spec = "USELESSKEY-SPEC-0002"
+surfaces = [
+  "README",
+  "docs/how-to/test-oidc-jwks-validation.md",
+  "docs/status/PUBLIC_CLAIMS.md",
+]
+proof_commands = [
+  "cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc",
+  "cargo xtask no-blob",
+]
+artifacts = [
+  "target/release-evidence/oidc/oidc-contract-pack-proof.json",
+  "target/release-evidence/oidc/oidc-contract-pack-proof.md",
+]
+docs = [
+  "docs/how-to/test-oidc-jwks-validation.md",
+  "docs/how-to/test-jwt-negative-validation.md",
+]
+release_lanes = ["minor"]
+boundary = "The OIDC/JWKS contract pack proves deterministic key-set and token-shape fixtures plus documented negatives; it does not prove production signing-key custody, full OpenID provider behavior, or downstream validator correctness."
+
+[[claim]]
+id = "public-crate-surface-cleanup"
+title = "Public crate-surface cleanup"
+status = "stable"
+spec = "USELESSKEY-SPEC-0002"
+surfaces = [
+  "README workspace crate list",
+  "docs/architecture/public-surface.md",
+  "docs/how-to/migrate-to-v0.8.md",
+  "docs/status/PUBLIC_CLAIMS.md",
+]
+proof_commands = [
+  "cargo xtask public-surface",
+  "cargo xtask publish-check",
+  "cargo xtask publish-preflight",
+]
+artifacts = [
+  "target/xtask/public-surface/latest.json",
+  "target/xtask/public-surface/latest.md",
+]
+docs = [
+  "docs/architecture/public-surface.md",
+  "docs/how-to/migrate-to-v0.8.md",
+]
+release_lanes = ["patch", "minor"]
+boundary = "The public crate surface is the supported published contract for the current release; removed internal compatibility shims are not promised as v0.8.0 crates."
+
+[[claim]]
+id = "external-cratesio-install-smoke"
+title = "External crates.io install smoke"
+status = "release-proof"
+spec = "USELESSKEY-SPEC-0002"
+surfaces = [
+  "release evidence",
+  "docs/release/post-release-audit.md",
+  "docs/status/PUBLIC_CLAIMS.md",
+]
+proof_commands = [
+  "cargo xtask cratesio-smoke --version 0.8.0",
+]
+artifacts = [
+  "target/xtask/cratesio-smoke",
+]
+docs = [
+  "docs/release/post-release-audit.md",
+]
+release_lanes = ["post-release", "minor"]
+boundary = "Crates.io smoke proves the external install path for one published version; it does not prove every downstream feature combination, docs.rs completion, or future registry state."
+
+[[claim]]
+id = "generated-badge-endpoints"
+title = "Generated badge endpoints"
+status = "stable"
+spec = "USELESSKEY-SPEC-0002"
+surfaces = [
+  "README badge masthead",
+  "badges/README.md",
+  "docs/VERIFICATION.md",
+  "docs/status/PUBLIC_CLAIMS.md",
+]
+proof_commands = [
+  "cargo xtask badges",
+  "cargo xtask badges --check",
+]
+artifacts = [
+  "badges/ripr-plus.json",
+  "badges/scanner-safe.json",
+  "target/xtask/badges",
+]
+docs = [
+  "badges/README.md",
+  "docs/VERIFICATION.md",
+]
+release_lanes = ["pr", "main", "patch", "minor"]
+boundary = "Generated badge endpoints are public Shields JSON receipts checked into badges/; detailed reports stay under target/ or CI artifacts and badge JSON must not be hand-written."
+
+[[claim]]
+id = "ripr-pr-review-evidence"
+title = "ripr PR review evidence"
+status = "advisory"
+spec = "USELESSKEY-SPEC-0002"
+surfaces = [
+  "PR summaries",
+  "GitHub warning annotations",
+  "CI artifacts",
+  "docs/VERIFICATION.md",
+  "docs/status/PUBLIC_CLAIMS.md",
+]
+proof_commands = [
+  "cargo xtask ripr-pr --check",
+  "cargo xtask ripr-review-comments --check",
+]
+artifacts = [
+  "target/ripr/pr/repo-exposure.json",
+  "target/ripr/pr/repo-exposure.md",
+  "target/ripr/review/comments.json",
+  "target/ripr/review/comments.md",
+]
+docs = [
+  "docs/VERIFICATION.md",
+  "docs/ci/test-evidence-lanes.md",
+]
+release_lanes = ["pr"]
+boundary = "ripr PR review evidence is diff-scoped and advisory; comments[] can produce non-blocking warnings, summary_only[] stays in summaries or artifacts, and inline PR comments remain disabled by default."


### PR DESCRIPTION
## Summary
- Adds `USELESSKEY-SPEC-0002` to define the public claim-ledger contract.
- Seeds `policy/claim-ledger.toml` with current public claims, proof commands, artifacts, docs, release lanes, and explicit boundaries.
- Adds `docs/status/PUBLIC_CLAIMS.md` as the reader-facing index for the ledger.

## Files added/changed
- `docs/specs/USELESSKEY-SPEC-0002-public-claim-ledger.md`
- `policy/claim-ledger.toml`
- `docs/status/PUBLIC_CLAIMS.md`
- `docs/specs/README.md`
- `docs/status/README.md`

## Validation
- `cargo xtask badges --check`
- `cargo xtask scanner-safe-reference --check`
- `cargo xtask docs-sync --check`
- `cargo xtask check-file-policy`
- `cargo xtask typos`
- referenced docs/badge path check with PowerShell
- `git diff --check`

## Non-goals
- No product behavior changes.
- No new fixture profiles or badge endpoints.
- No `spec-check` implementation or CI wiring in this PR.
- No unrelated SRP refactors or dependency changes.

## What this enables next
- Contract-pack and generated-evidence endpoint specs can link public claims to their proof commands.
- Later `cargo xtask spec-check` can parse and validate the ledger mechanically.