### PR TITLE
refactor(x509): split self-signed cert builder into SRP submodules

### DIFF
--- a/crates/uselesskey-x509/src/cert.rs
+++ b/crates/uselesskey-x509/src/cert.rs
@@ -4,29 +4,21 @@ use std::fmt;
 use std::sync::Arc;
 
 use rand_chacha::ChaCha20Rng;
-use rand_core::RngCore;
 use rand_core::SeedableRng;
-use rcgen::{
-    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-    KeyUsagePurpose, PKCS_RSA_SHA256,
-};
-use rustls_pki_types::PrivatePkcs8KeyDer;
-use time::Duration as TimeDuration;
 use uselesskey_core::negative::CorruptPem;
 use uselesskey_core::sink::TempArtifact;
 use uselesskey_core::{Error, Factory};
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
 
 use crate::chain::X509Chain;
 use crate::negative::{
     corrupt_cert_der_deterministic, corrupt_cert_pem, corrupt_cert_pem_deterministic,
     truncate_cert_der,
 };
-use crate::srp::derive::{
-    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
-};
 use crate::srp::negative::X509Negative;
-use crate::srp::spec::{ChainSpec, NotBeforeOffset, X509Spec};
+use crate::srp::spec::{ChainSpec, X509Spec};
+
+mod material;
+mod params;
 
 /// Cache domain for X.509 certificate fixtures.
 ///
@@ -487,101 +479,17 @@ fn load_inner_with_spec(
 
     factory.get_or_init(DOMAIN_X509_CERT, label, &spec_bytes, variant, |seed| {
         let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
-        // Generate RSA key using uselesskey-rsa for deterministic key generation.
-        // We use the label + variant to derive a unique key.
-        let key_label = format!("{}-key", label);
-        let rsa_spec = RsaSpec::new(spec.rsa_bits);
-        let rsa_keypair = factory.rsa(&key_label, rsa_spec);
+        let keys = material::generate(factory, label, spec.rsa_bits);
+        let base_time = params::deterministic_base_time(label, spec);
+        let cert_params = params::self_signed_params(spec, base_time, &mut rng);
 
-        // Get the PKCS#8 DER key and convert it to rcgen's KeyPair
-        let pkcs8_der = rsa_keypair.private_key_pkcs8_der();
-        let pkcs8_key = PrivatePkcs8KeyDer::from(pkcs8_der.to_vec());
-        let key_pair =
-            KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_key, &PKCS_RSA_SHA256).expect("key parse");
-
-        // Build certificate parameters
-        let mut params = CertificateParams::default();
-        params
-            .distinguished_name
-            .push(DnType::CommonName, spec.subject_cn.clone());
-
-        // Set validity period based on spec
-        let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
-        let base_time = deterministic_base_time_from_parts(&[
-            label.as_bytes(),
-            spec.subject_cn.as_bytes(),
-            spec.issuer_cn.as_bytes(),
-            &rsa_bits,
-        ]);
-
-        let not_before = match spec.not_before_offset {
-            NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
-            NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
-        };
-
-        let not_after = not_before + TimeDuration::days(spec.validity_days as i64);
-
-        params.not_before = not_before;
-        params.not_after = not_after;
-        params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        // Set CA status
-        if spec.is_ca {
-            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        } else {
-            params.is_ca = IsCa::NoCa;
-        }
-
-        // Set key usage
-        let mut key_usages = Vec::new();
-        if spec.key_usage.digital_signature {
-            key_usages.push(KeyUsagePurpose::DigitalSignature);
-        }
-        if spec.key_usage.key_encipherment {
-            key_usages.push(KeyUsagePurpose::KeyEncipherment);
-        }
-        if spec.key_usage.key_cert_sign {
-            key_usages.push(KeyUsagePurpose::KeyCertSign);
-        }
-        if spec.key_usage.crl_sign {
-            key_usages.push(KeyUsagePurpose::CrlSign);
-        }
-        params.key_usages = key_usages;
-
-        // Add extended key usage for TLS
-        if !spec.is_ca {
-            params.extended_key_usages = vec![
-                ExtendedKeyUsagePurpose::ServerAuth,
-                ExtendedKeyUsagePurpose::ClientAuth,
-            ];
-        }
-
-        // Add Subject Alternative Names
-        let mut sorted_sans = spec.sans.clone();
-        sorted_sans.sort();
-        sorted_sans.dedup();
-        for san in &sorted_sans {
-            params.subject_alt_names.push(rcgen::SanType::DnsName(
-                san.clone().try_into().expect("valid DNS name"),
-            ));
-        }
-
-        // Generate the self-signed certificate
-        let cert = params.self_signed(&key_pair).expect("cert generation");
-
-        let cert_der: Arc<[u8]> = Arc::from(cert.der().as_ref());
-        let cert_pem = cert.pem();
-
-        let private_key_pkcs8_der: Arc<[u8]> = Arc::from(pkcs8_der);
-        let private_key_pkcs8_pem = rsa_keypair.private_key_pkcs8_pem().to_string();
+        let cert = cert_params.self_signed(&keys.kp).expect("cert generation");
 
         Inner {
-            cert_der,
-            cert_pem,
-            private_key_pkcs8_der,
-            private_key_pkcs8_pem,
+            cert_der: Arc::from(cert.der().as_ref()),
+            cert_pem: cert.pem(),
+            private_key_pkcs8_der: Arc::from(keys.rsa.private_key_pkcs8_der()),
+            private_key_pkcs8_pem: keys.rsa.private_key_pkcs8_pem().to_string(),
         }
     })
 }
