### PR TITLE
test(cli): remove panic-family setup helpers

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -33,28 +33,26 @@ commands = [
 
 [[work_item]]
 id = "cli-tests"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/no-panic-burndown/implementation-plan.md"
 commands = [
   "cargo test -p uselesskey-cli --test cli",
   "cargo xtask check-no-panic-family",
-  "cargo xtask no-panic baseline",
   "cargo xtask pr-lite",
   "git diff --check",
 ]
 
 [[work_item]]
 id = "xtask-tests"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/no-panic-burndown/implementation-plan.md"
 commands = [
   "cargo test -p xtask",
   "cargo xtask check-no-panic-family",
-  "cargo xtask no-panic baseline",
   "cargo xtask pr-lite",
   "git diff --check",
 ]
@@ -68,7 +66,6 @@ plan = "plans/no-panic-burndown/implementation-plan.md"
 commands = [
   "cargo test -p uselesskey-core",
   "cargo xtask check-no-panic-family",
-  "cargo xtask no-panic baseline",
   "cargo xtask pr-lite",
   "git diff --check",
 ]
@@ -83,7 +80,6 @@ commands = [
   "cargo test -p uselesskey-jwk",
   "cargo test -p uselesskey-token",
   "cargo xtask check-no-panic-family",
-  "cargo xtask no-panic baseline",
   "cargo xtask pr-lite",
   "git diff --check",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4700,6 +4700,7 @@ dependencies = [
  "uselesskey-hmac",
  "uselesskey-jwk",
  "uselesskey-rsa",
+ "uselesskey-test-support",
  "uselesskey-token",
  "uselesskey-x509",
 ]

--- a/crates/uselesskey-cli/Cargo.toml
+++ b/crates/uselesskey-cli/Cargo.toml
@@ -52,6 +52,7 @@ insta.workspace = true
 predicates = "3.1.3"
 serde_json.workspace = true
 tempfile.workspace = true
+uselesskey-test-support.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -1,4 +1,6 @@
-use std::fs;
+use std::{fmt, fs};
+
+use uselesskey_test_support::{TestResult, require_ok, require_some};
 
 use assert_cmd::Command;
 use base64::Engine as _;
@@ -8,51 +10,70 @@ use predicates::prelude::*;
 use serde_json::Value;
 use tempfile::tempdir;
 
+trait TestContext<T> {
+    fn test_context(self, msg: impl fmt::Display) -> TestResult<T>;
+}
+
+impl<T, E: fmt::Display> TestContext<T> for Result<T, E> {
+    fn test_context(self, msg: impl fmt::Display) -> TestResult<T> {
+        require_ok(self, msg)
+    }
+}
+
+impl<T> TestContext<T> for Option<T> {
+    fn test_context(self, msg: impl fmt::Display) -> TestResult<T> {
+        require_some(self, msg)
+    }
+}
+
 #[test]
-fn generate_rsa_pem_is_deterministic() {
+fn generate_rsa_pem_is_deterministic() -> TestResult<()> {
     let output1 = run([
         "generate", "rsa", "--seed", "det-seed", "--label", "issuer", "--format", "pem",
-    ]);
+    ])?;
     let output2 = run([
         "generate", "rsa", "--seed", "det-seed", "--label", "issuer", "--format", "pem",
-    ]);
+    ])?;
     assert_eq!(output1, output2);
     let shape = serde_json::json!({
         "bytes_len": output1.len(),
-        "first_line": output1.lines().next().expect("header"),
-        "last_line": output1.lines().last().expect("footer"),
+        "first_line": output1.lines().next().test_context("header")?,
+        "last_line": output1.lines().last().test_context("footer")?,
         "line_count": output1.lines().count(),
     });
     assert_yaml_snapshot!("generate_rsa_pem_shape", shape);
+    Ok(())
 }
 
 #[test]
-fn generate_jwk_outputs_json() {
+fn generate_jwk_outputs_json() -> TestResult<()> {
     let out = run([
         "generate", "jwk", "--seed", "det-seed", "--label", "issuer", "--format", "jwk",
-    ]);
-    let value: Value = serde_json::from_str(&out).expect("valid json");
+    ])?;
+    let value: Value = serde_json::from_str(&out).test_context("valid json")?;
     assert_eq!(value["kty"], "RSA");
     assert_snapshot!("generate_jwk", out);
+    Ok(())
 }
 
 #[test]
-fn bad_format_for_kind_exits_nonzero() {
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+fn bad_format_for_kind_exits_nonzero() -> TestResult<()> {
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args([
         "generate", "hmac", "--seed", "det-seed", "--label", "issuer", "--format", "pem",
     ]);
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("unsupported format"));
+    Ok(())
 }
 
 #[test]
