### PR TITLE
docs: add agent bootstrap handoff

### DIFF
--- a/.uselesskey/goals/README.md
+++ b/.uselesskey/goals/README.md
@@ -14,3 +14,7 @@ record history; they should not be treated as active instructions.
 
 Do not create `active.toml` until the lane has an accepted proposal or spec to
 link to.
+
+When resuming agent work, read
+[`docs/handoffs/agent-bootstrap.md`](../../docs/handoffs/agent-bootstrap.md)
+before acting on older chat context.

--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -109,7 +109,7 @@ commands = [
 
 [[work_item]]
 id = "agent-bootstrap"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/claim-backed-verification/implementation-plan.md"
@@ -121,7 +121,7 @@ commands = [
 
 [[work_item]]
 id = "claim-proof-runner"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0002"
 plan = "plans/claim-backed-verification/implementation-plan.md"

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ agent state do not drift into one document.
 - [learnings](learnings/README.md) - Durable lessons from releases, incidents, and proof lanes
 - [plans](../plans/README.md) - PR sequencing and rollback plans
 - [active goals](../.uselesskey/goals/README.md) - Machine-readable current agent lane state
+- [agent bootstrap](handoffs/agent-bootstrap.md) - Read order and validation defaults for agents resuming work
 
 ## How-to Guides
 

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -7,6 +7,10 @@ Use handoffs for release gates, PR queue transitions, failed external
 dependencies, and lane closeout. Do not use handoffs as the active task source;
 current agent state belongs under `.uselesskey/goals/`.
 
+Start with [agent-bootstrap.md](agent-bootstrap.md) when resuming agent work.
+It defines the read order from `active.toml` to plans, specs, claim reports, and
+validation commands.
+
 ## Required Shape
 
 Use [the handoff template](../templates/handoff.md). A handoff should include:

--- a/docs/handoffs/agent-bootstrap.md
+++ b/docs/handoffs/agent-bootstrap.md
@@ -1,0 +1,66 @@
+# Agent Bootstrap
+
+Use this handoff when starting or resuming `uselesskey` repo work. The current
+lane state lives in the repo, not in chat history.
+
+## Startup Order
+
+1. Read `.uselesskey/goals/active.toml`.
+2. Read the `plan` paths linked from ready or active work items.
+3. Read the linked proposal, specs, and ADRs for the work item.
+4. Run `cargo xtask spec-check --strict` before changing source-of-truth files.
+5. Run `cargo xtask claim-report` when public claims, badges, contract packs, or
+   release evidence change.
+6. Use chat instructions as current operator intent, but do not treat old chat
+   prompts as source-of-truth state.
+
+## PR Body Contract
+
+Every PR in a multi-PR lane should include:
+
+- Summary
+- Files added/changed
+- Validation
+- Non-goals
+- What this enables next
+
+## Claim-Backed Work
+
+When a change touches public claims, badges, contract packs, release evidence,
+or fixture-safety boundaries, check the claim surfaces:
+
+```bash
+cargo xtask claim-report --check-public-claims
+cargo xtask claim-report
+cargo xtask badges --check
+```
+
+If the change touches contract-pack proof shape, also run:
+
+```bash
+cargo xtask contract-packs --check
+```
+
+## Validation Defaults
+
+Docs-only active-goal or handoff changes:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Code or xtask changes should add the narrow relevant tests first, then run:
+
+```bash
+cargo xtask pr
+git diff --check
+```
+
+## Non-Goals
+
+This bootstrap does not replace proposals, specs, ADRs, implementation plans,
+claim ledgers, release evidence, or PR review. It only defines the order an
+agent should use to find the current state.


### PR DESCRIPTION
## Summary
- Add `docs/handoffs/agent-bootstrap.md` as the repo-owned startup path for future agent work.
- Link the bootstrap from the docs index, handoff index, and active-goals README.
- Advance the active lane to the claim-proof runner item.

## Files added/changed
- `.uselesskey/goals/README.md`
- `.uselesskey/goals/active.toml`
- `docs/README.md`
- `docs/handoffs/README.md`
- `docs/handoffs/agent-bootstrap.md`

## Validation
- `cargo xtask spec-check --strict`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask pr`
- `git diff --check`

## Non-goals
- Does not change product behavior.
- Does not add `claim-proof`.
- Does not add new fixture profiles, TLS behavior, or badges.

## What this enables next
- Future sessions can resume the lane from `active.toml`, linked plans/specs, and repo checks instead of stale chat prompts.