@@ -589,6 +497,7 @@ fn load_inner_with_spec(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::srp::spec::NotBeforeOffset;
     use crate::testutil::fx;
     use uselesskey_core::Seed;
 

--- a/crates/uselesskey-x509/src/cert/material.rs
+++ b/crates/uselesskey-x509/src/cert/material.rs
@@ -1,0 +1,20 @@
+use rcgen::{KeyPair, PKCS_RSA_SHA256};
+use rustls_pki_types::PrivatePkcs8KeyDer;
+use uselesskey_core::Factory;
+use uselesskey_rsa::{RsaFactoryExt, RsaKeyPair, RsaSpec};
+
+pub(super) struct CertKeyMaterial {
+    pub(super) rsa: RsaKeyPair,
+    pub(super) kp: KeyPair,
+}
+
+pub(super) fn generate(factory: &Factory, label: &str, rsa_bits: usize) -> CertKeyMaterial {
+    let rsa_spec = RsaSpec::new(rsa_bits);
+    let rsa = factory.rsa(format!("{}-key", label), rsa_spec);
+    let kp = KeyPair::from_pkcs8_der_and_sign_algo(
+        &PrivatePkcs8KeyDer::from(rsa.private_key_pkcs8_der().to_vec()),
+        &PKCS_RSA_SHA256,
+    )
+    .expect("key parse");
+    CertKeyMaterial { rsa, kp }
+}

--- a/crates/uselesskey-x509/src/cert/params.rs
+++ b/crates/uselesskey-x509/src/cert/params.rs
@@ -1,0 +1,99 @@
+use rand_core::RngCore;
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+};
+use time::Duration as TimeDuration;
+use time::OffsetDateTime;
+
+use crate::srp::derive::{
+    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
+};
+use crate::srp::spec::{KeyUsage, NotBeforeOffset, X509Spec};
+
+pub(super) fn deterministic_base_time(label: &str, spec: &X509Spec) -> OffsetDateTime {
+    let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
+    deterministic_base_time_from_parts(&[
+        label.as_bytes(),
+        spec.subject_cn.as_bytes(),
+        spec.issuer_cn.as_bytes(),
+        &rsa_bits,
+    ])
+}
+
+pub(super) fn self_signed_params(
+    spec: &X509Spec,
+    base_time: OffsetDateTime,
+    rng: &mut impl RngCore,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.subject_cn.clone());
+
+    let not_before = apply_not_before(base_time, spec.not_before_offset);
+    params.not_before = not_before;
+    params.not_after = not_before + TimeDuration::days(spec.validity_days as i64);
+    params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
+        rng.fill_bytes(bytes);
+    }));
+
+    params.is_ca = ca_constraint(spec.is_ca);
+    params.key_usages = key_usage_purposes(spec.key_usage);
+    if !spec.is_ca {
+        params.extended_key_usages = tls_extended_key_usages();
+    }
+    add_sorted_dns_sans(&mut params, &spec.sans);
+
+    params
+}
+
+fn apply_not_before(base_time: OffsetDateTime, offset: NotBeforeOffset) -> OffsetDateTime {
+    match offset {
+        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
+        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
+    }
+}
+
+fn ca_constraint(is_ca: bool) -> IsCa {
+    if is_ca {
+        IsCa::Ca(BasicConstraints::Unconstrained)
+    } else {
+        IsCa::NoCa
+    }
+}
+
+fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
+    let mut purposes = Vec::new();
+    if key_usage.digital_signature {
+        purposes.push(KeyUsagePurpose::DigitalSignature);
+    }
+    if key_usage.key_encipherment {
+        purposes.push(KeyUsagePurpose::KeyEncipherment);
+    }
+    if key_usage.key_cert_sign {
+        purposes.push(KeyUsagePurpose::KeyCertSign);
+    }
+    if key_usage.crl_sign {
+        purposes.push(KeyUsagePurpose::CrlSign);
+    }
+    purposes
+}
+
+fn tls_extended_key_usages() -> Vec<ExtendedKeyUsagePurpose> {
+    vec![
+        ExtendedKeyUsagePurpose::ServerAuth,
+        ExtendedKeyUsagePurpose::ClientAuth,
+    ]
+}
+
+fn add_sorted_dns_sans(params: &mut CertificateParams, sans: &[String]) {
+    let mut sorted_sans = sans.to_vec();
+    sorted_sans.sort();
+    sorted_sans.dedup();
+
+    for san in &sorted_sans {
+        params.subject_alt_names.push(rcgen::SanType::DnsName(
+            san.clone().try_into().expect("valid DNS name"),
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

`load_inner_with_spec` in `crates/uselesskey-x509/src/cert.rs` was a 107-line closure that mixed six distinct responsibilities: RSA key material setup, deterministic time derivation, CA constraint setting, key-usage flag assembly, EKU assignment, and SAN sort/dedup. This PR splits it into two SRP submodules that mirror the pattern already established for `chain/`.

## Changes

- **New `cert/material.rs`** — RSA keypair generation and adaptation into an rcgen `KeyPair` (parallels `chain/material.rs`).
- **New `cert/params.rs`** — `CertificateParams` builder, with private helpers for not-before offset, CA constraint, key-usage purposes, TLS EKU, and sorted/deduplicated DNS SANs (parallels `chain/params.rs`).
- **`cert.rs`** — `load_inner_with_spec` shrinks from 107 lines to 23 lines of pure orchestration. Unused imports (`rcgen::*`, `rustls_pki_types`, `uselesskey_rsa::*`, `time::Duration`, `srp::derive::*`) are dropped. `NotBeforeOffset` moves into the test module since it is no longer used at module scope.

Cache domain (`DOMAIN_X509_CERT`), derivation inputs, key-label derivation (`{label}-key`), and serial-number RNG sequence are all preserved, so deterministic outputs are byte-stable.

## Test plan

- [x] `cargo build -p uselesskey-x509` — clean
- [x] `cargo clippy -p uselesskey-x509 --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p uselesskey-x509` — clean
- [x] `cargo test -p uselesskey-x509` — all unit, integration, and doctests pass
- [x] `cargo test -p uselesskey-x509 --test snapshots_x509` — all 4 insta snapshots pass (this is the strongest signal: PEM shape, key PEM shape, DER lengths, and full cert metadata are byte-stable)
- [x] `cargo build --workspace` — clean (no downstream consumers broken)


---
_Generated by [Claude Code](https://claude.ai/code/session_01D5kj9mFPzTEYEfc7Vy5EQb)_