-fn bundle_writes_manifest_schema() {
-    let dir = tempdir().expect("tempdir");
+fn bundle_writes_manifest_schema() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args([
         "bundle",
         "--seed",
@@ -62,41 +83,46 @@ fn bundle_writes_manifest_schema() {
         "--format",
         "jwk",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     cmd.assert().success();
 
     let manifest_path = bundle_dir.join("manifest.json");
     assert!(manifest_path.exists());
-    let value: Value = serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
-        .expect("manifest json");
+    let value: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("read manifest")?)
+            .test_context("manifest json")?;
     assert_eq!(value["version"], 1);
     assert_eq!(value["profile"], "scanner-safe");
     assert_eq!(value["seed"], "det-seed");
     assert_eq!(value["label"], "bundle-label");
-    assert!(value["files"].as_array().expect("array").len() >= 8);
+    assert!(value["files"].as_array().test_context("array")?.len() >= 8);
     assert!(bundle_dir.join("receipts/materialization.json").exists());
     assert!(bundle_dir.join("receipts/audit-surface.json").exists());
     assert!(
         value["files"]
             .as_array()
-            .expect("array")
+            .test_context("array")?
             .iter()
             .any(|file| file.as_str() == Some("receipts/materialization.json"))
     );
     assert!(
         value["files"]
             .as_array()
-            .expect("array")
+            .test_context("array")?
             .iter()
             .any(|file| file.as_str() == Some("receipts/audit-surface.json"))
     );
-    let artifacts = value["artifacts"].as_array().expect("artifacts array");
+    let artifacts = value["artifacts"]
+        .as_array()
+        .test_context("artifacts array")?;
     assert_eq!(
         artifacts.len(),
-        value["files"].as_array().expect("array").len() - 2
+        value["files"].as_array().test_context("array")?.len() - 2
     );
-    let receipts = value["receipts"].as_array().expect("receipts array");
+    let receipts = value["receipts"]
+        .as_array()
+        .test_context("receipts array")?;
     assert_eq!(receipts.len(), 2);
     assert!(receipts.iter().any(|receipt| {
         receipt["path"].as_str() == Some("receipts/materialization.json")
@@ -111,47 +137,48 @@ fn bundle_writes_manifest_schema() {
             .iter()
             .all(|artifact| artifact["scanner_safe"] == true)
     );
-    assert!(artifacts.iter().all(|artifact| {
-        artifact["lanes"]
-            .as_array()
-            .expect("lanes")
-            .iter()
-            .any(|lane| lane.as_str() == Some("runtime"))
-    }));
-    assert!(artifacts.iter().all(|artifact| {
-        artifact["lanes"]
-            .as_array()
-            .expect("lanes")
-            .iter()
-            .any(|lane| lane.as_str() == Some("materialized"))
-    }));
+    for artifact in artifacts {
+        let lanes = artifact["lanes"].as_array().test_context("lanes")?;
+        assert!(lanes.iter().any(|lane| lane.as_str() == Some("runtime")));
+        assert!(
+            lanes
+                .iter()
+                .any(|lane| lane.as_str() == Some("materialized"))
+        );
+    }
+    Ok(())
 }
 
 #[test]
-fn bundle_profile_scanner_safe_is_the_default_path() {
-    let dir = tempdir().expect("tempdir");
+fn bundle_profile_scanner_safe_is_the_default_path() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
-    cmd.args(["bundle", "--out", bundle_dir.to_str().expect("utf-8")]);
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    cmd.args([
+        "bundle",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
     cmd.assert().success();
 
     let manifest_path = bundle_dir.join("manifest.json");
-    let value: Value = serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
-        .expect("manifest json");
+    let value: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("read manifest")?)
+            .test_context("manifest json")?;
     assert_eq!(value["profile"], "scanner-safe");
     assert_eq!(value["format"], "jwk");
     assert_eq!(value["seed"], "uselesskey-bundle-seed");
     assert_eq!(value["label"], "bundle");
 
-    let hmac = fs::read_to_string(bundle_dir.join("hmac.jwk.json")).expect("hmac jwk");
+    let hmac = fs::read_to_string(bundle_dir.join("hmac.jwk.json")).test_context("hmac jwk")?;
     assert!(hmac.contains("not_base64url!*"));
 
-    let artifacts = value["artifacts"].as_array().expect("artifacts");
+    let artifacts = value["artifacts"].as_array().test_context("artifacts")?;
     let hmac_record = artifacts
         .iter()
         .find(|artifact| artifact["kind"].as_str() == Some("hmac"))
-        .expect("hmac artifact record");
+        .test_context("hmac artifact record")?;
     assert_eq!(
         hmac_record["description"],
         "scanner-safe symmetric JWK shape with invalid material"
@@ -159,24 +186,25 @@ fn bundle_profile_scanner_safe_is_the_default_path() {
     let token_record = artifacts
         .iter()
         .find(|artifact| artifact["kind"].as_str() == Some("token"))
-        .expect("token artifact record");
+        .test_context("token artifact record")?;
     assert_eq!(
         token_record["description"],
         "scanner-safe near-miss token shape for parser tests"
     );
 
-    let token: Value =
-        serde_json::from_slice(&fs::read(bundle_dir.join("token.json")).expect("token json"))
-            .expect("token manifest");
-    let token_value = token["value"].as_str().expect("token value");
+    let token: Value = serde_json::from_slice(
+        &fs::read(bundle_dir.join("token.json")).test_context("token json")?,
+    )
+    .test_context("token manifest")?;
+    let token_value = token["value"].as_str().test_context("token value")?;
     assert!(token_value.starts_with("uk_tset_"));
     assert!(!token_value.starts_with("uk_test_"));
 
     let materialization: Value = serde_json::from_slice(
         &fs::read(bundle_dir.join("receipts/materialization.json"))
-            .expect("materialization receipt"),
+            .test_context("materialization receipt")?,
     )
-    .expect("materialization receipt json");
+    .test_context("materialization receipt json")?;
     assert_eq!(materialization["receipt"], "materialization");
     assert_eq!(materialization["profile"], "scanner-safe");
     assert_eq!(
@@ -186,26 +214,27 @@ fn bundle_profile_scanner_safe_is_the_default_path() {
     assert!(
         materialization["lanes"]
             .as_array()
-            .expect("lanes")
+            .test_context("lanes")?
             .iter()
             .any(|lane| lane.as_str() == Some("runtime"))
     );
 
     let audit: Value = serde_json::from_slice(
-        &fs::read(bundle_dir.join("receipts/audit-surface.json")).expect("audit receipt"),
+        &fs::read(bundle_dir.join("receipts/audit-surface.json")).test_context("audit receipt")?,
     )
-    .expect("audit receipt json");
+    .test_context("audit receipt json")?;
     assert_eq!(audit["receipt"], "audit-surface");
     assert_eq!(audit["scanner_safe"], true);
     assert_eq!(audit["runtime_material_count"], 0);
+    Ok(())
 }
 
 #[test]
-fn bundle_profile_runtime_preserves_requested_material_format() {
-    let dir = tempdir().expect("tempdir");
+fn bundle_profile_runtime_preserves_requested_material_format() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args([
         "bundle",
         "--profile",
@@ -217,32 +246,34 @@ fn bundle_profile_runtime_preserves_requested_material_format() {
         "--label",
         "issuer",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     cmd.assert().success();
 
     assert!(bundle_dir.join("rsa.pem").exists());
     let manifest_path = bundle_dir.join("manifest.json");
-    let value: Value = serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
-        .expect("manifest json");
+    let value: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("read manifest")?)
+            .test_context("manifest json")?;
     assert_eq!(value["profile"], "runtime");
     assert_eq!(value["format"], "pem");
     assert!(
         value["artifacts"]
             .as_array()
-            .expect("artifacts")
+            .test_context("artifacts")?
             .iter()
             .any(|artifact| artifact["kind"].as_str() == Some("rsa")
                 && artifact["scanner_safe"] == false)
     );
+    Ok(())
 }
 
 #[test]
-fn bundle_profile_oidc_writes_contract_pack() {
-    let dir = tempdir().expect("tempdir");
+fn bundle_profile_oidc_writes_contract_pack() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("oidc");
 
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args([
         "bundle",
         "--profile",
@@ -252,13 +283,14 @@ fn bundle_profile_oidc_writes_contract_pack() {
         "--label",
         "issuer",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     cmd.assert().success();
 
     let manifest_path = bundle_dir.join("manifest.json");
-    let manifest: Value = serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
-        .expect("manifest json");
+    let manifest: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("read manifest")?)
+            .test_context("manifest json")?;
     assert_eq!(manifest["profile"], "oidc");
     assert_eq!(manifest["format"], "jwk");
     assert_eq!(manifest["files"][0], "jwks/valid.json");
@@ -270,7 +302,7 @@ fn bundle_profile_oidc_writes_contract_pack() {
     assert_eq!(manifest["files"][6], "receipts/materialization.json");
     assert_eq!(manifest["files"][7], "receipts/audit-surface.json");
 
-    let artifacts = manifest["artifacts"].as_array().expect("artifacts");
+    let artifacts = manifest["artifacts"].as_array().test_context("artifacts")?;
     assert_eq!(artifacts.len(), 6);
     assert!(
         artifacts
@@ -289,95 +321,102 @@ fn bundle_profile_oidc_writes_contract_pack() {
             .any(|artifact| artifact["description"] == "OIDC negative token with alg none")
     );
 
-    let valid_jwks: Value =
-        serde_json::from_slice(&fs::read(bundle_dir.join("jwks/valid.json")).expect("valid jwks"))
-            .expect("valid jwks json");
+    let valid_jwks: Value = serde_json::from_slice(
+        &fs::read(bundle_dir.join("jwks/valid.json")).test_context("valid jwks")?,
+    )
+    .test_context("valid jwks json")?;
     assert_eq!(valid_jwks["keys"][0]["kty"], "RSA");
     assert_eq!(valid_jwks["keys"][0]["alg"], "RS256");
     assert!(valid_jwks["keys"][0]["kid"].is_string());
 
     let duplicate: Value = serde_json::from_slice(
-        &fs::read(bundle_dir.join("jwks/negative-duplicate-kid.json")).expect("duplicate kid jwks"),
+        &fs::read(bundle_dir.join("jwks/negative-duplicate-kid.json"))
+            .test_context("duplicate kid jwks")?,
     )
-    .expect("duplicate kid jwks json");
-    let duplicate_keys = duplicate["keys"].as_array().expect("duplicate keys");
+    .test_context("duplicate kid jwks json")?;
+    let duplicate_keys = duplicate["keys"]
+        .as_array()
+        .test_context("duplicate keys")?;
     assert_eq!(duplicate_keys.len(), 2);
     assert_eq!(duplicate_keys[0]["kid"], duplicate_keys[1]["kid"]);
     assert_ne!(duplicate_keys[0], duplicate_keys[1]);
 
     let missing: Value = serde_json::from_slice(
-        &fs::read(bundle_dir.join("jwks/negative-missing-kid.json")).expect("missing kid jwks"),
+        &fs::read(bundle_dir.join("jwks/negative-missing-kid.json"))
+            .test_context("missing kid jwks")?,
     )
-    .expect("missing kid jwks json");
+    .test_context("missing kid jwks json")?;
     assert!(missing["keys"][0].get("kid").is_none());
 
     let valid_token: Value = serde_json::from_slice(
-        &fs::read(bundle_dir.join("tokens/valid-rs256.json")).expect("valid token"),
+        &fs::read(bundle_dir.join("tokens/valid-rs256.json")).test_context("valid token")?,
     )
-    .expect("valid token json");
+    .test_context("valid token json")?;
     assert_eq!(valid_token["alg"], "RS256");
-    let valid_header = decode_jwt_segment(valid_token["value"].as_str().expect("token"), 0);
+    let valid_header = decode_jwt_segment(valid_token["value"].as_str().test_context("token")?, 0)?;
     assert_eq!(valid_header["alg"], "RS256");
 
     let alg_none: Value = serde_json::from_slice(
-        &fs::read(bundle_dir.join("tokens/negative-alg-none.json")).expect("alg none token"),
+        &fs::read(bundle_dir.join("tokens/negative-alg-none.json"))
+            .test_context("alg none token")?,
     )
-    .expect("alg none token json");
+    .test_context("alg none token json")?;
     assert_eq!(alg_none["negative"], "alg_none");
-    let alg_none_header = decode_jwt_segment(alg_none["value"].as_str().expect("token"), 0);
+    let alg_none_header = decode_jwt_segment(alg_none["value"].as_str().test_context("token")?, 0)?;
     assert_eq!(alg_none_header["alg"], "none");
 
     let bad_audience: Value = serde_json::from_slice(
         &fs::read(bundle_dir.join("tokens/negative-bad-audience.json"))
-            .expect("bad audience token"),
+            .test_context("bad audience token")?,
     )
-    .expect("bad audience token json");
+    .test_context("bad audience token json")?;
     assert_eq!(bad_audience["negative"], "bad_audience");
     let bad_audience_payload =
-        decode_jwt_segment(bad_audience["value"].as_str().expect("token"), 1);
+        decode_jwt_segment(bad_audience["value"].as_str().test_context("token")?, 1)?;
     assert_eq!(bad_audience_payload["aud"], "wrong-audience");
 
     let audit: Value = serde_json::from_slice(
-        &fs::read(bundle_dir.join("receipts/audit-surface.json")).expect("audit receipt"),
+        &fs::read(bundle_dir.join("receipts/audit-surface.json")).test_context("audit receipt")?,
     )
-    .expect("audit receipt json");
+    .test_context("audit receipt json")?;
     assert_eq!(audit["profile"], "oidc");
     assert_eq!(audit["scanner_safe"], true);
     assert_eq!(audit["artifact_count"], 6);
     assert_eq!(audit["runtime_material_count"], 0);
 
-    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut verify = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     verify.args([
         "verify-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     verify
         .assert()
         .success()
         .stdout(predicate::str::contains("\"status\": \"ok\""));
+    Ok(())
 }
 
 #[test]
-fn inspect_bundle_summarizes_verified_scanner_safe_receipts() {
-    let dir = tempdir().expect("tempdir");
+fn inspect_bundle_summarizes_verified_scanner_safe_receipts() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     bundle.args([
         "bundle",
         "--profile",
         "scanner-safe",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     bundle.assert().success();
 
-    let mut inspect = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut inspect = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     inspect.args([
         "inspect-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     inspect
         .assert()
@@ -393,14 +432,15 @@ fn inspect_bundle_summarizes_verified_scanner_safe_receipts() {
         .stdout(predicate::str::contains(
             "Receipts: materialization, audit-surface",
         ));
+    Ok(())
 }
 
 #[test]
-fn inspect_bundle_reports_runtime_material_without_printing_payloads() {
-    let dir = tempdir().expect("tempdir");
+fn inspect_bundle_reports_runtime_material_without_printing_payloads() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("runtime");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     bundle.args([
         "bundle",
         "--profile",
@@ -408,18 +448,18 @@ fn inspect_bundle_reports_runtime_material_without_printing_payloads() {
         "--format",
         "pem",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     bundle.assert().success();
 
-    let mut inspect = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut inspect = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     inspect.args([
         "inspect-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     let output = inspect.assert().success().get_output().stdout.clone();
-    let summary = String::from_utf8(output).expect("utf-8");
+    let summary = String::from_utf8(output).test_context("utf-8")?;
 
     assert!(summary.contains("Bundle profile: runtime"));
     assert!(summary.contains("Scanner-safe: no"));
@@ -429,37 +469,43 @@ fn inspect_bundle_reports_runtime_material_without_printing_payloads() {
     assert!(summary.contains("Verification: ok"));
     assert!(!summary.contains("BEGIN PRIVATE KEY"));
     assert!(!summary.contains("uk_test_"));
+    Ok(())
 }
 
 #[test]
-fn inspect_bundle_fails_when_bundle_drift_is_detected() {
-    let dir = tempdir().expect("tempdir");
+fn inspect_bundle_fails_when_bundle_drift_is_detected() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
-    bundle.args(["bundle", "--out", bundle_dir.to_str().expect("utf-8")]);
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
     bundle.assert().success();
 
-    fs::write(bundle_dir.join("token.json"), "corrupt").expect("mutate token fixture");
+    fs::write(bundle_dir.join("token.json"), "corrupt").test_context("mutate token fixture")?;
 
-    let mut inspect = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut inspect = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     inspect.args([
         "inspect-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     inspect
         .assert()
         .failure()
         .stderr(predicate::str::contains("content mismatch"));
+    Ok(())
 }
 
 #[test]
-fn verify_bundle_accepts_generated_bundle_and_detects_mismatch() {
-    let dir = tempdir().expect("tempdir");
+fn verify_bundle_accepts_generated_bundle_and_detects_mismatch() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     bundle.args([
         "bundle",
         "--seed",
@@ -469,85 +515,87 @@ fn verify_bundle_accepts_generated_bundle_and_detects_mismatch() {
         "--format",
         "jwk",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     bundle.assert().success();
 
-    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut verify = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     verify.args([
         "verify-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     verify
         .assert()
         .success()
         .stdout(predicate::str::contains("\"status\": \"ok\""));
 
-    fs::write(bundle_dir.join("token.json"), "corrupt").expect("mutate token fixture");
+    fs::write(bundle_dir.join("token.json"), "corrupt").test_context("mutate token fixture")?;
 
-    let mut verify_bad = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut verify_bad = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     verify_bad.args([
         "verify-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     verify_bad
         .assert()
         .failure()
         .stderr(predicate::str::contains("content mismatch"));
+    Ok(())
 }
 
 #[test]
-fn verify_bundle_rejects_manifest_metadata_drift() {
-    let dir = tempdir().expect("tempdir");
+fn verify_bundle_rejects_manifest_metadata_drift() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     bundle.args([
         "bundle",
         "--profile",
         "scanner-safe",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     bundle.assert().success();
 
     let manifest_path = bundle_dir.join("manifest.json");
     let mut manifest: Value =
-        serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
-            .expect("manifest json");
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("read manifest")?)
+            .test_context("manifest json")?;
     manifest["artifacts"][0]["scanner_safe"] = Value::Bool(false);
     fs::write(
         &manifest_path,
-        serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+        serde_json::to_vec_pretty(&manifest).test_context("serialize manifest")?,
     )
-    .expect("mutate manifest");
+    .test_context("mutate manifest")?;
 
-    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut verify = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     verify.args([
         "verify-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     verify
         .assert()
         .failure()
         .stderr(predicate::str::contains("artifact metadata mismatch"));
+    Ok(())
 }
 
 #[test]
-fn verify_bundle_rejects_receipt_drift() {
-    let dir = tempdir().expect("tempdir");
+fn verify_bundle_rejects_receipt_drift() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     bundle.args([
         "bundle",
         "--profile",
         "scanner-safe",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     bundle.assert().success();
 
@@ -555,107 +603,119 @@ fn verify_bundle_rejects_receipt_drift() {
         bundle_dir.join("receipts/materialization.json"),
         "{\"receipt\":\"materialization\",\"mutated\":true}\n",
     )
-    .expect("mutate receipt");
+    .test_context("mutate receipt")?;
 
-    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut verify = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     verify.args([
         "verify-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     verify
         .assert()
         .failure()
         .stderr(predicate::str::contains("receipt mismatch"));
+    Ok(())
 }
 
 #[test]
-fn verify_bundle_rejects_receipt_metadata_drift() {
-    let dir = tempdir().expect("tempdir");
+fn verify_bundle_rejects_receipt_metadata_drift() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     bundle.args([
         "bundle",
         "--profile",
         "scanner-safe",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     bundle.assert().success();
 
     let manifest_path = bundle_dir.join("manifest.json");
     let mut manifest: Value =
-        serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
-            .expect("manifest json");
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("read manifest")?)
+            .test_context("manifest json")?;
     manifest["receipts"][0]["description"] = Value::String("mutated receipt".to_string());
     fs::write(
         &manifest_path,
-        serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+        serde_json::to_vec_pretty(&manifest).test_context("serialize manifest")?,
     )
-    .expect("mutate manifest");
+    .test_context("mutate manifest")?;
 
-    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut verify = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     verify.args([
         "verify-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     verify
         .assert()
         .failure()
         .stderr(predicate::str::contains("receipt metadata mismatch"));
+    Ok(())
 }
 
 #[test]
-fn verify_bundle_rejects_missing_receipt_metadata_on_current_manifest() {
-    let dir = tempdir().expect("tempdir");
+fn verify_bundle_rejects_missing_receipt_metadata_on_current_manifest() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     bundle.args([
         "bundle",
         "--profile",
         "scanner-safe",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     bundle.assert().success();
 
     let manifest_path = bundle_dir.join("manifest.json");
     let mut manifest: Value =
-        serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
-            .expect("manifest json");
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("read manifest")?)
+            .test_context("manifest json")?;
     manifest
         .as_object_mut()
-        .expect("manifest object")
+        .test_context("manifest object")?
         .remove("receipts");
-    let files = manifest["files"].as_array_mut().expect("files array");
-    files.retain(|file| !file.as_str().expect("file string").starts_with("receipts/"));
+    let files = manifest["files"]
+        .as_array_mut()
+        .test_context("files array")?;
+    let mut retained_files = Vec::new();
+    for file in files.iter() {
+        let path = file.as_str().test_context("file string")?;
+        if !path.starts_with("receipts/") {
+            retained_files.push(file.clone());
+        }
+    }
+    *files = retained_files;
     fs::write(
         &manifest_path,
-        serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+        serde_json::to_vec_pretty(&manifest).test_context("serialize manifest")?,
     )
-    .expect("write manifest");
+    .test_context("write manifest")?;
 
-    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut verify = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     verify.args([
         "verify-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     verify
         .assert()
         .failure()
         .stderr(predicate::str::contains("receipt metadata missing"));
+    Ok(())
 }
 
 #[test]
-fn verify_bundle_accepts_legacy_manifest_without_profile_metadata() {
-    let dir = tempdir().expect("tempdir");
+fn verify_bundle_accepts_legacy_manifest_without_profile_metadata() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     bundle.args([
         "bundle",
         "--profile",
@@ -667,161 +727,177 @@ fn verify_bundle_accepts_legacy_manifest_without_profile_metadata() {
         "--label",
         "legacy",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     bundle.assert().success();
 
     let manifest_path = bundle_dir.join("manifest.json");
     let mut manifest: Value =
-        serde_json::from_slice(&fs::read(&manifest_path).expect("read manifest"))
-            .expect("manifest json");
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("read manifest")?)
+            .test_context("manifest json")?;
     manifest
         .as_object_mut()
-        .expect("manifest object")
+        .test_context("manifest object")?
         .remove("profile");
     manifest
         .as_object_mut()
-        .expect("manifest object")
+        .test_context("manifest object")?
         .remove("artifacts");
     manifest
         .as_object_mut()
-        .expect("manifest object")
+        .test_context("manifest object")?
         .remove("receipts");
-    let files = manifest["files"].as_array_mut().expect("files array");
-    files.retain(|file| !file.as_str().expect("file string").starts_with("receipts/"));
+    let files = manifest["files"]
+        .as_array_mut()
+        .test_context("files array")?;
+    let mut retained_files = Vec::new();
+    for file in files.iter() {
+        let path = file.as_str().test_context("file string")?;
+        if !path.starts_with("receipts/") {
+            retained_files.push(file.clone());
+        }
+    }
+    *files = retained_files;
     fs::write(
         &manifest_path,
-        serde_json::to_vec_pretty(&manifest).expect("serialize manifest"),
+        serde_json::to_vec_pretty(&manifest).test_context("serialize manifest")?,
     )
-    .expect("write legacy manifest");
+    .test_context("write legacy manifest")?;
 
-    let mut verify = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut verify = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     verify.args([
         "verify-bundle",
         "--path",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     verify
         .assert()
         .success()
         .stdout(predicate::str::contains("\"status\": \"ok\""));
+    Ok(())
 }
 
 #[test]
-fn export_k8s_and_vault_payloads_from_scanner_safe_bundle() {
-    let dir = tempdir().expect("tempdir");
+fn export_k8s_and_vault_payloads_from_scanner_safe_bundle() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("bundle");
     let k8s_path = dir.path().join("secret.yaml");
     let vault_path = dir.path().join("kv-v2.json");
 
-    let mut bundle = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     bundle.args([
         "bundle",
         "--profile",
         "scanner-safe",
         "--out",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
     ]);
     bundle.assert().success();
 
-    let mut k8s = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut k8s = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     k8s.args([
         "export",
         "k8s",
         "--bundle-dir",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
         "--name",
         "uselesskey-fixtures",
         "--namespace",
         "tests",
         "--out",
-        k8s_path.to_str().expect("utf-8"),
+        k8s_path.to_str().test_context("utf-8")?,
     ]);
     k8s.assert().success();
 
-    let rendered_k8s = fs::read_to_string(&k8s_path).expect("k8s payload");
+    let rendered_k8s = fs::read_to_string(&k8s_path).test_context("k8s payload")?;
     assert!(rendered_k8s.contains("kind: Secret"));
     assert!(rendered_k8s.contains("  name: uselesskey-fixtures"));
     assert!(rendered_k8s.contains("  namespace: tests"));
     assert!(rendered_k8s.contains("  token.json: "));
 
-    let mut vault = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut vault = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     vault.args([
         "export",
         "vault-kv-json",
         "--bundle-dir",
-        bundle_dir.to_str().expect("utf-8"),
+        bundle_dir.to_str().test_context("utf-8")?,
         "--out",
-        vault_path.to_str().expect("utf-8"),
+        vault_path.to_str().test_context("utf-8")?,
     ]);
     vault.assert().success();
 
     let vault_json: Value =
-        serde_json::from_slice(&fs::read(&vault_path).expect("vault payload")).expect("vault json");
+        serde_json::from_slice(&fs::read(&vault_path).test_context("vault payload")?)
+            .test_context("vault json")?;
     assert_eq!(vault_json["metadata"]["source"], "uselesskey-cli");
     assert_eq!(vault_json["metadata"]["mode"], "one_shot_export");
     assert!(
         vault_json["data"]["token.json"]
             .as_str()
-            .expect("token payload")
+            .test_context("token payload")?
             .contains("uk_tset_")
     );
+    Ok(())
 }
 
-fn decode_jwt_segment(token: &str, index: usize) -> Value {
+fn decode_jwt_segment(token: &str, index: usize) -> TestResult<Value> {
     let segment = token
         .split('.')
         .nth(index)
-        .expect("jwt segment should exist");
+        .test_context("jwt segment should exist")?;
     let bytes = URL_SAFE_NO_PAD
         .decode(segment)
-        .expect("segment should be base64url");
-    serde_json::from_slice(&bytes).expect("segment should be json")
+        .test_context("segment should be base64url")?;
+    serde_json::from_slice(&bytes).test_context("segment should be json")
 }
 
 #[test]
-fn inspect_reads_stdin_writes_json() {
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+fn inspect_reads_stdin_writes_json() -> TestResult<()> {
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args(["inspect", "--format", "pem"])
         .write_stdin("-----BEGIN PRIVATE KEY-----\nabc\n")
         .assert()
         .success()
         .stdout(predicate::str::contains("\"detected\": \"private_key\""));
+    Ok(())
 }
 
 #[test]
-fn inspect_detects_jwks_json() {
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+fn inspect_detects_jwks_json() -> TestResult<()> {
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args(["inspect", "--format", "jwk"])
         .write_stdin("{\"keys\":[{\"kty\":\"RSA\"}]}")
         .assert()
         .success()
         .stdout(predicate::str::contains("\"detected\": \"jwks\""));
+    Ok(())
 }
 
 #[test]
-fn inspect_detects_jwk_json() {
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+fn inspect_detects_jwk_json() -> TestResult<()> {
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args(["inspect", "--format", "jwk"])
         .write_stdin("{\"kty\":\"RSA\",\"kid\":\"fixture\"}")
         .assert()
         .success()
         .stdout(predicate::str::contains("\"detected\": \"jwk\""));
+    Ok(())
 }
 
 #[test]
-fn inspect_leaves_non_key_json_unknown() {
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+fn inspect_leaves_non_key_json_unknown() -> TestResult<()> {
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args(["inspect", "--format", "jwk"])
         .write_stdin("{\"hello\":\"world\"}")
         .assert()
         .success()
         .stdout(predicate::str::contains("\"detected\": \"unknown\""));
+    Ok(())
 }
 
 #[test]
-fn materialize_writes_deterministic_fixtures() {
-    let dir = tempdir().expect("tempdir");
+fn materialize_writes_deterministic_fixtures() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let out_dir = dir.path().join("materialized");
     let manifest_path = dir.path().join("materialize.toml");
     let manifest = r#"
@@ -841,28 +917,29 @@ kind = "token.jwt_shape"
 seed = "materialize-seed"
 label = "svc.jwt"
 "#;
-    fs::write(&manifest_path, manifest).expect("manifest should be written");
+    fs::write(&manifest_path, manifest).test_context("manifest should be written")?;
 
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args([
         "materialize",
         "--manifest",
-        manifest_path.to_str().expect("utf-8"),
+        manifest_path.to_str().test_context("utf-8")?,
         "--out-dir",
-        out_dir.to_str().expect("utf-8"),
+        out_dir.to_str().test_context("utf-8")?,
     ])
     .assert()
     .success();
 
-    let entropy = fs::read(out_dir.join("seed.bin")).expect("materialized entropy");
-    let jwt = fs::read_to_string(out_dir.join("session.jwt")).expect("materialized jwt");
+    let entropy = fs::read(out_dir.join("seed.bin")).test_context("materialized entropy")?;
+    let jwt = fs::read_to_string(out_dir.join("session.jwt")).test_context("materialized jwt")?;
     assert_eq!(entropy.len(), 16);
     assert_eq!(jwt.split('.').count(), 3);
+    Ok(())
 }
 
 #[test]
-fn materialize_check_fails_on_mismatch() {
-    let dir = tempdir().expect("tempdir");
+fn materialize_check_fails_on_mismatch() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let out_dir = dir.path().join("materialized");
     let manifest_path = dir.path().join("materialize.toml");
     let manifest = r#"
@@ -875,38 +952,39 @@ seed = "materialize-seed-check"
 kind = "entropy.bytes"
 len = 8
 "#;
-    fs::write(&manifest_path, manifest).expect("manifest should be written");
+    fs::write(&manifest_path, manifest).test_context("manifest should be written")?;
 
-    let mut write = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut write = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     write.args([
         "materialize",
         "--manifest",
-        manifest_path.to_str().expect("utf-8"),
+        manifest_path.to_str().test_context("utf-8")?,
         "--out-dir",
-        out_dir.to_str().expect("utf-8"),
+        out_dir.to_str().test_context("utf-8")?,
     ]);
     write.assert().success();
 
     let actual = out_dir.join("seed.bin");
-    fs::write(&actual, b"corrupt").expect("mutate fixture");
+    fs::write(&actual, b"corrupt").test_context("mutate fixture")?;
 
-    let mut check = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut check = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     check.args([
         "verify",
         "--manifest",
-        manifest_path.to_str().expect("utf-8"),
+        manifest_path.to_str().test_context("utf-8")?,
         "--out-dir",
-        out_dir.to_str().expect("utf-8"),
+        out_dir.to_str().test_context("utf-8")?,
     ]);
     check
         .assert()
         .failure()
         .stderr(predicate::str::contains("content mismatch"));
+    Ok(())
 }
 
 #[test]
-fn materialize_can_emit_include_bytes_module() {
-    let dir = tempdir().expect("tempdir");
+fn materialize_can_emit_include_bytes_module() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
     let out_dir = dir.path().join("materialized");
     let manifest_path = dir.path().join("materialize.toml");
     let module_path = dir.path().join("fixtures.rs");
@@ -920,30 +998,31 @@ seed = "materialize-emit-rs"
 len = 4
 out = "seed.bin"
 "#;
-    fs::write(&manifest_path, manifest).expect("manifest should be written");
+    fs::write(&manifest_path, manifest).test_context("manifest should be written")?;
 
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args([
         "materialize",
         "--manifest",
-        manifest_path.to_str().expect("utf-8"),
+        manifest_path.to_str().test_context("utf-8")?,
         "--out-dir",
-        out_dir.to_str().expect("utf-8"),
+        out_dir.to_str().test_context("utf-8")?,
         "--emit-rs",
-        module_path.to_str().expect("utf-8"),
+        module_path.to_str().test_context("utf-8")?,
     ]);
     cmd.assert().success();
 
-    let emitted = fs::read_to_string(&module_path).expect("emitted module");
+    let emitted = fs::read_to_string(&module_path).test_context("emitted module")?;
     assert!(emitted.contains("pub const ENTROPY: &[u8] = include_bytes!"));
+    Ok(())
 }
 
-fn run<I, S>(args: I) -> String
+fn run<I, S>(args: I) -> TestResult<String>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<std::ffi::OsStr>,
 {
-    let mut cmd = Command::cargo_bin("uselesskey").expect("bin exists");
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     let assert = cmd.args(args).assert().success();
-    String::from_utf8(assert.get_output().stdout.clone()).expect("utf8")
+    String::from_utf8(assert.get_output().stdout.clone()).test_context("utf8")
 }

--- a/plans/no-panic-burndown/implementation-plan.md
+++ b/plans/no-panic-burndown/implementation-plan.md
@@ -38,14 +38,19 @@ production-path cluster needs case-by-case review: either remove the panic path
 or add a receipted allowlist entry with owner, classification, explanation, and
 expiry.
 
+`cargo xtask no-panic baseline` refuses to refresh while any unrelated new debt
+remains. Early burndown PRs should therefore use
+`cargo xtask check-no-panic-family` as a reduction receipt and leave baseline
+refresh for the point where all new-debt sites have been removed or receipted.
+
 ## Scope
 
 This lane covers:
 
 - migration of test-code panic-family sites to `uselesskey-test-support`
   fallible helpers;
-- deliberate baseline refreshes with `cargo xtask no-panic baseline` after
-  vanished entries are removed;
+- deliberate baseline refreshes with `cargo xtask no-panic baseline` only after
+  all new-debt sites are removed or receipted;
 - case-by-case production-path review;
 - receipted allowlist entries only for justified invariants or fixture
   boundaries;
@@ -93,11 +98,15 @@ Per-burndown PR:
 
 ```bash
 cargo xtask check-no-panic-family
-cargo xtask no-panic baseline
 cargo xtask pr-lite
 cargo xtask pr
 git diff --check
 ```
+
+`check-no-panic-family` is expected to keep failing until the final burndown PR;
+the useful receipt is the lower new-debt count and the absence of the target
+cluster. Do not run `cargo xtask no-panic baseline` until the command can
+refresh without absorbing unrelated new debt.
 
 Use focused crate tests before the broad gate. For example:
 


### PR DESCRIPTION
## Summary
- convert crates/uselesskey-cli/tests/cli.rs to fallible TestResult helpers instead of panic-family expect setup
- add the CLI test support dev-dependency needed for equire_ok / equire_some
- update the no-panic burndown plan and active goal with the live baseline-refresh rule: per-slice PRs reduce debt, but baseline refresh waits until unrelated new debt is gone or receipted

## Files added/changed
- .uselesskey/goals/active.toml
- plans/no-panic-burndown/implementation-plan.md
- crates/uselesskey-cli/Cargo.toml
- crates/uselesskey-cli/tests/cli.rs
- Cargo.lock

## Validation
- cargo test -p uselesskey-cli --test cli passed
- g \\.(expect|unwrap)\\(|panic!|todo!|unreachable!|assert!|assert_eq!|assert_ne! crates/uselesskey-cli/tests/cli.rs found no matches
- cargo xtask check-no-panic-family failed as expected with the repo still in no-new-debt mode, now reporting 88 remaining new-debt sites and no CLI test sites in the sampled output
- cargo xtask spec-check --strict passed
- cargo xtask docs-sync --check passed
- cargo xtask typos passed
- git diff --check passed
- RUSTUP_TOOLCHAIN=nightly cargo xtask pr-lite passed and wrote 	arget/pr-lite/pr-lite.{json,md}
- cargo xtask pr passed through docs/spec/public-surface, fmt, clippy, CLI tests, feature matrix, dep-guard, and BDD, then failed only in the local Windows fuzz step with STATUS_DLL_NOT_FOUND from the fuzz executable runtime

## Non-goals
- no no-panic baseline reset
- no policy weakening
- no production-path panic review in this slice
- no unrelated no-panic cleanup outside the CLI tests
- no fixture behavior changes

## What this enables next
- the next no-panic burndown slice can move to xtask tests with the largest CLI test cluster already removed from new debt