### PR TITLE
ops: start pr-lite evidence ergonomics lane

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -1,34 +1,30 @@
-id = "uselesskey-claim-backed-verification"
-title = "Claim-backed verification UX"
-status = "archived"
+id = "uselesskey-pr-lite-evidence"
+title = "PR-lite evidence ergonomics"
+status = "active"
 owner = "EffortlessMetrics"
 created = "2026-05-13"
 
 objective = """
-Make uselesskey's public claims discoverable, runnable, and reviewable from
-the repo itself. Users should be able to move from README badges and public
-claim docs to claim reports, proof commands, artifacts, release evidence, and
-explicit boundaries without relying on chat history.
+Make local PR evidence approximate hosted CI closely enough to reduce wasted CI
+cycles, and make heavy evidence routing explain itself with receipts that show
+what ran, what skipped, and why.
 """
 
 end_state = [
-  "README badges link to explanations, not just endpoint files.",
-  "cargo xtask claim-report emits Markdown and JSON from policy/claim-ledger.toml.",
-  "docs/status/PUBLIC_CLAIMS.md is checked against policy/claim-ledger.toml.",
-  "A user-facing guide explains how to verify public claims locally.",
-  "Contract-pack claims have a registry and check command.",
-  "Release evidence includes claim-report, contract-pack, and verification-pack receipts.",
-  "Agent bootstrap docs tell Codex to start from active.toml and linked plans.",
-  "cargo xtask claim-proof writes per-claim receipts from allowlisted handlers.",
-  "cargo xtask verification-pack builds metadata-only reviewer bundles.",
+  "cargo xtask pr-lite provides a bounded local approximation of hosted PR CI.",
+  "pr-lite writes Markdown and JSON receipts under target/pr-lite/.",
+  "heavy evidence routing explains why targeted mutation or deeper proof ran.",
+  "mutation routing receipts show changed files, owner crates, labels, ripr severity, and selected commands.",
+  "diff-scoped mutation is used only where safe and records fallback reasons.",
+  "agent docs distinguish partial local evidence from full hosted or release proof.",
 ]
 
 [[work_item]]
 id = "open-lane"
 status = "done"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0002"
-plan = "plans/claim-backed-verification/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/pr-lite-evidence/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
@@ -37,180 +33,13 @@ commands = [
 ]
 
 [[work_item]]
