### PR TITLE
ops: start no-panic burndown lane

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -1,22 +1,21 @@
-id = "uselesskey-pr-lite-evidence"
-title = "PR-lite evidence ergonomics"
-status = "archived"
+id = "uselesskey-no-panic-burndown"
+title = "No-panic burndown"
+status = "active"
 owner = "EffortlessMetrics"
 created = "2026-05-13"
 
 objective = """
-Make local PR evidence approximate hosted CI closely enough to reduce wasted CI
-cycles, and make heavy evidence routing explain itself with receipts that show
-what ran, what skipped, and why.
+Burn down the no-panic-family debt tracked by issue #575 without resetting the
+baseline, weakening policy, or absorbing new debt into the snapshot.
 """
 
 end_state = [
-  "cargo xtask pr-lite provides a bounded local approximation of hosted PR CI.",
-  "pr-lite writes Markdown and JSON receipts under target/pr-lite/.",
-  "heavy evidence routing explains why targeted mutation or deeper proof ran.",
-  "mutation routing receipts show changed files, owner crates, labels, ripr severity, and selected commands.",
-  "diff-scoped mutation is used only where safe and records fallback reasons.",
-  "agent docs distinguish partial local evidence from full hosted or release proof.",
+  "cargo xtask check-no-panic-family exits 0 in no-new-debt mode.",
+  "New-debt count reaches 0 without running cargo xtask no-panic baseline --reset.",
+  "Test-code panic-family sites move to fallible test-support helpers.",
+  "Production-path findings are removed or receipted in policy/no-panic-allowlist.toml.",
+  "Remaining exceptions have owner, explanation, classification, and expiry.",
+  "The policy can advance toward Stage C only after the baseline has burned down.",
 ]
 
 [[work_item]]
@@ -24,7 +23,7 @@ id = "open-lane"
 status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/pr-lite-evidence/implementation-plan.md"
+plan = "plans/no-panic-burndown/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
@@ -33,84 +32,84 @@ commands = [
 ]
 
 [[work_item]]
