### PR TITLE
docs: polish public verification UX

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -185,7 +185,7 @@ commands = [
 
 [[work_item]]
 id = "public-verification-ux-polish"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0002"
 plan = "plans/claim-backed-verification/implementation-plan.md"
@@ -194,4 +194,22 @@ commands = [
   "cargo xtask badges --check",
   "cargo xtask docs-sync --check",
   "cargo xtask typos",
+]
+
+[[work_item]]
+id = "lane-closeout"
+status = "ready"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/claim-backed-verification/implementation-plan.md"
+commands = [
+  "cargo xtask spec-check --strict",
+  "cargo xtask claim-report",
+  "cargo xtask claim-report --check-public-claims",
+  "cargo xtask contract-packs --check",
+  "cargo xtask claim-proof --all-stable",
+  "cargo xtask verification-pack --out target/uselesskey-verification",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "git diff --check",
 ]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Public claims are command-backed. Start with the
 [verification guide](docs/how-to/verify-uselesskey-public-claims.md) or the
 [public claim index](docs/status/PUBLIC_CLAIMS.md) to see what each badge and
 contract-pack claim proves, what command checks it, and what it does not prove.
+For reviewer handoff, generate a metadata-only proof bundle:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification
+```
 
 ## Why this exists
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,8 +42,8 @@ Task-oriented instructions for common workflows.
 - [test-oidc-jwks-validation.md](how-to/test-oidc-jwks-validation.md) — Using the OIDC/JWKS contract pack in validator tests
 - [test-jwt-negative-validation.md](how-to/test-jwt-negative-validation.md) — Using JWT-shaped negatives for policy rejection tests
 - [generate-scanner-safe-k8s-secret.md](how-to/generate-scanner-safe-k8s-secret.md) — Exporting scanner-safe Kubernetes and Vault-shaped payloads
-- [verify-uselesskey-public-claims.md](how-to/verify-uselesskey-public-claims.md) — Verifying badge, scanner-safe, contract-pack, and release-smoke claims
-- [share-uselesskey-verification-pack.md](how-to/share-uselesskey-verification-pack.md) — Collecting public-claim receipts for security and platform review
+- [verify-uselesskey-public-claims.md](how-to/verify-uselesskey-public-claims.md) — Verifying badge, scanner-safe, contract-pack, claim-proof, and release-smoke claims
+- [share-uselesskey-verification-pack.md](how-to/share-uselesskey-verification-pack.md) — Collecting metadata-only public-claim receipts for security and platform review
 
 ## Contributing
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -85,6 +85,34 @@ Use `cargo xtask claim-report --check-public-claims` to verify that the
 hand-written public claim page still contains every stable ledger claim, its
 proof commands, and its boundary.
 
+## Claim Proof Receipts
+
+`cargo xtask claim-proof` runs allowlisted proof handlers for selected claims
+and writes per-claim receipts:
+
+```bash
+cargo xtask claim-proof --claim scanner-safe-fixtures
+cargo xtask claim-proof --claim tls-contract-pack
+cargo xtask claim-proof --all-stable
+```
+
+The command uses symbolic handlers from `policy/claim-ledger.toml`; it does not
+shell-evaluate proof-command strings from the ledger. Receipts stay under
+`target/claim-proof/`.
+
+## Verification Packs
+
+Use `cargo xtask verification-pack` when a reviewer needs a shareable bundle of
+public-claim receipts:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification
+```
+
+The pack contains claim reports, contract-pack registry reports, badge endpoint
+JSON, and selected claim-proof receipts. It contains metadata and receipts only,
+not generated fixture payloads.
+
 ## Release Evidence Receipts
 
 Patch release evidence records the public claim index:
@@ -107,6 +135,7 @@ target/release-evidence/claims/public-claims.md
 target/release-evidence/claims/public-claims.json
 target/release-evidence/contract-packs/contract-packs.md
 target/release-evidence/contract-packs/contract-packs.json
+target/release-evidence/verification-pack/README.md
 ```
 
 ## Pull Request Evidence

--- a/docs/how-to/share-uselesskey-verification-pack.md
+++ b/docs/how-to/share-uselesskey-verification-pack.md
@@ -44,19 +44,8 @@ teach them, and which boundaries apply.
 
 ## 3. Include Claim Proof Receipts
 
-For scanner-safe fixtures:
-
-```bash
-cargo xtask claim-proof --claim scanner-safe-fixtures
-```
-
-For the TLS contract pack:
-
-```bash
-cargo xtask claim-proof --claim tls-contract-pack
-```
-
-Attach:
+The verification-pack command runs the selected claim proofs and copies the
+receipts into the pack. Attach:
 
 ```text
 target/uselesskey-verification/claim-proof/scanner-safe-fixtures/receipt.md
@@ -65,10 +54,11 @@ target/uselesskey-verification/claim-proof/tls-contract-pack/receipt.md
 target/uselesskey-verification/claim-proof/tls-contract-pack/receipt.json
 ```
 
-For all stable supported claims:
+If you need standalone receipts outside the pack:
 
 ```bash
-cargo xtask claim-proof --all-stable
+cargo xtask claim-proof --claim scanner-safe-fixtures
+cargo xtask claim-proof --claim tls-contract-pack
 ```
 
 Do not use `--all-stable` as crates.io release proof. Registry smoke remains a

--- a/docs/how-to/verify-uselesskey-public-claims.md
+++ b/docs/how-to/verify-uselesskey-public-claims.md
@@ -6,7 +6,7 @@ commands prove those claims, and where the receipts are written.
 The quick rule:
 
 ```text
-README badge -> public claim -> proof command -> receipt -> boundary
+README badge -> public claim -> claim report -> claim proof -> verification pack
 ```
 
 ## 1. Read the Claim Index
@@ -83,7 +83,19 @@ commit.
 
 ## 4. Verify Scanner-Safe Fixture Claims
 
-Run the scanner-safe reference checks:
+For a single runnable receipt, use the allowlisted claim-proof runner:
+
+```bash
+cargo xtask claim-proof --claim scanner-safe-fixtures
+```
+
+The receipt is written under:
+
+```text
+target/claim-proof/scanner-safe-fixtures/
+```
+
+To run the underlying checks directly:
 
 ```bash
 cargo xtask scanner-safe-reference --check
@@ -112,9 +124,17 @@ Run the TLS bundle proof:
 cargo xtask bundle-proof --profile tls --out target/release-evidence/tls
 ```
 
+For a single runnable claim receipt:
+
+```bash
+cargo xtask claim-proof --claim tls-contract-pack
+```
+
 Attach these receipts:
 
 ```text
+target/claim-proof/tls-contract-pack/receipt.md
+target/claim-proof/tls-contract-pack/receipt.json
 target/release-evidence/tls/tls-contract-pack-proof.md
 target/release-evidence/tls/tls-contract-pack-proof.json
 target/release-evidence/contract-packs/contract-packs.md
@@ -142,9 +162,22 @@ registry state.
 
 ## 7. Attach Review Evidence
 
+For the full reviewer bundle:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification
+```
+
 For a security, platform, or release review, attach:
 
 ```text
+target/uselesskey-verification/README.md
+target/uselesskey-verification/public-claims.md
+target/uselesskey-verification/public-claims.json
+target/uselesskey-verification/contract-packs.md
+target/uselesskey-verification/contract-packs.json
+target/uselesskey-verification/claim-proof/*/receipt.md
+target/uselesskey-verification/claim-proof/*/receipt.json
 target/claim-report/public-claims.md
 target/claim-report/public-claims.json
 target/release-evidence/tls/tls-contract-pack-proof.md
@@ -153,6 +186,9 @@ target/release-evidence/tls/tls-contract-pack-proof.json
 
 Also include the commands you ran and the exact version, branch, or commit under
 review.
+
+The verification pack contains metadata and receipts only. Do not attach
+generated fixture payloads such as PEM, DER, JWT, or key files.
 
 ## Boundaries to Keep Visible
 

--- a/docs/reference/verification-badges.md
+++ b/docs/reference/verification-badges.md
@@ -10,7 +10,8 @@ README badge -> public claim -> proof command -> receipt -> boundary
 ```
 
 Use [`docs/status/PUBLIC_CLAIMS.md`](../status/PUBLIC_CLAIMS.md) for the claim
-index and `cargo xtask claim-report` for the generated Markdown/JSON report.
+index, `cargo xtask claim-report` for the generated Markdown/JSON report, and
+`cargo xtask claim-proof --claim <claim-id>` for runnable claim receipts.
 
 `uselesskey` uses generated Shields endpoint JSON for badges that represent
 repo-owned proof:
@@ -96,7 +97,12 @@ target/release-evidence/contract-packs/contract-packs.md
 
 Patch release evidence includes the public claim report. Minor release evidence
 also includes the contract-pack registry because contract packs are public
-fixture-platform promises.
+fixture-platform promises. Minor release evidence also carries a metadata-only
+verification pack under:
+
+```text
+target/release-evidence/verification-pack/
+```
 
 ## Future Badges
 

--- a/docs/status/PUBLIC_CLAIMS.md
+++ b/docs/status/PUBLIC_CLAIMS.md
@@ -18,6 +18,18 @@ Check this page against the ledger:
 cargo xtask claim-report --check-public-claims
 ```
 
+Run a proof receipt for one claim:
+
+```bash
+cargo xtask claim-proof --claim scanner-safe-fixtures
+```
+
+Collect reviewer-facing receipts without generated fixture payloads:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification
+```
+
 ## Claim Statuses
 
 | Status | Meaning |
@@ -52,3 +64,8 @@ what is explicitly outside the boundary?
 
 If a claim cannot answer those questions, it should stay out of the README
 masthead and release headline until the proof path exists.
+
+Use `cargo xtask claim-proof --claim <claim-id>` when a reviewer needs runnable
+evidence for a supported claim. Use `cargo xtask verification-pack --out <dir>`
+when they need claim reports, badge endpoints, contract-pack receipts, and
+claim-proof receipts in one metadata-only bundle.


### PR DESCRIPTION
Summary
- Route users from README/public claims into claim-report, claim-proof, and verification-pack.
- Add claim-proof and verification-pack sections to the verification docs.
- Clarify that verification packs are metadata-only reviewer bundles.
- Mark the UX polish work item done and queue lane closeout in active.toml.

Files changed
- README.md
- docs/README.md
- docs/VERIFICATION.md
- docs/status/PUBLIC_CLAIMS.md
- docs/reference/verification-badges.md
- docs/how-to/verify-uselesskey-public-claims.md
- docs/how-to/share-uselesskey-verification-pack.md
- .uselesskey/goals/active.toml

Validation
- cargo xtask claim-report --check-public-claims
- cargo xtask badges --check
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask spec-check --strict
- cargo xtask pr
- git diff --check

Non-goals
- Does not add new claims, proof handlers, fixture profiles, or README badges.
- Does not change generated badge JSON.
- Does not add release execution, crates.io smoke, TLS behavior, or dependency churn.

What this enables next
- Lane closeout can archive the active goal with the user-facing proof path complete.