### PR TITLE
xtask: add verification-pack to release evidence

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -172,7 +172,7 @@ commands = [
 
 [[work_item]]
 id = "release-evidence-claim-proof"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0006"
 plan = "plans/claim-backed-verification/implementation-plan.md"
@@ -181,4 +181,17 @@ commands = [
   "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
   "cargo xtask claim-proof --all-stable",
   "cargo xtask verification-pack --out target/uselesskey-verification",
+]
+
+[[work_item]]
+id = "public-verification-ux-polish"
+status = "ready"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/claim-backed-verification/implementation-plan.md"
+commands = [
+  "cargo xtask claim-report --check-public-claims",
+  "cargo xtask badges --check",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
 ]

--- a/docs/specs/USELESSKEY-SPEC-0006-release-evidence-lanes.md
+++ b/docs/specs/USELESSKEY-SPEC-0006-release-evidence-lanes.md
@@ -93,6 +93,7 @@ cargo xtask badges --check
 cargo xtask scanner-safe-reference --check
 cargo xtask cratesio-smoke --version X
 cargo xtask bundle-proof --profile tls --out target/release-evidence/tls
+cargo xtask verification-pack --out target/release-evidence/verification-pack
 cargo xtask publish-check
 cargo xtask publish-preflight
 ```
@@ -120,6 +121,8 @@ This spec is implemented when:
 
 - release evidence includes `spec-check`;
 - patch and minor release evidence clearly show which public claims were proven;
+- minor release evidence includes a metadata-only verification-pack receipt
+  bundle;
 - claim-ledger entries can name the release lanes that carry each claim.
 
 ## Acceptance Examples
@@ -178,6 +181,8 @@ Lane mapping should be tested at the command and receipt level:
 - `cargo xtask scanner-safe-reference --check` covers scanner-safe reference
   evidence.
 - `cargo xtask bundle-proof --profile <profile>` covers contract-pack proof.
+- `cargo xtask verification-pack --out <dir>` covers shareable claim-proof
+  receipt bundles without generated fixture payloads.
 - `cargo xtask cratesio-smoke --version X` covers external registry smoke.
 - `cargo xtask release-evidence --version X ...` writes release evidence
   artifacts and summaries.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2941,6 +2941,37 @@ fn release_evidence_steps_minor() -> Vec<ReleaseEvidenceStep> {
             ],
         },
         ReleaseEvidenceStep {
+            name: "verification-pack",
+            command: &[
+                "cargo",
+                "xtask",
+                "verification-pack",
+                "--out",
+                "target/release-evidence/verification-pack",
+            ],
+            artifacts: &[
+                "target/release-evidence/verification-pack/README.md",
+                "target/release-evidence/verification-pack/public-claims.json",
+                "target/release-evidence/verification-pack/public-claims.md",
+                "target/release-evidence/verification-pack/contract-packs.json",
+                "target/release-evidence/verification-pack/contract-packs.md",
+                "target/release-evidence/verification-pack/badges/ripr-plus.json",
+                "target/release-evidence/verification-pack/badges/scanner-safe.json",
+                "target/release-evidence/verification-pack/claim-proof/scanner-safe-fixtures/receipt.json",
+                "target/release-evidence/verification-pack/claim-proof/scanner-safe-fixtures/receipt.md",
+                "target/release-evidence/verification-pack/claim-proof/ripr-plus-evidence-endpoint/receipt.json",
+                "target/release-evidence/verification-pack/claim-proof/ripr-plus-evidence-endpoint/receipt.md",
+                "target/release-evidence/verification-pack/claim-proof/tls-contract-pack/receipt.json",
+                "target/release-evidence/verification-pack/claim-proof/tls-contract-pack/receipt.md",
+                "target/release-evidence/verification-pack/claim-proof/oidc-jwks-contract-pack/receipt.json",
+                "target/release-evidence/verification-pack/claim-proof/oidc-jwks-contract-pack/receipt.md",
+                "target/release-evidence/verification-pack/claim-proof/public-crate-surface-cleanup/receipt.json",
+                "target/release-evidence/verification-pack/claim-proof/public-crate-surface-cleanup/receipt.md",
+                "target/release-evidence/verification-pack/claim-proof/generated-badge-endpoints/receipt.json",
+                "target/release-evidence/verification-pack/claim-proof/generated-badge-endpoints/receipt.md",
+            ],
+        },
+        ReleaseEvidenceStep {
             name: "publish-preflight",
             command: &["cargo", "xtask", "publish-preflight"],
             artifacts: &["target/xtask/receipt.json"],
@@ -3139,6 +3170,29 @@ fn release_evidence_steps_patch() -> Vec<ReleaseEvidenceStep> {
             artifacts: &[
                 "target/release-evidence/claims/public-claims.json",
                 "target/release-evidence/claims/public-claims.md",
+            ],
+        },
+        ReleaseEvidenceStep {
+            name: "verification-pack-scanner-safe",
+            command: &[
+                "cargo",
+                "xtask",
+                "verification-pack",
+                "--out",
+                "target/release-evidence/verification-pack",
+                "--claim",
+                "scanner-safe-fixtures",
+            ],
+            artifacts: &[
+                "target/release-evidence/verification-pack/README.md",
+                "target/release-evidence/verification-pack/public-claims.json",
+                "target/release-evidence/verification-pack/public-claims.md",
+                "target/release-evidence/verification-pack/contract-packs.json",
+                "target/release-evidence/verification-pack/contract-packs.md",
+                "target/release-evidence/verification-pack/badges/ripr-plus.json",
+                "target/release-evidence/verification-pack/badges/scanner-safe.json",
+                "target/release-evidence/verification-pack/claim-proof/scanner-safe-fixtures/receipt.json",
+                "target/release-evidence/verification-pack/claim-proof/scanner-safe-fixtures/receipt.md",
             ],
         },
         ReleaseEvidenceStep {
@@ -3442,6 +3496,7 @@ fn render_release_evidence_summary_markdown(receipt: &ReleaseEvidenceReceipt) ->
             ),
             ("Scanner-safe reference", &["scanner-safe-reference"][..]),
             ("Crates.io install smoke", &["cratesio-smoke-local"][..]),
+            ("Verification pack", &["verification-pack-scanner-safe"][..]),
             (
                 "Docs, examples, and scanner guard",
                 &["docs-sync", "examples-smoke", "no-blob"][..],
@@ -3479,6 +3534,7 @@ fn render_release_evidence_summary_markdown(receipt: &ReleaseEvidenceReceipt) ->
             ),
             ("TLS contract-pack proof", &["tls-contract-pack-proof"][..]),
             ("RIPR exposure", &["ripr-pr", "impacted-evidence"][..]),
+            ("Verification pack", &["verification-pack"][..]),
             ("Nightly mutation scope", &["mutants-nightly-public"][..]),
             ("Performance evidence", &["perf"][..]),
             (
@@ -7567,6 +7623,32 @@ index 1111111..2222222 100644
     }
 
     #[test]
+    fn release_evidence_patch_step_list_includes_scanner_safe_verification_pack() {
+        let steps = release_evidence_steps_patch();
+        let step = steps
+            .iter()
+            .find(|step| step.name == "verification-pack-scanner-safe")
+            .expect("patch lane must wire scanner-safe verification pack");
+        assert_eq!(
+            step.command,
+            &[
+                "cargo",
+                "xtask",
+                "verification-pack",
+                "--out",
+                "target/release-evidence/verification-pack",
+                "--claim",
+                "scanner-safe-fixtures",
+            ],
+        );
+        assert!(
+            step.artifacts.contains(
+                &"target/release-evidence/verification-pack/claim-proof/scanner-safe-fixtures/receipt.json"
+            ),
+        );
+    }
+
+    #[test]
     fn shields_badge_validation_accepts_expected_shape() {
         let badge = ShieldsEndpointBadge {
             schema_version: 1,
@@ -7702,6 +7784,32 @@ index 1111111..2222222 100644
             step.artifacts
                 .contains(&"target/release-evidence/contract-packs/contract-packs.json"),
         );
+    }
+
+    #[test]
+    fn release_evidence_minor_step_list_includes_verification_pack() {
+        let steps = release_evidence_steps_minor();
+        let step = steps
+            .iter()
+            .find(|step| step.name == "verification-pack")
+            .expect("minor lane must wire full verification pack");
+        assert_eq!(
+            step.command,
+            &[
+                "cargo",
+                "xtask",
+                "verification-pack",
+                "--out",
+                "target/release-evidence/verification-pack",
+            ],
+        );
+        assert!(
+            step.artifacts
+                .contains(&"target/release-evidence/verification-pack/README.md"),
+        );
+        assert!(step.artifacts.contains(
+            &"target/release-evidence/verification-pack/claim-proof/tls-contract-pack/receipt.json"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Add a patch release-evidence step that builds a scanner-safe verification pack.
- Add a minor release-evidence step that builds the full stable verification pack.
- Surface verification-pack status in the release-evidence summary table.
- Update the release-evidence spec and active goal state for the next UX polish slice.

Files changed
- xtask/src/main.rs
- docs/specs/USELESSKEY-SPEC-0006-release-evidence-lanes.md
- .uselesskey/goals/active.toml

Validation
- cargo test -p xtask release_evidence
- cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary
- cargo xtask release-evidence --version 0.9.0 --dry-run --summary
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo xtask spec-check --strict
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask pr
- git diff --check

Non-goals
- Does not run crates.io smoke without an explicit version.
- Does not add fixture profiles, TLS behavior, public claims, or README badges.
- Does not add archives, signing, attestation, SBOMs, or CI uploads.
- Does not include generated secret-shaped payloads in verification packs.

What this enables next
- Public verification UX polish can now point at release-carried verification-pack receipts.

Security surface
- Release evidence references metadata-only verification packs; payload exclusion remains enforced by the verification-pack command.