### PR TITLE
feat(cli): add profile discovery commands

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -62,7 +62,7 @@ commands = [
 
 [[work_item]]
 id = "cli-profile-discovery"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0003"
 plan = "plans/first-run-ux/implementation-plan.md"
@@ -75,7 +75,7 @@ commands = [
 
 [[work_item]]
 id = "cli-proof-handoff"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0009"
 plan = "plans/first-run-ux/implementation-plan.md"

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -33,6 +33,8 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
     Generate(GenerateArgs),
+    Profiles(ProfilesArgs),
+    Profile(ProfileArgs),
     Bundle(BundleArgs),
     VerifyBundle(VerifyBundleArgs),
     InspectBundle(InspectBundleArgs),
@@ -40,6 +42,19 @@ enum Commands {
     Inspect(InspectArgs),
     Materialize(MaterializeArgs),
     Verify(VerifyArgs),
+}
+
+#[derive(clap::Args, Debug)]
+struct ProfilesArgs {
+    #[arg(long)]
+    explain: bool,
+}
+
+#[derive(clap::Args, Debug)]
+struct ProfileArgs {
+    profile: BundleProfile,
+    #[arg(long)]
+    explain: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -216,7 +231,25 @@ impl BundleProfile {
             Self::Runtime => "runtime",
         }
     }
+
+    const fn output_dir_hint(self) -> &'static str {
+        match self {
+            Self::ScannerSafe => "target/uselesskey-bundle",
+            Self::Oidc => "target/uselesskey-oidc",
+            Self::Tls => "target/uselesskey-tls",
+            Self::Webhook => "target/uselesskey-webhook",
+            Self::Runtime => "target/uselesskey-runtime",
+        }
+    }
 }
