### PR TITLE
docs: add start-here task router

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -36,7 +36,7 @@ commands = [
 
 [[work_item]]
 id = "task-router"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0002"
 plan = "plans/first-run-ux/implementation-plan.md"
@@ -48,7 +48,7 @@ commands = [
 
 [[work_item]]
 id = "contract-pack-index"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0003"
 plan = "plans/first-run-ux/implementation-plan.md"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@
 
 `uselesskey` is a **test-fixture factory**, not a crypto library. It generates key material, certificates, token-shaped fixtures, and negative artifacts at runtime so tests do not need committed PEM/DER/JWK blobs.
 
+If you already know what you are trying to test, start with the task router:
+[docs/how-to/start-here.md](docs/how-to/start-here.md). It maps common jobs to
+one dependency snippet or command before introducing the internal proof system.
+
 Public claims are command-backed. Start with the
 [verification guide](docs/how-to/verify-uselesskey-public-claims.md) or the
 [public claim index](docs/status/PUBLIC_CLAIMS.md) to see what each badge and

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ agent state do not drift into one document.
 Task-oriented instructions for common workflows.
 
 - [choose-lane.md](how-to/choose-lane.md) — Pick the cheapest correct lane first
+- [start-here.md](how-to/start-here.md) — Pick a user job and copy the first command or dependency snippet
 - [migration.md](how-to/migration.md) — Migrating between uselesskey versions
 - [publishing.md](how-to/publishing.md) — Publishing crates to crates.io
 - [release.md](how-to/release.md) — Cutting a release

--- a/docs/how-to/start-here.md
+++ b/docs/how-to/start-here.md
@@ -1,0 +1,144 @@
+# Start Here
+
+Use this page when you know what you are trying to test and want the shortest
+path to a working fixture.
+
+`uselesskey` is a test-fixture factory. It is not production key generation,
+certificate management, provider compatibility certification, scanner evasion,
+or cryptographic assurance.
+
+## Pick Your Job
+
+| I need to... | Start with | Copy this |
+| --- | --- | --- |
+| use fake RSA/JWK fixtures in Rust tests | facade crate | `uselesskey = { version = "0.9.0", features = ["rsa", "jwk"] }` |
+| use token-shaped strings without keygen | token lane | `uselesskey = { version = "0.9.0", default-features = false, features = ["token"] }` |
+| generate a deterministic scanner-safe bundle | CLI scanner-safe profile | `uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle` |
+| test TLS verifier behavior | TLS contract pack | `uselesskey bundle --profile tls --out target/uselesskey-tls` |
+| test OIDC/JWKS validator behavior | OIDC/JWKS contract pack | `uselesskey bundle --profile oidc --out target/uselesskey-oidc` |
+| test webhook signature negatives | webhook contract pack | `uselesskey bundle --profile webhook --out target/uselesskey-webhook` |
+| prove public claims for a reviewer | verification pack | `cargo xtask verification-pack --out target/uselesskey-verification` |
+
+Install the CLI when you want bundle commands outside this workspace:
+
+```bash
+cargo install uselesskey-cli --version 0.9.0
+```
+
+Inside the workspace, use:
+
+```bash
+cargo run -p uselesskey-cli -- bundle --profile webhook --out target/uselesskey-webhook
+```
+
+## Rust Test Fixtures
+
+Add the smallest feature set that preserves your test semantics:
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.9.0", features = ["rsa", "jwk"] }
+```
+
+Then generate fixtures at runtime:
+
+```rust
+use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
+
+let fx = Factory::deterministic_from_str("my-test-seed");
+let rsa = fx.rsa("issuer", RsaSpec::rs256());
+
+let pkcs8_pem = rsa.private_key_pkcs8_pem();
+let jwk = rsa.public_jwk();
+```
+
+What this gives you:
+
+- deterministic fixture material for tests;
+- no committed PEM, DER, JWK, or token blobs;
+- realistic artifact shapes for parser and verifier paths.
+
+What it does not give you:
+
+- production key generation;
+- production secret storage;
+- proof your verifier is correct.
+
+For feature selection, see [choose-features.md](choose-features.md).
+
+## Deterministic Bundle Fixtures
+
+Generate and verify a bundle:
+
+```bash
+uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle
+uselesskey verify-bundle --path target/uselesskey-bundle
+```
+
+Keep generated payloads under `target/`. Commit metadata, docs, and policy when
+needed, not generated secret-shaped payloads.
+
+For Kubernetes and Vault-shaped exports, see
+[generate-scanner-safe-k8s-secret.md](generate-scanner-safe-k8s-secret.md).
+
+## Contract Packs
+
+Use contract packs when you want fixtures plus documented positive and negative
+cases.
+
+### TLS
+
+```bash
+uselesskey bundle --profile tls --out target/uselesskey-tls
+uselesskey verify-bundle --path target/uselesskey-tls
+cargo xtask claim-proof --claim tls-contract-pack
+```
+
+Proves documented TLS fixture paths and negative validation cases. Does not
+prove production PKI, revocation, certificate transparency, mTLS, browser
+trust-store behavior, or downstream verifier correctness.
+
+### OIDC/JWKS
+
+```bash
+uselesskey bundle --profile oidc --out target/uselesskey-oidc
+uselesskey verify-bundle --path target/uselesskey-oidc
+cargo xtask claim-report --claim oidc-jwks-contract-pack
+```
+
+Proves documented OIDC/JWKS fixture shapes and negative validator inputs. Does
+not prove provider compatibility, issuer policy, or production token security.
+
+### Webhook
+
+```bash
+uselesskey bundle --profile webhook --out target/uselesskey-webhook
+uselesskey verify-bundle --path target/uselesskey-webhook
+cargo xtask claim-proof --claim webhook-contract-pack
+```
+
+Proves deterministic HMAC webhook verifier fixtures for valid, tampered-body,
+wrong-secret, stale-timestamp, missing-signature, and malformed-signature cases.
+Does not prove provider compatibility, secret rotation, replay protection
+completeness, delivery behavior, or transport security.
+
+## Reviewer Proof
+
+Build a metadata-only review bundle:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification
+```
+
+For one claim:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification --claim webhook-contract-pack
+```
+
+Attach the generated `target/uselesskey-verification/README.md` and receipt
+files. Do not attach generated PEM, DER, JWT, key, Kubernetes Secret, or Vault
+payload files.
+
+For the full public-claim workflow, see
+[verify-uselesskey-public-claims.md](verify-uselesskey-public-claims.md).


### PR DESCRIPTION
## Summary

- Adds `docs/how-to/start-here.md` as the first-run task router.
- Links the task router from README and the docs index.
- Advances the active goal: `task-router` is done and `contract-pack-index` is ready.

## Files added/changed

- `docs/how-to/start-here.md`
- `README.md`
- `docs/README.md`
- `.uselesskey/goals/active.toml`

## Validation

- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `git diff --check`

## Non-goals

- No contract-pack product index yet.
- No README first-run rewrite yet.
- No CLI profile/proof commands, doctor command, or user-path smoke checks.
- No new fixture families, public claims, badges, shipper work, dependency churn, or no-panic baseline work.

## What this enables next

- Next PR: `docs: make contract packs a visible product family`.