### PR TITLE
docs(spec): define generated evidence endpoint policy

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,7 @@ Specifications and formal definitions.
 
 - [dependency-economics.md](reference/dependency-economics.md) — Current lane cost receipts
 - [audit-surface.md](reference/audit-surface.md) — Current audit/island receipts
+- [verification-badges.md](reference/verification-badges.md) — Generated README badge endpoint rules and boundaries
 - [requirements-v0.3.md](reference/requirements-v0.3.md) — v0.3 acceptance specification
 - [requirements-v0.4.md](reference/requirements-v0.4.md) — v0.4 RNG boundary refactor specification
 - [failure-atlas.md](reference/failure-atlas.md) — Failure classes covered by protocol-shaped negative fixtures

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,6 +83,7 @@ NNNN-short-title.md
 | ID | Title | Status | Date |
 |----|-------|--------|------|
 | [USELESSKEY-ADR-0001](USELESSKEY-ADR-0001-contract-packs-are-proof-backed-fixture-profiles.md) | Contract packs are proof-backed fixture profiles | Accepted | 2026-05-13 |
+| [USELESSKEY-ADR-0002](USELESSKEY-ADR-0002-public-claims-require-command-backed-evidence.md) | Public claims require command-backed evidence | Accepted | 2026-05-13 |
 
 ## References
 

--- a/docs/adr/USELESSKEY-ADR-0002-public-claims-require-command-backed-evidence.md
+++ b/docs/adr/USELESSKEY-ADR-0002-public-claims-require-command-backed-evidence.md
@@ -1,0 +1,72 @@
++++
+id = "USELESSKEY-ADR-0002"
+kind = "adr"
+title = "Public claims require command-backed evidence"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = ["USELESSKEY-SPEC-0002", "USELESSKEY-SPEC-0004"]
++++
+
+# USELESSKEY-ADR-0002: Public Claims Require Command-Backed Evidence
+
+## Decision
+
+Public `uselesskey` claims must be backed by generated evidence, proof commands,
+release evidence rows, or an explicit advisory/experimental status.
+
+README badges must use repo-scoped generated endpoints. PR-scoped artifacts must
+stay in PR summaries, annotations, and CI artifacts.
+
+## Context
+
+`uselesskey` operates in a space where wording can easily overclaim. A
+scanner-safe badge, a TLS contract-pack claim, and a `ripr+` badge are useful
+only when users can find the proof command and boundary behind them.
+
+The badge endpoint work created generated `ripr+` and scanner-safe Shields JSON
+under `badges/`. That should become the rule for public trust markers: generated
+or absent, not hand-written.
+
+## Consequences
+
+README stays compact and durable because it links to repo-owned receipts instead
+of embedding a proof matrix.
+
+Claims become auditable through `policy/claim-ledger.toml`, docs, and proof
+commands.
+
+Badge additions get a higher bar. New badge endpoints need stable evidence and
+documented boundaries before they become public masthead signals.
+
+PR evidence remains useful without becoming public badge theater. Diff-scoped
+`ripr` comments and summaries stay in the PR lane.
+
+## Alternatives Considered
+
+Allow hand-written badge JSON.
+
+Rejected because it can drift from evidence and turns badges into slogans.
+
+Use PR-scoped `ripr` artifacts for README badges.
+
+Rejected because PR evidence is diff-scoped and advisory; public README badges
+must represent repo-scoped state.
+
+Expose every CI guardrail as a README badge.
+
+Rejected because the masthead should be a small front panel, not a dashboard.
+
+Require proof for every claim before it can be documented anywhere.
+
+Rejected because proposals and specs need room to describe planned behavior.
+Planned or advisory claims must be labeled honestly until command-backed proof
+exists.
+
+## Follow-up Specs / Plans
+
+- `USELESSKEY-SPEC-0002` defines the claim-ledger fields.
+- `USELESSKEY-SPEC-0004` defines generated badge endpoint behavior.
+- Future `cargo xtask spec-check` should validate claim entries and generated
+  endpoint ownership.

