### PR TITLE
feat: generate stable RIPR PR summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,14 @@ jobs:
           print(f"ripr_severe_gap={str(bool(ripr.get('requires_targeted_evidence'))).lower()}")
           PY
 
+      - name: ripr PR summary
+        if: always()
+        run: cargo xtask ripr-pr-summary
+
+      - name: ripr PR summary contract
+        if: always()
+        run: cargo xtask ripr-pr-summary --check
+
       - name: xtask pr
         id: xtask_pr
         run: cargo xtask pr
@@ -173,156 +181,16 @@ jobs:
       - name: PR evidence summary
         if: always()
         shell: bash
-        env:
-          RIPR_STEP: ${{ steps.ripr_pr.conclusion }}
-          RIPR_REVIEW_STEP: ${{ steps.ripr_review.conclusion }}
-          XTASK_PR_STEP: ${{ steps.xtask_pr.conclusion }}
-          DOCS_SYNC_STEP: ${{ steps.docs_sync.conclusion }}
-          PUBLISH_PREFLIGHT_STEP: ${{ steps.publish_preflight.conclusion }}
-          EXAMPLES_SMOKE_STEP: ${{ steps.examples_smoke.conclusion }}
-          ECONOMICS_STEP: ${{ steps.economics_receipt.conclusion }}
-          AUDIT_SURFACE_STEP: ${{ steps.audit_surface_receipt.conclusion }}
-          RECEIPT_DOCS_STEP: ${{ steps.receipt_docs_drift.conclusion }}
-          TARGETED_MUTATION_STEP: ${{ steps.targeted_mutation.conclusion }}
-          FULL_OWNER_MUTATION_STEP: ${{ steps.targeted_full_owner_mutation.conclusion }}
-          MUTATION_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'mutation') }}
-          FULL_OWNER_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'mutation/full-owner') }}
-          RELEASE_RISK_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'release-risk') }}
         run: |
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          def load_json(path):
-              path = Path(path)
-              if not path.exists():
-                  return None
-              try:
-                  return json.loads(path.read_text(encoding="utf-8"))
-              except json.JSONDecodeError as exc:
-                  return {"status": "invalid-json", "path": str(path), "error": str(exc)}
-
-          def yes_no(value):
-              return "yes" if value else "no"
-
-          def env_bool(name):
-              return str(os.environ.get(name, "")).lower() == "true"
-
-          def conclusion(name):
-              return os.environ.get(name) or "not-run"
-
-          ripr_json = load_json("target/ripr/pr/repo-exposure.json") or {}
-          impacted = load_json("target/xtask/impacted-evidence/latest.json") or {}
-          receipt = load_json("target/xtask/receipt.json") or {}
-
-          ripr_summary = ripr_json.get("summary") or {}
-          ripr_routing = impacted.get("ripr") or {}
-          owner_crates = impacted.get("owner_crates") or []
-          reasons = impacted.get("reasons") or []
-          ripr_owner_crates = ripr_routing.get("owner_crates") or []
-          ripr_reasons = ripr_routing.get("reasons") or []
-          ripr_actions = ripr_routing.get("suggested_actions") or []
-
-          requires_targeted = bool(impacted.get("requires_targeted_mutation"))
-          requires_ripr_targeted = bool(ripr_routing.get("requires_targeted_evidence"))
-          label_mutation = env_bool("MUTATION_LABEL")
-          label_full_owner = env_bool("FULL_OWNER_LABEL")
-          label_release_risk = env_bool("RELEASE_RISK_LABEL")
-          targeted_required = (
-              requires_targeted
-              or requires_ripr_targeted
-              or label_mutation
-              or label_full_owner
-              or label_release_risk
-          )
-
-          if label_full_owner:
-              mutation_step = conclusion("FULL_OWNER_MUTATION_STEP")
-          elif targeted_required:
-              mutation_step = conclusion("TARGETED_MUTATION_STEP")
-          else:
-              mutation_step = "not-required"
-
-          receipt_steps = receipt.get("steps") or []
-          receipt_failures = [
-              step.get("name", "unknown")
-              for step in receipt_steps
-              if str(step.get("status", "")).lower() not in {"ok", "success", "skipped"}
-          ]
-
-          lines = []
-          lines.append("# PR Evidence Summary")
-          lines.append("")
-          lines.append("## Fast Gate")
-          lines.append("")
-          lines.append("| Check | Status |")
-          lines.append("| --- | --- |")
-          for name, env_name in [
-              ("ripr-pr", "RIPR_STEP"),
-              ("ripr-review", "RIPR_REVIEW_STEP"),
-              ("xtask pr", "XTASK_PR_STEP"),
-              ("docs-sync", "DOCS_SYNC_STEP"),
-              ("publish-preflight", "PUBLISH_PREFLIGHT_STEP"),
-              ("examples-smoke", "EXAMPLES_SMOKE_STEP"),
-              ("economics receipt", "ECONOMICS_STEP"),
-              ("audit-surface receipt", "AUDIT_SURFACE_STEP"),
-              ("receipt docs drift", "RECEIPT_DOCS_STEP"),
-          ]:
-              lines.append(f"| {name} | `{conclusion(env_name)}` |")
-
-          lines.append("")
-          lines.append("## RIPR")
-          lines.append("")
-          lines.append(f"- Status: `{ripr_json.get('status', 'available')}`")
-          lines.append(f"- Findings: `{ripr_summary.get('findings', 0)}`")
-          lines.append(f"- Exposed: `{ripr_summary.get('exposed', 0)}`")
-          lines.append(f"- Weakly exposed: `{ripr_summary.get('weakly_exposed', 0)}`")
-          lines.append(f"- Reachable unrevealed: `{ripr_summary.get('reachable_unrevealed', 0)}`")
-          lines.append(f"- No static path: `{ripr_summary.get('no_static_path', 0)}`")
-          lines.append(f"- Severe gap routed: `{yes_no(requires_ripr_targeted)}`")
-          if ripr_owner_crates:
-              lines.append(f"- RIPR owner crates: `{', '.join(ripr_owner_crates)}`")
-          if ripr_reasons:
-              lines.append(f"- RIPR reasons: `{', '.join(ripr_reasons)}`")
-
-          lines.append("")
-          lines.append("## Targeted Mutation")
-          lines.append("")
-          lines.append(f"- Required: `{yes_no(targeted_required)}`")
-          lines.append(f"- Step: `{mutation_step}`")
-          lines.append(f"- Full-owner label: `{yes_no(label_full_owner)}`")
-          if owner_crates:
-              lines.append(f"- Impacted owner crates: `{', '.join(owner_crates)}`")
-          if reasons:
-              lines.append(f"- Impacted reasons: `{', '.join(reasons)}`")
-          if ripr_actions:
-              lines.append("- Suggested actions:")
-              for action in ripr_actions:
-                  lines.append(f"  - {action}")
-
-          lines.append("")
-          lines.append("## Artifacts")
-          lines.append("")
-          lines.append("- `ripr-pr`: `target/ripr/pr/`")
-          lines.append("- `ripr-review`: `target/ripr/review/`")
-          lines.append("- `impacted-evidence`: `target/xtask/impacted-evidence/`")
-          lines.append("- `receipt-pr`: `target/xtask/receipt.json`")
-          lines.append("- `lane-receipts-pr`: economics and audit-surface receipts")
-          if receipt_failures:
-              lines.append("")
-              lines.append("Receipt steps with non-success status:")
-              for name in receipt_failures:
-                  lines.append(f"- `{name}`")
-
-          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-          if summary_path:
-              with open(summary_path, "a", encoding="utf-8") as fh:
-                  fh.write("\n".join(lines))
-                  fh.write("\n")
-          else:
-              print("\n".join(lines))
-          PY
+          if [ -f target/ripr/pr/summary.md ]; then
+            cat target/ripr/pr/summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "# PR Evidence Summary"
+              echo
+              echo "No PR evidence summary was produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload lane receipts
         uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ cargo xtask ci              # Main CI pipeline: fmt + clippy + tests + matrix + 
 cargo xtask pr              # Fast PR-scoped tests based on git diff (emits JSON receipt)
 cargo xtask pr --with-mutants # PR-scoped tests plus targeted mutation
 cargo xtask ripr-pr         # Advisory PR oracle-exposure evidence (requires external ripr)
