### PR TITLE
xtask: include spec-check in docs and PR evidence

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -120,7 +120,7 @@ commands = [
 
 [[work_item]]
 id = "spec-check"
-status = "active"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/spec-system/implementation-plan.md"
@@ -129,4 +129,17 @@ commands = [
   "cargo xtask spec-check",
   "cargo xtask spec-check --format json",
   "cargo xtask docs-sync --check",
+]
+
+[[work_item]]
+id = "wire-spec-check-docs-pr"
+status = "active"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0006"
+plan = "plans/spec-system/implementation-plan.md"
+commands = [
+  "cargo xtask spec-check",
+  "cargo xtask docs-sync --check",
+  "cargo xtask pr",
+  "git diff --check",
 ]

--- a/plans/spec-system/implementation-plan.md
+++ b/plans/spec-system/implementation-plan.md
@@ -83,10 +83,10 @@ Completed:
 9. Add `USELESSKEY-SPEC-0007` for PR review evidence.
 10. Add `USELESSKEY-ADR-0004` for README badge front-panel policy.
 11. Add standalone `cargo xtask spec-check`.
+12. Wire `spec-check` into docs and PR evidence.
 
 Remaining:
 
-12. Wire `spec-check` into docs and PR evidence.
 13. Wire `spec-check` into patch and minor release evidence.
 14. Close out the lane with a learning record and archived or updated active
     goal manifest.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -452,7 +452,7 @@ fn main() -> Result<()> {
             NoBlobCmd::Scan => no_blob_gate(),
             NoBlobCmd::Migrate => no_blob_migrate(),
         },
-        Cmd::DocsSync { check } => docs_sync::docs_sync_cmd(check),
+        Cmd::DocsSync { check } => docs_sync_with_spec_check(check),
         Cmd::PublicSurface => public_surface::public_surface_cmd(PUBLISH_CRATES),
         Cmd::ExamplesSmoke { run } => docs_sync::examples_smoke_cmd(run),
         Cmd::PublishCheck => publish_check(),
@@ -2697,6 +2697,18 @@ fn pr(with_mutants: bool) -> Result<()> {
     result
 }
 
+fn docs_sync_with_spec_check(check: bool) -> Result<()> {
+    docs_sync::docs_sync_cmd(check)?;
+    if check {
+        spec_check::run(
+            &workspace_root_path(),
+            false,
+            spec_check::OutputFormat::Human,
+        )?;
+    }
+    Ok(())
+}
+
 fn mutants_pr(changed: bool, crates: Vec<String>, all: bool, full_owner: bool) -> Result<()> {
     let selector_count = usize::from(changed) + usize::from(!crates.is_empty()) + usize::from(all);
     if selector_count != 1 {
@@ -4253,6 +4265,14 @@ fn run_pr_plan(
 
     runner.step("public-surface", None, || {
         public_surface::public_surface_cmd(PUBLISH_CRATES)
+    })?;
+
+    runner.step("spec-check", None, || {
+        spec_check::run(
+            &workspace_root_path(),
+            false,
+            spec_check::OutputFormat::Human,
+        )
     })?;
 
     if plan.docs_only {


### PR DESCRIPTION
## Summary
- Run `spec-check` from `cargo xtask docs-sync --check` so docs drift checks include source-of-truth validation.
- Add `spec-check` as a PR receipt step before docs-only fast-path skips.
- Advance the spec-system active goal and implementation plan to the wiring step.

## Files added/changed
- `xtask/src/main.rs`
- `.uselesskey/goals/active.toml`
- `plans/spec-system/implementation-plan.md`

## Validation
- `cargo xtask fmt`
- `cargo test -p xtask spec_check`
- `cargo xtask spec-check`
- `cargo xtask docs-sync --check`
- `cargo xtask pr`
- `cargo xtask typos`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `git diff --check`

## Non-goals
- No new spec semantics or source-of-truth artifacts.
- No release-evidence wiring yet.
- No product behavior changes.

## What this enables next
- Wire `spec-check --strict` into patch and minor release evidence once this PR evidence path is stable.