### PR TITLE
ops: start first-run UX lane

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -1,92 +1,143 @@
-id = "uselesskey-v0.9.0-release"
-title = "Prepare and cut v0.9.0"
-status = "archived"
+id = "uselesskey-first-run-ux"
+title = "First-run UX and contract-pack adoption"
+status = "active"
 owner = "EffortlessMetrics"
-created = "2026-05-14"
+created = "2026-05-15"
 
 objective = """
-Ship v0.9.0 as the release where uselesskey's public claims are
-command-backed, reviewable, locally evidenced, and product-useful through
-generated badge endpoints, claim-report, claim-proof, verification-pack,
-PR-lite, no-panic new-debt cleanup, and the webhook contract pack.
+Compress the path from user intent to a working fixture, verifier pack, and
+proof boundary. Users should be able to pick a job, copy one command or
+dependency snippet, generate a useful fixture, and optionally prove the claim
+without learning the repo's internal proof machinery first.
 """
 
 end_state = [
-  "CHANGELOG.md describes v0.9.0 as the command-backed fixture-platform release.",
-  "docs/release/evidence-matrix-v0.9.0.md maps release claims to proof commands.",
-  "Full minor release evidence passes for version 0.9.0.",
-  "v0.9.0 is published through cargo xtask publish, not shipper.",
-  "Post-release audit records crates.io, docs.rs, claim-proof, and bundle-proof state honestly.",
+  "README and docs route users by job before introducing internal proof machinery.",
+  "docs/how-to/start-here.md maps common user jobs to one copyable command or snippet.",
+  "Contract packs are visible as a product family with generate, verify, proof, and boundary rows.",
+  "CLI profile discovery explains available profiles, generated files, proof commands, and boundaries.",
+  "Reviewer evidence has a user-facing handoff that stays metadata-only.",
+  "Maintainers can diagnose local proof environment issues before running broad gates.",
+  "User-path smoke checks keep first-run examples honest.",
 ]
 
 [[work_item]]
-id = "release-notes-evidence-matrix"
+id = "open-lane"
 status = "done"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0006"
-plan = "plans/v0.9.0-release/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/first-run-ux/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
-  "cargo xtask claim-report --check-public-claims",
-  "cargo xtask contract-packs --check",
   "cargo xtask docs-sync --check",
   "cargo xtask typos",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "release-candidate-proof"