--- a/docs/reference/verification-badges.md
+++ b/docs/reference/verification-badges.md
@@ -1,0 +1,81 @@
+# Verification Badges
+
+README badges are public, repo-scoped trust markers. They are not the full
+evidence system.
+
+`uselesskey` uses generated Shields endpoint JSON for badges that represent
+repo-owned proof:
+
+```text
+badges/ripr-plus.json
+badges/scanner-safe.json
+```
+
+Regenerate:
+
+```bash
+cargo xtask badges
+```
+
+Check drift:
+
+```bash
+cargo xtask badges --check
+```
+
+## `ripr+`
+
+`ripr+` is a repo-scoped static evidence and test-efficiency inbox-zero counter.
+It is generated from repo-scope `ripr` evidence and the test-efficiency report.
+
+It is not:
+
+- coverage;
+- runtime mutation proof;
+- correctness proof;
+- a PR-scoped review result.
+
+Diff-scoped `ripr` artifacts such as `target/ripr/review/comments.json` belong
+in PR summaries, annotations, and artifacts, not README badges.
+
+## `scanner-safe fixtures`
+
+The scanner-safe fixture badge means repository automation found no committed
+secret-shaped fixture blobs under the configured fixture policy.
+
+It is not:
+
+- proof every generated export is safe to commit;
+- production key management;
+- scanner evasion;
+- cryptographic assurance.
+
+Generated fixture exports should normally stay under `target/` and be
+regenerated in CI or release evidence.
+
+## Endpoint Rules
+
+Committed endpoint files under `badges/` are the public surface. Detailed
+reports stay under `target/` or CI artifacts.
+
+Endpoint JSON uses this minimal Shields shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "fixtures",
+  "message": "scanner-safe",
+  "color": "brightgreen"
+}
+```
+
+If scanner-safe generation fails, `cargo xtask badges` may write a red debug
+endpoint under `target/xtask/badges/`, but it must fail before overwriting the
+committed public endpoint.
+
+## Future Badges
+
+Future endpoints must be generated or absent. Candidate badges such as
+`feature-matrix`, `cratesio-smoke`, or `supply-chain` need stable proof
+commands, claim-ledger entries, and documented boundaries before they belong in
+the README masthead.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -38,3 +38,4 @@ public crate-surface cleanup.
 - [USELESSKEY-SPEC-0001: Source-of-truth model](USELESSKEY-SPEC-0001-source-of-truth-model.md)
 - [USELESSKEY-SPEC-0002: Public claim ledger](USELESSKEY-SPEC-0002-public-claim-ledger.md)
 - [USELESSKEY-SPEC-0003: Contract-pack profile requirements](USELESSKEY-SPEC-0003-contract-pack-profile.md)
+- [USELESSKEY-SPEC-0004: Generated evidence endpoints](USELESSKEY-SPEC-0004-generated-evidence-endpoints.md)

--- a/docs/specs/USELESSKEY-SPEC-0004-generated-evidence-endpoints.md
+++ b/docs/specs/USELESSKEY-SPEC-0004-generated-evidence-endpoints.md
@@ -1,0 +1,223 @@
++++
+id = "USELESSKEY-SPEC-0004"
+kind = "spec"
+title = "Generated evidence endpoints"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+milestone = "v0.9.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_adrs = ["USELESSKEY-ADR-0002"]
+linked_plan = "plans/spec-system/implementation-plan.md"
+support_tier_impact = ["docs/status/PUBLIC_CLAIMS.md"]
+policy_impact = ["policy/claim-ledger.toml"]
++++
+
+# USELESSKEY-SPEC-0004: Generated Evidence Endpoints
+
+## Problem
+
+README badges are useful only when they expose real repo-owned evidence. A
+badge that is hand-written or copied from another repo becomes a slogan instead
+of a public receipt.
+
+`uselesskey` now exposes generated Shields endpoint JSON for `ripr+` and
+scanner-safe fixtures. This spec defines the contract for those endpoint files
+so the badge row stays small, stable, repo-scoped, and command-backed.
+
+## Behavior
+
+Public badge endpoints live under `badges/` as generated Shields endpoint JSON.
+The committed public endpoint files are:
+
+```text
+badges/ripr-plus.json
+badges/scanner-safe.json
+```
+
+Each endpoint must use the minimal Shields shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "ripr+",
+  "message": "0",
+  "color": "brightgreen"
+}
+```
+
+`cargo xtask badges` must:
+
+- anchor paths at the workspace root;
+- refresh repo-scoped `ripr+` evidence;
+- refresh scanner-safe fixture status;
+- write public endpoint JSON under `badges/`;
+- write detailed reports under `target/`;
+- validate Shields endpoint shape before writing committed JSON;
+- support `RIPR_BIN` for local or CI pinning.
+
+`cargo xtask badges --check` must:
+
+- regenerate endpoints into `target/xtask/badges/`;
+- compare generated endpoint files to committed `badges/*.json`;
+- fail when committed endpoints drift;
+- avoid mutating committed endpoint files.
+
+If scanner-safe generation fails, the command may write a red debug endpoint
+under `target/xtask/badges/scanner-safe.json`, but it must fail before
+overwriting committed `badges/scanner-safe.json`.
+
+README badge scope is fixed:
+
+- `ripr+` is repo-scoped public static evidence.
+- scanner-safe is repo-scoped fixture-policy evidence.
+- PR-scoped `ripr` review guidance is not a README badge source.
+
+## Non-goals
+
+This spec does not add new badge endpoints.
+
+This spec does not make badge counts a complete proof of correctness, coverage,
+mutation adequacy, production crypto safety, or scanner evasion.
+
+This spec does not publish target-only reports, full `ripr` reports, or PR
+artifacts as README badge data.
+
+This spec does not require bot-driven badge refreshes before endpoint behavior
+has settled.
+
+## Required Evidence
+
+Endpoint drift proof:
+
+```bash
+cargo xtask badges --check
+```
+
+Badge shape tests:
+
+```bash
+cargo test -p xtask badge
+```
+
+Docs and claim mapping:
+
+```bash
+cargo xtask docs-sync --check
+git diff --check
+```
+
+## Acceptance
+
+This spec is accepted when:
+
+- it defines committed badge endpoint ownership;
+- it defines the Shields JSON shape;
+- it separates repo-scoped badges from PR-scoped evidence;
+- it defines scanner-safe failure behavior;
+- it names the proof commands for endpoint drift and shape.
+
+This spec is implemented by the existing badge command when:
+
+- `cargo xtask badges --check` passes;
+- `cargo test -p xtask badge` passes;
+- README badges point at the committed endpoint paths under `badges/`.
+
+## Acceptance Examples
+
+Valid `ripr+` endpoint:
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "ripr+",
+  "message": "511",
+  "color": "red"
+}
+```
+
+Valid scanner-safe endpoint:
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "fixtures",
+  "message": "scanner-safe",
+  "color": "brightgreen"
+}
+```
+
+Target-only scanner-safe failure debug endpoint:
+
+```json
+{
+  "schemaVersion": 1,
+  "label": "fixtures",
+  "message": "blob-risk",
+  "color": "red"
+}
+```
+
+Invalid public badge source:
+
+```text
+target/ripr/review/comments.json
+```
+
+That file is PR-scoped review guidance and must stay in summaries or artifacts.
+
+## Test Mapping
+
+Generated endpoint behavior maps to:
+
+- `cargo xtask badges` for refreshing committed public endpoint JSON;
+- `cargo xtask badges --check` for drift detection;
+- `cargo test -p xtask badge` for endpoint shape and command behavior tests;
+- `cargo xtask test-efficiency-report` for the repo-scoped test-efficiency
+  report consumed by `ripr+`;
+- `cargo xtask scanner-safe-reference --check` and `cargo xtask no-blob` for
+  scanner-safe fixture-policy evidence.
+
+## Implementation Mapping
+
+Endpoint generation is owned by:
+
+- `README.md` for the public masthead links;
+- `badges/` for committed Shields endpoint JSON;
+- `badges/README.md` for regeneration instructions;
+- `xtask` for endpoint generation and drift checks;
+- `docs/VERIFICATION.md` for badge meanings and limits;
+- `docs/reference/verification-badges.md` for detailed badge policy;
+- `policy/claim-ledger.toml` for public claim mapping.
+
+## CI Proof
+
+Badge endpoint PRs should run:
+
+```bash
+cargo xtask badges --check
+cargo test -p xtask badge
+cargo xtask docs-sync --check
+git diff --check
+```
+
+Scanner-safe or fixture-policy changes should also run:
+
+```bash
+cargo xtask scanner-safe-reference --check
+cargo xtask no-blob
+```
+
+## Metrics / Promotion Rule
+
+Optional future endpoints may be added only after their evidence is stable and
+generated:
+
+```text
+feature-matrix.json
+cratesio-smoke.json
+supply-chain.json
+```
+
+They should remain absent until the proof command, artifact ownership, README
+boundary, and claim-ledger entry are in place.


### PR DESCRIPTION
## Summary
- Adds `USELESSKEY-SPEC-0004` to define generated Shields endpoint behavior for public evidence badges.
- Records `USELESSKEY-ADR-0002`, requiring public claims to be command-backed or explicitly advisory/planned.
- Adds `docs/reference/verification-badges.md` for badge meanings, endpoint rules, and future-badge boundaries.

## Files added/changed
- `docs/specs/USELESSKEY-SPEC-0004-generated-evidence-endpoints.md`
- `docs/adr/USELESSKEY-ADR-0002-public-claims-require-command-backed-evidence.md`
- `docs/reference/verification-badges.md`
- `docs/specs/README.md`
- `docs/adr/README.md`
- `docs/README.md`

## Validation
- `cargo xtask badges --check`
- `cargo test -p xtask badge`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `git diff --check`

## Non-goals
- No product behavior changes.
- No new badge endpoints.
- No badge refresh workflow changes.
- No `spec-check` implementation or CI wiring in this PR.

## What this enables next
- Active agent lane-state specs can link README claims, proof endpoints, and current Codex work without relying on chat history.
- Later `spec-check` can validate generated endpoint ownership and claim-ledger coverage.