-id = "pr-lite-spec"
-status = "done"
+id = "cli-tests"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0010"
-plan = "plans/pr-lite-evidence/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/no-panic-burndown/implementation-plan.md"
 commands = [
-  "cargo xtask spec-check --strict",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "pr-lite-command"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0010"
-plan = "plans/pr-lite-evidence/implementation-plan.md"
-commands = [
-  "cargo test -p xtask pr_lite",
+  "cargo test -p uselesskey-cli --test cli",
+  "cargo xtask check-no-panic-family",
+  "cargo xtask no-panic baseline",
   "cargo xtask pr-lite",
-  "cargo xtask pr-lite --format json",
-  "cargo xtask spec-check --strict",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "xtask-tests"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/no-panic-burndown/implementation-plan.md"
+commands = [
+  "cargo test -p xtask",
+  "cargo xtask check-no-panic-family",
+  "cargo xtask no-panic baseline",
+  "cargo xtask pr-lite",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "core-tests"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/no-panic-burndown/implementation-plan.md"
+commands = [
+  "cargo test -p uselesskey-core",
+  "cargo xtask check-no-panic-family",
+  "cargo xtask no-panic baseline",
+  "cargo xtask pr-lite",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "jwk-token-tests"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/no-panic-burndown/implementation-plan.md"
+commands = [
+  "cargo test -p uselesskey-jwk",
+  "cargo test -p uselesskey-token",
+  "cargo xtask check-no-panic-family",
+  "cargo xtask no-panic baseline",
+  "cargo xtask pr-lite",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "production-path-review"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/no-panic-burndown/implementation-plan.md"
+commands = [
+  "cargo xtask check-no-panic-family",
+  "cargo xtask no-panic propose",
+  "cargo xtask pr-lite",
   "cargo xtask pr",
   "git diff --check",
 ]
-
 [[work_item]]
-id = "mutation-routing-receipt"
-status = "done"
+id = "policy-stage-flip"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0010"
-plan = "plans/pr-lite-evidence/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/no-panic-burndown/implementation-plan.md"
 commands = [
-  "cargo test -p xtask impacted_evidence",
-  "cargo xtask impacted-evidence",
-  "cargo xtask mutants-pr --changed --explain",
-  "cargo xtask pr-lite",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "diff-scoped-mutation"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0010"
-plan = "plans/pr-lite-evidence/implementation-plan.md"
-commands = [
-  "cargo test -p xtask mutants_pr",
-  "cargo xtask mutants-pr --changed --explain",
-  "cargo xtask pr-lite",
+  "cargo xtask check-no-panic-family",
+  "cargo xtask check-lint-policy",
   "cargo xtask pr",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "local-validation-guide"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0010"
-plan = "plans/pr-lite-evidence/implementation-plan.md"
-commands = [
-  "cargo xtask spec-check --strict",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "lane-closeout"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0010"
-plan = "plans/pr-lite-evidence/implementation-plan.md"
-commands = [
-  "cargo xtask pr-lite",
-  "cargo xtask spec-check --strict",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
   "git diff --check",
 ]

--- a/plans/README.md
+++ b/plans/README.md
@@ -10,6 +10,7 @@ Plans do not define product truth. Link to proposals for why and specs for what.
 - [spec-system](spec-system/README.md) - Source-of-truth and spec-system rollout
 - [claim-backed-verification](claim-backed-verification/README.md) - User-facing claim proof and verification-pack rollout
 - [pr-lite-evidence](pr-lite-evidence/README.md) - Local PR evidence and heavy-routing receipt rollout
+- [no-panic-burndown](no-panic-burndown/README.md) - No-panic-family debt burndown without baseline reset
 
 ## Templates
 

--- a/plans/no-panic-burndown/README.md
+++ b/plans/no-panic-burndown/README.md
@@ -1,0 +1,9 @@
+# No-Panic Burndown Plan Area
+
+This directory tracks the lane that burns down no-panic-family debt without
+resetting the baseline or weakening panic policy.
+
+## Plan Files
+
+- [implementation-plan.md](implementation-plan.md) - PR sequence, proof
+  commands, non-goals, and stop conditions.

--- a/plans/no-panic-burndown/implementation-plan.md
+++ b/plans/no-panic-burndown/implementation-plan.md
@@ -1,0 +1,119 @@
++++
+id = "USELESSKEY-PLAN-0007"
+kind = "plan"
+title = "No-panic burndown"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+milestone = "v0.9.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0005",
+]
+linked_adrs = []
++++
+
+# No-Panic Burndown
+
+## Objective
+
+Burn down the no-panic-family debt tracked by issue #575 without resetting the
+baseline, weakening policy, or absorbing new debt into the snapshot.
+
+## Source State
+
+Issue #575 is the tracking ticket. Its live snapshot reports:
+
+```text
+4307 finding(s)
+4157 baselined
+150 new-debt
+54 stale-baseline
+0 expired
+mode = no-new-debt
+```
+
+The largest clusters are test-code `expect` and `unwrap` sites. The remaining
+production-path cluster needs case-by-case review: either remove the panic path
+or add a receipted allowlist entry with owner, classification, explanation, and
+expiry.
+
+## Scope
+
+This lane covers:
+
+- migration of test-code panic-family sites to `uselesskey-test-support`
+  fallible helpers;
+- deliberate baseline refreshes with `cargo xtask no-panic baseline` after
+  vanished entries are removed;
+- case-by-case production-path review;
+- receipted allowlist entries only for justified invariants or fixture
+  boundaries;
+- final policy-stage preparation once no-new-debt is clean.
+
+## Non-Goals
+
+Do not mix these into this lane:
+
+- `cargo xtask no-panic baseline --reset`;
+- baseline reset or absorption of new debt;
+- weakening `policy/clippy-lints.toml`;
+- broad refactors unrelated to panic-family debt;
+- new fixture profiles;
+- release execution;
+- shipper migration work;
+- README badge changes;
+- dependency churn.
+
+## PR Sequence
+
+1. Open this active lane and implementation plan.
+2. Migrate `crates/uselesskey-cli/tests/cli.rs` to fallible test helpers.
+3. Migrate xtask tests.
+4. Migrate core test modules.
+5. Migrate JWK and token test modules.
+6. Review remaining production-path findings and either propagate errors or
+   add receipted allowlist entries.
+7. Flip policy stage only when `check-no-panic-family` is clean and remaining
+   exceptions are receipted.
+8. Close out the lane with a learning record and archived active goal.
+
+## Proof Commands
+
+Lane-opening PR:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Per-burndown PR:
+
+```bash
+cargo xtask check-no-panic-family
+cargo xtask no-panic baseline
+cargo xtask pr-lite
+cargo xtask pr
+git diff --check
+```
+
+Use focused crate tests before the broad gate. For example:
+
+```bash
+cargo test -p uselesskey-cli --test cli
+cargo test -p xtask
+cargo test -p uselesskey-core
+cargo test -p uselesskey-jwk
+cargo test -p uselesskey-token
+```
+
+## Stop Conditions
+
+Pause and split work if a PR would require baseline reset, policy weakening,
+unrelated refactors, public API changes, release execution, new fixture
+profiles, shipper work, or dependency churn.
+
+Do not mark the lane complete until `cargo xtask check-no-panic-family` exits 0
+in `no-new-debt` mode without `--reset`.


### PR DESCRIPTION
## Summary
- open the no-panic burndown active goal after closing the pr-lite lane
- add a no-panic burndown implementation plan tied to issue #575
- record the PR sequence and explicit stop conditions, especially no baseline reset and no policy weakening

## Files added/changed
- .uselesskey/goals/active.toml
- plans/no-panic-burndown/README.md
- plans/no-panic-burndown/implementation-plan.md
- plans/README.md

## Validation
- cargo xtask spec-check --strict
- cargo xtask docs-sync --check
- cargo xtask typos
- git diff --check

## Non-goals
- no panic-site migration in this PR
- no cargo xtask no-panic baseline --reset
- no policy weakening, production behavior changes, dependency churn, release work, shipper work, fixture profiles, or badge changes

## What this enables next
- the first execution PR can migrate crates/uselesskey-cli/tests/cli.rs to fallible test helpers under a clear lane plan