### PR TITLE
docs: close out no-panic new-debt lane

### DIFF
--- a/.uselesskey/goals/archive/2026-05-no-panic-burndown.toml
+++ b/.uselesskey/goals/archive/2026-05-no-panic-burndown.toml
@@ -97,6 +97,7 @@ commands = [
   "cargo xtask pr",
   "git diff --check",
 ]
+
 [[work_item]]
 id = "policy-stage-flip"
 status = "done"

--- a/docs/learnings/2026-05-no-panic-burndown.md
+++ b/docs/learnings/2026-05-no-panic-burndown.md
@@ -1,0 +1,66 @@
++++
+id = "USELESSKEY-LEARNING-2026-05-no-panic-burndown"
+kind = "learning"
+title = "No-panic progress needs a stage between advisory and deny"
+status = "implemented"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0005",
+]
+linked_adrs = []
+linked_plan = "plans/no-panic-burndown/implementation-plan.md"
++++
+
+# No-Panic Progress Needs a Stage Between Advisory and Deny
+
+## Trigger
+
+Issue #575 showed that the repo had already moved past an advisory-only
+panic-family posture: `cargo xtask check-no-panic-family` was running in
+`no-new-debt` mode, but 150 unreceipted new-debt sites still blocked the lane.
+
+## What Changed
+
+The lane burned down those new-debt sites without resetting the baseline.
+Test setup migrated toward fallible helper APIs, production-path findings were
+removed or receipted, and the baseline was refreshed only after the checker was
+clean.
+
+The repo now records this as Stage A.5:
+
+```text
+warn-level Clippy panic-family lints
++ semantic no-panic checker in no-new-debt mode
++ historical baseline still active
+```
+
+## Evidence
+
+- `cargo xtask check-no-panic-family` exits 0 with 0 new-debt, 0 stale
+  allowlist entries, and 0 expired allowlist entries.
+- `policy/no-panic-allowlist.toml` carries receipted production-path
+  invariants.
+- `policy/no-panic-baseline.toml` was refreshed with
+  `cargo xtask no-panic baseline`, not `--reset`.
+- `policy/clippy-lints.toml` records Stage A.5 instead of pretending the repo is
+  ready for Stage C.
+
+## Rule to Keep
+
+Do not equate "0 new debt" with "panic-family lint deny is ready." Stage C
+requires historical baseline debt to be removed or receipted so the allowlist is
+the authoritative ledger.
+
+## Follow-up Artifacts
+
+Future no-panic work should update:
+
+- `policy/no-panic-allowlist.toml` when an exception is intentionally retained;
+- `policy/no-panic-baseline.toml` with `cargo xtask no-panic baseline` after a
+  deliberate burndown PR;
+- `docs/NO_PANIC_POLICY.md` and `policy/clippy-lints.toml` when the rollout
+  stage changes;
+- `.uselesskey/goals/active.toml` and the linked implementation plan for active
+  lane state.

--- a/docs/learnings/README.md
+++ b/docs/learnings/README.md
@@ -22,3 +22,4 @@ include:
 - [2026-05-spec-system.md](2026-05-spec-system.md) - public fixture claims need command-backed source of truth
 - [2026-05-claim-backed-verification.md](2026-05-claim-backed-verification.md) - public claims are useful when users can run the proof
 - [2026-05-pr-lite-evidence.md](2026-05-pr-lite-evidence.md) - local evidence is useful when its boundary is explicit
+- [2026-05-no-panic-burndown.md](2026-05-no-panic-burndown.md) - no-panic progress needs a stage between advisory and deny

--- a/plans/no-panic-burndown/README.md
+++ b/plans/no-panic-burndown/README.md
@@ -7,3 +7,5 @@ resetting the baseline or weakening panic policy.
 
 - [implementation-plan.md](implementation-plan.md) - PR sequence, proof
   commands, non-goals, and stop conditions.
+- [closeout.md](closeout.md) - implemented surface, proof, and remaining
+  policy debt.

