### PR TITLE
xtask: add user-path smoke checks

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -116,7 +116,7 @@ commands = [
 
 [[work_item]]
 id = "user-path-smoke"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0006"
 plan = "plans/first-run-ux/implementation-plan.md"
@@ -129,7 +129,7 @@ commands = [
 
 [[work_item]]
 id = "lane-closeout"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/first-run-ux/implementation-plan.md"

--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "6879",
+  "message": "6880",
   "color": "orange"
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -30,6 +30,7 @@ mod public_surface;
 mod receipt;
 mod spec_check;
 mod test_efficiency;
+mod user_path_smoke;
 mod verification_pack;
 
 #[derive(Parser)]
@@ -99,6 +100,8 @@ enum Cmd {
         #[arg(long)]
         run: bool,
     },
+    /// Run bounded first-run user-path smoke checks.
+    UserPathSmoke,
     /// Run publish dry-runs for crates in dependency order.
     PublishCheck,
     /// Run PR-scoped tests based on git diff.
@@ -572,6 +575,7 @@ fn main() -> Result<()> {
         Cmd::DocsSync { check } => docs_sync_with_spec_check(check),
         Cmd::PublicSurface => public_surface::public_surface_cmd(PUBLISH_CRATES),
         Cmd::ExamplesSmoke { run } => docs_sync::examples_smoke_cmd(run),
+        Cmd::UserPathSmoke => user_path_smoke::run(&workspace_root_path()),
         Cmd::PublishCheck => publish_check(),
         Cmd::Pr { with_mutants } => pr(with_mutants),
         Cmd::PrLite { format } => pr_lite(format),

--- a/xtask/src/user_path_smoke.rs
+++ b/xtask/src/user_path_smoke.rs
@@ -1,0 +1,128 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{Context, Result, bail};
+
+use crate::verification_pack;
+
+const USER_PATH_PROFILES: &[&str] = &["scanner-safe", "tls", "oidc", "webhook"];
+
+pub fn run(root: &Path) -> Result<()> {
+    let out_root = root.join("target/user-path-smoke");
+    reset_target_output(root, &out_root)?;
+
+    for profile in USER_PATH_PROFILES {
+        let bundle_dir = out_root.join(profile);
+        run_cli(
+            root,
+            &[
+                "bundle",
+                "--profile",
+                profile,
+                "--out",
+                bundle_dir
+                    .to_str()
+                    .context("user-path-smoke output path is not UTF-8")?,
+            ],
+        )
+        .with_context(|| format!("user-path-smoke bundle profile `{profile}` failed"))?;
+
+        run_cli(
+            root,
+            &[
+                "verify-bundle",
+                "--path",
+                bundle_dir
+                    .to_str()
+                    .context("user-path-smoke output path is not UTF-8")?,
+            ],
+        )
+        .with_context(|| format!("user-path-smoke verify profile `{profile}` failed"))?;
+    }
+
+    verification_pack::run(
+        root,
+        &out_root.join("verification-webhook"),
+        Some("webhook-contract-pack"),
+    )
+    .context("user-path-smoke webhook verification-pack failed")?;
+
+    println!("user-path-smoke: wrote {}", out_root.display());
+    Ok(())
+}
+
+fn run_cli(root: &Path, args: &[&str]) -> Result<()> {
+    let status = Command::new("cargo")
+        .args(["run", "--quiet", "-p", "uselesskey-cli", "--"])
+        .args(args)
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .status()
+        .context("failed to spawn uselesskey-cli via cargo run")?;
+    if !status.success() {
+        bail!("uselesskey-cli exited with {status}");
+    }
+    Ok(())
+}
+
+fn reset_target_output(root: &Path, out_root: &Path) -> Result<()> {
+    ensure_target_child(root, out_root)?;
+    if out_root.exists() {
+        fs::remove_dir_all(out_root)
+            .with_context(|| format!("failed to remove {}", out_root.display()))?;
+    }
+    fs::create_dir_all(out_root).with_context(|| format!("failed to create {}", out_root.display()))
+}
+
+fn ensure_target_child(root: &Path, path: &Path) -> Result<()> {
+    let absolute = absolute_path(root, path);
+    let target_root = absolute_path(root, &root.join("target"));
+    if !absolute.starts_with(&target_root) {
+        bail!(
+            "user-path-smoke refuses to write outside target/: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn absolute_path(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_path_smoke_profiles_are_bounded() {
+        assert_eq!(
+            USER_PATH_PROFILES,
+            ["scanner-safe", "tls", "oidc", "webhook"]
+        );
+    }
+
+    #[test]
+    fn user_path_smoke_rejects_non_target_output() {
+        let root = std::env::temp_dir().join("uselesskey-user-path-smoke-test");
+        let outside = root
+            .parent()
+            .unwrap_or_else(|| Path::new("/"))
+            .join("outside-user-path-smoke");
+        let err = ensure_target_child(&root, &outside).unwrap_err();
+
+        assert!(err.to_string().contains("outside target"));
+    }
+
+    #[test]
+    fn user_path_smoke_accepts_target_output() {
+        let root = std::env::temp_dir().join("uselesskey-user-path-smoke-test");
+
+        ensure_target_child(&root, &root.join("target/user-path-smoke")).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- Add cargo xtask user-path-smoke as a bounded first-run adoption check.
- Exercise scanner-safe, TLS, OIDC, and webhook bundle generation plus verify-bundle.
- Build a webhook-focused metadata-only verification pack and advance the active goal to lane closeout.
- Refresh the generated ripr+ badge endpoint for the added xtask tests.

## Files added/changed
- xtask/src/user_path_smoke.rs
- xtask/src/main.rs
- .uselesskey/goals/active.toml
- badges/ripr-plus.json

## Validation
- cargo xtask fmt --fix
- cargo test -p xtask user_path_smoke
- cargo xtask user-path-smoke
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo xtask pr-lite
- cargo xtask badges --check
- git diff --check

Generated smoke artifacts were removed from target/user-path-smoke, target/release-evidence/webhook, and target/claim-proof/webhook-contract-pack after validation.

## Non-goals
- No new fixture profile or public claim.
- No release evidence widening.
- No generated payloads committed.
- No README badge additions.

## What this enables next
- The first-run UX lane can close with a concrete adoption smoke command covering the visible bundle and reviewer-proof paths.