### PR TITLE
docs(agent): add local validation evidence guide

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -90,11 +90,25 @@ commands = [
 
 [[work_item]]
 id = "local-validation-guide"
+status = "done"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0010"
+plan = "plans/pr-lite-evidence/implementation-plan.md"
+commands = [
+  "cargo xtask spec-check --strict",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "lane-closeout"
 status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0010"
 plan = "plans/pr-lite-evidence/implementation-plan.md"
 commands = [
+  "cargo xtask pr-lite",
   "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
   "cargo xtask typos",

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -11,6 +11,10 @@ Start with [agent-bootstrap.md](agent-bootstrap.md) when resuming agent work.
 It defines the read order from `active.toml` to plans, specs, claim reports, and
 validation commands.
 
+Use [local-validation.md](local-validation.md) when reporting local PR evidence
+or deciding what `pr-lite`, hosted CI, targeted mutation, and release evidence
+each prove.
+
 ## Required Shape
 
 Use [the handoff template](../templates/handoff.md). A handoff should include:

--- a/docs/handoffs/agent-bootstrap.md
+++ b/docs/handoffs/agent-bootstrap.md
@@ -55,9 +55,14 @@ git diff --check
 Code or xtask changes should add the narrow relevant tests first, then run:
 
 ```bash
+cargo xtask pr-lite
 cargo xtask pr
 git diff --check
 ```
+
+Use [local-validation.md](local-validation.md) to report partial local evidence
+honestly. Do not say "all gates passed" unless the relevant local command and
+hosted required checks have both completed.
 
 ## Non-Goals
 

--- a/docs/handoffs/local-validation.md
+++ b/docs/handoffs/local-validation.md
@@ -1,0 +1,136 @@
+# Local Validation and Evidence Routing
+
+Use this handoff when preparing, reviewing, or reporting local PR evidence.
+Local evidence is useful only when its boundary is explicit.
+
+## First Command
+
+For non-trivial repo work, start with:
+
+```bash
+cargo xtask pr-lite
+```
+
+`pr-lite` is the bounded local approximation of hosted PR CI. It writes:
+
+```text
+target/pr-lite/pr-lite.json
+target/pr-lite/pr-lite.md
+```
+
+Use those receipts to report what ran locally, what skipped, and what hosted CI
+still owns.
+
+## What PR-Lite Covers
+
+`pr-lite` focuses on cheap, deterministic checks:
+
+- source-of-truth drift with `cargo xtask spec-check --strict`;
+- docs synchronization with `cargo xtask docs-sync --check`;
+- file policy, no-blob, and public-surface checks;
+- impacted-evidence routing;
+- existing `ripr` PR artifact contracts when artifacts exist;
+- cheap focused test paths such as xtask tests, examples smoke, BDD checks, or
+  fuzz build when the changed paths justify them.
+
+It does not replace `cargo xtask pr`, hosted CI, targeted mutation, full fuzzing,
+or release evidence.
+
+## Heavy Evidence Routing
+
+Use the mutation routing receipt when targeted mutation is surprising or slow:
+
+```bash
+cargo xtask mutants-pr --changed --explain
+```
+
+The receipt lives under:
+
+```text
+target/xtask/mutation-routing/latest.json
+target/xtask/mutation-routing/latest.md
+```
+
+It should explain:
+
+- changed files considered;
+- owner crates selected;
+- whether targeted mutation is required;
+- RIPR severe-gap routing;
+- labels that hosted CI may consider;
+- selected mutation command;
+- whether diff-scoped mutation is available;
+- fallback reason when crate-scope mutation is used.
+
+Diff-scoped mutation is allowed only when changed owner paths map cleanly to
+Rust hunks. If mapping, diff generation, or diff-file writing fails,
+`mutants-pr` falls back to crate-scope mutation and records the reason.
+
+`--full-owner` is intentionally crate-scoped. Do not describe it as
+diff-scoped proof.
+
+## Reporting Language
+
+Use precise validation language in PR bodies and handoffs.
+
+Say:
+
+```text
+Local PR-lite passed; hosted CI and full PR evidence remain separate.
+```
+
+Say:
+
+```text
+cargo xtask pr passed locally.
+```
+
+Only say:
+
+```text
+All required gates passed.
+```
+
+after the relevant local command and hosted required checks have completed.
+
+Do not use `pr-lite` success to claim release readiness, mutation adequacy,
+runtime correctness, or public-claim proof.
+
+## Evidence Map
+
+Docs-only PRs usually need:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Non-trivial code or xtask PRs should add:
+
+```bash
+cargo xtask pr-lite
+cargo xtask pr
+```
+
+Public-claim changes should add:
+
+```bash
+cargo xtask claim-report --check-public-claims
+```
+
+Contract-pack changes should add:
+
+```bash
+cargo xtask contract-packs --check
+```
+
+Mutation-routing changes should add:
+
+```bash
+cargo xtask mutants-pr --changed --explain
+```
+
+Release work remains separate. Use release-evidence commands from
+`docs/specs/USELESSKEY-SPEC-0006-release-evidence-lanes.md`.


### PR DESCRIPTION
## Summary
- add a local-validation handoff for PR-lite, hosted CI, mutation routing, and evidence language
- link the guide from handoff and agent bootstrap docs
- advance the pr-lite lane active goal to closeout

## Files added/changed
- .uselesskey/goals/active.toml
- docs/handoffs/local-validation.md
- docs/handoffs/README.md
- docs/handoffs/agent-bootstrap.md

## Validation
- cargo xtask spec-check --strict
- cargo xtask docs-sync --check
- cargo xtask typos
- git diff --check

## Non-goals
- no proof command changes
- no product behavior changes
- no public claim, badge, release, shipper, no-panic, or fixture-profile work

## What this enables next
- the pr-lite evidence ergonomics lane can close out with durable guidance for honest local-vs-hosted evidence reporting