### PR TITLE
ops: start webhook contract-pack lane

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -1,21 +1,22 @@
-id = "uselesskey-no-panic-burndown"
-title = "No-panic burndown"
-status = "archived"
+id = "uselesskey-webhook-contract-pack"
+title = "Webhook contract pack"
+status = "active"
 owner = "EffortlessMetrics"
-created = "2026-05-13"
+created = "2026-05-14"
 
 objective = """
-Burn down the no-panic-family debt tracked by issue #575 without resetting the
-baseline, weakening policy, or absorbing new debt into the snapshot.
+Ship a bounded webhook contract pack that proves deterministic HMAC webhook
+verifier behavior through the existing spec, claim, proof, verification-pack,
+release-evidence, PR-lite, and no-panic rails.
 """
 
 end_state = [
-  "cargo xtask check-no-panic-family exits 0 in no-new-debt mode.",
-  "New-debt count reaches 0 without running cargo xtask no-panic baseline --reset.",
-  "Test-code panic-family sites move to fallible test-support helpers.",
-  "Production-path findings are removed or receipted in policy/no-panic-allowlist.toml.",
-  "Remaining exceptions have owner, explanation, classification, and expiry.",
-  "The policy can advance toward Stage C only after the baseline has burned down.",
+  "uselesskey bundle --profile webhook materializes a deterministic webhook fixture pack.",
+  "cargo xtask bundle-proof --profile webhook verifies the pack and writes release-evidence receipts.",
+  "webhook-contract-pack is registered in the claim ledger and contract-pack registry.",
+  "cargo xtask claim-proof --claim webhook-contract-pack runs a whitelisted proof handler.",
+  "verification-pack can include webhook-contract-pack metadata-only receipts.",
+  "User docs explain what webhook fixtures prove and explicitly do not prove.",
 ]
 
 [[work_item]]
@@ -23,7 +24,7 @@ id = "open-lane"
 status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/no-panic-burndown/implementation-plan.md"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
@@ -32,96 +33,133 @@ commands = [
 ]
 
 [[work_item]]