+cargo xtask ripr-pr-summary # Stable PR evidence summary from generated artifacts
 cargo xtask impacted-evidence --base origin/main # Changed-path evidence owners + mutation routing
 cargo xtask mutants-pr --changed # Explicit PR-scoped mutation targets
 cargo xtask mutants-nightly --scope public --dry-run # Nightly/manual mutation scope planning

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -158,6 +158,13 @@ targeted mutation when routing rules require it.
 `ripr` may suggest focused tests or route targeted mutation. It does not edit
 code, generate tests, run mutation, or make merge decisions by default.
 
+The first-screen PR evidence summary is generated from machine-readable
+artifacts and written to:
+
+```text
+target/ripr/pr/summary.md
+```
+
 Line-placeable `ripr` review guidance is emitted as non-blocking annotations
 from `comments[]` only. Summary-only findings stay in summaries and artifacts;
 inline PR comments are disabled by default.

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -238,6 +238,11 @@ artifacts under `target/ripr/pr/`:
 - `summary.md`;
 - `review.md`.
 
+`cargo xtask ripr-pr-summary` regenerates `summary.md` from the available
+machine-readable PR artifacts after `ripr` review guidance and impacted
+evidence have been produced. Missing data is represented explicitly rather than
+filled in from prose.
+
 Pull request CI uploads that directory as the `ripr-pr` artifact.
 
 `cargo xtask ripr-review-comments` runs `ripr review-comments` with explicit