-id = "claim-report"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0002"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo test -p xtask claim_report",
-  "cargo xtask claim-report",
-  "cargo xtask claim-report --format json",
-  "cargo xtask claim-report --claim scanner-safe-fixtures",
-]
-
-[[work_item]]
-id = "public-claims-check"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0002"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo xtask claim-report --check-public-claims",
-  "cargo xtask spec-check --strict",
-]
-
-[[work_item]]
-id = "verification-guide"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0002"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo xtask claim-report",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "contract-pack-registry"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0003"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo test -p xtask contract_pack",
-  "cargo xtask contract-packs --check",
-  "cargo xtask contract-packs --format json",
-]
-
-[[work_item]]
-id = "release-claim-receipts"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0006"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary",
-  "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
-]
-
-[[work_item]]
-id = "verification-boundary-polish"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0004"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo xtask badges --check",
-  "cargo xtask claim-report",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-]
-
-[[work_item]]
-id = "agent-bootstrap"
-status = "done"
+id = "pr-lite-spec"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/claim-backed-verification/implementation-plan.md"
+plan = "plans/pr-lite-evidence/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-]
-
-[[work_item]]
-id = "claim-proof-policy"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0008"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo xtask spec-check --strict",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "claim-proof-runner"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0008"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo test -p xtask claim_proof",
-  "cargo xtask claim-proof --claim scanner-safe-fixtures",
-  "cargo xtask claim-proof --claim tls-contract-pack",
-]
-
-[[work_item]]
-id = "verification-pack-spec"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0009"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo xtask spec-check --strict",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "verification-pack-command"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0009"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo test -p xtask verification_pack",
-  "cargo xtask verification-pack --out target/uselesskey-verification",
-  "cargo xtask no-blob",
-  "cargo xtask check-file-policy",
-]
-
-[[work_item]]
-id = "release-evidence-claim-proof"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0006"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary",
-  "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
-  "cargo xtask claim-proof --all-stable",
-  "cargo xtask verification-pack --out target/uselesskey-verification",
-]
-
-[[work_item]]
-id = "public-verification-ux-polish"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0002"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo xtask claim-report --check-public-claims",
-  "cargo xtask badges --check",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-]
-
-[[work_item]]
-id = "lane-closeout"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0005"
-plan = "plans/claim-backed-verification/implementation-plan.md"
-commands = [
-  "cargo xtask spec-check --strict",
-  "cargo xtask claim-report",
-  "cargo xtask claim-report --check-public-claims",
-  "cargo xtask contract-packs --check",
-  "cargo xtask claim-proof --all-stable",
-  "cargo xtask verification-pack --out target/uselesskey-verification",
   "cargo xtask docs-sync --check",
   "cargo xtask typos",
   "git diff --check",

--- a/plans/README.md
+++ b/plans/README.md
@@ -9,6 +9,7 @@ Plans do not define product truth. Link to proposals for why and specs for what.
 
 - [spec-system](spec-system/README.md) - Source-of-truth and spec-system rollout
 - [claim-backed-verification](claim-backed-verification/README.md) - User-facing claim proof and verification-pack rollout
+- [pr-lite-evidence](pr-lite-evidence/README.md) - Local PR evidence and heavy-routing receipt rollout
 
 ## Templates
 

--- a/plans/pr-lite-evidence/README.md
+++ b/plans/pr-lite-evidence/README.md
@@ -1,0 +1,9 @@
+# PR-Lite Evidence Plan Area
+
+This directory tracks the lane that makes local PR evidence cheaper and closer
+to hosted CI while making heavy evidence routing explain itself.
+
+## Plan Files
+
+- [implementation-plan.md](implementation-plan.md) - PR sequence, proof
+  commands, non-goals, and stop conditions.

--- a/plans/pr-lite-evidence/implementation-plan.md
+++ b/plans/pr-lite-evidence/implementation-plan.md
@@ -1,0 +1,84 @@
++++
+id = "USELESSKEY-PLAN-0005"
+kind = "plan"
+title = "PR-lite evidence ergonomics"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+milestone = "v0.9.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0005",
+]
+linked_adrs = []
++++
+
+# PR-Lite Evidence Ergonomics
+
+## Objective
+
+Make local PR evidence approximate hosted CI closely enough to reduce wasted CI
+cycles, and make heavy evidence routing explain itself.
+
+## Scope
+
+This lane covers developer and agent evidence ergonomics:
+
+- `cargo xtask pr-lite` as local bounded PR evidence;
+- Markdown and JSON PR-lite receipts under `target/pr-lite/`;
+- mutation routing receipts explaining why targeted mutation runs or skips;
+- safe diff-scoped mutation only when supported, with fallback receipts;
+- agent and local-validation docs for honest evidence reporting.
+
+## Non-Goals
+
+Do not mix these into this lane:
+
+- new product claims;
+- new fixture profiles;
+- release execution;
+- shipper re-migration;
+- no-panic burndown;
+- mutation policy weakening;
+- TLS mTLS, revocation, CT, or browser trust-store behavior;
+- dependency churn;
+- new README badges.
+
+## PR Sequence
+
+1. Open this active lane and implementation plan.
+2. Add `USELESSKEY-SPEC-0010` for PR-lite evidence and heavy-routing receipts.
+3. Add `cargo xtask pr-lite` with Markdown and JSON receipts.
+4. Add mutation routing explanation receipts.
+5. Add diff-scoped mutation where safe, with fallback.
+6. Add local validation and evidence routing docs.
+7. Close out the lane with a learning record and archived goal manifest.
+
+## Proof Commands
+
+Lane-opening PR:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Final lane proof:
+
+```bash
+cargo xtask pr-lite
+cargo xtask pr-lite --format json
+cargo xtask mutants-pr --changed --explain
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+## Stop Conditions
+
+Pause and split work if a PR would require product behavior, release execution,
+new fixture profiles, TLS expansion, dependency churn, or weakening mutation
+requirements.


### PR DESCRIPTION
﻿## Summary
- Open the pr-lite evidence ergonomics active lane.
- Add the implementation plan and plan-area README for the lane.
- Register the plan area in plans/README.md.

## Files added/changed
- .uselesskey/goals/active.toml
- plans/pr-lite-evidence/README.md
- plans/pr-lite-evidence/implementation-plan.md
- plans/README.md

## Validation
- cargo xtask spec-check --strict - pass
- cargo xtask docs-sync --check - pass
- cargo xtask typos - pass
- git diff --check - pass

## Non-goals
- No product behavior changes.
- No new fixture profiles.
- No release execution.
- No mutation policy changes.
- No README badge changes.

## What this enables next
- Adds the repo-owned control plane for the next slice: USELESSKEY-SPEC-0010 for PR-lite and heavy evidence routing.
