### PR TITLE
ops: start claim-backed verification lane

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -1,159 +1,94 @@
-id = "uselesskey-spec-system"
-title = "Encode source-of-truth and spec system"
-status = "archived"
+id = "uselesskey-claim-backed-verification"
+title = "Claim-backed verification UX"
+status = "active"
 owner = "EffortlessMetrics"
 created = "2026-05-13"
 
 objective = """
-Make proposals, specs, ADRs, implementation plans, active goal manifests,
-claim ledgers, and generated evidence endpoints the normal operating model
-for uselesskey.
+Make uselesskey's public claims discoverable, runnable, and reviewable from
+the repo itself. Users should be able to move from README badges and public
+claim docs to claim reports, proof commands, artifacts, release evidence, and
+explicit boundaries without relying on chat history.
 """
 
 end_state = [
-  "Every public README claim has a claim-ledger entry.",
-  "Every accepted spec has proof commands.",
-  "Every active agent lane points to active.toml.",
-  "No automation prompt carries stale lane policy inline.",
-  "cargo xtask spec-check validates source-of-truth artifacts.",
+  "README badges link to explanations, not just endpoint files.",
+  "cargo xtask claim-report emits Markdown and JSON from policy/claim-ledger.toml.",
+  "docs/status/PUBLIC_CLAIMS.md is checked against policy/claim-ledger.toml.",
+  "A user-facing guide explains how to verify public claims locally.",
+  "Contract-pack claims have a registry and check command.",
+  "Release evidence includes claim-report receipts.",
+  "Agent bootstrap docs tell Codex to start from active.toml and linked plans.",
 ]
 
 [[work_item]]