--- a/docs/specs/USELESSKEY-SPEC-0007-pr-review-evidence.md
+++ b/docs/specs/USELESSKEY-SPEC-0007-pr-review-evidence.md
@@ -35,6 +35,7 @@ Expected artifacts:
 ```text
 target/ripr/pr/repo-exposure.json
 target/ripr/pr/repo-exposure.md
+target/ripr/pr/summary.md
 target/ripr/review/comments.json
 target/ripr/review/comments.md
 ```
@@ -46,6 +47,8 @@ cargo xtask ripr-pr
 cargo xtask ripr-pr --check
 cargo xtask ripr-review-comments
 cargo xtask ripr-review-comments --check
+cargo xtask ripr-pr-summary
+cargo xtask ripr-pr-summary --check
 ```
 
 `ripr` review guidance is routed by field:
@@ -83,6 +86,7 @@ PR review evidence checks:
 ```bash
 cargo xtask ripr-pr --check
 cargo xtask ripr-review-comments --check
+cargo xtask ripr-pr-summary --check
 ```
 
 Docs-only changes to this spec should run:
@@ -115,7 +119,7 @@ This spec is accepted when:
 This spec is implemented when:
 
 - CI emits `ripr` PR evidence and review guidance;
-- PR summaries include review guidance when available;
+- PR summaries are generated from machine-readable PR evidence artifacts;
 - `comments[]` can produce non-blocking changed-line annotations;
 - artifacts are uploaded for `target/ripr/pr` and `target/ripr/review`;
 - `cargo xtask spec-check` can validate the documented contract.
@@ -169,6 +173,7 @@ PR review evidence maps to:
 - `cargo xtask ripr-pr --check` for artifact contract validation;
 - `cargo xtask ripr-review-comments` for PR-scoped review guidance;
 - `cargo xtask ripr-review-comments --check` for review artifact validation;
+- `cargo xtask ripr-pr-summary --check` for stable summary contract validation;
 - `scripts/ripr-annotations.py` or equivalent CI logic for non-blocking
   annotations from `comments[]`;
 - `cargo xtask impacted-evidence` for targeted mutation routing;
@@ -201,6 +206,7 @@ cargo xtask ripr-pr
 cargo xtask ripr-review-comments
 cargo xtask ripr-pr --check
 cargo xtask ripr-review-comments --check
+cargo xtask ripr-pr-summary --check
 cargo xtask pr
 ```
 

