### PR TITLE
docs(spec): define claim-proof execution policy

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -120,10 +120,23 @@ commands = [
 ]
 
 [[work_item]]
+id = "claim-proof-policy"
+status = "done"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0008"
+plan = "plans/claim-backed-verification/implementation-plan.md"
+commands = [
+  "cargo xtask spec-check --strict",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "git diff --check",
+]
+
+[[work_item]]
 id = "claim-proof-runner"
 status = "ready"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0002"
+spec = "USELESSKEY-SPEC-0008"
 plan = "plans/claim-backed-verification/implementation-plan.md"
 commands = [
   "cargo test -p xtask claim_proof",

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -42,3 +42,4 @@ public crate-surface cleanup.
 - [USELESSKEY-SPEC-0005: Agent lane state](USELESSKEY-SPEC-0005-agent-lane-state.md)
 - [USELESSKEY-SPEC-0006: Release evidence lanes](USELESSKEY-SPEC-0006-release-evidence-lanes.md)
 - [USELESSKEY-SPEC-0007: PR review evidence](USELESSKEY-SPEC-0007-pr-review-evidence.md)
+- [USELESSKEY-SPEC-0008: Claim-proof execution](USELESSKEY-SPEC-0008-claim-proof-execution.md)

--- a/docs/specs/USELESSKEY-SPEC-0008-claim-proof-execution.md
+++ b/docs/specs/USELESSKEY-SPEC-0008-claim-proof-execution.md
@@ -1,0 +1,212 @@
++++
+id = "USELESSKEY-SPEC-0008"
+kind = "spec"
+title = "Claim-proof execution"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+milestone = "v0.9.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_adrs = ["USELESSKEY-ADR-0002"]
+linked_plan = "plans/claim-backed-verification/implementation-plan.md"
+support_tier_impact = ["docs/status/PUBLIC_CLAIMS.md"]
+policy_impact = ["policy/claim-ledger.toml"]
++++
+
+# USELESSKEY-SPEC-0008: Claim-Proof Execution
+
+## Problem
+
+`cargo xtask claim-report` makes public claims discoverable, but it deliberately
+does not run proof commands. Users still need a safe way to prove a selected
+claim without manually copying commands from the ledger.
+
+Executing claim proofs is more sensitive than reporting claims because
+`policy/claim-ledger.toml` contains reader-facing command strings. Those strings
+must not become arbitrary shell input.
+
+## Behavior
+
+`cargo xtask claim-proof` runs proof handlers for selected public claims and
+writes per-claim receipts under:
+
+```text
+target/claim-proof/<claim>/
+```
+
+Required command shapes:
+
+```bash
+cargo xtask claim-proof --claim scanner-safe-fixtures
+cargo xtask claim-proof --claim tls-contract-pack
+cargo xtask claim-proof --all-stable
+```
+
+Claim-proof execution must use symbolic, repo-owned handlers. It must not
+shell-evaluate arbitrary strings from `policy/claim-ledger.toml`.
+
+Initial handler mapping:
+
+| Claim | Handlers |
+| --- | --- |
+| `scanner-safe-fixtures` | `scanner_safe_reference_check`, `no_blob`, `badges_check` |
+| `ripr-plus-evidence-endpoint` | `badges_check`, `test_efficiency_report` |
+| `tls-contract-pack` | `bundle_proof_tls`, `no_blob` |
+| `oidc-jwks-contract-pack` | `bundle_proof_oidc`, `no_blob` |
+| `public-crate-surface-cleanup` | `public_surface`, `publish_check`, `publish_preflight` |
+| `generated-badge-endpoints` | `badges_check` |
+| `external-cratesio-install-smoke` | `cratesio_smoke_version` with explicit version only |
+
+`--all-stable` runs stable claims with claim-proof handlers. It must not run
+release-proof claims such as `external-cratesio-install-smoke` unless the user
+passes an explicit version option in a later command shape.
+
+Each receipt must record:
+
+- claim id;
+- status;
+- proof handlers run;
+- command argv executed by each handler;
+- artifacts checked or written;
+- boundary;
+- exit status;
+- timestamp;
+- git head.
+
+## Non-goals
+
+This spec does not implement `cargo xtask claim-proof`.
+
+This spec does not add new public claims.
+
+This spec does not allow arbitrary shell execution from TOML command strings.
+
+This spec does not run broad mutation, fuzzing, or full release evidence from
+`claim-proof --all-stable`.
+
+This spec does not make crates.io smoke implicit. Registry smoke requires an
+explicit version.
+
+## Required Evidence
+
+Docs-only changes to this spec should run:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+The implementation PR must add and run:
+
+```bash
+cargo test -p xtask claim_proof
+cargo xtask claim-proof --claim scanner-safe-fixtures
+cargo xtask claim-proof --claim tls-contract-pack
+cargo xtask claim-proof --all-stable
+```
+
+## Acceptance
+
+This spec is accepted when:
+
+- it defines claim-proof as a runner, not a report;
+- it requires symbolic handler mappings instead of shell execution from TOML;
+- it defines initial supported claims and handlers;
+- it defines receipt paths and required receipt fields;
+- it excludes implicit crates.io smoke, mutation, fuzzing, and full release
+  evidence from default claim-proof runs.
+
+This spec is implemented when:
+
+- `cargo xtask claim-proof --claim scanner-safe-fixtures` writes a passing
+  receipt;
+- `cargo xtask claim-proof --claim tls-contract-pack` writes a passing receipt;
+- `cargo xtask claim-proof --all-stable` runs all stable supported claims;
+- unsupported claims fail or report unsupported status explicitly;
+- receipts include boundaries and command argv without exposing generated
+  secret-shaped payloads.
+
+## Acceptance Examples
+
+Valid handler policy:
+
+```toml
+[[claim_proof]]
+claim = "scanner-safe-fixtures"
+handlers = ["scanner_safe_reference_check", "no_blob", "badges_check"]
+```
+
+Invalid handler policy:
+
+```toml
+[[claim_proof]]
+claim = "scanner-safe-fixtures"
+command = "cargo xtask scanner-safe-reference --check && cargo xtask no-blob"
+```
+
+The invalid example stores shell text as policy. Claim-proof must use known
+handler identifiers and construct command argv in code.
+
+Valid release-proof behavior:
+
+```text
+cargo xtask claim-proof --all-stable
+```
+
+This does not run crates.io smoke because `external-cratesio-install-smoke` is
+not a stable claim and registry proof needs an explicit version.
+
+## Test Mapping
+
+Claim-proof implementation tests must cover:
+
+- handler mapping for `scanner-safe-fixtures`;
+- handler mapping for `tls-contract-pack`;
+- `--all-stable` selection;
+- unknown claim rejection;
+- release-proof claim rejection without explicit version;
+- receipt JSON and Markdown shape;
+- command failures returning claim-local failure receipts.
+
+## Implementation Mapping
+
+Claim-proof execution is owned by:
+
+- `xtask` command parsing for `claim-proof`;
+- `policy/claim-ledger.toml` for symbolic handler policy;
+- `policy/claim-ledger.toml` claim rows for boundaries and status;
+- `target/claim-proof/<claim>/receipt.json` and `.md` for receipts;
+- this spec for the execution safety contract.
+
+## CI Proof
+
+Docs-only policy/spec PR:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Implementation PR:
+
+```bash
+cargo test -p xtask claim_proof
+cargo xtask claim-proof --claim scanner-safe-fixtures
+cargo xtask claim-proof --claim tls-contract-pack
+cargo xtask claim-proof --all-stable
+cargo xtask pr
+git diff --check
+```
+
+## Metrics / Promotion Rule
+
+This spec remains `accepted` until `claim-proof` exists and writes receipts for
+the initial supported stable claims.
+
+It can move to `implemented` when `claim-proof --all-stable` is stable enough to
+be consumed by release evidence or verification-pack without arbitrary command
+execution.

--- a/plans/claim-backed-verification/implementation-plan.md
+++ b/plans/claim-backed-verification/implementation-plan.md
@@ -14,6 +14,7 @@ linked_specs = [
   "USELESSKEY-SPEC-0005",
   "USELESSKEY-SPEC-0006",
   "USELESSKEY-SPEC-0007",
+  "USELESSKEY-SPEC-0008",
 ]
 linked_adrs = [
   "USELESSKEY-ADR-0001",
@@ -51,7 +52,9 @@ surface:
 - release-evidence rows for claim-report and contract-pack receipts;
 - badge and claim-boundary documentation polish;
 - an agent bootstrap guide that starts from `.uselesskey/goals/active.toml`;
-- an allowlisted claim-proof runner for selected stable claims.
+- a claim-proof execution policy and allowlisted runner for selected stable
+  claims;
+- a verification-pack receipt bundle for users and reviewers.
 
 ## Non-Goals
 
@@ -77,8 +80,13 @@ Do not mix these into this lane:
 6. Add claim-report and contract-pack receipts to release evidence.
 7. Tighten badge meaning and claim-boundary docs.
 8. Add an agent bootstrap guide.
-9. Add an allowlisted `cargo xtask claim-proof` runner.
-10. Close out the lane with a learning record and archived goal manifest.
+9. Define the claim-proof execution policy.
+10. Add an allowlisted `cargo xtask claim-proof` runner.
+11. Define the verification-pack receipt bundle.
+12. Add `cargo xtask verification-pack`.
+13. Wire claim-proof and verification-pack receipts into release evidence.
+14. Polish the public verification UX.
+15. Close out the lane with a learning record and archived goal manifest.
 
 ## Proof Commands
 

--- a/policy/claim-ledger.toml
+++ b/policy/claim-ledger.toml
@@ -2,6 +2,51 @@ schema_version = 1
 owner = "EffortlessMetrics"
 updated = "2026-05-13"
 
+# `claim_proof` entries are symbolic execution policy, not shell commands.
+# `cargo xtask claim-proof` must map these handler IDs to argv in code.
+[[claim_proof]]
+claim = "scanner-safe-fixtures"
+status = "planned"
+include_in_all_stable = true
+handlers = ["scanner_safe_reference_check", "no_blob", "badges_check"]
+
+[[claim_proof]]
+claim = "ripr-plus-evidence-endpoint"
+status = "planned"
+include_in_all_stable = true
+handlers = ["badges_check", "test_efficiency_report"]
+
+[[claim_proof]]
+claim = "tls-contract-pack"
+status = "planned"
+include_in_all_stable = true
+handlers = ["bundle_proof_tls", "no_blob"]
+
+[[claim_proof]]
+claim = "oidc-jwks-contract-pack"
+status = "planned"
+include_in_all_stable = true
+handlers = ["bundle_proof_oidc", "no_blob"]
+
+[[claim_proof]]
+claim = "public-crate-surface-cleanup"
+status = "planned"
+include_in_all_stable = true
+handlers = ["public_surface", "publish_check", "publish_preflight"]
+
+[[claim_proof]]
+claim = "generated-badge-endpoints"
+status = "planned"
+include_in_all_stable = true
+handlers = ["badges_check"]
+
+[[claim_proof]]
+claim = "external-cratesio-install-smoke"
+status = "planned"
+include_in_all_stable = false
+requires_explicit_version = true
+handlers = ["cratesio_smoke_version"]
+
 [[claim]]
 id = "scanner-safe-fixtures"
 title = "Scanner-safe fixtures"


### PR DESCRIPTION
## Summary
- Add USELESSKEY-SPEC-0008 for safe claim-proof execution.
- Add symbolic `claim_proof` policy entries to `policy/claim-ledger.toml` without executable shell strings.
- Update the claim-backed verification plan and active goal so the next slice is the runner implementation.

## Files added/changed
- `.uselesskey/goals/active.toml`
- `docs/specs/README.md`
- `docs/specs/USELESSKEY-SPEC-0008-claim-proof-execution.md`
- `plans/claim-backed-verification/implementation-plan.md`
- `policy/claim-ledger.toml`

## Validation
- `cargo xtask spec-check --strict`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask pr`
- `git diff --check`

## Non-goals
- Does not implement `cargo xtask claim-proof` yet.
- Does not add new public claims.
- Does not allow arbitrary command execution from TOML.
- Does not add fixture profiles, TLS behavior, badges, or dependency churn.

## What this enables next
- The next PR can implement `claim-proof` against symbolic handler IDs and write claim-local receipts without shell-evaluating ledger text.