### PR TITLE
xtask: add spec-check to release evidence

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -133,13 +133,27 @@ commands = [
 
 [[work_item]]
 id = "wire-spec-check-docs-pr"
-status = "active"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0006"
 plan = "plans/spec-system/implementation-plan.md"
 commands = [
   "cargo xtask spec-check",
   "cargo xtask docs-sync --check",
+  "cargo xtask pr",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "wire-spec-check-release-evidence"
+status = "active"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0006"
+plan = "plans/spec-system/implementation-plan.md"
+commands = [
+  "cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary",
+  "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
+  "cargo xtask spec-check --strict",
   "cargo xtask pr",
   "git diff --check",
 ]

--- a/plans/spec-system/implementation-plan.md
+++ b/plans/spec-system/implementation-plan.md
@@ -84,10 +84,10 @@ Completed:
 10. Add `USELESSKEY-ADR-0004` for README badge front-panel policy.
 11. Add standalone `cargo xtask spec-check`.
 12. Wire `spec-check` into docs and PR evidence.
+13. Wire `spec-check` into patch and minor release evidence.
 
 Remaining:
 
-13. Wire `spec-check` into patch and minor release evidence.
 14. Close out the lane with a learning record and archived or updated active
     goal manifest.
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2821,6 +2821,11 @@ fn release_evidence_steps_minor() -> Vec<ReleaseEvidenceStep> {
             artifacts: &[],
         },
         ReleaseEvidenceStep {
+            name: "spec-check-strict",
+            command: &["cargo", "xtask", "spec-check", "--strict"],
+            artifacts: &[],
+        },
+        ReleaseEvidenceStep {
             name: "publish-preflight",
             command: &["cargo", "xtask", "publish-preflight"],
             artifacts: &["target/xtask/receipt.json"],
@@ -3006,6 +3011,11 @@ fn release_evidence_steps_patch() -> Vec<ReleaseEvidenceStep> {
         ReleaseEvidenceStep {
             name: "docs-sync",
             command: &["cargo", "xtask", "docs-sync", "--check"],
+            artifacts: &[],
+        },
+        ReleaseEvidenceStep {
+            name: "spec-check-strict",
+            command: &["cargo", "xtask", "spec-check", "--strict"],
             artifacts: &[],
         },
         ReleaseEvidenceStep {


### PR DESCRIPTION
## Summary
- Add an explicit `spec-check --strict` step to both minor and patch release-evidence lanes.
- Keep release receipts honest about source-of-truth validation instead of relying only on the docs-sync wrapper.
- Advance the spec-system active goal and implementation plan to the release-evidence wiring step.

## Files added/changed
- `xtask/src/main.rs`
- `.uselesskey/goals/active.toml`
- `plans/spec-system/implementation-plan.md`

## Validation
- `cargo xtask fmt`
- `cargo test -p xtask spec_check`
- `cargo xtask spec-check --strict`
- `cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary`
- `cargo xtask release-evidence --version 0.9.0 --dry-run --summary`
- `cargo xtask pr`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `git diff --check`

## Non-goals
- No release execution, tagging, or publish work.
- No new spec semantics or claim-ledger entries.
- No product behavior changes.

## What this enables next
- Close out the spec-system lane with archived active state and a learning record once the release-evidence receipt path lands.