--- a/docs/status/PUBLIC_CLAIMS.md
+++ b/docs/status/PUBLIC_CLAIMS.md
@@ -50,7 +50,7 @@ cargo xtask verification-pack --out target/uselesskey-verification
 | `public-crate-surface-cleanup` | Public crate-surface cleanup | `stable` | `cargo xtask public-surface`; `cargo xtask publish-check`; `cargo xtask publish-preflight` | The supported public crate surface is the current published contract; removed internal shims are not promised as supported public crates. |
 | `external-cratesio-install-smoke` | External crates.io install smoke | `release-proof` | `cargo xtask cratesio-smoke --version 0.9.0` | Crates.io smoke proves an external install path for a published version, not every downstream feature combination. |
 | `generated-badge-endpoints` | Generated badge endpoints | `stable` | `cargo xtask badges`; `cargo xtask badges --check` | Badge JSON is a generated Shields endpoint receipt, not a hand-written slogan. |
-| `ripr-pr-review-evidence` | `ripr` PR review evidence | `advisory` | `cargo xtask ripr-pr --check`; `cargo xtask ripr-review-comments --check` | PR evidence is diff-scoped and advisory; it is not the repo-scoped README `ripr+` badge. |
+| `ripr-pr-review-evidence` | `ripr` PR review evidence | `advisory` | `cargo xtask ripr-pr --check`; `cargo xtask ripr-review-comments --check`; `cargo xtask ripr-pr-summary --check` | PR evidence is diff-scoped and advisory; it is not the repo-scoped README `ripr+` badge. |
 
 ## Reader Rule
 

