### PR TITLE
xtask: add claim receipts to release evidence

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -85,13 +85,38 @@ commands = [
 
 [[work_item]]
 id = "release-claim-receipts"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0006"
 plan = "plans/claim-backed-verification/implementation-plan.md"
 commands = [
   "cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary",
   "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
+]
+
+[[work_item]]
+id = "verification-boundary-polish"
+status = "ready"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0004"
+plan = "plans/claim-backed-verification/implementation-plan.md"
+commands = [
+  "cargo xtask badges --check",
+  "cargo xtask claim-report",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+]
+
+[[work_item]]
+id = "agent-bootstrap"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/claim-backed-verification/implementation-plan.md"
+commands = [
+  "cargo xtask spec-check --strict",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
 ]
 
 [[work_item]]

--- a/xtask/src/claim_report.rs
+++ b/xtask/src/claim_report.rs
@@ -125,6 +125,20 @@ pub fn run(
     Ok(())
 }
 
+pub(crate) fn write_release_receipt(root: &Path, out_dir: &Path) -> Result<()> {
+    let report = build_report(root, None)?;
+    let claims_dir = out_dir.join("claims");
+    fs::create_dir_all(&claims_dir).with_context(|| format!("create {}", claims_dir.display()))?;
+
+    let json_path = claims_dir.join("public-claims.json");
+    let md_path = claims_dir.join("public-claims.md");
+    write_json_pretty(&json_path, &report)?;
+    fs::write(&md_path, render_markdown(&report))
+        .with_context(|| format!("write {}", md_path.display()))?;
+
+    Ok(())
+}
+
 fn check_public_claims_doc(root: &Path, report: &ClaimReport) -> Result<()> {
     let errors = public_claim_errors(root, report)?;
     if !errors.is_empty() {

--- a/xtask/src/contract_packs.rs
+++ b/xtask/src/contract_packs.rs
@@ -96,6 +96,27 @@ pub fn run(root: &Path, check: bool, format: OutputFormat) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn write_release_receipt(root: &Path, out_dir: &Path) -> Result<()> {
+    let report = build_report(root)?;
+    if !report.errors.is_empty() {
+        bail!(
+            "contract-packs: policy/contract-packs.toml failed with {} error(s)",
+            report.errors.len()
+        );
+    }
+
+    let packs_dir = out_dir.join("contract-packs");
+    fs::create_dir_all(&packs_dir).with_context(|| format!("create {}", packs_dir.display()))?;
+    write_json_pretty(&packs_dir.join("contract-packs.json"), &report)?;
+    fs::write(
+        packs_dir.join("contract-packs.md"),
+        render_markdown_report(&report),
+    )
+    .with_context(|| format!("write {}", packs_dir.join("contract-packs.md").display()))?;
+
+    Ok(())
+}
+
 fn build_report(root: &Path) -> Result<ContractPackReport> {
     let registry_path = root.join("policy/contract-packs.toml");
     let registry_text = fs::read_to_string(&registry_path)
@@ -315,6 +336,38 @@ fn print_human_report(report: &ContractPackReport) {
             println!("- {error}");
         }
     }
+}
+
+fn render_markdown_report(report: &ContractPackReport) -> String {
+    let mut md = String::new();
+    md.push_str("# Contract-Pack Registry Report\n\n");
+    md.push_str(&format!("- Status: `{}`\n", report.status));
+    md.push_str(&format!("- Packs: `{}`\n", report.packs.len()));
+    md.push_str(&format!("- Errors: `{}`\n", report.errors.len()));
+
+    md.push_str("\n## Packs\n\n");
+    md.push_str("| Pack | Status | Profile | Claim | Proof command | How-to |\n");
+    md.push_str("| --- | --- | --- | --- | --- | --- |\n");
+    for pack in &report.packs {
+        md.push_str(&format!(
+            "| `{}` | `{}` | `{}` | `{}` | `{}` | `{}` |\n",
+            pack.id, pack.status, pack.profile, pack.claim, pack.proof_command, pack.how_to
+        ));
+    }
+
+    if !report.errors.is_empty() {
+        md.push_str("\n## Errors\n\n");
+        for error in &report.errors {
+            md.push_str(&format!("- {error}\n"));
+        }
+    }
+
+    md
+}
+
+fn write_json_pretty(path: &Path, value: &impl Serialize) -> Result<()> {
+    let json = serde_json::to_string_pretty(value)?;
+    fs::write(path, json + "\n").with_context(|| format!("write {}", path.display()))
 }
 
 #[cfg(test)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2892,6 +2892,29 @@ fn release_evidence_steps_minor() -> Vec<ReleaseEvidenceStep> {
             artifacts: &[],
         },
         ReleaseEvidenceStep {
+            name: "claim-report",
+            command: &["cargo", "xtask", "claim-report", "--format", "json"],
+            artifacts: &[
+                "target/release-evidence/claims/public-claims.json",
+                "target/release-evidence/claims/public-claims.md",
+            ],
+        },
+        ReleaseEvidenceStep {
+            name: "contract-pack-registry",
+            command: &[
+                "cargo",
+                "xtask",
+                "contract-packs",
+                "--check",
+                "--format",
+                "json",
+            ],
+            artifacts: &[
+                "target/release-evidence/contract-packs/contract-packs.json",
+                "target/release-evidence/contract-packs/contract-packs.md",
+            ],
+        },
+        ReleaseEvidenceStep {
             name: "publish-preflight",
             command: &["cargo", "xtask", "publish-preflight"],
             artifacts: &["target/xtask/receipt.json"],
@@ -3085,6 +3108,14 @@ fn release_evidence_steps_patch() -> Vec<ReleaseEvidenceStep> {
             artifacts: &[],
         },
         ReleaseEvidenceStep {
+            name: "claim-report",
+            command: &["cargo", "xtask", "claim-report", "--format", "json"],
+            artifacts: &[
+                "target/release-evidence/claims/public-claims.json",
+                "target/release-evidence/claims/public-claims.md",
+            ],
+        },
+        ReleaseEvidenceStep {
             name: "no-blob",
             command: &["cargo", "xtask", "no-blob"],
             artifacts: &[],
@@ -3152,7 +3183,9 @@ fn release_evidence(
 
     for (idx, step) in steps.iter().enumerate() {
         receipt.commands[idx].status = "running".to_string();
-        match run_release_evidence_step(step) {
+        match run_release_evidence_step(step)
+            .and_then(|()| write_release_evidence_step_receipts(step, out_dir))
+        {
             Ok(()) => receipt.commands[idx].status = "ok".to_string(),
             Err(err) => {
                 receipt.commands[idx].status = "failed".to_string();
@@ -3176,6 +3209,15 @@ fn release_evidence(
         );
     }
     Ok(())
+}
+
+fn write_release_evidence_step_receipts(step: &ReleaseEvidenceStep, out_dir: &Path) -> Result<()> {
+    let root = workspace_root_path();
+    match step.name {
+        "claim-report" => claim_report::write_release_receipt(&root, out_dir),
+        "contract-pack-registry" => contract_packs::write_release_receipt(&root, out_dir),
+        _ => Ok(()),
+    }
 }
 
 fn release_evidence_receipt(
@@ -7342,6 +7384,8 @@ index 1111111..2222222 100644
         for expected in [
             "public-surface",
             "docs-sync",
+            "claim-report",
+            "contract-pack-registry",
             "publish-preflight",
             "publish-check",
             "pr",
@@ -7370,6 +7414,14 @@ index 1111111..2222222 100644
                 .artifacts
                 .contains(&"target/ripr/pr/summary.md".to_string())
         );
+        assert!(
+            receipt
+                .artifacts
+                .contains(&"target/release-evidence/claims/public-claims.json".to_string())
+        );
+        assert!(receipt.artifacts.contains(
+            &"target/release-evidence/contract-packs/contract-packs.json".to_string()
+        ));
         assert!(receipt.artifacts.contains(
             &"target/release-evidence/scanner-safe/scanner-safe-bundle-proof.md".to_string()
         ));
@@ -7466,6 +7518,23 @@ index 1111111..2222222 100644
         assert_eq!(
             step.command,
             &["cargo", "xtask", "scanner-safe-reference", "--check"],
+        );
+    }
+
+    #[test]
+    fn release_evidence_patch_step_list_includes_claim_report() {
+        let steps = release_evidence_steps_patch();
+        let step = steps
+            .iter()
+            .find(|step| step.name == "claim-report")
+            .expect("patch lane must wire claim-report");
+        assert_eq!(
+            step.command,
+            &["cargo", "xtask", "claim-report", "--format", "json"],
+        );
+        assert!(
+            step.artifacts
+                .contains(&"target/release-evidence/claims/public-claims.json"),
         );
     }
 
@@ -7580,6 +7649,30 @@ index 1111111..2222222 100644
         assert!(
             step.artifacts
                 .contains(&"target/release-evidence/tls/tls-contract-pack-proof.md"),
+        );
+    }
+
+    #[test]
+    fn release_evidence_minor_step_list_includes_contract_pack_registry() {
+        let steps = release_evidence_steps_minor();
+        let step = steps
+            .iter()
+            .find(|step| step.name == "contract-pack-registry")
+            .expect("minor lane must wire contract-pack registry");
+        assert_eq!(
+            step.command,
+            &[
+                "cargo",
+                "xtask",
+                "contract-packs",
+                "--check",
+                "--format",
+                "json",
+            ],
+        );
+        assert!(
+            step.artifacts
+                .contains(&"target/release-evidence/contract-packs/contract-packs.json"),
         );
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7419,9 +7419,11 @@ index 1111111..2222222 100644
                 .artifacts
                 .contains(&"target/release-evidence/claims/public-claims.json".to_string())
         );
-        assert!(receipt.artifacts.contains(
-            &"target/release-evidence/contract-packs/contract-packs.json".to_string()
-        ));
+        assert!(
+            receipt.artifacts.contains(
+                &"target/release-evidence/contract-packs/contract-packs.json".to_string()
+            )
+        );
         assert!(receipt.artifacts.contains(
             &"target/release-evidence/scanner-safe/scanner-safe-bundle-proof.md".to_string()
         ));


### PR DESCRIPTION
## Summary
- Add claim-report receipts to patch and minor release evidence.
- Add contract-pack registry receipts to the minor release evidence lane.
- Write release-evidence copies under `target/release-evidence/claims/` and `target/release-evidence/contract-packs/`.
- Advance the active claim-backed verification lane to badge and claim-boundary polish.

## Files added/changed
- `.uselesskey/goals/active.toml`
- `xtask/src/claim_report.rs`
- `xtask/src/contract_packs.rs`
- `xtask/src/main.rs`

## Validation
- `cargo test -p xtask release_evidence`
- `cargo test -p xtask claim_report`
- `cargo test -p xtask contract_pack`
- `cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary`
- `cargo xtask release-evidence --version 0.9.0 --dry-run --summary`
- `cargo xtask claim-report --format json`
- `cargo xtask contract-packs --check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo xtask spec-check --strict`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask pr`
- `git diff --check`

## Non-goals
- Does not run proof commands from the claim ledger.
- Does not add `claim-proof`.
- Does not add new fixture profiles, TLS behavior, or badges.

## What this enables next
- The release lane now carries public-claim and contract-pack index receipts, so the next PR can tighten badge and boundary docs against the runnable verification surface.