### PR TITLE
docs(adr): record README badge front-panel policy

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -95,7 +95,7 @@ commands = [
 
 [[work_item]]
 id = "pr-review-evidence"
-status = "active"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0007"
 plan = "plans/spec-system/implementation-plan.md"
@@ -103,6 +103,18 @@ commands = [
   "cargo xtask ripr-pr --check",
   "cargo xtask ripr-review-comments --check",
   "cargo xtask docs-sync --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "readme-badge-front-panel-adr"
+status = "active"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0004"
+plan = "plans/spec-system/implementation-plan.md"
+commands = [
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
   "git diff --check",
 ]
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -85,6 +85,7 @@ NNNN-short-title.md
 | [USELESSKEY-ADR-0001](USELESSKEY-ADR-0001-contract-packs-are-proof-backed-fixture-profiles.md) | Contract packs are proof-backed fixture profiles | Accepted | 2026-05-13 |
 | [USELESSKEY-ADR-0002](USELESSKEY-ADR-0002-public-claims-require-command-backed-evidence.md) | Public claims require command-backed evidence | Accepted | 2026-05-13 |
 | [USELESSKEY-ADR-0003](USELESSKEY-ADR-0003-repo-goals-are-the-agent-control-plane.md) | Repo goals are the agent control plane | Accepted | 2026-05-13 |
+| [USELESSKEY-ADR-0004](USELESSKEY-ADR-0004-readme-badges-are-front-panel-not-dashboard.md) | README badges are a front panel, not a dashboard | Accepted | 2026-05-13 |
 
 ## References
 

--- a/docs/adr/USELESSKEY-ADR-0004-readme-badges-are-front-panel-not-dashboard.md
+++ b/docs/adr/USELESSKEY-ADR-0004-readme-badges-are-front-panel-not-dashboard.md
@@ -1,0 +1,90 @@
++++
+id = "USELESSKEY-ADR-0004"
+kind = "adr"
+title = "README badges are a front panel, not a dashboard"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = ["USELESSKEY-SPEC-0002", "USELESSKEY-SPEC-0004"]
++++
+
+# USELESSKEY-ADR-0004: README Badges Are a Front Panel, Not a Dashboard
+
+## Decision
+
+The `uselesskey` README masthead will stay small, public, repo-scoped,
+generated where proof-specific, and grouped by meaning.
+
+The standard public badge stack is:
+
+```text
+CI | Codecov | ripr+ | scanner-safe
+Release | crates.io downloads | docs.rs
+MSRV | license
+```
+
+Detailed proof belongs in claim ledgers, specs, verification docs, CI summaries,
+and release evidence. The badge row is a front panel, not a dashboard.
+
+## Context
+
+`uselesskey` has many real checks: PR gates, `ripr` evidence, impacted evidence,
+scanner-safe checks, release evidence, bundle proofs, public-surface checks,
+publish preflight, and crates.io smoke.
+
+Putting every guardrail in the README would make the masthead noisy and weaker.
+Users need a few stable public trust markers, plus clear links to the proof
+system behind them.
+
+The generated badge endpoint work already made the important split:
+
+- public README badges are repo-scoped;
+- PR evidence is diff-scoped;
+- generated endpoint JSON lives under `badges/`;
+- detailed reports stay under `target/` or CI artifacts.
+
+## Consequences
+
+README stays readable and durable.
+
+Badges must have a clear public meaning and a stable source. Proof-specific
+badges such as `ripr+` and scanner-safe fixtures must be generated, not
+hand-written.
+
+More checks can exist without becoming masthead noise. They should appear in
+CI summaries, release evidence, `docs/VERIFICATION.md`, `docs/status/`, or
+reference docs.
+
+New badges have a higher bar. They need a generated endpoint, claim-ledger
+entry, proof command, and documented boundary before becoming public masthead
+signals.
+
+## Alternatives Considered
+
+Add a badge for every CI guardrail.
+
+Rejected because it turns the README into a dashboard and obscures the product
+boundary.
+
+Use vanity or repository-health badges.
+
+Rejected because stars, forks, last commit, and similar badges do not prove a
+fixture-platform claim.
+
+Use static hand-written proof badges.
+
+Rejected because they drift and become slogan badges.
+
+Move all proof detail out of the README without badges.
+
+Rejected because users benefit from a compact front panel when it links to real
+repo-owned evidence.
+
+## Follow-up Specs / Plans
+
+- `USELESSKEY-SPEC-0002` defines public claim-ledger mapping.
+- `USELESSKEY-SPEC-0004` defines generated evidence endpoint behavior.
+- `docs/reference/verification-badges.md` documents badge meanings and limits.
+- Future `cargo xtask spec-check` should validate the linked source-of-truth
+  artifacts that make README badges auditable.

--- a/plans/spec-system/implementation-plan.md
+++ b/plans/spec-system/implementation-plan.md
@@ -20,6 +20,7 @@ linked_adrs = [
   "USELESSKEY-ADR-0001",
   "USELESSKEY-ADR-0002",
   "USELESSKEY-ADR-0003",
+  "USELESSKEY-ADR-0004",
 ]
 +++
 
@@ -80,13 +81,14 @@ Completed:
    `.uselesskey/goals/active.toml`, and this plan.
 8. Add `USELESSKEY-SPEC-0006` for release evidence lanes.
 9. Add `USELESSKEY-SPEC-0007` for PR review evidence.
+10. Add `USELESSKEY-ADR-0004` for README badge front-panel policy.
 
 Remaining:
 
-10. Add standalone `cargo xtask spec-check`.
-11. Wire `spec-check` into docs and PR evidence.
-12. Wire `spec-check` into patch and minor release evidence.
-13. Close out the lane with a learning record and archived or updated active
+11. Add standalone `cargo xtask spec-check`.
+12. Wire `spec-check` into docs and PR evidence.
+13. Wire `spec-check` into patch and minor release evidence.
+14. Close out the lane with a learning record and archived or updated active
     goal manifest.
 
 ## Proof Commands


### PR DESCRIPTION
## Summary
- Adds `USELESSKEY-ADR-0004` to record that README badges are a compact front panel, not a full proof dashboard.
- Updates the spec-system plan and active manifest so the upcoming `spec-check` linked-ID validation has no missing ADR reference.

## Files added/changed
- `docs/adr/USELESSKEY-ADR-0004-readme-badges-are-front-panel-not-dashboard.md`
- `docs/adr/README.md`
- `plans/spec-system/implementation-plan.md`
- `.uselesskey/goals/active.toml`

## Validation
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `git diff --check`

## Non-goals
- No product behavior changes.
- No badge endpoint changes.
- No `spec-check` implementation or CI wiring in this PR.

## What this enables next
- Standalone `cargo xtask spec-check` can validate linked proposal/spec/ADR IDs without special-casing the missing ADR4 reference.