### PR TITLE
docs: add public claim verification guide

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -59,6 +59,19 @@ commands = [
 ]
 
 [[work_item]]
+id = "verification-guide"
+status = "done"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/claim-backed-verification/implementation-plan.md"
+commands = [
+  "cargo xtask claim-report",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "git diff --check",
+]
+
+[[work_item]]
 id = "contract-pack-registry"
 status = "ready"
 proposal = "USELESSKEY-PROP-0001"

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Task-oriented instructions for common workflows.
 - [test-oidc-jwks-validation.md](how-to/test-oidc-jwks-validation.md) — Using the OIDC/JWKS contract pack in validator tests
 - [test-jwt-negative-validation.md](how-to/test-jwt-negative-validation.md) — Using JWT-shaped negatives for policy rejection tests
 - [generate-scanner-safe-k8s-secret.md](how-to/generate-scanner-safe-k8s-secret.md) — Exporting scanner-safe Kubernetes and Vault-shaped payloads
+- [verify-uselesskey-public-claims.md](how-to/verify-uselesskey-public-claims.md) — Verifying badge, scanner-safe, contract-pack, and release-smoke claims
 
 ## Contributing
 

--- a/docs/how-to/verify-uselesskey-public-claims.md
+++ b/docs/how-to/verify-uselesskey-public-claims.md
@@ -1,0 +1,148 @@
+# Verify `uselesskey` Public Claims
+
+Use this guide when you need to show a reviewer what `uselesskey` claims, which
+commands prove those claims, and where the receipts are written.
+
+The quick rule:
+
+```text
+README badge -> public claim -> proof command -> receipt -> boundary
+```
+
+## 1. Read the Claim Index
+
+Start with the human-facing claim index:
+
+```text
+docs/status/PUBLIC_CLAIMS.md
+```
+
+Then generate the machine-readable report from the ledger:
+
+```bash
+cargo xtask claim-report
+```
+
+The command writes:
+
+```text
+target/claim-report/public-claims.md
+target/claim-report/public-claims.json
+```
+
+For a single claim:
+
+```bash
+cargo xtask claim-report --claim scanner-safe-fixtures
+```
+
+## 2. Check the Human Page Against the Ledger
+
+`docs/status/PUBLIC_CLAIMS.md` is hand-written so it can stay readable. The
+ledger under `policy/claim-ledger.toml` is the parser target.
+
+Check that the page still matches the ledger:
+
+```bash
+cargo xtask claim-report --check-public-claims
+```
+
+This fails if a stable ledger claim is missing from the page, if the page
+references an unknown claim id, if status drifted, if proof commands are not
+visible, or if a boundary cell is empty.
+
+## 3. Verify README Badge Claims
+
+The README badge row is a front panel. The generated endpoint JSON is the public
+receipt.
+
+```bash
+cargo xtask badges --check
+```
+
+This checks:
+
+```text
+badges/ripr-plus.json
+badges/scanner-safe.json
+```
+
+`ripr+` is repo-scoped static evidence plus test-efficiency debt. It is not
+coverage, runtime mutation proof, or correctness proof.
+
+`scanner-safe fixtures` means repository policy found no committed
+secret-shaped fixture blobs. It does not mean every generated export is safe to
+commit.
+
+## 4. Verify Scanner-Safe Fixture Claims
+
+Run the scanner-safe reference checks:
+
+```bash
+cargo xtask scanner-safe-reference --check
+cargo xtask no-blob
+cargo xtask badges --check
+```
+
+Use these when the reviewer is asking whether the repo has committed
+secret-shaped fixture blobs under the configured policy.
+
+Do not use this as proof of production key safety, scanner evasion, or
+cryptographic assurance.
+
+## 5. Verify the TLS Contract Pack
+
+Run the TLS bundle proof:
+
+```bash
+cargo xtask bundle-proof --profile tls --out target/release-evidence/tls
+```
+
+Attach these receipts:
+
+```text
+target/release-evidence/tls/tls-contract-pack-proof.md
+target/release-evidence/tls/tls-contract-pack-proof.json
+```
+
+This proves the documented generated TLS fixtures, receipts, and negative
+validation paths. It does not prove mTLS, revocation, certificate transparency,
+browser trust-store behavior, production CA custody, or downstream verifier
+correctness.
+
+## 6. Verify the Published Install Path
+
+For the current published release:
+
+```bash
+cargo xtask cratesio-smoke --version 0.8.0
+```
+
+For a future release, replace `0.8.0` with the version under review.
+
+This proves an external crates.io install path for that version. It does not
+prove every downstream feature combination, docs.rs completion, or future
+registry state.
+
+## 7. Attach Review Evidence
+
+For a security, platform, or release review, attach:
+
+```text
+target/claim-report/public-claims.md
+target/claim-report/public-claims.json
+target/release-evidence/tls/tls-contract-pack-proof.md
+target/release-evidence/tls/tls-contract-pack-proof.json
+```
+
+Also include the commands you ran and the exact version, branch, or commit under
+review.
+
+## Boundaries to Keep Visible
+
+- Public claims are command-backed, not trust-by-README.
+- README badges are repo-scoped public markers, not PR evidence.
+- PR `ripr` artifacts are diff-scoped and advisory.
+- Scanner-safe fixture material is not production key management.
+- Contract packs prove documented fixture paths, not complete downstream
+  security behavior.


### PR DESCRIPTION
## Summary
- Adds a task-first guide for verifying uselesskey public claims locally.
- Covers claim-report, PUBLIC_CLAIMS drift checks, badge endpoints, scanner-safe checks, TLS bundle proof, crates.io smoke, and review artifacts.
- Links the guide from docs/README.md.
- Updates active.toml with a completed verification-guide work item.

## Files added/changed
- docs/how-to/verify-uselesskey-public-claims.md
- docs/README.md
- .uselesskey/goals/active.toml

## Validation
- cargo xtask claim-report
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask spec-check --strict
- cargo xtask pr
- git diff --check

## Non-goals
- Does not add new proof commands.
- Does not add contract-pack registry support.
- Does not add claim-proof runner support.
- Does not add badges, fixture profiles, or release evidence wiring.

## What this enables next
- PR 4 can add the contract-pack registry and check command.