### PR TITLE
xtask: add webhook contract-pack proof

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -63,7 +63,7 @@ commands = [
 
 [[work_item]]
 id = "bundle-proof"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0011"
 plan = "plans/webhook-contract-pack/implementation-plan.md"
@@ -77,7 +77,7 @@ commands = [
 
 [[work_item]]
 id = "claim-registration"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0011"
 plan = "plans/webhook-contract-pack/implementation-plan.md"

--- a/xtask/src/bundle_proof.rs
+++ b/xtask/src/bundle_proof.rs
@@ -118,6 +118,14 @@ const TLS_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY: &[&str] = &[
     "bundle proof is fixture-platform evidence, not production key management or scanner evasion",
 ];
 
+const WEBHOOK_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY: &[&str] = &[
+    "Webhook contract-pack proof covers deterministic HMAC verifier fixtures, not production webhook provider compatibility",
+    "Webhook proof verifies pack shape and fixture presence (valid request + five negative classes), not downstream verifier correctness",
+    "Webhook proof does not cover secret rotation, delivery retries, replay protection completeness, transport security, or production secret management",
+    "Webhook request artifacts intentionally contain runtime signing material and belong under target/ or other generated-output paths, not committed fixture paths",
+    "bundle proof is fixture-platform evidence, not production key management or scanner evasion",
+];
+
 pub(crate) fn run(profile: &str, out_dir: Option<&Path>) -> Result<()> {
     let profile = profile.trim();
     ensure_supported_bundle_proof_profile(profile)?;
@@ -180,6 +188,7 @@ fn run_profile_commands(profile: &str, paths: &BundleProofPaths) -> Result<Bundl
         "scanner-safe" => run_scanner_safe_exports(paths, &mut execution)?,
         "oidc" => run_oidc_contract_pack_checks(&mut execution)?,
         "tls" => run_tls_contract_pack_checks(&mut execution)?,
+        "webhook" => run_webhook_contract_pack_checks(&mut execution)?,
         _ => ensure_supported_bundle_proof_profile(profile)?,
     }
     append_no_blob_check(&mut execution)?;
@@ -346,6 +355,33 @@ fn run_tls_contract_pack_checks(execution: &mut BundleProofExecution) -> Result<
     Ok(())
 }
 
+fn run_webhook_contract_pack_checks(execution: &mut BundleProofExecution) -> Result<()> {
+    execution.commands.push(run_bundle_proof_command(
+        "cli-webhook-contract-pack-test",
+        vec![
+            "cargo".to_string(),
+            "test".to_string(),
+            "-p".to_string(),
+            "uselesskey-cli".to_string(),
+            "webhook".to_string(),
+            "--all-features".to_string(),
+        ],
+        Vec::new(),
+    )?);
+    execution.commands.push(run_bundle_proof_command(
+        "webhook-owner-tests",
+        vec![
+            "cargo".to_string(),
+            "test".to_string(),
+            "-p".to_string(),
+            "uselesskey-webhook".to_string(),
+            "--all-features".to_string(),
+        ],
+        Vec::new(),
+    )?);
+    Ok(())
+}
+
 fn append_no_blob_check(execution: &mut BundleProofExecution) -> Result<()> {
     execution.commands.push(run_bundle_proof_command(
         "no-blob",
@@ -405,8 +441,10 @@ pub(crate) fn ensure_supported_bundle_proof_profile(profile: &str) -> Result<()>
 /// Profiles supported by `cargo xtask bundle-proof --profile <name>`.
 ///
 /// Order matches the v0.7.0 -> v0.8.0 release lane introduction order:
-/// scanner-safe (v0.7.0), oidc (v0.7.0), tls (v0.8.0 PR-C).
-pub(crate) const BUNDLE_PROOF_SUPPORTED_PROFILES: &[&str] = &["scanner-safe", "oidc", "tls"];
+/// scanner-safe (v0.7.0), oidc (v0.7.0), tls (v0.8.0 PR-C),
+/// webhook (v0.9.0 lane).
+pub(crate) const BUNDLE_PROOF_SUPPORTED_PROFILES: &[&str] =
+    &["scanner-safe", "oidc", "tls", "webhook"];
 
 fn unsupported_bundle_proof_profile_message() -> String {
     format!(
@@ -420,6 +458,7 @@ pub(crate) fn default_bundle_proof_out_dir(profile: &str) -> Result<PathBuf> {
         "scanner-safe" => "target/release-evidence/scanner-safe",
         "oidc" => "target/release-evidence/oidc",
         "tls" => "target/release-evidence/tls",
+        "webhook" => "target/release-evidence/webhook",
         _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     }))
 }
@@ -429,6 +468,7 @@ pub(crate) fn bundle_proof_json_filename(profile: &str) -> Result<&'static str> 
         "scanner-safe" => "scanner-safe-bundle-proof.json",
         "oidc" => "oidc-contract-pack-proof.json",
         "tls" => "tls-contract-pack-proof.json",
+        "webhook" => "webhook-contract-pack-proof.json",
         _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
@@ -438,6 +478,7 @@ pub(crate) fn bundle_proof_markdown_filename(profile: &str) -> Result<&'static s
         "scanner-safe" => "scanner-safe-bundle-proof.md",
         "oidc" => "oidc-contract-pack-proof.md",
         "tls" => "tls-contract-pack-proof.md",
+        "webhook" => "webhook-contract-pack-proof.md",
         _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
@@ -447,6 +488,7 @@ pub(crate) fn bundle_proof_markdown_title(profile: &str) -> Result<&'static str>
         "scanner-safe" => "Scanner-Safe Bundle Proof",
         "oidc" => "OIDC Contract-Pack Proof",
         "tls" => "TLS Contract-Pack Proof",
+        "webhook" => "Webhook Contract-Pack Proof",
         _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
@@ -456,6 +498,7 @@ fn bundle_proof_claim_boundary(profile: &str) -> Result<Vec<&'static str>> {
         "scanner-safe" => SCANNER_SAFE_BUNDLE_PROOF_CLAIM_BOUNDARY.to_vec(),
         "oidc" => OIDC_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY.to_vec(),
         "tls" => TLS_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY.to_vec(),
+        "webhook" => WEBHOOK_CONTRACT_PACK_PROOF_CLAIM_BOUNDARY.to_vec(),
         _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
@@ -534,6 +577,43 @@ pub(crate) fn bundle_proof_expected_artifacts(
                 description: "TLS profile per-fixture rejection-expectation evidence",
             },
         ],
+        "webhook" => vec![
+            BundleProofExpectedArtifact {
+                name: "valid_request",
+                path: "requests/valid.json",
+                description: "Webhook valid HMAC request",
+            },
+            BundleProofExpectedArtifact {
+                name: "negative_tampered_body",
+                path: "requests/negative-tampered-body.json",
+                description: "Webhook negative request with modified body",
+            },
+            BundleProofExpectedArtifact {
+                name: "negative_wrong_secret",
+                path: "requests/negative-wrong-secret.json",
+                description: "Webhook negative request signed with the wrong secret",
+            },
+            BundleProofExpectedArtifact {
+                name: "negative_stale_timestamp",
+                path: "requests/negative-stale-timestamp.json",
+                description: "Webhook negative request outside timestamp tolerance",
+            },
+            BundleProofExpectedArtifact {
+                name: "negative_missing_signature",
+                path: "requests/negative-missing-signature.json",
+                description: "Webhook negative request missing the signature header",
+            },
+            BundleProofExpectedArtifact {
+                name: "negative_malformed_signature",
+                path: "requests/negative-malformed-signature.json",
+                description: "Webhook negative request with malformed signature",
+            },
+            BundleProofExpectedArtifact {
+                name: "webhook_evidence_doc",
+                path: "evidence/webhook-profile.md",
+                description: "Webhook profile verifier expectation evidence",
+            },
+        ],
         _ => bail!("{}", unsupported_bundle_proof_profile_message()),
     })
 }