-status = "done"
+id = "task-router"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0006"
-plan = "plans/v0.9.0-release/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/first-run-ux/implementation-plan.md"
 commands = [
-  "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
-  "cargo xtask claim-proof --all-stable",
-  "cargo xtask verification-pack --out target/uselesskey-verification",
-  "cargo xtask bundle-proof --profile tls --out target/release-evidence/tls",
-  "cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc",
-  "cargo xtask bundle-proof --profile webhook --out target/release-evidence/webhook",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "contract-pack-index"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0003"
+plan = "plans/first-run-ux/implementation-plan.md"
+commands = [
+  "cargo xtask contract-packs --check",
+  "cargo xtask claim-report --check-public-claims",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "cli-profile-discovery"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0003"
+plan = "plans/first-run-ux/implementation-plan.md"
+commands = [
+  "cargo test -p uselesskey-cli --all-features profile",
   "cargo xtask pr-lite",
   "cargo xtask pr",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "cut-v0.9.0"
-status = "done"
+id = "cli-proof-handoff"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0006"
-plan = "plans/v0.9.0-release/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0009"
+plan = "plans/first-run-ux/implementation-plan.md"
 commands = [
-  "cargo xtask release-evidence --version 0.9.0 --dry-run --summary",
-  "cargo xtask publish-preflight",
-  "cargo xtask publish-check",
+  "cargo test -p uselesskey-cli --all-features prove",
+  "cargo xtask verification-pack --out target/uselesskey-verification --claim webhook-contract-pack",
   "cargo xtask no-blob",
-  "cargo xtask check-no-panic-family",
-  "cargo xtask badges --check",
-  "cargo xtask docs-sync --check",
   "cargo xtask pr",
   "git diff --check",
-  "cargo xtask publish",
 ]
 
 [[work_item]]
-id = "post-release-audit"
-status = "done"
+id = "doctor"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0010"
+plan = "plans/first-run-ux/implementation-plan.md"
+commands = [
+  "cargo test -p xtask doctor",
+  "cargo xtask doctor",
+  "cargo xtask doctor --format json",
+  "cargo xtask pr-lite",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "readme-first-run"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/first-run-ux/implementation-plan.md"
+commands = [
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "cargo xtask badges --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "user-path-smoke"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0006"
-plan = "plans/v0.9.0-release/implementation-plan.md"
+plan = "plans/first-run-ux/implementation-plan.md"
 commands = [
-  "cargo xtask cratesio-smoke --version 0.9.0",
-  "cargo xtask claim-proof --all-stable",
-  "cargo xtask verification-pack --out target/uselesskey-verification",
-  "cargo xtask bundle-proof --profile tls --out target/release-evidence/tls",
-  "cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc",
-  "cargo xtask bundle-proof --profile webhook --out target/release-evidence/webhook",
-  "cargo xtask public-surface",
-  "cargo xtask publish-check",
-  "cargo xtask badges --check",
-  "cargo xtask check-no-panic-family",
+  "cargo test -p xtask user_path_smoke",
+  "cargo xtask user-path-smoke",
+  "cargo xtask pr-lite",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "lane-closeout"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/first-run-ux/implementation-plan.md"
+commands = [
+  "cargo xtask user-path-smoke",
+  "cargo xtask doctor",
+  "cargo xtask docs-sync --check",
+  "cargo xtask pr-lite",
+  "cargo xtask pr",
   "git diff --check",
 ]

--- a/plans/README.md
+++ b/plans/README.md
@@ -13,6 +13,7 @@ Plans do not define product truth. Link to proposals for why and specs for what.
 - [no-panic-burndown](no-panic-burndown/README.md) - No-panic-family debt burndown without baseline reset
 - [webhook-contract-pack](webhook-contract-pack/README.md) - Webhook contract-pack product lane
 - [v0.9.0-release](v0.9.0-release/README.md) - v0.9.0 release preparation, proof, publish, and audit
+- [first-run-ux](first-run-ux/README.md) - First-run task routing and contract-pack adoption UX
 
 ## Templates
 

--- a/plans/first-run-ux/README.md
+++ b/plans/first-run-ux/README.md
@@ -1,0 +1,13 @@
+# First-Run UX Plan Area
+
+This directory tracks the lane that turns the command-backed fixture platform
+into a simpler first-run user experience.
+
+The v0.9.0 release shipped the proof rails. This lane spends those rails on the
+front door: task routing, contract-pack discovery, CLI profile explanations,
+reviewer handoffs, local environment diagnosis, and cheap user-path smoke
+checks.
+
+## Plan Files
+
+- [implementation-plan.md](implementation-plan.md) - PR sequence, proof commands, non-goals, and stop conditions

--- a/plans/first-run-ux/implementation-plan.md
+++ b/plans/first-run-ux/implementation-plan.md
@@ -1,0 +1,240 @@
++++
+id = "USELESSKEY-PLAN-0013"
+kind = "plan"
+title = "First-run UX and contract-pack adoption"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-15"
+milestone = "v0.10.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0002",
+  "USELESSKEY-SPEC-0003",
+  "USELESSKEY-SPEC-0005",
+  "USELESSKEY-SPEC-0006",
+  "USELESSKEY-SPEC-0008",
+  "USELESSKEY-SPEC-0009",
+  "USELESSKEY-SPEC-0010",
+  "USELESSKEY-SPEC-0011",
+]
+linked_adrs = [
+  "USELESSKEY-ADR-0001",
+  "USELESSKEY-ADR-0002",
+  "USELESSKEY-ADR-0003",
+  "USELESSKEY-ADR-0004",
+]
++++
+
+# First-Run UX and Contract-Pack Adoption
+
+## Objective
+
+Make `uselesskey` easier to use without weakening its proof boundaries.
+
+The target experience is:
+
+```text
+I know which lane I need.
+I copy one command or one dependency snippet.
+I get a fixture that works.
+I can prove what it claims.
+I know what it does not claim.
+I never have to understand the repo's internal proof machinery unless I choose to.
+```
+
+## Scope
+
+This lane covers:
+
+- a task-first "start here" router;
+- a visible contract-pack product-family index;
+- CLI profile discovery and explanation commands;
+- user-facing proof/reviewer handoff commands or a documented spec if direct
+  CLI support is not clean yet;
+- a local proof-environment doctor for maintainers and agents;
+- a compressed README first-run path;
+- bounded user-path smoke checks for the documented copy/paste flows;
+- lane closeout and learning artifacts.
+
+## Non-Goals
+
+Do not mix these into the first-run UX lane:
+
+- new fixture families or contract packs;
+- new crypto or provider compatibility claims;
+- new README badges;
+- shipper migration work;
+- historical no-panic baseline cleanup;
+- dependency churn;
+- production secret-management, production PKI, replay-protection, or provider
+  compatibility promises.
+
+## PR Sequence
+
+1. `ops: start first-run UX lane`
+   - Open `.uselesskey/goals/active.toml`.
+   - Add this plan area.
+   - Validation:
+
+     ```bash
+     cargo xtask spec-check --strict
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+2. `docs: add start-here task router`
+   - Add `docs/how-to/start-here.md`.
+   - Route from README near the first-run section.
+   - Include one command or dependency snippet for each common user job.
+   - Validation:
+
+     ```bash
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+3. `docs: make contract packs a visible product family`
+   - Add `docs/contract-packs/README.md`.
+   - List scanner-safe, TLS, OIDC/JWKS, and webhook profiles.
+   - For each row, include generate, verify, proof, what it proves, and what it
+     does not prove.
+   - Validation:
+
+     ```bash
+     cargo xtask contract-packs --check
+     cargo xtask claim-report --check-public-claims
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+4. `feat(cli): add profile discovery commands`
+   - Add `uselesskey profiles`.
+   - Add `uselesskey profile <name> --explain`.
+   - Explain generated files, scanner-safe/runtime-material posture, proof
+     commands, and claim boundaries.
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-cli --all-features profile
+     cargo xtask pr-lite
+     cargo xtask pr
+     git diff --check
+     ```
+
+5. `feat(cli): add proof handoff commands`
+   - Prefer a user-facing CLI command for reviewer evidence, such as
+     `uselesskey prove --claim webhook-contract-pack --out target/uselesskey-verification`.
+   - If CLI architecture cannot cleanly own this yet, add the spec and defer the
+     command rather than duplicating unsafe proof execution.
+   - Keep verification packs metadata-only.
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-cli --all-features prove
+     cargo xtask verification-pack --out target/uselesskey-verification --claim webhook-contract-pack
+     cargo xtask no-blob
+     cargo xtask pr
+     git diff --check
+     ```
+
+6. `xtask: add local proof doctor`
+   - Add `cargo xtask doctor`.
+   - Add `cargo xtask doctor --format json`.
+   - Check Rust toolchain, required helper tools, Windows ASAN runtime
+     availability, crates.io auth presence, GitHub CLI availability, dirty tree
+     state, and generated badge drift.
+   - Validation:
+
+     ```bash
+     cargo test -p xtask doctor
+     cargo xtask doctor
+     cargo xtask doctor --format json
+     cargo xtask pr-lite
+     git diff --check
+     ```
+
+7. `docs: compress README first-run path`
+   - Keep depth, but move it below a task-first opening.
+   - Ensure the first runnable command appears early.
+   - Keep proof and claim boundaries visible without forcing users through
+     ledgers first.
+   - Validation:
+
+     ```bash
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     cargo xtask badges --check
+     git diff --check
+     ```
+
+8. `xtask: add user-path smoke checks`
+   - Add `cargo xtask user-path-smoke`.
+   - Exercise bounded documented flows: scanner-safe, TLS, OIDC/JWKS, webhook,
+     bundle verification, and webhook verification-pack generation.
+   - Validation:
+
+     ```bash
+     cargo test -p xtask user_path_smoke
+     cargo xtask user-path-smoke
+     cargo xtask pr-lite
+     git diff --check
+     ```
+
+9. `docs: close out first-run UX lane`
+   - Add `plans/first-run-ux/closeout.md`.
+   - Add `docs/learnings/2026-05-first-run-ux.md`.
+   - Archive `.uselesskey/goals/active.toml`.
+   - Validation:
+
+     ```bash
+     cargo xtask user-path-smoke
+     cargo xtask doctor
+     cargo xtask docs-sync --check
+     cargo xtask pr-lite
+     cargo xtask pr
+     git diff --check
+     ```
+
+## UX Acceptance
+
+A Rust user can answer in under two minutes:
+
+- which feature flags they need;
+- what to copy into `Cargo.toml`;
+- how to make output deterministic;
+- how to avoid committed fixture blobs.
+
+A CLI user can answer in under two minutes:
+
+- which profile they need;
+- what files will be generated;
+- which files are reviewable metadata;
+- which generated payloads belong under `target/`.
+
+A reviewer can answer in under five minutes:
+
+- what the project claims;
+- which command proves it;
+- what to attach;
+- what is explicitly out of scope.
+
+A maintainer or agent can answer before opening a PR:
+
+- whether the local machine can run the proof stack;
+- which gate failed;
+- whether the failure is code, environment, or generated drift;
+- which command reproduces hosted CI.
+
+## Stop Conditions
+
+Pause or split the lane if:
+
+- CLI proof handoff would require shell-evaluating claim-ledger command strings;
+- a proof bundle would copy generated secret-shaped payloads instead of
+  metadata;
+- the UX work creates a new public claim without claim-ledger and proof updates;
+- the lane starts adding new contract packs, provider matrices, dependency
+  churn, or release machinery.


### PR DESCRIPTION
## Summary

- Opens the first-run UX and contract-pack adoption lane.
- Replaces the archived v0.9.0 release active goal with the new UX active goal.
- Adds the first-run UX implementation plan and marks the task-router slice as the next ready work.

## Files added/changed

- `.uselesskey/goals/active.toml`
- `plans/first-run-ux/README.md`
- `plans/first-run-ux/implementation-plan.md`
- `plans/README.md`

## Validation

- `cargo xtask spec-check --strict`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `git diff --check`

## Non-goals

- No README rewrite in this PR.
- No CLI profile/proof/doctor implementation in this PR.
- No user-path smoke implementation in this PR.
- No new fixture families, contract packs, badges, shipper work, dependency churn, or historical no-panic baseline work.

## What this enables next

- Next PR: `docs: add start-here task router`.