### PR TITLE
feat(cli): explain bundle profiles in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ CLI contract packs start with:
 cargo install uselesskey-cli --version 0.9.0
 uselesskey profiles
 uselesskey profile webhook --explain
+uselesskey bundle --profile webhook --explain
 ```
 
 Generate and verify a webhook pack:

--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "6880",
+  "message": "6887",
   "color": "orange"
 }

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -82,6 +82,8 @@ struct BundleArgs {
     profile: BundleProfile,
     #[arg(long)]
     out: Option<PathBuf>,
+    #[arg(long)]
+    explain: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -294,6 +296,13 @@ fn run_generate(args: GenerateArgs) -> Result<()> {
 }
 
 fn run_bundle(args: BundleArgs) -> Result<()> {
+    if args.explain {
+        return emit_artifact(
+            &Artifact::Text(render_profile_explanation(args.profile)),
+            None,
+        );
+    }
+
     let out_dir = args
         .out
         .clone()
@@ -876,6 +885,7 @@ fn render_profile_summary(profile: BundleProfile) -> String {
             "Verify: uselesskey verify-bundle --path {}\n",
             "Proof: {}\n",
             "Explain: uselesskey profile {} --explain\n",
+            "Bundle explain: uselesskey bundle --profile {} --explain\n",
         ),
         info.profile.manifest_name(),
         info.title,
@@ -884,6 +894,7 @@ fn render_profile_summary(profile: BundleProfile) -> String {
         info.profile.output_dir_hint(),
         info.profile.output_dir_hint(),
         info.proof_command,
+        info.profile.manifest_name(),
         info.profile.manifest_name(),
     )
 }

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -82,6 +82,31 @@ fn profile_command_summary_has_copyable_webhook_paths() -> TestResult<()> {
 }
 
 #[test]
+fn bundle_explain_has_copyable_webhook_paths_without_writing_bundle() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("bundle");
+    let out = run([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--explain",
+    ])?;
+
+    assert!(out.contains("Profile: webhook"));
+    assert!(
+        out.contains(
+            "Generate: uselesskey bundle --profile webhook --out target/uselesskey-webhook"
+        )
+    );
+    assert!(out.contains("Does not prove"));
+    assert!(out.contains("provider compatibility"));
+    assert!(!bundle_dir.exists());
+    Ok(())
+}
+
+#[test]
 fn bad_format_for_kind_exits_nonzero() -> TestResult<()> {
     let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     cmd.args([

--- a/docs/contract-packs/README.md
+++ b/docs/contract-packs/README.md
@@ -20,6 +20,7 @@ Discover available profiles from the CLI:
 ```bash
 uselesskey profiles
 uselesskey profile webhook --explain
+uselesskey bundle --profile webhook --explain
 ```
 
 ## Quick Index

--- a/docs/how-to/start-here.md
+++ b/docs/how-to/start-here.md
@@ -24,6 +24,7 @@ Install the CLI when you want bundle commands outside this workspace:
 ```bash
 cargo install uselesskey-cli --version 0.9.0
 uselesskey profiles
+uselesskey bundle --profile webhook --explain
 ```
 
 Inside the workspace, use:
@@ -72,6 +73,7 @@ For feature selection, see [choose-features.md](choose-features.md).
 Generate and verify a bundle:
 
 ```bash
+uselesskey bundle --profile scanner-safe --explain
 uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle
 uselesskey verify-bundle --path target/uselesskey-bundle
 ```

--- a/docs/learnings/2026-05-first-run-ux.md
+++ b/docs/learnings/2026-05-first-run-ux.md
@@ -51,6 +51,8 @@ claim ledger, specs, receipts, or release evidence.
 - `uselesskey profiles` and `uselesskey profile <name> --explain` expose
   profile purpose, generated files, proof commands, and claim boundaries in the
   tool.
+- `uselesskey bundle --profile <name> --explain` gives users the same boundary
+  check at the command they were about to run, without materializing a bundle.
 - `USELESSKEY-SPEC-0012` prevents a premature CLI proof wrapper from shelling
   out to repo-local `xtask` or arbitrary ledger strings.
 - `cargo xtask doctor` reports local proof-environment readiness.

--- a/plans/first-run-ux/closeout.md
+++ b/plans/first-run-ux/closeout.md
@@ -53,6 +53,8 @@ selected.
   verify, proof, and verification-pack commands.
 - `uselesskey profile <name> --explain` explains generated files, scanner-safe
   posture, proof commands, and claim boundaries for each profile.
+- `uselesskey bundle --profile <name> --explain` exposes the same profile
+  explanation from the bundle command without writing generated fixture files.
 - `USELESSKEY-SPEC-0012` defines the CLI proof-handoff boundary and keeps
   executable proof in allowlisted `xtask` surfaces until a safe reusable proof
   engine exists.


### PR DESCRIPTION
## Summary
- Add uselesskey bundle --profile <profile> --explain as a read-only profile explanation path.
- Keep bundle explanation aligned with uselesskey profile <profile> --explain and prevent accidental bundle materialization.
- Update README/start-here/contract-pack docs plus first-run UX closeout records.
- Refresh the generated ripr+ endpoint for the new CLI regression test.

## Files added/changed
- crates/uselesskey-cli/src/main.rs
- crates/uselesskey-cli/tests/cli.rs
- README.md
- docs/how-to/start-here.md
- docs/contract-packs/README.md
- plans/first-run-ux/closeout.md
- docs/learnings/2026-05-first-run-ux.md
- badges/ripr-plus.json

## Validation
- cargo xtask fmt --fix
- cargo run -p uselesskey-cli -- bundle --profile webhook --explain
- cargo test -p uselesskey-cli --all-features bundle_explain
- cargo test -p uselesskey-cli --all-features profile
- cargo test -p uselesskey-cli --all-features
- cargo clippy -p uselesskey-cli --all-targets --all-features -- -D warnings
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask user-path-smoke
- cargo +nightly xtask pr-lite
- cargo xtask badges --check
- cargo xtask doctor --format json
- cargo +nightly xtask pr
- git diff --check

Note: plain cargo xtask pr-lite was attempted first and failed at fuzz-build because stable rustc rejects cargo-fuzz sanitizer -Z flags. The same gate passed under cargo +nightly xtask pr-lite, and doctor reports nightly is installed while warning that the Windows ASAN runtime DLL is not on PATH.

## Non-goals
- No new fixture profile or public claim.
- No provider compatibility or production-security claim.
- No executable CLI proof wrapper.
- No generated fixture payloads committed.

## What this enables next
- Users can ask for the boundary at the exact bundle command they were about to run, before any files are written.