@@ -609,17 +689,8 @@ pub(crate) fn bundle_proof_receipt(
     if manifest.artifacts.is_empty() {
         bail!("bundle proof expected artifact metadata");
     }
-    if !scanner_safe {
-        bail!("bundle proof expected all artifacts to be scanner-safe");
-    }
-    if runtime_material_count != 0 {
-        bail!("bundle proof expected zero runtime material artifacts");
-    }
     if private_key_material {
         bail!("bundle proof found private key material");
-    }
-    if symmetric_secret_material {
-        bail!("bundle proof found symmetric secret material");
     }
     for expected in ["materialization", "audit-surface"] {
         if !receipts_present.iter().any(|kind| kind == expected) {
@@ -633,15 +704,20 @@ pub(crate) fn bundle_proof_receipt(
             missing.path
         );
     }
-    if audit_surface
-        .get("scanner_safe")
-        .and_then(serde_json::Value::as_bool)
-        != Some(true)
-    {
-        bail!("bundle proof expected audit-surface scanner_safe=true");
-    }
-    if json_u64(audit_surface, "runtime_material_count") != 0 {
-        bail!("bundle proof expected audit-surface runtime_material_count=0");
+
+    match profile {
+        "webhook" => enforce_webhook_proof_posture(
+            scanner_safe,
+            runtime_material_count,
+            symmetric_secret_material,
+            audit_surface,
+        )?,
+        _ => enforce_scanner_safe_proof_posture(
+            scanner_safe,
+            runtime_material_count,
+            symmetric_secret_material,
+            audit_surface,
+        )?,
     }
 
     Ok(BundleProofReceipt {
@@ -669,6 +745,62 @@ pub(crate) fn bundle_proof_receipt(
     })
 }
 
+fn enforce_scanner_safe_proof_posture(
+    scanner_safe: bool,
+    runtime_material_count: usize,
+    symmetric_secret_material: bool,
+    audit_surface: &serde_json::Value,
+) -> Result<()> {
+    if !scanner_safe {
+        bail!("bundle proof expected all artifacts to be scanner-safe");
+    }
+    if runtime_material_count != 0 {
+        bail!("bundle proof expected zero runtime material artifacts");
+    }
+    if symmetric_secret_material {
+        bail!("bundle proof found symmetric secret material");
+    }
+    if audit_surface
+        .get("scanner_safe")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+    {
+        bail!("bundle proof expected audit-surface scanner_safe=true");
+    }
+    if json_u64(audit_surface, "runtime_material_count") != 0 {
+        bail!("bundle proof expected audit-surface runtime_material_count=0");
+    }
+    Ok(())
+}
+
+fn enforce_webhook_proof_posture(
+    scanner_safe: bool,
+    runtime_material_count: usize,
+    symmetric_secret_material: bool,
+    audit_surface: &serde_json::Value,
+) -> Result<()> {
+    if scanner_safe {
+        bail!("webhook bundle proof expected runtime webhook material");
+    }
+    if runtime_material_count != 6 {
+        bail!("webhook bundle proof expected six runtime request artifacts");
+    }
+    if !symmetric_secret_material {
+        bail!("webhook bundle proof expected symmetric signing material metadata");
+    }
+    if audit_surface
+        .get("scanner_safe")
+        .and_then(serde_json::Value::as_bool)
+        != Some(false)
+    {
+        bail!("webhook bundle proof expected audit-surface scanner_safe=false");
+    }
+    if json_u64(audit_surface, "runtime_material_count") != 6 {
+        bail!("webhook bundle proof expected audit-surface runtime_material_count=6");
+    }
+    Ok(())
+}
+
 fn bundle_proof_artifact_contains_private_key_material(
     artifact: &BundleProofArtifactRecord,
 ) -> bool {
@@ -680,7 +812,7 @@ fn bundle_proof_artifact_contains_private_key_material(
 fn bundle_proof_artifact_contains_symmetric_secret_material(
     artifact: &BundleProofArtifactRecord,
 ) -> bool {
-    artifact.kind == "hmac" && !artifact.scanner_safe
+    matches!(artifact.kind.as_str(), "hmac" | "webhook") && !artifact.scanner_safe
 }
 
 fn write_bundle_proof_artifacts(out_dir: &Path, receipt: &BundleProofReceipt) -> Result<()> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -182,7 +182,7 @@ enum Cmd {
     },
     /// Generate, verify, inspect, and export a bundle proof artifact for release evidence.
     BundleProof {
-        /// Bundle profile to prove. Supports `scanner-safe`, `oidc`, and `tls`.
+        /// Bundle profile to prove. Supports `scanner-safe`, `oidc`, `tls`, and `webhook`.
         #[arg(long, default_value = "scanner-safe")]
         profile: String,
         /// Output directory for proof artifacts.
@@ -8727,6 +8727,48 @@ index 1111111..2222222 100644
     }
 
     #[test]
+    fn bundle_proof_webhook_profile_constant_includes_webhook() -> Result<()> {
+        assert!(
+            BUNDLE_PROOF_SUPPORTED_PROFILES.contains(&"webhook"),
+            "webhook must be a supported bundle-proof profile",
+        );
+        ensure_supported_bundle_proof_profile("webhook")?;
+        assert_eq!(
+            bundle_proof_json_filename("webhook")?,
+            "webhook-contract-pack-proof.json",
+        );
+        assert_eq!(
+            bundle_proof_markdown_filename("webhook")?,
+            "webhook-contract-pack-proof.md",
+        );
+        assert_eq!(
+            bundle_proof_markdown_title("webhook")?,
+            "Webhook Contract-Pack Proof",
+        );
+        assert_eq!(
+            default_bundle_proof_out_dir("webhook")?,
+            PathBuf::from("target/release-evidence/webhook"),
+        );
+        let expected = bundle_proof_expected_artifacts("webhook")?;
+        let paths = expected.iter().map(|e| e.path).collect::<Vec<_>>();
+        for required in [
+            "requests/valid.json",
+            "requests/negative-tampered-body.json",
+            "requests/negative-wrong-secret.json",
+            "requests/negative-stale-timestamp.json",
+            "requests/negative-missing-signature.json",
+            "requests/negative-malformed-signature.json",
+            "evidence/webhook-profile.md",
+        ] {
+            assert!(
+                paths.contains(&required),
+                "webhook expected artifacts missing {required}",
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
     fn bundle_proof_receipt_enforces_scanner_safe_posture() {
         let manifest = scanner_safe_bundle_proof_manifest();
         let audit_surface = serde_json::json!({
@@ -8809,9 +8851,7 @@ index 1111111..2222222 100644
         .expect_err("runtime material should fail scanner-safe proof");
 
         assert!(
-            error
-                .to_string()
-                .contains("all artifacts to be scanner-safe"),
+            error.to_string().contains("private key material"),
             "unexpected error: {error}"
         );
     }
@@ -9040,6 +9080,103 @@ index 1111111..2222222 100644
         assert!(markdown.contains("downstream TLS verifier"));
     }
 
+    #[test]
+    fn bundle_proof_receipt_allows_webhook_runtime_material() -> Result<()> {
+        let manifest = webhook_bundle_proof_manifest();
+        let audit_surface = serde_json::json!({
+            "scanner_safe": false,
+            "runtime_material_count": 6,
+        });
+        let receipt = bundle_proof_receipt(BundleProofReceiptInput {
+            profile: "webhook",
+            bundle_dir: Path::new("target/release-evidence/webhook/bundle"),
+            manifest_path: Path::new("target/release-evidence/webhook/bundle/manifest.json"),
+            inspect_summary_path: Path::new("target/release-evidence/webhook/inspect-bundle.txt"),
+            manifest: &manifest,
+            audit_surface: &audit_surface,
+            expected_artifacts: bundle_proof_expected_artifacts("webhook")?,
+            commands: Vec::new(),
+            exports_generated: Vec::new(),
+        })?;
+
+        assert_eq!(receipt.profile, "webhook");
+        assert_eq!(receipt.artifact_count, 7);
+        assert_eq!(receipt.contract_pack_checks.len(), 7);
+        assert_eq!(receipt.scanner_safe_artifact_count, 1);
+        assert_eq!(receipt.runtime_material_count, 6);
+        assert!(!receipt.private_key_material);
+        assert!(receipt.symmetric_secret_material);
+        assert!(
+            receipt
+                .contract_pack_checks
+                .iter()
+                .all(|check| check.present)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn bundle_proof_receipt_rejects_incomplete_webhook_contract_pack() -> Result<()> {
+        let mut manifest = webhook_bundle_proof_manifest();
+        manifest
+            .files
+            .retain(|path| path != "requests/negative-malformed-signature.json");
+        manifest
+            .artifacts
+            .retain(|artifact| artifact.path != "requests/negative-malformed-signature.json");
+        let audit_surface = serde_json::json!({
+            "scanner_safe": false,
+            "runtime_material_count": 5,
+        });
+        let error = bundle_proof_receipt(BundleProofReceiptInput {
+            profile: "webhook",
+            bundle_dir: Path::new("target/release-evidence/webhook/bundle"),
+            manifest_path: Path::new("target/release-evidence/webhook/bundle/manifest.json"),
+            inspect_summary_path: Path::new("target/release-evidence/webhook/inspect-bundle.txt"),
+            manifest: &manifest,
+            audit_surface: &audit_surface,
+            expected_artifacts: bundle_proof_expected_artifacts("webhook")?,
+            commands: Vec::new(),
+            exports_generated: Vec::new(),
+        })
+        .err()
+        .context("missing webhook artifact should fail proof")?;
+
+        assert!(
+            error.to_string().contains("negative_malformed_signature"),
+            "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn bundle_proof_markdown_summarizes_webhook_contract_checks() -> Result<()> {
+        let manifest = webhook_bundle_proof_manifest();
+        let audit_surface = serde_json::json!({
+            "scanner_safe": false,
+            "runtime_material_count": 6,
+        });
+        let receipt = bundle_proof_receipt(BundleProofReceiptInput {
+            profile: "webhook",
+            bundle_dir: Path::new("target/release-evidence/webhook/bundle"),
+            manifest_path: Path::new("target/release-evidence/webhook/bundle/manifest.json"),
+            inspect_summary_path: Path::new("target/release-evidence/webhook/inspect-bundle.txt"),
+            manifest: &manifest,
+            audit_surface: &audit_surface,
+            expected_artifacts: bundle_proof_expected_artifacts("webhook")?,
+            commands: Vec::new(),
+            exports_generated: Vec::new(),
+        })?;
+        let markdown = render_bundle_proof_markdown(&receipt)?;
+
+        assert!(markdown.contains("# Webhook Contract-Pack Proof"));
+        assert!(markdown.contains("negative_tampered_body"));
+        assert!(markdown.contains("requests/negative-malformed-signature.json"));
+        assert!(markdown.contains("Runtime material count: `6`"));
+        assert!(markdown.contains("provider compatibility"));
+        Ok(())
+    }
+
     fn scanner_safe_bundle_proof_manifest() -> BundleProofManifest {
         BundleProofManifest {
             profile: "scanner-safe".to_string(),
@@ -9254,6 +9391,97 @@ index 1111111..2222222 100644
                     path: "receipts/audit-surface.json".to_string(),
                     kind: "audit-surface".to_string(),
                     profile: "tls".to_string(),
+                    description: "scanner-safety and lane metadata receipt".to_string(),
+                },
+            ],
+        }
+    }
+
+    fn webhook_bundle_proof_manifest() -> BundleProofManifest {
+        BundleProofManifest {
+            profile: "webhook".to_string(),
+            files: vec![
+                "requests/valid.json".to_string(),
+                "requests/negative-tampered-body.json".to_string(),
+                "requests/negative-wrong-secret.json".to_string(),
+                "requests/negative-stale-timestamp.json".to_string(),
+                "requests/negative-missing-signature.json".to_string(),
+                "requests/negative-malformed-signature.json".to_string(),
+                "evidence/webhook-profile.md".to_string(),
+                "receipts/materialization.json".to_string(),
+                "receipts/audit-surface.json".to_string(),
+            ],
+            artifacts: vec![
+                BundleProofArtifactRecord {
+                    path: "requests/valid.json".to_string(),
+                    kind: "webhook".to_string(),
+                    format: "json-manifest".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: false,
+                    description: "Webhook valid HMAC request".to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "requests/negative-tampered-body.json".to_string(),
+                    kind: "webhook".to_string(),
+                    format: "json-manifest".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: false,
+                    description: "Webhook negative request with modified body".to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "requests/negative-wrong-secret.json".to_string(),
+                    kind: "webhook".to_string(),
+                    format: "json-manifest".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: false,
+                    description: "Webhook negative request signed with the wrong secret"
+                        .to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "requests/negative-stale-timestamp.json".to_string(),
+                    kind: "webhook".to_string(),
+                    format: "json-manifest".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: false,
+                    description: "Webhook negative request outside timestamp tolerance".to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "requests/negative-missing-signature.json".to_string(),
+                    kind: "webhook".to_string(),
+                    format: "json-manifest".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: false,
+                    description: "Webhook negative request missing the signature header"
+                        .to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "requests/negative-malformed-signature.json".to_string(),
+                    kind: "webhook".to_string(),
+                    format: "json-manifest".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: false,
+                    description: "Webhook negative request with malformed signature".to_string(),
+                },
+                BundleProofArtifactRecord {
+                    path: "evidence/webhook-profile.md".to_string(),
+                    kind: "webhook".to_string(),
+                    format: "json-manifest".to_string(),
+                    lanes: vec!["runtime".to_string(), "materialized".to_string()],
+                    scanner_safe: true,
+                    description: "Webhook profile verifier expectation evidence".to_string(),
+                },
+            ],
+            receipts: vec![
+                BundleProofReceiptRecord {
+                    path: "receipts/materialization.json".to_string(),
+                    kind: "materialization".to_string(),
+                    profile: "webhook".to_string(),
+                    description: "deterministic bundle materialization receipt".to_string(),
+                },
+                BundleProofReceiptRecord {
+                    path: "receipts/audit-surface.json".to_string(),
+                    kind: "audit-surface".to_string(),
+                    profile: "webhook".to_string(),
                     description: "scanner-safety and lane metadata receipt".to_string(),
                 },
             ],


### PR DESCRIPTION
﻿## Summary
- Add webhook to cargo xtask bundle-proof with dedicated receipt names, output paths, expected artifacts, and claim boundaries.
- Make bundle-proof scanner-safety posture profile-aware so webhook can prove intentional target-only runtime signing material without weakening scanner-safe/OIDC/TLS checks.
- Add focused xtask coverage for supported profile constants, webhook runtime-material receipts, missing-fixture failures, and markdown summaries.
- Mark the active webhook lane proof slice done and move claim registration to ready.

## Files added/changed
- .uselesskey/goals/active.toml
- xtask/src/bundle_proof.rs
- xtask/src/main.rs

## Validation
- cargo test -p xtask bundle_proof
- cargo xtask bundle-proof --profile webhook --out target/release-evidence/webhook
- cargo xtask check-no-panic-family
- cargo xtask spec-check --strict
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask pr-lite
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo xtask pr
- git diff --check

## Non-goals
- No claim-ledger or contract-pack registry registration yet.
- No claim-proof --claim webhook-contract-pack handler yet.
- No release-evidence lane wiring yet.
- No provider-specific webhook compatibility matrix, production secret management, replay-policy claim, README badge, TLS expansion, shipper work, or historical no-panic baseline work.

## What this enables next
- The next PR can register webhook-contract-pack in the public claim ledger and contract-pack registry using the now-working undle-proof --profile webhook proof command.