+
+const DISCOVERABLE_PROFILES: [BundleProfile; 5] = [
+    BundleProfile::ScannerSafe,
+    BundleProfile::Tls,
+    BundleProfile::Oidc,
+    BundleProfile::Webhook,
+    BundleProfile::Runtime,
+];
 
 #[derive(Debug)]
 enum Artifact {
@@ -229,6 +262,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Generate(args) => run_generate(args),
+        Commands::Profiles(args) => run_profiles(args),
+        Commands::Profile(args) => run_profile(args),
         Commands::Bundle(args) => run_bundle(args),
         Commands::VerifyBundle(args) => run_verify_bundle(args),
         Commands::InspectBundle(args) => run_inspect_bundle(args),
@@ -237,6 +272,19 @@ fn main() -> Result<()> {
         Commands::Materialize(args) => run_materialize(args),
         Commands::Verify(args) => run_verify(args),
     }
+}
+
+fn run_profiles(args: ProfilesArgs) -> Result<()> {
+    emit_artifact(&Artifact::Text(render_profiles(args.explain)), None)
+}
+
+fn run_profile(args: ProfileArgs) -> Result<()> {
+    let report = if args.explain {
+        render_profile_explanation(args.profile)
+    } else {
+        render_profile_summary(args.profile)
+    };
+    emit_artifact(&Artifact::Text(report), None)
 }
 
 fn run_generate(args: GenerateArgs) -> Result<()> {
@@ -632,6 +680,264 @@ fn yes_no_unknown(value: Option<bool>) -> &'static str {
 
 fn count_or_unknown(value: Option<usize>) -> String {
     value.map_or_else(|| "unknown".to_string(), |count| count.to_string())
+}
+
+#[derive(Clone, Copy)]
+struct ProfileInfo {
+    profile: BundleProfile,
+    title: &'static str,
+    purpose: &'static str,
+    required_feature: &'static str,
+    scanner_posture: &'static str,
+    proof_command: &'static str,
+    claim: Option<&'static str>,
+    docs: &'static str,
+    generates: &'static [&'static str],
+    proves: &'static [&'static str],
+    not_proves: &'static [&'static str],
+}
+
+fn profile_info(profile: BundleProfile) -> ProfileInfo {
+    match profile {
+        BundleProfile::ScannerSafe => ProfileInfo {
+            profile,
+            title: "Scanner-safe baseline bundle",
+            purpose: "baseline scanner-safe fixtures, receipts, and export handoff metadata",
+            required_feature: "uselesskey-cli default features",
+            scanner_posture: "scanner-safe fixture material; generated exports still belong under target/",
+            proof_command: "cargo xtask claim-proof --claim scanner-safe-fixtures",
+            claim: Some("scanner-safe-fixtures"),
+            docs: "docs/how-to/generate-scanner-safe-k8s-secret.md",
+            generates: &[
+                "RSA/ECDSA/Ed25519/HMAC public fixture shapes",
+                "token and X.509 fixture shapes",
+                "manifest.json",
+                "receipts/materialization.json",
+                "receipts/audit-surface.json",
+            ],
+            proves: &[
+                "repo policy found no committed secret-shaped fixture blobs",
+                "the bundle has a manifest and audit receipts",
+                "scanner-safe badge drift checks still agree with policy",
+            ],
+            not_proves: &[
+                "every derived encoded export is safe to commit",
+                "production key management",
+                "scanner evasion",
+                "cryptographic assurance",
+            ],
+        },
+        BundleProfile::Tls => ProfileInfo {
+            profile,
+            title: "TLS contract pack",
+            purpose: "TLS chain and certificate rejection fixtures",
+            required_feature: "uselesskey-cli default features",
+            scanner_posture: "generated PEM payloads stay under target/; proof receipts are metadata",
+            proof_command: "cargo xtask claim-proof --claim tls-contract-pack",
+            claim: Some("tls-contract-pack"),
+            docs: "docs/how-to/test-tls-chain-validation.md",
+            generates: &[
+                "certs/valid-leaf.pem",
+                "certs/valid-chain.pem",
+                "expired, not-yet-valid, wrong-hostname, and untrusted-root negatives",
+                "evidence/tls-profile.md",
+                "manifest and receipts",
+            ],
+            proves: &[
+                "documented TLS fixture files are generated",
+                "positive and negative certificate paths are present",
+                "receipts and evidence docs are present",
+            ],
+            not_proves: &[
+                "production PKI",
+                "revocation, OCSP, certificate transparency, or mTLS",
+                "browser trust-store behavior",
+                "downstream verifier correctness",
+            ],
+        },
+        BundleProfile::Oidc => ProfileInfo {
+            profile,
+            title: "OIDC/JWKS contract pack",
+            purpose: "OIDC/JWKS validator fixtures and JWT-shaped negatives",
+            required_feature: "uselesskey-cli default features",
+            scanner_posture: "generated token/JWKS payloads stay under target/; proof receipts are metadata",
+            proof_command: "cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc",
+            claim: Some("oidc-jwks-contract-pack"),
+            docs: "docs/how-to/test-oidc-jwks-validation.md",
+            generates: &[
+                "valid JWKS and RS256 JWT-shaped fixtures",
+                "duplicate-kid and missing-kid JWKS negatives",
+                "alg-none and bad-audience token negatives",
+                "manifest and receipts",
+            ],
+            proves: &[
+                "deterministic JWKS and JWT-shaped fixtures are generated",
+                "documented validator negative inputs exist",
+                "receipts and evidence docs are present",
+            ],
+            not_proves: &[
+                "production signing-key custody",
+                "full OpenID provider behavior",
+                "issuer policy",
+                "downstream validator correctness",
+            ],
+        },
+        BundleProfile::Webhook => ProfileInfo {
+            profile,
+            title: "Webhook contract pack",
+            purpose: "HMAC webhook signature positives and negatives",
+            required_feature: "uselesskey-cli default features",
+            scanner_posture: "generated request payloads stay under target/; proof receipts are metadata",
+            proof_command: "cargo xtask claim-proof --claim webhook-contract-pack",
+            claim: Some("webhook-contract-pack"),
+            docs: "docs/how-to/test-webhook-signature-validation.md",
+            generates: &[
+                "requests/valid.json",
+                "tampered-body, wrong-secret, stale-timestamp, missing-signature, and malformed-signature negatives",
+                "evidence/webhook-profile.md",
+                "manifest and receipts",
+            ],
+            proves: &[
+                "deterministic HMAC verifier fixture behavior",
+                "valid signature acceptance and documented rejection classes",
+                "receipts and evidence docs are present",
+            ],
+            not_proves: &[
+                "provider compatibility",
+                "production secret management",
+                "replay protection completeness",
+                "delivery retries or transport security",
+                "downstream verifier correctness",
+            ],
+        },
+        BundleProfile::Runtime => ProfileInfo {
+            profile,
+            title: "Runtime bundle",
+            purpose: "general runtime fixture bundle for local experimentation",
+            required_feature: "uselesskey-cli default features",
+            scanner_posture: "may include runtime fixture material; keep generated payloads under target/",
+            proof_command: "uselesskey verify-bundle --path target/uselesskey-runtime",
+            claim: None,
+            docs: "README.md",
+            generates: &[
+                "general JWK/JWKS/X.509 fixture outputs",
+                "manifest.json",
+                "receipts/materialization.json",
+                "receipts/audit-surface.json",
+            ],
+            proves: &[
+                "the bundle can be regenerated and verified against its manifest",
+                "local output shape is internally consistent",
+            ],
+            not_proves: &[
+                "a public contract-pack claim",
+                "scanner-safe commit posture",
+                "production security behavior",
+            ],
+        },
+    }
+}
+
+fn render_profiles(explain: bool) -> String {
+    let mut out = String::new();
+    out.push_str("Available uselesskey profiles\n\n");
+    out.push_str("| Profile | Purpose | Proof |\n");
+    out.push_str("|---|---|---|\n");
+    for profile in DISCOVERABLE_PROFILES {
+        let info = profile_info(profile);
+        out.push_str(&format!(
+            "| `{}` | {} | `{}` |\n",
+            info.profile.manifest_name(),
+            info.purpose,
+            info.proof_command
+        ));
+    }
+    out.push_str("\nUse `uselesskey profile <name> --explain` for generated files, boundaries, and copyable commands.\n");
+
+    if explain {
+        out.push('\n');
+        for profile in DISCOVERABLE_PROFILES {
+            out.push_str(&render_profile_explanation(profile));
+            out.push('\n');
+        }
+    }
+
+    out
+}
+
+fn render_profile_summary(profile: BundleProfile) -> String {
+    let info = profile_info(profile);
+    format!(
+        concat!(
+            "Profile: {}\n",
+            "Title: {}\n",
+            "Purpose: {}\n",
+            "Generate: uselesskey bundle --profile {} --out {}\n",
+            "Verify: uselesskey verify-bundle --path {}\n",
+            "Proof: {}\n",
+            "Explain: uselesskey profile {} --explain\n",
+        ),
+        info.profile.manifest_name(),
+        info.title,
+        info.purpose,
+        info.profile.manifest_name(),
+        info.profile.output_dir_hint(),
+        info.profile.output_dir_hint(),
+        info.proof_command,
+        info.profile.manifest_name(),
+    )
+}
+
+fn render_profile_explanation(profile: BundleProfile) -> String {
+    let info = profile_info(profile);
+    let mut out = render_profile_summary(profile);
+    out.push_str(&format!("Required feature: {}\n", info.required_feature));
+    out.push_str(&format!("Scanner/runtime posture: {}\n", info.scanner_posture));
+    if let Some(claim) = info.claim {
+        out.push_str(&format!("Claim: {claim}\n"));
+    }
+    out.push_str(&format!("Docs: {}\n", info.docs));
+    push_list(&mut out, "\nGenerates", info.generates);
+    push_list(&mut out, "\nProves", info.proves);
+    push_list(&mut out, "\nDoes not prove", info.not_proves);
+    out
+}
+
+fn push_list(out: &mut String, title: &str, items: &[&str]) {
+    out.push_str(title);
+    out.push_str(":\n");
+    for item in items {
+        out.push_str("- ");
+        out.push_str(item);
+        out.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod profile_discovery_tests {
+    use super::*;
+
+    #[test]
+    fn profile_list_includes_contract_pack_boundaries() {
+        let rendered = render_profiles(false);
+
+        assert!(rendered.contains("scanner-safe"));
+        assert!(rendered.contains("tls"));
+        assert!(rendered.contains("oidc"));
+        assert!(rendered.contains("webhook"));
+        assert!(rendered.contains("claim-proof --claim webhook-contract-pack"));
+    }
+
+    #[test]
+    fn webhook_profile_explain_mentions_negative_classes_and_limits() {
+        let rendered = render_profile_explanation(BundleProfile::Webhook);
+
+        assert!(rendered.contains("requests/valid.json"));
+        assert!(rendered.contains("wrong-secret"));
+        assert!(rendered.contains("missing-signature"));
+        assert!(rendered.contains("provider compatibility"));
+        assert!(rendered.contains("production secret management"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -892,7 +892,10 @@ fn render_profile_explanation(profile: BundleProfile) -> String {
     let info = profile_info(profile);
     let mut out = render_profile_summary(profile);
     out.push_str(&format!("Required feature: {}\n", info.required_feature));
-    out.push_str(&format!("Scanner/runtime posture: {}\n", info.scanner_posture));
+    out.push_str(&format!(
+        "Scanner/runtime posture: {}\n",
+        info.scanner_posture
+    ));
     if let Some(claim) = info.claim {
         out.push_str(&format!("Claim: {claim}\n"));
     }

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -57,6 +57,31 @@ fn generate_jwk_outputs_json() -> TestResult<()> {
 }
 
 #[test]
+fn profiles_command_lists_copyable_contract_pack_paths() -> TestResult<()> {
+    let out = run(["profiles"])?;
+
+    assert!(out.contains("Available uselesskey profiles"));
+    assert!(out.contains("uselesskey profile <name> --explain"));
+    assert!(out.contains("claim-proof --claim webhook-contract-pack"));
+    Ok(())
+}
+
+#[test]
+fn profile_command_summary_has_copyable_webhook_paths() -> TestResult<()> {
+    let out = run(["profile", "webhook"])?;
+
+    assert!(out.contains("Profile: webhook"));
+    assert!(
+        out.contains(
+            "Generate: uselesskey bundle --profile webhook --out target/uselesskey-webhook"
+        )
+    );
+    assert!(out.contains("Verify: uselesskey verify-bundle --path target/uselesskey-webhook"));
+    assert!(out.contains("Proof: cargo xtask claim-proof --claim webhook-contract-pack"));
+    Ok(())
+}
+
+#[test]
 fn bad_format_for_kind_exits_nonzero() -> TestResult<()> {
     let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args([

--- a/docs/contract-packs/README.md
+++ b/docs/contract-packs/README.md
@@ -15,6 +15,13 @@ cargo install uselesskey-cli --version 0.9.0
 
 Inside this workspace, prefix CLI examples with `cargo run -p uselesskey-cli --`.
 
+Discover available profiles from the CLI:
+
+```bash
+uselesskey profiles
+uselesskey profile webhook --explain
+```
+
 ## Quick Index
 
 | Profile | Use when you need | Generate | Proof |

--- a/docs/how-to/start-here.md
+++ b/docs/how-to/start-here.md
@@ -23,6 +23,7 @@ Install the CLI when you want bundle commands outside this workspace:
 
 ```bash
 cargo install uselesskey-cli --version 0.9.0
+uselesskey profiles
 ```
 
 Inside the workspace, use:


### PR DESCRIPTION
## Summary

- Adds `uselesskey profiles` for a compact profile table.
- Adds `uselesskey profile <name> --explain` for generated files, proof commands, posture, and boundaries.
- Documents CLI profile discovery from the start-here and contract-pack pages.
- Advances the active goal: `cli-profile-discovery` is done and `cli-proof-handoff` is ready.

## Files added/changed

- `crates/uselesskey-cli/src/main.rs`
- `crates/uselesskey-cli/tests/cli.rs`
- `docs/contract-packs/README.md`
- `docs/how-to/start-here.md`
- `.uselesskey/goals/active.toml`

## Validation

- `cargo test -p uselesskey-cli --all-features profile`
- `cargo run -p uselesskey-cli -- profiles`
- `cargo run -p uselesskey-cli -- profile webhook --explain`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo +nightly xtask pr-lite`
- `cargo xtask mutants-pr --changed`
- `cargo clippy -p uselesskey-cli --all-features --all-targets -- -D warnings`
- `git diff --check`

Notes:

- Plain `cargo xtask pr-lite` failed locally because this shell used stable Rust for `cargo fuzz build`; rerunning as `cargo +nightly xtask pr-lite` passed.
- Local `cargo xtask pr` passed fmt, clippy, CLI tests, and BDD after the formatting fix, then failed at the Windows fuzz runtime with `STATUS_DLL_NOT_FOUND` for the ASAN DLL. The hosted Linux `pr` check is the authoritative PR gate for this branch.
- The first hosted mutation run exposed CLI profile-output coverage gaps; this PR now adds integration tests for `profiles` and `profile webhook`, and local `cargo xtask mutants-pr --changed` passes with 12 caught / 1 unviable.

## Non-goals

- No proof handoff CLI command in this PR.
- No doctor command, README rewrite, or user-path smoke implementation.
- No new profiles, fixture families, public claims, badges, shipper work, dependency churn, or no-panic baseline work.

## What this enables next

- Next PR: `feat(cli): add proof handoff commands`.