### PR TITLE
docs: make contract packs visible

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -48,7 +48,7 @@ commands = [
 
 [[work_item]]
 id = "contract-pack-index"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0003"
 plan = "plans/first-run-ux/implementation-plan.md"
@@ -62,7 +62,7 @@ commands = [
 
 [[work_item]]
 id = "cli-profile-discovery"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0003"
 plan = "plans/first-run-ux/implementation-plan.md"

--- a/README.md
+++ b/README.md
@@ -400,6 +400,9 @@ cargo run -p uselesskey-cli -- bundle --profile oidc --out target/uselesskey-oid
 
 For the reference manifest, receipts, and payload shapes see [`examples/scanner-safe-bundle/README.md`](examples/scanner-safe-bundle/README.md). For OIDC/JWT validator-test recipes see [`docs/how-to/test-oidc-jwks-validation.md`](docs/how-to/test-oidc-jwks-validation.md) and [`docs/how-to/test-jwt-negative-validation.md`](docs/how-to/test-jwt-negative-validation.md).
 
+For a task-first list of scanner-safe, TLS, OIDC/JWKS, and webhook profiles,
+see [`docs/contract-packs/README.md`](docs/contract-packs/README.md).
+
 ## Adapter crates
 
 Adapter crates are separate packages, not facade features. That keeps integration versioning explicit and avoids coupling the facade to every downstream ecosystem type.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,13 @@ Task-oriented instructions for common workflows.
 - [verify-uselesskey-public-claims.md](how-to/verify-uselesskey-public-claims.md) — Verifying badge, scanner-safe, contract-pack, claim-proof, and release-smoke claims
 - [share-uselesskey-verification-pack.md](how-to/share-uselesskey-verification-pack.md) — Collecting metadata-only public-claim receipts for security and platform review
 
+## Contract Packs
+
+Deterministic fixture bundles with documented positive and negative verifier
+paths.
+
+- [contract-packs](contract-packs/README.md) — Generate, verify, prove, and understand scanner-safe, TLS, OIDC/JWKS, and webhook profiles
+
 ## Contributing
 
 Repository operating rules for agents and maintainers.

--- a/docs/contract-packs/README.md
+++ b/docs/contract-packs/README.md
@@ -1,0 +1,209 @@
+# Contract Packs
+
+Contract packs are deterministic fixture bundles with a documented verifier job,
+negative cases, proof command, and explicit boundary.
+
+Use this page when you already know the verifier surface you need and want the
+copyable command first. For a broader task router, see
+[`../how-to/start-here.md`](../how-to/start-here.md).
+
+Run installed CLI commands as shown below:
+
+```bash
+cargo install uselesskey-cli --version 0.9.0
+```
+
+Inside this workspace, prefix CLI examples with `cargo run -p uselesskey-cli --`.
+
+## Quick Index
+
+| Profile | Use when you need | Generate | Proof |
+| --- | --- | --- | --- |
+| `scanner-safe` | scanner-safe baseline fixtures and export receipts | `uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle` | `cargo xtask claim-proof --claim scanner-safe-fixtures` |
+| `tls` | TLS chain and certificate rejection fixtures | `uselesskey bundle --profile tls --out target/uselesskey-tls` | `cargo xtask claim-proof --claim tls-contract-pack` |
+| `oidc` | OIDC/JWKS validator fixtures and JWT-shaped negatives | `uselesskey bundle --profile oidc --out target/uselesskey-oidc` | `cargo xtask claim-report --claim oidc-jwks-contract-pack` |
+| `webhook` | HMAC webhook signature positives and negatives | `uselesskey bundle --profile webhook --out target/uselesskey-webhook` | `cargo xtask claim-proof --claim webhook-contract-pack` |
+
+Every generated bundle should stay under `target/` or another ignored build
+directory. Commit docs and receipts only when the repo has an explicit tracked
+receipt path. Do not commit generated PEM, DER, JWT, key, Kubernetes Secret, or
+Vault payload files.
+
+## Scanner-Safe Baseline
+
+Generate:
+
+```bash
+uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle
+```
+
+Verify:
+
+```bash
+uselesskey verify-bundle --path target/uselesskey-bundle
+uselesskey inspect-bundle --path target/uselesskey-bundle
+```
+
+Prove:
+
+```bash
+cargo xtask claim-proof --claim scanner-safe-fixtures
+```
+
+What it proves:
+
+- repository policy found no committed secret-shaped fixture blobs;
+- the generated baseline bundle has receipts and an audit surface;
+- badge drift checks still agree with scanner-safe policy.
+
+What it does not prove:
+
+- every derived encoded export is safe to commit;
+- production key management;
+- scanner evasion;
+- cryptographic assurance.
+
+Docs:
+
+- [`../how-to/generate-scanner-safe-k8s-secret.md`](../how-to/generate-scanner-safe-k8s-secret.md)
+- [`../how-to/downstream-fixture-policy.md`](../how-to/downstream-fixture-policy.md)
+
+## TLS
+
+Generate:
+
+```bash
+uselesskey bundle --profile tls --out target/uselesskey-tls
+```
+
+Verify:
+
+```bash
+uselesskey verify-bundle --path target/uselesskey-tls
+uselesskey inspect-bundle --path target/uselesskey-tls
+```
+
+Prove:
+
+```bash
+cargo xtask claim-proof --claim tls-contract-pack
+cargo xtask bundle-proof --profile tls --out target/release-evidence/tls
+```
+
+What it proves:
+
+- documented TLS fixture files are generated;
+- valid chain material exists;
+- expired, not-yet-valid, wrong-hostname, and untrusted-root negatives exist;
+- receipts and evidence docs are present.
+
+What it does not prove:
+
+- production PKI;
+- revocation, OCSP, certificate transparency, or mTLS;
+- browser trust-store behavior;
+- production CA custody;
+- downstream verifier correctness.
+
+Docs:
+
+- [`../how-to/test-tls-chain-validation.md`](../how-to/test-tls-chain-validation.md)
+
+## OIDC/JWKS
+
+Generate:
+
+```bash
+uselesskey bundle --profile oidc --out target/uselesskey-oidc
+```
+
+Verify:
+
+```bash
+uselesskey verify-bundle --path target/uselesskey-oidc
+uselesskey inspect-bundle --path target/uselesskey-oidc
+```
+
+Prove:
+
+```bash
+cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc
+cargo xtask claim-report --claim oidc-jwks-contract-pack
+```
+
+What it proves:
+
+- deterministic JWKS and JWT-shaped fixtures are generated;
+- documented negative inputs exist for validator rejection paths;
+- receipts and evidence docs are present.
+
+What it does not prove:
+
+- production signing-key custody;
+- full OpenID provider behavior;
+- issuer policy;
+- downstream validator correctness.
+
+Docs:
+
+- [`../how-to/test-oidc-jwks-validation.md`](../how-to/test-oidc-jwks-validation.md)
+- [`../how-to/test-jwt-negative-validation.md`](../how-to/test-jwt-negative-validation.md)
+
+## Webhook
+
+Generate:
+
+```bash
+uselesskey bundle --profile webhook --out target/uselesskey-webhook
+```
+
+Verify:
+
+```bash
+uselesskey verify-bundle --path target/uselesskey-webhook
+uselesskey inspect-bundle --path target/uselesskey-webhook
+```
+
+Prove:
+
+```bash
+cargo xtask claim-proof --claim webhook-contract-pack
+cargo xtask bundle-proof --profile webhook --out target/release-evidence/webhook
+```
+
+What it proves:
+
+- valid HMAC webhook signature fixtures are generated;
+- tampered-body, wrong-secret, stale-timestamp, missing-signature, and
+  malformed-signature negatives exist;
+- receipts and evidence docs are present.
+
+What it does not prove:
+
+- provider compatibility;
+- production secret management;
+- replay protection completeness;
+- delivery retries;
+- transport security;
+- downstream verifier correctness.
+
+Docs:
+
+- [`../how-to/test-webhook-signature-validation.md`](../how-to/test-webhook-signature-validation.md)
+
+## Reviewer Bundle
+
+When a reviewer needs all public-claim receipts in one metadata-only directory:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification
+```
+
+For one claim:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification --claim webhook-contract-pack
+```
+
+The verification pack contains metadata and receipts only. It must not copy raw
+generated fixture payloads into the review bundle.

--- a/docs/how-to/start-here.md
+++ b/docs/how-to/start-here.md
@@ -86,6 +86,9 @@ For Kubernetes and Vault-shaped exports, see
 Use contract packs when you want fixtures plus documented positive and negative
 cases.
 
+For the product-family view, see
+[`../contract-packs/README.md`](../contract-packs/README.md).
+
 ### TLS
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `docs/contract-packs/README.md` as the product-family index for scanner-safe, TLS, OIDC/JWKS, and webhook profiles.
- Links the index from README, docs index, and the start-here router.
- Advances the active goal: `contract-pack-index` is done and `cli-profile-discovery` is ready.

## Files added/changed

- `docs/contract-packs/README.md`
- `docs/how-to/start-here.md`
- `docs/README.md`
- `README.md`
- `.uselesskey/goals/active.toml`

## Validation

- `cargo xtask contract-packs --check`
- `cargo xtask claim-report --check-public-claims`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `git diff --check`

## Non-goals

- No new contract packs or public claims.
- No CLI profile discovery implementation yet.
- No proof handoff, doctor, README rewrite, or user-path smoke implementation.
- No new badges, shipper work, dependency churn, or historical no-panic baseline work.

## What this enables next

- Next PR: `feat(cli): add profile discovery commands`.