--- a/policy/claim-ledger.toml
+++ b/policy/claim-ledger.toml
@@ -274,10 +274,12 @@ surfaces = [
 proof_commands = [
   "cargo xtask ripr-pr --check",
   "cargo xtask ripr-review-comments --check",
+  "cargo xtask ripr-pr-summary --check",
 ]
 artifacts = [
   "target/ripr/pr/repo-exposure.json",
   "target/ripr/pr/repo-exposure.md",
+  "target/ripr/pr/summary.md",
   "target/ripr/review/comments.json",
   "target/ripr/review/comments.md",
 ]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -124,6 +124,12 @@ enum Cmd {
         #[arg(long)]
         check: bool,
     },
+    /// Generate the stable PR evidence summary from machine-readable PR artifacts.
+    RiprPrSummary {
+        /// Verify the generated PR evidence summary instead of writing it.
+        #[arg(long)]
+        check: bool,
+    },
     /// Generate the repo-scoped RIPR test-efficiency report used by ripr+ badge output.
     TestEfficiencyReport,
     /// Run PR-scoped mutation testing explicitly.
@@ -549,6 +555,7 @@ fn main() -> Result<()> {
         Cmd::PrLite { format } => pr_lite(format),
         Cmd::RiprPr { check } => ripr_pr(check),
         Cmd::RiprReviewComments { check } => ripr_review_comments(check),
+        Cmd::RiprPrSummary { check } => ripr_pr_summary(check),
         Cmd::TestEfficiencyReport => test_efficiency::test_efficiency_report_cmd(),
         Cmd::MutantsPr {
             changed,
@@ -4765,15 +4772,15 @@ fn impacted_evidence_report_with_ripr(
 }
 
 fn read_optional_ripr_pr_json(path: &Path) -> Result<Option<serde_json::Value>> {
+    read_optional_json_file(path)
+}
+
+fn read_optional_json_file(path: &Path) -> Result<Option<serde_json::Value>> {
     if !path.is_file() {
         return Ok(None);
     }
 
-    let raw =
-        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let json = serde_json::from_str(&raw)
-        .with_context(|| format!("failed to parse {}", path.display()))?;
-    Ok(Some(json))
+    read_json_file(path).map(Some)
 }
 
 fn ripr_evidence_routing(
@@ -5333,8 +5340,11 @@ fn ripr_pr(check: bool) -> Result<()> {
     fs::write(&exposure_path, &markdown)
         .with_context(|| format!("failed to write {}", exposure_path.display()))?;
     let summary_path = out_dir.join("summary.md");
-    fs::write(&summary_path, &markdown)
-        .with_context(|| format!("failed to write {}", summary_path.display()))?;
+    fs::write(
+        &summary_path,
+        render_pr_evidence_summary(Some(&json), None, None),
+    )
+    .with_context(|| format!("failed to write {}", summary_path.display()))?;
     let review_path = out_dir.join("review.md");
     fs::write(&review_path, &markdown)
         .with_context(|| format!("failed to write {}", review_path.display()))?;
@@ -5347,9 +5357,10 @@ fn ripr_pr(check: bool) -> Result<()> {
         json_u64(summary, "weakly_exposed")
     );
     println!(
-        "ripr-pr: wrote {}, {}, and {}",
+        "ripr-pr: wrote {}, {}, {}, and {}",
         json_path.display(),
         exposure_path.display(),
+        summary_path.display(),
         review_path.display()
     );
     Ok(())
@@ -5369,6 +5380,223 @@ fn check_ripr_pr_contract(out_dir: &Path) -> Result<()> {
     }
     println!("ripr-pr: output contract is intact");
     Ok(())
+}
+
+fn ripr_pr_summary(check: bool) -> Result<()> {
+    let workspace_root = workspace_root_path();
+    let out_dir = workspace_root.join(RIPR_PR_DIR);
+    let summary_path = out_dir.join("summary.md");
+    let markdown = render_pr_evidence_summary_for_root(&workspace_root)?;
+
+    if check {
+        let existing = fs::read_to_string(&summary_path)
+            .with_context(|| format!("failed to read {}", summary_path.display()))?;
+        if existing != markdown {
+            bail!(
+                "{} drifted; run `cargo xtask ripr-pr-summary` after regenerating PR evidence",
+                summary_path.display()
+            );
+        }
+        println!("ripr-pr-summary: output contract is intact");
+        return Ok(());
+    }
+
+    fs::create_dir_all(&out_dir)
+        .with_context(|| format!("failed to create {}", out_dir.display()))?;
+    fs::write(&summary_path, markdown)
+        .with_context(|| format!("failed to write {}", summary_path.display()))?;
+    println!("ripr-pr-summary: wrote {}", summary_path.display());
+    Ok(())
+}
+
+fn render_pr_evidence_summary_for_root(workspace_root: &Path) -> Result<String> {
+    let ripr_json =
+        read_optional_json_file(&workspace_root.join(RIPR_PR_DIR).join("repo-exposure.json"))?;
+    let review_json =
+        read_optional_json_file(&workspace_root.join(RIPR_REVIEW_DIR).join("comments.json"))?;
+    let impacted_json = read_optional_json_file(
+        &workspace_root
+            .join("target/xtask/impacted-evidence")
+            .join("latest.json"),
+    )?;
+    Ok(render_pr_evidence_summary(
+        ripr_json.as_ref(),
+        review_json.as_ref(),
+        impacted_json.as_ref(),
+    ))
+}
+
+fn render_pr_evidence_summary(
+    ripr_json: Option<&serde_json::Value>,
+    review_json: Option<&serde_json::Value>,
+    impacted_json: Option<&serde_json::Value>,
+) -> String {
+    let null = serde_json::Value::Null;
+    let ripr = ripr_json.unwrap_or(&null);
+    let review = review_json.unwrap_or(&null);
+    let impacted = impacted_json.unwrap_or(&null);
+    let ripr_summary = ripr.get("summary").unwrap_or(&null);
+    let ripr_routing = impacted.get("ripr").unwrap_or(&null);
+
+    let base = json_str(ripr, "base")
+        .or_else(|| json_str(impacted, "base"))
+        .unwrap_or("unknown");
+    let head = json_str(ripr, "head").unwrap_or("HEAD");
+    let ripr_status = json_str(ripr, "status").unwrap_or(if ripr_json.is_some() {
+        "available"
+    } else {
+        "missing"
+    });
+    let review_status = json_str(review, "status").unwrap_or(if review_json.is_some() {
+        "available"
+    } else {
+        "missing"
+    });
+    let impacted_status = if impacted_json.is_some() {
+        "available"
+    } else {
+        "missing"
+    };
+
+    let impacted_reasons = json_string_vec(impacted, "reasons");
+    let ripr_reasons = json_string_vec(ripr_routing, "reasons");
+    let ripr_actions = json_string_vec(ripr_routing, "suggested_actions");
+    let owner_crates = json_string_vec(impacted, "owner_crates");
+    let ripr_owner_crates = json_string_vec(ripr_routing, "owner_crates");
+    let requires_targeted_mutation = json_bool(impacted, "requires_targeted_mutation")
+        || json_bool(ripr_routing, "requires_targeted_evidence");
+    let routing_reason =
+        pr_summary_routing_reason(requires_targeted_mutation, &impacted_reasons, &ripr_reasons);
+
+    let mut md = String::new();
+    md.push_str("# PR Evidence Summary\n\n");
+    md.push_str(
+        "Generated from machine-readable PR evidence artifacts. Missing data is explicit.\n\n",
+    );
+
+    md.push_str("## Fast Gate\n\n");
+    md.push_str("| Artifact | Status |\n");
+    md.push_str("| --- | --- |\n");
+    md.push_str(&format!(
+        "| `target/ripr/pr/repo-exposure.json` | `{ripr_status}` |\n"
+    ));
+    md.push_str(&format!(
+        "| `target/ripr/review/comments.json` | `{review_status}` |\n"
+    ));
+    md.push_str(&format!(
+        "| `target/xtask/impacted-evidence/latest.json` | `{impacted_status}` |\n"
+    ));
+    md.push('\n');
+
+    md.push_str("## RIPR\n\n");
+    md.push_str("- Scope: `diff`\n");
+    md.push_str(&format!("- Base: `{base}`\n"));
+    md.push_str(&format!("- Head: `{head}`\n"));
+    md.push_str(&format!("- Status: `{ripr_status}`\n"));
+    if let Some(reason) = json_str(ripr, "reason") {
+        md.push_str(&format!("- Reason: `{reason}`\n"));
+    }
+    md.push_str(&format!(
+        "- Findings: `{}`\n",
+        json_u64(ripr_summary, "findings")
+    ));
+    md.push_str(&format!(
+        "- Exposed: `{}`\n",
+        json_u64(ripr_summary, "exposed")
+    ));
+    md.push_str(&format!(
+        "- Weakly exposed: `{}`\n",
+        json_u64(ripr_summary, "weakly_exposed")
+    ));
+    md.push_str(&format!(
+        "- Reachable unrevealed: `{}`\n",
+        json_u64(ripr_summary, "reachable_unrevealed")
+    ));
+    md.push_str(&format!(
+        "- No static path: `{}`\n",
+        json_u64(ripr_summary, "no_static_path")
+    ));
+    md.push_str(&format!(
+        "- Review comments: `{}`\n",
+        json_array_len(review, "comments")
+    ));
+    md.push_str(&format!(
+        "- Summary-only guidance: `{}`\n",
+        json_array_len(review, "summary_only")
+    ));
+    md.push_str(&format!(
+        "- Suppressed guidance: `{}`\n",
+        json_array_len(review, "suppressed")
+    ));
+    md.push_str(&format!(
+        "- Review warnings: `{}`\n",
+        json_array_len(review, "warnings")
+    ));
+    md.push_str(&format!(
+        "- Severe gap routed: `{}`\n",
+        yes_no(json_bool(ripr_routing, "requires_targeted_evidence"))
+    ));
+    if !ripr_owner_crates.is_empty() {
+        md.push_str(&format!(
+            "- RIPR owner crates: `{}`\n",
+            ripr_owner_crates.join(", ")
+        ));
+    }
+    if !ripr_reasons.is_empty() {
+        md.push_str(&format!("- RIPR reasons: `{}`\n", ripr_reasons.join(", ")));
+    }
+    md.push('\n');
+
+    md.push_str("## Targeted Mutation\n\n");
+    md.push_str(&format!(
+        "- Required by artifacts: `{}`\n",
+        yes_no(requires_targeted_mutation)
+    ));
+    md.push_str(&format!("- Routing reason: `{routing_reason}`\n"));
+    if !owner_crates.is_empty() {
+        md.push_str(&format!(
+            "- Impacted owner crates: `{}`\n",
+            owner_crates.join(", ")
+        ));
+    }
+    if !impacted_reasons.is_empty() {
+        md.push_str(&format!(
+            "- Impacted reasons: `{}`\n",
+            impacted_reasons.join(", ")
+        ));
+    }
+    if !ripr_actions.is_empty() {
+        md.push_str("- Suggested actions:\n");
+        for action in &ripr_actions {
+            md.push_str(&format!("  - {action}\n"));
+        }
+    }
+    md.push('\n');
+
+    md.push_str("## Artifacts\n\n");
+    md.push_str("- `ripr-pr`: `target/ripr/pr/`\n");
+    md.push_str("- `ripr-review`: `target/ripr/review/`\n");
+    md.push_str("- `impacted-evidence`: `target/xtask/impacted-evidence/`\n");
+    md.push_str("- `receipt-pr`: `target/xtask/receipt.json`\n");
+    md.push_str("- `summary`: `target/ripr/pr/summary.md`\n");
+    md
+}
+
+fn pr_summary_routing_reason(
+    requires_targeted_mutation: bool,
+    impacted_reasons: &[String],
+    ripr_reasons: &[String],
+) -> String {
+    if !impacted_reasons.is_empty() || !ripr_reasons.is_empty() {
+        let mut reasons = impacted_reasons.to_vec();
+        reasons.extend(ripr_reasons.iter().cloned());
+        return reasons.join(", ");
+    }
+    if requires_targeted_mutation {
+        "targeted mutation routed by artifact policy".to_string()
+    } else {
+        "fast PR evidence only".to_string()
+    }
 }
 
 fn write_ripr_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) -> Result<()> {
@@ -5396,8 +5624,11 @@ fn write_ripr_skipped_artifacts(out_dir: &Path, base_ref: &str, reason: &str) ->
             out_dir.join("repo-exposure.md").display()
         )
     })?;
-    fs::write(out_dir.join("summary.md"), &markdown)
-        .with_context(|| format!("failed to write {}", out_dir.join("summary.md").display()))?;
+    fs::write(
+        out_dir.join("summary.md"),
+        render_pr_evidence_summary(Some(&json), None, None),
+    )
+    .with_context(|| format!("failed to write {}", out_dir.join("summary.md").display()))?;
     fs::write(out_dir.join("review.md"), &markdown)
         .with_context(|| format!("failed to write {}", out_dir.join("review.md").display()))?;
     Ok(())
@@ -5645,6 +5876,31 @@ fn json_u64(value: &serde_json::Value, key: &str) -> u64 {
 
 fn json_str<'a>(value: &'a serde_json::Value, key: &str) -> Option<&'a str> {
     value.get(key).and_then(serde_json::Value::as_str)
+}
+
+fn json_bool(value: &serde_json::Value, key: &str) -> bool {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn json_string_vec(value: &serde_json::Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
 }
 
 fn git_changed_files(base_ref: &str) -> Result<Vec<String>> {
@@ -7502,7 +7758,7 @@ mod tests {
 
         let summary =
             fs::read_to_string(dir.path().join("summary.md")).expect("read summary markdown");
-        assert!(summary.contains("Status: skipped"));
+        assert!(summary.contains("- Status: `skipped`"));
         assert!(summary.contains("ripr missing"));
         assert!(dir.path().join("review.md").exists());
     }
@@ -10237,6 +10493,63 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
     fn pr_lite_examples_touched_normalizes_windows_paths() {
         assert!(pr_lite_examples_touched(&["examples\\demo.rs".to_string()]));
         assert!(!pr_lite_examples_touched(&["docs/guide.md".to_string()]));
+    }
+
+    #[test]
+    fn pr_evidence_summary_reports_missing_artifacts() {
+        let markdown = render_pr_evidence_summary(None, None, None);
+
+        assert!(markdown.contains("# PR Evidence Summary"));
+        assert!(markdown.contains("| `target/ripr/pr/repo-exposure.json` | `missing` |"));
+        assert!(markdown.contains("| `target/ripr/review/comments.json` | `missing` |"));
+        assert!(markdown.contains("- Routing reason: `fast PR evidence only`"));
+    }
+
+    #[test]
+    fn pr_evidence_summary_renders_counts_and_routing() {
+        let ripr = serde_json::json!({
+            "status": "available",
+            "base": "origin/main",
+            "head": "HEAD",
+            "summary": {
+                "findings": 3,
+                "exposed": 1,
+                "weakly_exposed": 2,
+                "reachable_unrevealed": 0,
+                "no_static_path": 1
+            }
+        });
+        let review = serde_json::json!({
+            "status": "advisory",
+            "comments": [{"path": "crates/uselesskey-x509/src/lib.rs"}],
+            "summary_only": [{"title": "focused test"}],
+            "suppressed": [],
+            "warnings": [{"code": "advisory"}]
+        });
+        let impacted = serde_json::json!({
+            "base": "origin/main",
+            "owner_crates": ["uselesskey-x509"],
+            "requires_targeted_mutation": false,
+            "reasons": [],
+            "ripr": {
+                "requires_targeted_evidence": true,
+                "severe_gap_count": 1,
+                "owner_crates": ["uselesskey-x509"],
+                "reasons": ["no-static-path"],
+                "suggested_actions": [
+                    "Run cargo xtask mutants-pr --crate uselesskey-x509"
+                ]
+            }
+        });
+
+        let markdown = render_pr_evidence_summary(Some(&ripr), Some(&review), Some(&impacted));
+
+        assert!(markdown.contains("- Findings: `3`"));
+        assert!(markdown.contains("- Review comments: `1`"));
+        assert!(markdown.contains("- Summary-only guidance: `1`"));
+        assert!(markdown.contains("- Severe gap routed: `yes`"));
+        assert!(markdown.contains("- Routing reason: `no-static-path`"));
+        assert!(markdown.contains("Run cargo xtask mutants-pr --crate uselesskey-x509"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `cargo xtask ripr-pr-summary` to render `target/ripr/pr/summary.md` from generated RIPR, review-guidance, and impacted-evidence artifacts
- wire PR CI to generate/check that summary and append it to the GitHub step summary instead of hand-rendering a separate Python summary
- update the PR review evidence spec, verification docs, public claim map, and claim ledger with the new summary command/artifact

## Validation
- `cargo check -p xtask --locked`
- `cargo xtask ripr-pr`
- `cargo xtask ripr-review-comments`
- `cargo xtask impacted-evidence`
- `cargo xtask ripr-pr-summary`
- `cargo xtask ripr-pr-summary --check`
- `cargo xtask ripr-pr --check`
- `cargo xtask ripr-review-comments --check`
- `python scripts/ripr-annotations.py`
- `cargo clippy -p xtask --all-targets --locked -- -D warnings`
- `cargo test -p xtask --locked`
- `cargo xtask spec-check --strict`
- `cargo xtask claim-report --check-public-claims`
- `cargo xtask docs-sync --check`
- `cargo xtask badges --check`
- `cargo xtask pr-lite`
- `cargo xtask claim-proof --claim scanner-safe-fixtures`
- `cargo xtask pr`
- `git diff --check`