-id = "cli-tests"
-status = "done"
+id = "webhook-spec"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/no-panic-burndown/implementation-plan.md"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-cli --test cli",
-  "cargo xtask check-no-panic-family",
-  "cargo xtask pr-lite",
+  "cargo xtask spec-check --strict",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "xtask-tests"
-status = "done"
+id = "bundle-profile"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/no-panic-burndown/implementation-plan.md"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
 commands = [
-  "cargo test -p xtask",
-  "cargo xtask check-no-panic-family",
+  "cargo test -p uselesskey-webhook --all-features",
+  "cargo test -p uselesskey-cli --all-features webhook",
   "cargo xtask pr-lite",
+  "cargo xtask no-blob",
+  "cargo xtask check-file-policy",
+  "cargo xtask pr",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "core-tests"
-status = "done"
+id = "bundle-proof"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/no-panic-burndown/implementation-plan.md"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-core",
-  "cargo xtask check-no-panic-family",
-  "cargo xtask pr-lite",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "jwk-token-tests"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0005"
-plan = "plans/no-panic-burndown/implementation-plan.md"
-commands = [
-  "cargo test -p uselesskey-jwk",
-  "cargo test -p uselesskey-token",
-  "cargo xtask check-no-panic-family",
-  "cargo xtask pr-lite",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "production-path-review"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0005"
-plan = "plans/no-panic-burndown/implementation-plan.md"
-commands = [
-  "cargo xtask check-no-panic-family",
-  "cargo xtask no-panic propose",
+  "cargo test -p xtask bundle_proof",
+  "cargo xtask bundle-proof --profile webhook --out target/release-evidence/webhook",
   "cargo xtask pr-lite",
   "cargo xtask pr",
   "git diff --check",
 ]
+
 [[work_item]]
-id = "policy-stage-flip"
-status = "done"
+id = "claim-registration"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/no-panic-burndown/implementation-plan.md"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
 commands = [
-  "cargo xtask check-no-panic-family",
-  "cargo xtask check-lint-policy",
+  "cargo xtask claim-report --check-public-claims",
+  "cargo xtask contract-packs --check",
+  "cargo xtask spec-check --strict",
+  "cargo xtask docs-sync --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "claim-proof"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
+commands = [
+  "cargo test -p xtask claim_proof",
+  "cargo xtask claim-proof --claim webhook-contract-pack",
+  "cargo xtask claim-proof --all-stable",
+  "cargo xtask verification-pack --out target/uselesskey-verification --claim webhook-contract-pack",
+  "cargo xtask pr-lite",
   "cargo xtask pr",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "how-to"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
+commands = [
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "cargo xtask claim-report --check-public-claims",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "release-evidence"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
+commands = [
+  "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
+  "cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary",
+  "cargo xtask spec-check --strict",
+  "cargo xtask pr-lite",
+  "cargo xtask pr",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "verification-polish"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
+commands = [
+  "cargo xtask verification-pack --out target/uselesskey-verification --claim webhook-contract-pack",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
   "git diff --check",
 ]
 
 [[work_item]]
 id = "lane-closeout"
-status = "done"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/no-panic-burndown/closeout.md"
+plan = "plans/webhook-contract-pack/implementation-plan.md"
 commands = [
-  "cargo xtask check-no-panic-family",
-  "cargo xtask check-lint-policy",
   "cargo xtask spec-check --strict",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
+  "cargo xtask claim-report --check-public-claims",
+  "cargo xtask contract-packs --check",
+  "cargo xtask claim-proof --claim webhook-contract-pack",
+  "cargo xtask verification-pack --out target/uselesskey-verification --claim webhook-contract-pack",
+  "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
+  "cargo xtask pr-lite",
   "cargo xtask pr",
   "git diff --check",
 ]

--- a/plans/README.md
+++ b/plans/README.md
@@ -11,6 +11,7 @@ Plans do not define product truth. Link to proposals for why and specs for what.
 - [claim-backed-verification](claim-backed-verification/README.md) - User-facing claim proof and verification-pack rollout
 - [pr-lite-evidence](pr-lite-evidence/README.md) - Local PR evidence and heavy-routing receipt rollout
 - [no-panic-burndown](no-panic-burndown/README.md) - No-panic-family debt burndown without baseline reset
+- [webhook-contract-pack](webhook-contract-pack/README.md) - Webhook contract-pack product lane
 
 ## Templates
 

--- a/plans/webhook-contract-pack/README.md
+++ b/plans/webhook-contract-pack/README.md
@@ -1,0 +1,9 @@
+# Webhook Contract-Pack Plan Area
+
+This directory tracks the lane that turns the completed verification and
+evidence infrastructure into a user-visible webhook contract pack.
+
+## Plan Files
+
+- [implementation-plan.md](implementation-plan.md) - PR sequence, proof
+  commands, non-goals, and stop conditions.

--- a/plans/webhook-contract-pack/implementation-plan.md
+++ b/plans/webhook-contract-pack/implementation-plan.md
@@ -1,0 +1,168 @@
++++
+id = "USELESSKEY-PLAN-0009"
+kind = "plan"
+title = "Webhook contract pack"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-14"
+milestone = "v0.9.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0005",
+]
+linked_adrs = []
++++
+
+# Webhook Contract Pack
+
+## Objective
+
+Ship a bounded webhook contract pack that lets users generate deterministic
+HMAC-SHA256 webhook verification fixtures, run positive and negative verifier
+checks locally, produce command-backed receipts, and share metadata-only proof
+with reviewers.
+
+This lane spends the completed source-of-truth, claim-backed verification,
+PR-lite, and no-panic rails on user-visible product value.
+
+## Scope
+
+This lane covers:
+
+- a product spec for the webhook contract pack and its claim boundary;
+- `uselesskey bundle --profile webhook`;
+- deterministic request fixtures for one valid case and bounded negative cases;
+- `cargo xtask bundle-proof --profile webhook`;
+- claim-ledger and contract-pack registry entries;
+- a whitelisted `claim-proof` handler for `webhook-contract-pack`;
+- task-first user docs for webhook signature validation;
+- minor release-evidence integration;
+- verification-pack documentation and closeout.
+
+## Claim Boundary
+
+The webhook contract pack proves deterministic HMAC webhook verifier behavior
+for fixture requests.
+
+It does not prove production webhook provider compatibility, secret rotation,
+delivery retries, timestamp policy suitability, replay protection completeness,
+transport security, or production secret management.
+
+## Target Fixture Shape
+
+The generated pack should use a small, stable shape:
+
+```text
+manifest.json
+requests/valid.json
+requests/negative-tampered-body.json
+requests/negative-wrong-secret.json
+requests/negative-stale-timestamp.json
+requests/negative-missing-signature.json
+requests/negative-malformed-signature.json
+receipts/materialization.json
+receipts/audit-surface.json
+evidence/webhook-profile.md
+```
+
+Each request fixture should record:
+
+```text
+method
+path
+timestamp
+body
+headers
+expected_result
+rejection_class
+```
+
+Expected rejection classes should be stable identifiers:
+
+```text
+valid
+tampered_body
+wrong_secret
+stale_timestamp
+missing_signature
+malformed_signature
+```
+
+## Non-Goals
+
+Do not mix these into this lane:
+
+- provider-specific webhook compatibility matrices;
+- production secret management;
+- replay-policy product claims;
+- transport-security claims;
+- TLS, mTLS, revocation, CT, or browser trust-store behavior;
+- shipper migration work;
+- no-panic historical baseline burndown;
+- README badge additions;
+- dependency churn.
+
+## PR Sequence
+
+1. Open this active lane and implementation plan.
+2. Add `docs/specs/USELESSKEY-SPEC-0011-webhook-contract-pack.md`.
+3. Implement `uselesskey bundle --profile webhook`.
+4. Add `cargo xtask bundle-proof --profile webhook`.
+5. Register `webhook-contract-pack` in `policy/claim-ledger.toml`,
+   `policy/contract-packs.toml`, and `docs/status/PUBLIC_CLAIMS.md`.
+6. Add a whitelisted `cargo xtask claim-proof --claim webhook-contract-pack`
+   handler.
+7. Add task-first webhook signature validation docs.
+8. Wire webhook proof into minor release evidence while keeping patch evidence
+   cheap unless webhook surfaces are touched.
+9. Polish verification-pack docs for the webhook user path.
+10. Close out the lane with a learning record and archived active goal.
+
+## Proof Commands
+
+Lane-opening PR:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Product implementation PRs:
+
+```bash
+cargo test -p uselesskey-webhook --all-features
+cargo test -p uselesskey-cli --all-features webhook
+cargo xtask bundle-proof --profile webhook --out target/release-evidence/webhook
+cargo xtask claim-proof --claim webhook-contract-pack
+cargo xtask verification-pack --out target/uselesskey-verification --claim webhook-contract-pack
+cargo xtask pr-lite
+cargo xtask pr
+git diff --check
+```
+
+Release-evidence PR:
+
+```bash
+cargo xtask release-evidence --version 0.9.0 --dry-run --summary
+cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary
+cargo xtask spec-check --strict
+cargo xtask pr-lite
+cargo xtask pr
+git diff --check
+```
+
+## Rollback
+
+Each PR should be independently revertible. If the implementation proves too
+broad, revert the product-code PRs and leave the lane plan active for a smaller
+spec revision. Do not leave claim-ledger or contract-pack registry entries for
+unimplemented behavior.
+
+## Stop Conditions
+
+Pause and split work if the lane requires provider-specific compatibility
+claims, production secret management semantics, dependency additions, new README
+badges, historical no-panic baseline work, release execution, shipper work, or
+TLS expansion.


### PR DESCRIPTION
## Summary
- Start the webhook contract-pack product lane as the next active goal.
- Add a PR-sized implementation plan for the post-TLS webhook pack.
- Keep the lane bounded to generic deterministic HMAC webhook verifier fixtures and proof receipts.

## Files added/changed
- `.uselesskey/goals/active.toml`
- `plans/webhook-contract-pack/README.md`
- `plans/webhook-contract-pack/implementation-plan.md`
- `plans/README.md`

## Validation
- `cargo xtask spec-check --strict`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `git diff --check`

## Non-goals
- No provider-specific webhook compatibility matrix.
- No production secret management or replay-policy product claims.
- No TLS expansion, shipper work, no-panic historical baseline work, dependency churn, or README badge additions.
- No product code yet.

## What this enables next
- The next PR can add `USELESSKEY-SPEC-0011-webhook-contract-pack.md` with the fixture contract, rejection classes, proof command, and explicit claim boundary.