### PR TITLE
test(xtask): remove panic-family test debt

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -46,7 +46,7 @@ commands = [
 
 [[work_item]]
 id = "xtask-tests"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/no-panic-burndown/implementation-plan.md"
@@ -86,7 +86,7 @@ commands = [
 
 [[work_item]]
 id = "production-path-review"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/no-panic-burndown/implementation-plan.md"

--- a/xtask/src/claim_proof.rs
+++ b/xtask/src/claim_proof.rs
@@ -72,10 +72,10 @@ pub(crate) fn run(root: &Path, claim: Option<&str>, all_stable: bool) -> Result<
     }
 
     let ledger = read_ledger(root)?;
-    let selected = if all_stable {
-        stable_claims_with_policy(&ledger)?
-    } else {
-        vec![claim.expect("checked above").to_string()]
+    let selected = match (all_stable, claim) {
+        (true, _) => stable_claims_with_policy(&ledger)?,
+        (false, Some(claim)) => vec![claim.to_string()],
+        (false, None) => bail!("claim-proof: pass exactly one of --claim <id> or --all-stable"),
     };
 
     let mut failures = Vec::new();
@@ -374,9 +374,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn stable_claim_selection_uses_include_in_all_stable() {
+    fn stable_claim_selection_uses_include_in_all_stable() -> Result<()> {
         let ledger = minimal_ledger();
-        let selected = stable_claims_with_policy(&ledger).unwrap();
+        let selected = stable_claims_with_policy(&ledger)?;
 
         assert_eq!(
             selected,
@@ -385,10 +385,11 @@ mod tests {
                 "tls-contract-pack".to_string()
             ]
         );
+        Ok(())
     }
 
     #[test]
-    fn stable_claim_selection_rejects_missing_policy() {
+    fn stable_claim_selection_rejects_missing_policy() -> Result<()> {
         let mut ledger = minimal_ledger();
         ledger.claim.push(ClaimEntry {
             id: "generated-badge-endpoints".to_string(),
@@ -398,49 +399,62 @@ mod tests {
             artifacts: Vec::new(),
         });
 
-        let err = stable_claims_with_policy(&ledger).unwrap_err();
+        let err = match stable_claims_with_policy(&ledger) {
+            Ok(selected) => bail!("unexpected stable claim selection: {selected:?}"),
+            Err(err) => err,
+        };
 
         assert!(
             err.to_string()
                 .contains("stable claim `generated-badge-endpoints` has no claim-proof policy"),
             "unexpected error: {err}"
         );
+        Ok(())
     }
 
     #[test]
-    fn handler_specs_construct_argv_without_shell() {
-        let spec = handler_spec("scanner_safe_reference_check").unwrap();
+    fn handler_specs_construct_argv_without_shell() -> Result<()> {
+        let spec = handler_spec("scanner_safe_reference_check")?;
 
         assert_eq!(
             spec.argv,
             vec!["cargo", "xtask", "scanner-safe-reference", "--check"]
         );
         assert!(!spec.argv.iter().any(|part| part.contains("&&")));
+        Ok(())
     }
 
     #[test]
-    fn unknown_handler_is_rejected() {
-        let err = handler_spec("cargo xtask no-blob").unwrap_err();
+    fn unknown_handler_is_rejected() -> Result<()> {
+        let err = match handler_spec("cargo xtask no-blob") {
+            Ok(spec) => bail!("unexpected handler spec: {spec:?}"),
+            Err(err) => err,
+        };
 
         assert!(
             err.to_string()
                 .contains("unknown claim-proof handler `cargo xtask no-blob`"),
             "unexpected error: {err}"
         );
+        Ok(())
     }
 
     #[test]
-    fn explicit_version_handler_is_not_implicit() {
-        let err = handler_spec("cratesio_smoke_version").unwrap_err();
+    fn explicit_version_handler_is_not_implicit() -> Result<()> {
+        let err = match handler_spec("cratesio_smoke_version") {
+            Ok(spec) => bail!("unexpected handler spec: {spec:?}"),
+            Err(err) => err,
+        };
 
         assert!(
             err.to_string().contains("requires an explicit version"),
             "unexpected error: {err}"
         );
+        Ok(())
     }
 
     #[test]
-    fn receipt_markdown_includes_boundary() {
+    fn receipt_markdown_includes_boundary() -> Result<()> {
         let receipt = ClaimProofReceipt {
             schema_version: 1,
             claim: "scanner-safe-fixtures".to_string(),
@@ -467,16 +481,18 @@ mod tests {
 
         assert!(markdown.contains("scanner-safe-fixtures"));
         assert!(markdown.contains("Not production key management."));
+        Ok(())
     }
 
     #[test]
-    fn invalid_claim_ids_are_rejected() {
+    fn invalid_claim_ids_are_rejected() -> Result<()> {
         for claim_id in ["", "../bad", "BadClaim", "bad_claim"] {
             assert!(
                 validate_claim_id(claim_id).is_err(),
                 "{claim_id} should be invalid"
             );
         }
+        Ok(())
     }
 
     fn minimal_ledger() -> ClaimLedger {

--- a/xtask/src/claim_report.rs
+++ b/xtask/src/claim_report.rs
@@ -569,9 +569,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn report_includes_claim_ledger_fields() {
-        let dir = minimal_repo();
-        let report = build_report(dir.path(), None).unwrap();
+    fn report_includes_claim_ledger_fields() -> Result<()> {
+        let dir = minimal_repo()?;
+        let report = build_report(dir.path(), None)?;
 
         assert_eq!(report.claims.len(), 2);
         let claim = &report.claims[0];
@@ -593,55 +593,63 @@ mod tests {
             "warnings: {:?}",
             report.warnings
         );
+        Ok(())
     }
 
     #[test]
-    fn claim_filter_selects_one_claim() {
-        let dir = minimal_repo();
-        let report = build_report(dir.path(), Some("tls-contract-pack")).unwrap();
+    fn claim_filter_selects_one_claim() -> Result<()> {
+        let dir = minimal_repo()?;
+        let report = build_report(dir.path(), Some("tls-contract-pack"))?;
 
         assert_eq!(report.claims.len(), 1);
         assert_eq!(report.claims[0].id, "tls-contract-pack");
         assert_eq!(report.filter.as_deref(), Some("tls-contract-pack"));
+        Ok(())
     }
 
     #[test]
-    fn unknown_claim_filter_fails() {
-        let dir = minimal_repo();
-        let err = build_report(dir.path(), Some("missing-claim")).unwrap_err();
+    fn unknown_claim_filter_fails() -> Result<()> {
+        let dir = minimal_repo()?;
+        let err = match build_report(dir.path(), Some("missing-claim")) {
+            Ok(report) => bail!("unexpected claim report: {report:?}"),
+            Err(err) => err,
+        };
 
         assert!(
             err.to_string().contains("no claim found"),
             "unexpected error: {err}"
         );
+        Ok(())
     }
 
     #[test]
-    fn markdown_renders_proof_commands_and_boundaries() {
-        let dir = minimal_repo();
-        let report = build_report(dir.path(), Some("scanner-safe-fixtures")).unwrap();
+    fn markdown_renders_proof_commands_and_boundaries() -> Result<()> {
+        let dir = minimal_repo()?;
+        let report = build_report(dir.path(), Some("scanner-safe-fixtures"))?;
         let markdown = render_markdown(&report);
 
         assert!(markdown.contains("# Public Claim Report"));
         assert!(markdown.contains("cargo xtask scanner-safe-reference --check"));
         assert!(markdown.contains("Scanner-safe fixture material"));
+        Ok(())
     }
 
     #[test]
-    fn public_claims_check_accepts_synced_markdown() {
-        let dir = minimal_repo();
-        let report = build_report(dir.path(), None).unwrap();
-        let errors = public_claim_errors(dir.path(), &report).unwrap();
+    fn public_claims_check_accepts_synced_markdown() -> Result<()> {
+        let dir = minimal_repo()?;
+        let report = build_report(dir.path(), None)?;
+        let errors = public_claim_errors(dir.path(), &report)?;
 
         assert!(errors.is_empty(), "errors: {errors:?}");
+        Ok(())
     }
 
     #[test]
-    fn public_claims_check_requires_stable_claim_rows() {
-        let dir = minimal_repo();
-        write_public_claims(dir.path(), "tls-contract-pack").unwrap();
-        let report = build_report(dir.path(), None).unwrap();
-        let errors = public_claim_errors(dir.path(), &report).unwrap();
+    fn public_claims_check_requires_stable_claim_rows() -> Result<()> {
+        let dir = minimal_repo()?;
+        write_public_claims(dir.path(), "tls-contract-pack")?;
+        let report = build_report(dir.path(), None)?;
+        let errors = public_claim_errors(dir.path(), &report)?;
 
         assert!(
             errors
@@ -649,19 +657,20 @@ mod tests {
                 .any(|error| error.contains("stable claim `tls-contract-pack` is missing")),
             "errors: {errors:?}"
         );
+        Ok(())
     }
 
     #[test]
-    fn public_claims_check_rejects_unknown_claim_ids() {
-        let dir = minimal_repo();
+    fn public_claims_check_rejects_unknown_claim_ids() -> Result<()> {
+        let dir = minimal_repo()?;
         let path = dir.path().join("docs/status/PUBLIC_CLAIMS.md");
-        let mut markdown = fs::read_to_string(&path).unwrap();
+        let mut markdown = fs::read_to_string(&path)?;
         markdown.push_str(
             "| `unknown-claim` | Unknown | `stable` | `cargo xtask unknown` | Boundary. |\n",
         );
-        fs::write(&path, markdown).unwrap();
-        let report = build_report(dir.path(), None).unwrap();
-        let errors = public_claim_errors(dir.path(), &report).unwrap();
+        fs::write(&path, markdown)?;
+        let report = build_report(dir.path(), None)?;
+        let errors = public_claim_errors(dir.path(), &report)?;
 
         assert!(
             errors
@@ -669,18 +678,17 @@ mod tests {
                 .any(|error| error.contains("references unknown claim `unknown-claim`")),
             "errors: {errors:?}"
         );
+        Ok(())
     }
 
     #[test]
-    fn public_claims_check_requires_all_proof_commands() {
-        let dir = minimal_repo();
+    fn public_claims_check_requires_all_proof_commands() -> Result<()> {
+        let dir = minimal_repo()?;
         let path = dir.path().join("docs/status/PUBLIC_CLAIMS.md");
-        let markdown = fs::read_to_string(&path)
-            .unwrap()
-            .replace("; `cargo xtask badges --check`", "");
-        fs::write(&path, markdown).unwrap();
-        let report = build_report(dir.path(), None).unwrap();
-        let errors = public_claim_errors(dir.path(), &report).unwrap();
+        let markdown = fs::read_to_string(&path)?.replace("; `cargo xtask badges --check`", "");
+        fs::write(&path, markdown)?;
+        let report = build_report(dir.path(), None)?;
+        let errors = public_claim_errors(dir.path(), &report)?;
 
         assert!(
             errors.iter().any(|error| error.contains(
@@ -688,15 +696,16 @@ mod tests {
             )),
             "errors: {errors:?}"
         );
+        Ok(())
     }
 
-    fn minimal_repo() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().unwrap();
-        fs::create_dir_all(dir.path().join("policy")).unwrap();
-        fs::create_dir_all(dir.path().join("docs/status")).unwrap();
-        fs::create_dir_all(dir.path().join("docs/specs")).unwrap();
-        fs::create_dir_all(dir.path().join("docs/adr")).unwrap();
-        fs::create_dir_all(dir.path().join("docs/how-to")).unwrap();
+    fn minimal_repo() -> Result<tempfile::TempDir> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join("policy"))?;
+        fs::create_dir_all(dir.path().join("docs/status"))?;
+        fs::create_dir_all(dir.path().join("docs/specs"))?;
+        fs::create_dir_all(dir.path().join("docs/adr"))?;
+        fs::create_dir_all(dir.path().join("docs/how-to"))?;
 
         fs::write(
             dir.path().join("policy/claim-ledger.toml"),
@@ -730,15 +739,13 @@ docs = ["docs/how-to/tls.md"]
 release_lanes = ["minor"]
 boundary = "TLS fixtures do not prove production PKI."
 "#,
-        )
-        .unwrap();
-        write_public_claims(dir.path(), "").unwrap();
+        )?;
+        write_public_claims(dir.path(), "")?;
         fs::write(
             dir.path().join("docs/how-to/scanner-safe.md"),
             "# Scanner\n",
-        )
-        .unwrap();
-        fs::write(dir.path().join("docs/how-to/tls.md"), "# TLS\n").unwrap();
+        )?;
+        fs::write(dir.path().join("docs/how-to/tls.md"), "# TLS\n")?;
         fs::write(
             dir.path().join("docs/specs/USELESSKEY-SPEC-0002-claims.md"),
             r#"+++
@@ -750,8 +757,7 @@ status = "accepted"
 
 # Spec
 "#,
-        )
-        .unwrap();
+        )?;
         fs::write(
             dir.path()
                 .join("docs/adr/USELESSKEY-ADR-0001-contract-packs.md"),
@@ -764,10 +770,9 @@ status = "accepted"
 
 # ADR
 "#,
-        )
-        .unwrap();
+        )?;
 
-        dir
+        Ok(dir)
     }
 
     fn write_public_claims(root: &Path, omit_id: &str) -> Result<()> {

--- a/xtask/src/contract_packs.rs
+++ b/xtask/src/contract_packs.rs
@@ -379,20 +379,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn registry_passes_for_supported_pack() {
-        let dir = minimal_repo();
-        let report = build_report(dir.path()).unwrap();
+    fn registry_passes_for_supported_pack() -> Result<()> {
+        let dir = minimal_repo()?;
+        let report = build_report(dir.path())?;
 
         assert_eq!(report.status, "pass");
         assert_eq!(report.packs.len(), 1);
         assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
+        Ok(())
     }
 
     #[test]
-    fn registry_rejects_unsupported_profile() {
-        let dir = minimal_repo();
-        replace_registry(dir.path(), "profile = \"tls\"", "profile = \"bad\"").unwrap();
-        let report = build_report(dir.path()).unwrap();
+    fn registry_rejects_unsupported_profile() -> Result<()> {
+        let dir = minimal_repo()?;
+        replace_registry(dir.path(), "profile = \"tls\"", "profile = \"bad\"")?;
+        let report = build_report(dir.path())?;
 
         assert!(
             report
@@ -402,13 +403,14 @@ mod tests {
             "errors: {:?}",
             report.errors
         );
+        Ok(())
     }
 
     #[test]
-    fn registry_rejects_missing_how_to() {
-        let dir = minimal_repo();
-        fs::remove_file(dir.path().join("docs/how-to/test.md")).unwrap();
-        let report = build_report(dir.path()).unwrap();
+    fn registry_rejects_missing_how_to() -> Result<()> {
+        let dir = minimal_repo()?;
+        fs::remove_file(dir.path().join("docs/how-to/test.md"))?;
+        let report = build_report(dir.path())?;
 
         assert!(
             report
@@ -418,18 +420,18 @@ mod tests {
             "errors: {:?}",
             report.errors
         );
+        Ok(())
     }
 
     #[test]
-    fn registry_rejects_unregistered_claim_proof_command() {
-        let dir = minimal_repo();
+    fn registry_rejects_unregistered_claim_proof_command() -> Result<()> {
+        let dir = minimal_repo()?;
         replace_registry(
             dir.path(),
             "cargo xtask bundle-proof --profile tls --out target/release-evidence/tls",
             "cargo xtask bundle-proof --profile tls --out target/other",
-        )
-        .unwrap();
-        let report = build_report(dir.path()).unwrap();
+        )?;
+        let report = build_report(dir.path())?;
 
         assert!(
             report
@@ -439,14 +441,15 @@ mod tests {
             "errors: {:?}",
             report.errors
         );
+        Ok(())
     }
 
-    fn minimal_repo() -> tempfile::TempDir {
-        let dir = tempfile::tempdir().unwrap();
-        fs::create_dir_all(dir.path().join("policy")).unwrap();
-        fs::create_dir_all(dir.path().join("docs/specs")).unwrap();
-        fs::create_dir_all(dir.path().join("docs/how-to")).unwrap();
-        fs::write(dir.path().join("docs/how-to/test.md"), "# Test\n").unwrap();
+    fn minimal_repo() -> Result<tempfile::TempDir> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join("policy"))?;
+        fs::create_dir_all(dir.path().join("docs/specs"))?;
+        fs::create_dir_all(dir.path().join("docs/how-to"))?;
+        fs::write(dir.path().join("docs/how-to/test.md"), "# Test\n")?;
         fs::write(
             dir.path().join("docs/specs/USELESSKEY-SPEC-0003-pack.md"),
             r#"+++
@@ -458,8 +461,7 @@ status = "accepted"
 
 # Spec
 "#,
-        )
-        .unwrap();
+        )?;
         fs::write(
             dir.path().join("policy/claim-ledger.toml"),
             r#"[[claim]]
@@ -468,8 +470,7 @@ status = "stable"
 proof_commands = ["cargo xtask bundle-proof --profile tls --out target/release-evidence/tls"]
 docs = ["docs/how-to/test.md"]
 "#,
-        )
-        .unwrap();
+        )?;
         fs::write(
             dir.path().join("policy/contract-packs.toml"),
             r#"[[pack]]
@@ -484,9 +485,8 @@ how_to = "docs/how-to/test.md"
 release_lane = "minor"
 boundary = "Boundary."
 "#,
-        )
-        .unwrap();
-        dir
+        )?;
+        Ok(dir)
     }
 
     fn replace_registry(root: &Path, from: &str, to: &str) -> Result<()> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8451,7 +8451,7 @@ index 1111111..2222222 100644
     }
 
     #[test]
-    fn release_evidence_patch_step_list_includes_scanner_safe_reference() {
+    fn release_evidence_patch_step_list_includes_scanner_safe_reference() -> Result<()> {
         let steps = release_evidence_steps_patch();
         let names = steps.iter().map(|step| step.name).collect::<BTreeSet<_>>();
         assert!(
@@ -8461,20 +8461,21 @@ index 1111111..2222222 100644
         let step = steps
             .iter()
             .find(|step| step.name == "scanner-safe-reference")
-            .expect("scanner-safe-reference step");
+            .context("scanner-safe-reference step")?;
         assert_eq!(
             step.command,
             &["cargo", "xtask", "scanner-safe-reference", "--check"],
         );
+        Ok(())
     }
 
     #[test]
-    fn release_evidence_patch_step_list_includes_claim_report() {
+    fn release_evidence_patch_step_list_includes_claim_report() -> Result<()> {
         let steps = release_evidence_steps_patch();
         let step = steps
             .iter()
             .find(|step| step.name == "claim-report")
-            .expect("patch lane must wire claim-report");
+            .context("patch lane must wire claim-report")?;
         assert_eq!(
             step.command,
             &["cargo", "xtask", "claim-report", "--format", "json"],
@@ -8483,15 +8484,16 @@ index 1111111..2222222 100644
             step.artifacts
                 .contains(&"target/release-evidence/claims/public-claims.json"),
         );
+        Ok(())
     }
 
     #[test]
-    fn release_evidence_patch_step_list_includes_scanner_safe_verification_pack() {
+    fn release_evidence_patch_step_list_includes_scanner_safe_verification_pack() -> Result<()> {
         let steps = release_evidence_steps_patch();
         let step = steps
             .iter()
             .find(|step| step.name == "verification-pack-scanner-safe")
-            .expect("patch lane must wire scanner-safe verification pack");
+            .context("patch lane must wire scanner-safe verification pack")?;
         assert_eq!(
             step.command,
             &[
@@ -8509,10 +8511,11 @@ index 1111111..2222222 100644
                 &"target/release-evidence/verification-pack/claim-proof/scanner-safe-fixtures/receipt.json"
             ),
         );
+        Ok(())
     }
 
     #[test]
-    fn shields_badge_validation_accepts_expected_shape() {
+    fn shields_badge_validation_accepts_expected_shape() -> Result<()> {
         let badge = ShieldsEndpointBadge {
             schema_version: 1,
             label: "ripr+".to_string(),
@@ -8520,11 +8523,12 @@ index 1111111..2222222 100644
             color: "brightgreen".to_string(),
         };
 
-        validate_shields_badge(&badge, Some("ripr+")).expect("valid badge shape");
+        validate_shields_badge(&badge, Some("ripr+"))?;
+        Ok(())
     }
 
     #[test]
-    fn scanner_safe_badge_success_shape_is_stable() {
+    fn scanner_safe_badge_success_shape_is_stable() -> Result<()> {
         let badge = ShieldsEndpointBadge {
             schema_version: 1,
             label: "fixtures".to_string(),
@@ -8532,16 +8536,17 @@ index 1111111..2222222 100644
             color: "brightgreen".to_string(),
         };
 
-        let json = serde_json::to_string_pretty(&badge).expect("serialize badge");
+        let json = serde_json::to_string_pretty(&badge)?;
 
         assert!(json.contains(r#""schemaVersion": 1"#));
         assert!(json.contains(r#""label": "fixtures""#));
         assert!(json.contains(r#""message": "scanner-safe""#));
         assert!(json.contains(r#""color": "brightgreen""#));
+        Ok(())
     }
 
     #[test]
-    fn release_evidence_patch_step_list_includes_cratesio_smoke() {
+    fn release_evidence_patch_step_list_includes_cratesio_smoke() -> Result<()> {
         let steps = release_evidence_steps_patch();
         let names = steps.iter().map(|step| step.name).collect::<BTreeSet<_>>();
         assert!(
@@ -8551,7 +8556,7 @@ index 1111111..2222222 100644
         let step = steps
             .iter()
             .find(|step| step.name == "cratesio-smoke-local")
-            .expect("cratesio-smoke-local step");
+            .context("cratesio-smoke-local step")?;
         assert_eq!(
             step.command,
             &[
@@ -8563,6 +8568,7 @@ index 1111111..2222222 100644
                 "--skip-install-cli",
             ],
         );
+        Ok(())
     }
 
     #[test]
@@ -8597,12 +8603,12 @@ index 1111111..2222222 100644
     }
 
     #[test]
-    fn release_evidence_minor_step_list_includes_tls_contract_pack_proof() {
+    fn release_evidence_minor_step_list_includes_tls_contract_pack_proof() -> Result<()> {
         let steps = release_evidence_steps_minor();
         let step = steps
             .iter()
             .find(|step| step.name == "tls-contract-pack-proof")
-            .expect("minor lane must wire tls-contract-pack-proof");
+            .context("minor lane must wire tls-contract-pack-proof")?;
         assert_eq!(
             step.command,
             &[
@@ -8623,15 +8629,16 @@ index 1111111..2222222 100644
             step.artifacts
                 .contains(&"target/release-evidence/tls/tls-contract-pack-proof.md"),
         );
+        Ok(())
     }
 
     #[test]
-    fn release_evidence_minor_step_list_includes_contract_pack_registry() {
+    fn release_evidence_minor_step_list_includes_contract_pack_registry() -> Result<()> {
         let steps = release_evidence_steps_minor();
         let step = steps
             .iter()
             .find(|step| step.name == "contract-pack-registry")
-            .expect("minor lane must wire contract-pack registry");
+            .context("minor lane must wire contract-pack registry")?;
         assert_eq!(
             step.command,
             &[
@@ -8647,15 +8654,16 @@ index 1111111..2222222 100644
             step.artifacts
                 .contains(&"target/release-evidence/contract-packs/contract-packs.json"),
         );
+        Ok(())
     }
 
     #[test]
-    fn release_evidence_minor_step_list_includes_verification_pack() {
+    fn release_evidence_minor_step_list_includes_verification_pack() -> Result<()> {
         let steps = release_evidence_steps_minor();
         let step = steps
             .iter()
             .find(|step| step.name == "verification-pack")
-            .expect("minor lane must wire full verification pack");
+            .context("minor lane must wire full verification pack")?;
         assert_eq!(
             step.command,
             &[
@@ -8673,33 +8681,33 @@ index 1111111..2222222 100644
         assert!(step.artifacts.contains(
             &"target/release-evidence/verification-pack/claim-proof/tls-contract-pack/receipt.json"
         ));
+        Ok(())
     }
 
     #[test]
-    fn bundle_proof_tls_profile_constant_includes_tls() {
+    fn bundle_proof_tls_profile_constant_includes_tls() -> Result<()> {
         assert!(
             BUNDLE_PROOF_SUPPORTED_PROFILES.contains(&"tls"),
             "tls must be a supported bundle-proof profile",
         );
-        ensure_supported_bundle_proof_profile("tls")
-            .expect("tls profile must pass ensure_supported_bundle_proof_profile");
+        ensure_supported_bundle_proof_profile("tls")?;
         assert_eq!(
-            bundle_proof_json_filename("tls").unwrap(),
+            bundle_proof_json_filename("tls")?,
             "tls-contract-pack-proof.json",
         );
         assert_eq!(
-            bundle_proof_markdown_filename("tls").unwrap(),
+            bundle_proof_markdown_filename("tls")?,
             "tls-contract-pack-proof.md",
         );
         assert_eq!(
-            bundle_proof_markdown_title("tls").unwrap(),
+            bundle_proof_markdown_title("tls")?,
             "TLS Contract-Pack Proof",
         );
         assert_eq!(
-            default_bundle_proof_out_dir("tls").unwrap(),
+            default_bundle_proof_out_dir("tls")?,
             PathBuf::from("target/release-evidence/tls"),
         );
-        let expected = bundle_proof_expected_artifacts("tls").expect("tls expected artifacts");
+        let expected = bundle_proof_expected_artifacts("tls")?;
         let paths = expected.iter().map(|e| e.path).collect::<Vec<_>>();
         for required in [
             "certs/valid-leaf.pem",
@@ -8715,6 +8723,7 @@ index 1111111..2222222 100644
                 "tls expected artifacts missing {required}",
             );
         }
+        Ok(())
     }
 
     #[test]
@@ -9826,15 +9835,14 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
     }
 
     #[test]
-    fn impacted_test_targets_drops_deleted_crates_and_bdd() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn impacted_test_targets_drops_deleted_crates_and_bdd() -> Result<()> {
+        let dir = tempfile::tempdir()?;
         let root = dir.path();
         let crates_dir = root.join("crates");
         for name in &["uselesskey-core", "uselesskey-rsa"] {
             let crate_dir = crates_dir.join(name);
-            std::fs::create_dir_all(&crate_dir).expect("create crate dir");
-            std::fs::write(crate_dir.join("Cargo.toml"), "[package]\nname = \"x\"\n")
-                .expect("write Cargo.toml");
+            std::fs::create_dir_all(&crate_dir)?;
+            std::fs::write(crate_dir.join("Cargo.toml"), "[package]\nname = \"x\"\n")?;
         }
 
         let mut input = std::collections::BTreeSet::new();
@@ -9846,19 +9854,19 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
 
         let targets = impacted_test_targets(&input, root);
         assert_eq!(targets, vec!["uselesskey-core", "uselesskey-rsa"]);
+        Ok(())
     }
 
     #[test]
-    fn impacted_test_targets_keeps_only_dirs_with_cargo_toml() {
-        let dir = tempfile::tempdir().expect("tempdir");
+    fn impacted_test_targets_keeps_only_dirs_with_cargo_toml() -> Result<()> {
+        let dir = tempfile::tempdir()?;
         let root = dir.path();
         let crates_dir = root.join("crates");
         // Directory exists but no Cargo.toml (e.g. stale subdir) — should be skipped.
-        std::fs::create_dir_all(crates_dir.join("stale-dir")).expect("create stale-dir");
+        std::fs::create_dir_all(crates_dir.join("stale-dir"))?;
         let good = crates_dir.join("uselesskey-core");
-        std::fs::create_dir_all(&good).expect("create core dir");
-        std::fs::write(good.join("Cargo.toml"), "[package]\nname = \"x\"\n")
-            .expect("write Cargo.toml");
+        std::fs::create_dir_all(&good)?;
+        std::fs::write(good.join("Cargo.toml"), "[package]\nname = \"x\"\n")?;
 
         let mut input = std::collections::BTreeSet::new();
         input.insert("uselesskey-core".to_string());
@@ -9866,6 +9874,7 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
 
         let targets = impacted_test_targets(&input, root);
         assert_eq!(targets, vec!["uselesskey-core".to_string()]);
+        Ok(())
     }
 
     fn pr_lite_test_impacted_report() -> ImpactedEvidenceReport {
@@ -10016,15 +10025,15 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
     }
 
     #[test]
-    fn mutation_command_for_crate_passes_diff_filter_to_cargo_mutants() {
+    fn mutation_command_for_crate_passes_diff_filter_to_cargo_mutants() -> Result<()> {
         let tool_env = MutationToolEnv {
             all_features_requested: true,
             nasm_available: true,
         };
         let diff_path = Path::new("target/xtask/mutants-pr.diff");
         let cmd = mutation_command_for_crate("uselesskey-x509", None, &tool_env, Some(diff_path))
-            .unwrap()
-            .expect("uselesskey-x509 has a mutation command");
+            .context("build mutation command")?
+            .context("uselesskey-x509 has a mutation command")?;
         let args = cmd
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())
@@ -10032,12 +10041,13 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
         let in_diff = args
             .iter()
             .position(|arg| arg == "--in-diff")
-            .expect("cargo-mutants command includes --in-diff");
+            .context("cargo-mutants command includes --in-diff")?;
 
         assert_eq!(
             args.get(in_diff + 1),
             Some(&diff_path.display().to_string())
         );
+        Ok(())
     }
 
     #[test]
@@ -10083,9 +10093,8 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
     }
 
     #[test]
-    fn mutants_pr_explain_flag_parses_with_changed() {
-        let parsed = Cli::try_parse_from(["xtask", "mutants-pr", "--changed", "--explain"])
-            .expect("mutants-pr --changed --explain parses");
+    fn mutants_pr_explain_flag_parses_with_changed() -> Result<()> {
+        let parsed = Cli::try_parse_from(["xtask", "mutants-pr", "--changed", "--explain"])?;
 
         match parsed.cmd {
             Cmd::MutantsPr {
@@ -10094,7 +10103,8 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
                 assert!(changed);
                 assert!(explain);
             }
-            _ => panic!("expected mutants-pr command"),
+            _ => bail!("expected mutants-pr command"),
         }
+        Ok(())
     }
 }

--- a/xtask/src/spec_check.rs
+++ b/xtask/src/spec_check.rs
@@ -620,36 +620,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn split_toml_front_matter_extracts_body() {
+    fn split_toml_front_matter_extracts_body() -> Result<()> {
         let input = "+++\nid = \"X\"\n+++\n# Title\n";
-        let (front, body) = split_toml_front_matter(input).unwrap();
+        let (front, body) = split_toml_front_matter(input)?;
         assert_eq!(front, "id = \"X\"");
         assert_eq!(body, "# Title");
+        Ok(())
     }
 
     #[test]
-    fn heading_match_is_case_insensitive() {
+    fn heading_match_is_case_insensitive() -> Result<()> {
         let body = "## Problem\n\n## Required Evidence\n";
         assert!(has_heading(body, "problem"));
         assert!(has_heading(body, "required evidence"));
         assert!(!has_heading(body, "CI Proof"));
+        Ok(())
     }
 
     #[test]
-    fn minimal_spec_system_passes() {
-        let dir = tempfile::tempdir().unwrap();
-        write_minimal_repo(dir.path(), full_spec_body()).unwrap();
-        let report = build_report(dir.path(), false).unwrap();
+    fn minimal_spec_system_passes() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        write_minimal_repo(dir.path(), full_spec_body())?;
+        let report = build_report(dir.path(), false)?;
         assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
         assert_eq!(report.artifacts.len(), 4);
         assert_eq!(report.claims.len(), 1);
+        Ok(())
     }
 
     #[test]
-    fn accepted_spec_requires_required_sections() {
-        let dir = tempfile::tempdir().unwrap();
-        write_minimal_repo(dir.path(), "## Problem\n\n## Behavior\n").unwrap();
-        let report = build_report(dir.path(), false).unwrap();
+    fn accepted_spec_requires_required_sections() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        write_minimal_repo(dir.path(), "## Problem\n\n## Behavior\n")?;
+        let report = build_report(dir.path(), false)?;
         assert!(
             report
                 .errors
@@ -658,6 +661,7 @@ mod tests {
             "errors: {:?}",
             report.errors
         );
+        Ok(())
     }
 
     fn write_minimal_repo(root: &Path, spec_body: &str) -> Result<()> {

--- a/xtask/src/test_efficiency.rs
+++ b/xtask/src/test_efficiency.rs
@@ -86,7 +86,7 @@ pub(crate) fn write_test_efficiency_report(root: &Path) -> Result<()> {
 fn build_report(root: &Path) -> Result<TestEfficiencyReport> {
     let mut tests = Vec::new();
     let fn_regex = Regex::new(r"\b(?:async\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
-        .expect("valid function regex");
+        .context("valid function regex")?;
 
     for path in rust_files(root)? {
         collect_tests_from_file(root, &path, &fn_regex, &mut tests)?;

--- a/xtask/src/verification_pack.rs
+++ b/xtask/src/verification_pack.rs
@@ -347,9 +347,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_selection_uses_stable_all_stable_claims() {
+    fn default_selection_uses_stable_all_stable_claims() -> Result<()> {
         let ledger = minimal_ledger();
-        let selected = selected_claims(&ledger, None).unwrap();
+        let selected = selected_claims(&ledger, None)?;
 
         assert_eq!(
             selected
@@ -358,21 +358,26 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["scanner-safe-fixtures", "tls-contract-pack"]
         );
+        Ok(())
     }
 
     #[test]
-    fn claim_selection_rejects_unknown_claim() {
+    fn claim_selection_rejects_unknown_claim() -> Result<()> {
         let ledger = minimal_ledger();
-        let err = selected_claims(&ledger, Some("missing")).unwrap_err();
+        let err = match selected_claims(&ledger, Some("missing")) {
+            Ok(claims) => bail!("unexpected claim selection: {claims:?}"),
+            Err(err) => err,
+        };
 
         assert!(
             err.to_string().contains("unknown claim `missing`"),
             "unexpected error: {err}"
         );
+        Ok(())
     }
 
     #[test]
-    fn readme_records_boundaries_and_commands() {
+    fn readme_records_boundaries_and_commands() -> Result<()> {
         let claims = vec![ClaimEntry {
             id: "scanner-safe-fixtures".to_string(),
             title: "Scanner-safe fixtures".to_string(),
@@ -385,10 +390,11 @@ mod tests {
         assert!(markdown.contains("cargo xtask claim-proof --claim scanner-safe-fixtures"));
         assert!(markdown.contains("Not every export is safe to commit."));
         assert!(markdown.contains("intentionally excludes generated fixture payloads"));
+        Ok(())
     }
 
     #[test]
-    fn forbidden_payload_paths_are_rejected() {
+    fn forbidden_payload_paths_are_rejected() -> Result<()> {
         for path in [
             "certs/valid-leaf.pem",
             "payload.der",
@@ -407,49 +413,58 @@ mod tests {
         ] {
             assert!(!forbidden_payload_path(path), "{path} should be allowed");
         }
+        Ok(())
     }
 
     #[test]
-    fn target_output_dir_can_be_recreated() {
-        let dir = tempfile::tempdir().unwrap();
+    fn target_output_dir_can_be_recreated() -> Result<()> {
+        let dir = tempfile::tempdir()?;
         let out = dir.path().join("target/uselesskey-verification");
-        fs::create_dir_all(&out).unwrap();
-        fs::write(out.join("old.txt"), "old").unwrap();
+        fs::create_dir_all(&out)?;
+        fs::write(out.join("old.txt"), "old")?;
 
-        let prepared =
-            prepare_out_dir(dir.path(), Path::new("target/uselesskey-verification")).unwrap();
+        let prepared = prepare_out_dir(dir.path(), Path::new("target/uselesskey-verification"))?;
 
         assert_eq!(prepared, out);
         assert!(!prepared.join("old.txt").exists());
+        Ok(())
     }
 
     #[test]
-    fn non_target_nonempty_output_dir_is_rejected() {
-        let dir = tempfile::tempdir().unwrap();
+    fn non_target_nonempty_output_dir_is_rejected() -> Result<()> {
+        let dir = tempfile::tempdir()?;
         let out = dir.path().join("review-pack");
-        fs::create_dir_all(&out).unwrap();
-        fs::write(out.join("old.txt"), "old").unwrap();
+        fs::create_dir_all(&out)?;
+        fs::write(out.join("old.txt"), "old")?;
 
-        let err = prepare_out_dir(dir.path(), &out).unwrap_err();
+        let err = match prepare_out_dir(dir.path(), &out) {
+            Ok(path) => bail!("unexpected prepared output dir: {}", path.display()),
+            Err(err) => err,
+        };
 
         assert!(
             err.to_string()
                 .contains("non-target output directory must be empty"),
             "unexpected error: {err}"
         );
+        Ok(())
     }
 
     #[test]
-    fn target_root_output_dir_is_rejected() {
-        let dir = tempfile::tempdir().unwrap();
+    fn target_root_output_dir_is_rejected() -> Result<()> {
+        let dir = tempfile::tempdir()?;
 
-        let err = prepare_out_dir(dir.path(), Path::new("target")).unwrap_err();
+        let err = match prepare_out_dir(dir.path(), Path::new("target")) {
+            Ok(path) => bail!("unexpected prepared output dir: {}", path.display()),
+            Err(err) => err,
+        };
 
         assert!(
             err.to_string()
                 .contains("refusing to use target root as output directory"),
             "unexpected error: {err}"
         );
+        Ok(())
     }
 
     fn minimal_ledger() -> ClaimLedger {


### PR DESCRIPTION
## Summary
- convert current xtask no-panic-family test debt to fallible Result-returning tests and ? propagation
- replace the small claim-proof checked invariant expect with an explicit error path
- replace the 	est_efficiency regex construction expect with contextual error propagation
- advance the active no-panic goal from xtask-tests to production-path-review

## Files added/changed
- .uselesskey/goals/active.toml
- xtask/src/claim_proof.rs
- xtask/src/claim_report.rs
- xtask/src/contract_packs.rs
- xtask/src/main.rs
- xtask/src/spec_check.rs
- xtask/src/test_efficiency.rs
- xtask/src/verification_pack.rs

## Validation
- cargo test -p xtask claim_proof passed
- cargo test -p xtask claim_report passed
- cargo test -p xtask contract_packs passed
- cargo test -p xtask verification_pack passed
- cargo test -p xtask spec_check passed
- cargo test -p xtask test_efficiency passed
- cargo test -p xtask passed: 299 tests
- cargo xtask check-no-panic-family failed as expected in 
o-new-debt mode, now down to 7 remaining new-debt sites, all in webhook/x509 production-path code
- cargo xtask spec-check --strict passed
- cargo xtask docs-sync --check passed
- cargo xtask typos passed
- cargo xtask pr-lite passed
- cargo xtask pr passed
- git diff --check passed

## Non-goals
- no no-panic baseline reset
- no policy weakening
- no production-path webhook/x509 review in this slice
- no public API or fixture behavior changes
- no unrelated historical baseline cleanup

## What this enables next
- the active lane can move to production-path review for the remaining 7 webhook/x509 no-panic findings