--- a/plans/no-panic-burndown/closeout.md
+++ b/plans/no-panic-burndown/closeout.md
@@ -1,0 +1,81 @@
++++
+id = "USELESSKEY-PLAN-0008"
+kind = "plan"
+title = "No-panic new-debt burndown closeout"
+status = "implemented"
+owner = "EffortlessMetrics"
+created = "2026-05-13"
+milestone = "v0.9.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0005",
+]
+linked_adrs = []
++++
+
+# No-Panic New-Debt Burndown Closeout
+
+## Current State
+
+The no-panic new-debt burndown lane is implemented. `uselesskey` now runs the
+semantic no-panic checker in `no-new-debt` mode with zero unreceipted new debt.
+
+The active goal manifest for this lane is archived at
+`.uselesskey/goals/archive/2026-05-no-panic-burndown.toml`. The root
+`.uselesskey/goals/active.toml` records the lane as archived until a new lane is
+selected.
+
+## Implemented Surface
+
+- `cargo xtask check-no-panic-family` exits 0 in `no-new-debt` mode.
+- The new-debt count from issue #575 was burned down without
+  `cargo xtask no-panic baseline --reset`.
+- CLI and xtask panic-family test setup moved to fallible test-support helpers.
+- Production-path new debt was either removed or moved into
+  `policy/no-panic-allowlist.toml` with owner, classification, explanation, and
+  expiry.
+- `policy/no-panic-baseline.toml` was refreshed with
+  `cargo xtask no-panic baseline` only after the checker was clean.
+- `policy/clippy-lints.toml` now records Stage A.5: warn-level Clippy
+  panic-family lints plus no-new-debt semantic enforcement.
+
+## Remaining Policy Debt
+
+Stage A.5 is not Stage C. The historical baseline still contains existing
+panic-family debt, so Clippy panic-family lints remain at `warn` and the
+semantic checker remains in `no-new-debt` mode.
+
+The next no-panic lane should burn down or receipt historical baseline entries
+until the allowlist can become the authoritative ledger. Only then should the
+repo advance to Stage B or Stage C.
+
+## Proof
+
+The closeout proof is:
+
+```bash
+cargo test -p uselesskey-core
+cargo test -p uselesskey-jwk
+cargo test -p uselesskey-token
+cargo xtask check-no-panic-family
+cargo xtask check-lint-policy
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+cargo xtask pr-lite
+cargo xtask pr
+git diff --check
+```
+
+## Non-Goals Held
+
+This lane did not reset the baseline, weaken panic policy, flip Clippy
+panic-family lints to `deny`, reclassify historical baseline debt as reviewed,
+add fixture profiles, execute a release, migrate to shipper, add README badges,
+or introduce dependency churn.
+
+## Next Safe Action
+
+Start the next lane from a fresh `.uselesskey/goals/active.toml` and linked
+plan. The archived no-panic new-debt goal is historical state, not live
+instructions.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -20,7 +20,8 @@ suppression_style = "expect-with-reason"
 # Do not use `clippy::all`/`pedantic`/`nursery` blanket categories.
 blanket_categories = false
 # Promote panic-family clippy lints to `deny` only when the no-panic
-# allowlist is the authoritative ledger. Currently warn-stage.
+# allowlist is the authoritative ledger. Currently Stage A.5: the semantic
+# checker blocks new debt while historical baseline debt burns down.
 panic_family_level = "warn"
 # `cargo xtask check-no-panic-family` is the authoritative ledger for
 # panic-family exceptions. Clippy is the immediate code-shape detector.
@@ -144,14 +145,18 @@ keys = [
 
 # Stage tracking for the panic-family rollout.
 #
-# Stage A (current): warn-level panic-family lints, advisory no-panic checker.
-# Stage B: burn down debt, every remaining exception receipted in
-#          policy/no-panic-allowlist.toml with owner/reason/expiry.
-# Stage C: flip panic-family lints to deny.
+# Stage A: warn-level panic-family lints, advisory no-panic checker.
+# Stage A.5 (current): warn-level panic-family lints, no-new-debt semantic
+#          checker, historical baseline still active.
+# Stage B: move historical debt out of the baseline, shrinking it toward
+#          zero or receipting exceptions in policy/no-panic-allowlist.toml
+#          with owner/reason/expiry.
+# Stage C: flip panic-family lints to deny after the allowlist is the
+#          authoritative panic-family ledger.
 #
 # Bare-allow rollout:
 #   - bare `#[allow(...)]` is a hard error today (every suppression must carry
 #     `reason = "..."`); the workspace is at zero bare allows.
 [stage]
-current = "A"
-description = "Warn-stage panic-family lints; semantic no-panic checker advisory; bare-allow blocking."
+current = "A.5"
+description = "Warn-stage panic-family lints; semantic no-panic checker blocks new debt; bare-allow blocking."


### PR DESCRIPTION
## Summary
- Close out the no-panic new-debt burndown lane and archive the active goal.
- Record Stage A.5 in `policy/clippy-lints.toml`: panic-family Clippy lints stay warn-level while the semantic no-panic checker blocks new debt.
- Add a closeout and learning record that preserve the remaining historical-baseline debt boundary.

## Files added/changed
- `.uselesskey/goals/active.toml`
- `.uselesskey/goals/archive/2026-05-no-panic-burndown.toml`
- `plans/no-panic-burndown/closeout.md`
- `plans/no-panic-burndown/README.md`
- `docs/learnings/2026-05-no-panic-burndown.md`
- `docs/learnings/README.md`
- `policy/clippy-lints.toml`

## Validation
- `cargo test -p uselesskey-core`
- `cargo test -p uselesskey-jwk`
- `cargo test -p uselesskey-token`
- `cargo xtask spec-check --strict`
- `cargo xtask check-lint-policy`
- `cargo xtask check-no-panic-family`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo xtask pr-lite`
- `cargo xtask pr`
- `git diff --check`

## Non-goals
- No baseline reset.
- No panic-family Clippy deny flip.
- No claim that historical baseline debt is gone.
- No product behavior, fixture profile, release, badge, shipper, or dependency changes.

## What this enables next
- A future Stage B/C lane can burn down or receipt historical baseline entries without confusing that work with the completed no-new-debt cleanup.

Refs #575.