### PR TITLE
docs: tighten verification claim boundaries

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -96,7 +96,7 @@ commands = [
 
 [[work_item]]
 id = "verification-boundary-polish"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0004"
 plan = "plans/claim-backed-verification/implementation-plan.md"
@@ -109,7 +109,7 @@ commands = [
 
 [[work_item]]
 id = "agent-bootstrap"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/claim-backed-verification/implementation-plan.md"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@
 
 `uselesskey` is a **test-fixture factory**, not a crypto library. It generates key material, certificates, token-shaped fixtures, and negative artifacts at runtime so tests do not need committed PEM/DER/JWK blobs.
 
+Public claims are command-backed. Start with the
+[verification guide](docs/how-to/verify-uselesskey-public-claims.md) or the
+[public claim index](docs/status/PUBLIC_CLAIMS.md) to see what each badge and
+contract-pack claim proves, what command checks it, and what it does not prove.
+
 ## Why this exists
 
 `uselesskey` is a **test-fixture layer**, not a runtime crypto service.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -9,6 +9,10 @@
 Badges are the front panel. The generated evidence, CI receipts, and release
 artifacts remain the source of truth.
 
+For the public claim index and local proof path, see
+[`docs/status/PUBLIC_CLAIMS.md`](status/PUBLIC_CLAIMS.md) and
+[`docs/how-to/verify-uselesskey-public-claims.md`](how-to/verify-uselesskey-public-claims.md).
+
 ## README badges
 
 ### `ripr+`
@@ -58,6 +62,52 @@ cargo xtask badges --check
 
 Committed endpoint files live under `badges/`. Detailed reports stay under
 `target/` locally or in CI artifacts.
+
+## Claim Reports
+
+`cargo xtask claim-report` turns `policy/claim-ledger.toml` into reader and
+machine receipts:
+
+```bash
+cargo xtask claim-report
+cargo xtask claim-report --format json
+cargo xtask claim-report --claim scanner-safe-fixtures
+```
+
+The command writes:
+
+```text
+target/claim-report/public-claims.md
+target/claim-report/public-claims.json
+```
+
+Use `cargo xtask claim-report --check-public-claims` to verify that the
+hand-written public claim page still contains every stable ledger claim, its
+proof commands, and its boundary.
+
+## Release Evidence Receipts
+
+Patch release evidence records the public claim index:
+
+```bash
+cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary
+```
+
+Minor release evidence records both public claims and contract-pack registry
+state:
+
+```bash
+cargo xtask release-evidence --version 0.9.0 --dry-run --summary
+```
+
+Non-dry release evidence writes these receipts:
+
+```text
+target/release-evidence/claims/public-claims.md
+target/release-evidence/claims/public-claims.json
+target/release-evidence/contract-packs/contract-packs.md
+target/release-evidence/contract-packs/contract-packs.json
+```
 
 ## Pull Request Evidence
 

--- a/docs/how-to/verify-uselesskey-public-claims.md
+++ b/docs/how-to/verify-uselesskey-public-claims.md
@@ -30,6 +30,13 @@ target/claim-report/public-claims.md
 target/claim-report/public-claims.json
 ```
 
+Release evidence also carries a copy under:
+
+```text
+target/release-evidence/claims/public-claims.md
+target/release-evidence/claims/public-claims.json
+```
+
 For a single claim:
 
 ```bash
@@ -92,6 +99,13 @@ cryptographic assurance.
 
 ## 5. Verify the TLS Contract Pack
 
+Check that stable contract packs are registered against claims, specs, how-tos,
+release lanes, and proof commands:
+
+```bash
+cargo xtask contract-packs --check
+```
+
 Run the TLS bundle proof:
 
 ```bash
@@ -103,6 +117,8 @@ Attach these receipts:
 ```text
 target/release-evidence/tls/tls-contract-pack-proof.md
 target/release-evidence/tls/tls-contract-pack-proof.json
+target/release-evidence/contract-packs/contract-packs.md
+target/release-evidence/contract-packs/contract-packs.json
 ```
 
 This proves the documented generated TLS fixtures, receipts, and negative

--- a/docs/reference/verification-badges.md
+++ b/docs/reference/verification-badges.md
@@ -3,6 +3,15 @@
 README badges are public, repo-scoped trust markers. They are not the full
 evidence system.
 
+The badge row is a front panel:
+
+```text
+README badge -> public claim -> proof command -> receipt -> boundary
+```
+
+Use [`docs/status/PUBLIC_CLAIMS.md`](../status/PUBLIC_CLAIMS.md) for the claim
+index and `cargo xtask claim-report` for the generated Markdown/JSON report.
+
 `uselesskey` uses generated Shields endpoint JSON for badges that represent
 repo-owned proof:
 
@@ -72,6 +81,22 @@ Endpoint JSON uses this minimal Shields shape:
 If scanner-safe generation fails, `cargo xtask badges` may write a red debug
 endpoint under `target/xtask/badges/`, but it must fail before overwriting the
 committed public endpoint.
+
+## Release Receipts
+
+Badge endpoint JSON is intentionally small. Release evidence carries the wider
+claim and contract-pack receipts:
+
+```text
+target/release-evidence/claims/public-claims.json
+target/release-evidence/claims/public-claims.md
+target/release-evidence/contract-packs/contract-packs.json
+target/release-evidence/contract-packs/contract-packs.md
+```
+
+Patch release evidence includes the public claim report. Minor release evidence
+also includes the contract-pack registry because contract packs are public
+fixture-platform promises.
 
 ## Future Badges
 

--- a/docs/status/PUBLIC_CLAIMS.md
+++ b/docs/status/PUBLIC_CLAIMS.md
@@ -3,8 +3,20 @@
 This page summarizes public `uselesskey` claims and points to the command-backed
 ledger in [`policy/claim-ledger.toml`](../../policy/claim-ledger.toml).
 
-The Markdown page is for readers. The TOML ledger is the future parser target
-for `cargo xtask spec-check`.
+The Markdown page is for readers. The TOML ledger is the parser target for
+`cargo xtask spec-check` and the source for `cargo xtask claim-report`.
+
+Generate the current claim report:
+
+```bash
+cargo xtask claim-report
+```
+
+Check this page against the ledger:
+
+```bash
+cargo xtask claim-report --check-public-claims
+```
 
 ## Claim Statuses
 


### PR DESCRIPTION
## Summary
- Point the README from the badge masthead into the public claim verification path.
- Document claim-report and release-evidence receipt locations in verification docs.
- Clarify that badge JSON is the front panel while claim and contract-pack receipts carry the wider proof.
- Advance the active lane to the agent-bootstrap item.

## Files added/changed
- `.uselesskey/goals/active.toml`
- `README.md`
- `docs/VERIFICATION.md`
- `docs/how-to/verify-uselesskey-public-claims.md`
- `docs/reference/verification-badges.md`
- `docs/status/PUBLIC_CLAIMS.md`

## Validation
- `cargo xtask claim-report --check-public-claims`
- `cargo xtask badges --check`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask pr`
- `git diff --check`

## Non-goals
- Does not add badges.
- Does not add new fixture profiles or TLS behavior.
- Does not add `claim-proof`.

## What this enables next
- Agents and reviewers now have clearer docs for moving from README badges to claim reports, release receipts, and explicit boundaries.