-id = "source-of-truth-model"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0001"
-plan = "plans/spec-system/implementation-plan.md"
-commands = [
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "public-claim-ledger"
-status = "done"
+id = "open-lane"
+status = "active"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0002"
-plan = "plans/spec-system/implementation-plan.md"
+plan = "plans/claim-backed-verification/implementation-plan.md"
 commands = [
-  "cargo xtask badges --check",
-  "cargo xtask scanner-safe-reference --check",
+  "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
+  "cargo xtask typos",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "contract-pack-profile"
-status = "done"
+id = "claim-report"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/claim-backed-verification/implementation-plan.md"
+commands = [
+  "cargo test -p xtask claim_report",
+  "cargo xtask claim-report",
+  "cargo xtask claim-report --format json",
+  "cargo xtask claim-report --claim scanner-safe-fixtures",
+]
+
+[[work_item]]
+id = "public-claims-check"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/claim-backed-verification/implementation-plan.md"
+commands = [
+  "cargo xtask claim-report --check-public-claims",
+  "cargo xtask spec-check --strict",
+]
+
+[[work_item]]
+id = "contract-pack-registry"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0003"
-plan = "plans/spec-system/implementation-plan.md"
+plan = "plans/claim-backed-verification/implementation-plan.md"
 commands = [
-  "cargo xtask bundle-proof --profile tls --out target/release-evidence/tls",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
+  "cargo test -p xtask contract_pack",
+  "cargo xtask contract-packs --check",
+  "cargo xtask contract-packs --format json",
 ]
 
 [[work_item]]
-id = "generated-evidence-endpoints"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0004"
-plan = "plans/spec-system/implementation-plan.md"
-commands = [
-  "cargo xtask badges --check",
-  "cargo test -p xtask badge",
-  "cargo xtask docs-sync --check",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "active-agent-lane-state"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0005"
-plan = "plans/spec-system/implementation-plan.md"
-commands = [
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "release-evidence-lanes"
-status = "done"
+id = "release-claim-receipts"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0006"
-plan = "plans/spec-system/implementation-plan.md"
-commands = [
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "pr-review-evidence"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0007"
-plan = "plans/spec-system/implementation-plan.md"
-commands = [
-  "cargo xtask ripr-pr --check",
-  "cargo xtask ripr-review-comments --check",
-  "cargo xtask docs-sync --check",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "readme-badge-front-panel-adr"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0004"
-plan = "plans/spec-system/implementation-plan.md"
-commands = [
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "spec-check"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0005"
-plan = "plans/spec-system/implementation-plan.md"
-commands = [
-  "cargo test -p xtask spec_check",
-  "cargo xtask spec-check",
-  "cargo xtask spec-check --format json",
-  "cargo xtask docs-sync --check",
-]
-
-[[work_item]]
-id = "wire-spec-check-docs-pr"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0006"
-plan = "plans/spec-system/implementation-plan.md"
-commands = [
-  "cargo xtask spec-check",
-  "cargo xtask docs-sync --check",
-  "cargo xtask pr",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "wire-spec-check-release-evidence"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0006"
-plan = "plans/spec-system/implementation-plan.md"
+plan = "plans/claim-backed-verification/implementation-plan.md"
 commands = [
   "cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary",
   "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
-  "cargo xtask spec-check --strict",
-  "cargo xtask pr",
-  "git diff --check",
+]
+
+[[work_item]]
+id = "claim-proof-runner"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/claim-backed-verification/implementation-plan.md"
+commands = [
+  "cargo test -p xtask claim_proof",
+  "cargo xtask claim-proof --claim scanner-safe-fixtures",
+  "cargo xtask claim-proof --claim tls-contract-pack",
 ]

--- a/plans/claim-backed-verification/README.md
+++ b/plans/claim-backed-verification/README.md
@@ -1,0 +1,12 @@
+# Claim-Backed Verification Plan Area
+
+This directory tracks the lane that turns the completed source-of-truth system
+into a user-facing verification layer.
+
+The spec-system lane is closed out. This lane uses it rather than rebuilding it:
+claim ledger, claim reports, contract-pack registry checks, release-evidence
+receipts, and task-first verification docs.
+
+## Plan Files
+
+- [implementation-plan.md](implementation-plan.md) - PR sequence, proof commands, non-goals, and stop conditions

--- a/plans/claim-backed-verification/implementation-plan.md
+++ b/plans/claim-backed-verification/implementation-plan.md
@@ -1,0 +1,110 @@
++++
+id = "USELESSKEY-PLAN-0003"
+kind = "plan"
+title = "Claim-backed verification UX"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+milestone = "v0.9.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0002",
+  "USELESSKEY-SPEC-0003",
+  "USELESSKEY-SPEC-0004",
+  "USELESSKEY-SPEC-0005",
+  "USELESSKEY-SPEC-0006",
+  "USELESSKEY-SPEC-0007",
+]
+linked_adrs = [
+  "USELESSKEY-ADR-0001",
+  "USELESSKEY-ADR-0002",
+  "USELESSKEY-ADR-0003",
+  "USELESSKEY-ADR-0004",
+]
++++
+
+# Claim-Backed Verification UX
+
+## Objective
+
+Make `uselesskey`'s public claims discoverable, runnable, and reviewable from
+the repo itself.
+
+The intended user path is:
+
+```text
+README badge -> docs/reference/verification-badges.md
+  -> docs/status/PUBLIC_CLAIMS.md
+    -> cargo xtask claim-report
+      -> cargo xtask claim-proof --claim <claim>
+```
+
+## Scope
+
+This lane turns the completed spec-system into a product-facing verification
+surface:
+
+- claim-report Markdown and JSON generated from `policy/claim-ledger.toml`;
+- drift checks between `docs/status/PUBLIC_CLAIMS.md` and the claim ledger;
+- a task-first public-claim verification guide;
+- a contract-pack registry and check command;
+- release-evidence rows for claim-report and contract-pack receipts;
+- badge and claim-boundary documentation polish;
+- an agent bootstrap guide that starts from `.uselesskey/goals/active.toml`;
+- an allowlisted claim-proof runner for selected stable claims.
+
+## Non-Goals
+
+Do not mix these into this lane:
+
+- new fixture profiles;
+- TLS mTLS, revocation, CT, or browser trust-store behavior;
+- shipper re-migration;
+- no-panic burndown;
+- dependency churn;
+- compatibility-shim churn;
+- new badges unless backed by an existing stable command;
+- hand-written generated badge JSON;
+- automatic direct-to-main badge writes.
+
+## PR Sequence
+
+1. Open this active lane and implementation plan.
+2. Add `cargo xtask claim-report`.
+3. Check `docs/status/PUBLIC_CLAIMS.md` against `policy/claim-ledger.toml`.
+4. Add `docs/how-to/verify-uselesskey-public-claims.md`.
+5. Add `policy/contract-packs.toml` and `cargo xtask contract-packs`.
+6. Add claim-report and contract-pack receipts to release evidence.
+7. Tighten badge meaning and claim-boundary docs.
+8. Add an agent bootstrap guide.
+9. Add an allowlisted `cargo xtask claim-proof` runner.
+10. Close out the lane with a learning record and archived goal manifest.
+
+## Proof Commands
+
+Lane-opening PR:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Final lane proof:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask claim-report
+cargo xtask claim-report --format json
+cargo xtask contract-packs --check
+cargo xtask badges --check
+cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary
+cargo xtask release-evidence --version 0.9.0 --dry-run --summary
+```
+
+## Stop Conditions
+
+Pause and split work if a PR would require product behavior, release execution,
+new fixture profiles, TLS expansion, dependency churn, or direct-to-main badge
+automation.


### PR DESCRIPTION
## Summary
- Start the `claim-backed verification UX` lane in `.uselesskey/goals/active.toml`.
- Add `plans/claim-backed-verification/` with the PR sequence, proof commands, non-goals, and stop conditions.
- Keep the completed spec-system lane as the foundation rather than rebuilding it.

## Files added/changed
- `.uselesskey/goals/active.toml`
- `plans/claim-backed-verification/README.md`
- `plans/claim-backed-verification/implementation-plan.md`

## Validation
- `cargo xtask spec-check --strict`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask pr`
- `git diff --check`

## Non-goals
- No product behavior changes.
- No new fixture profiles or TLS expansion.
- No claim-report implementation yet.
- No contract-pack registry yet.
- No badge additions or generated badge JSON changes.

## What this enables next
- The next PR can add `cargo xtask claim-report` against the active lane and plan now recorded in the repo.