### PR TITLE
test(ssh): cover host certs, accessors, debug redaction, and stable_bytes deltas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4990,6 +4990,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "ssh-key",
  "uselesskey-core",
+ "uselesskey-test-support",
 ]
 
 [[package]]

--- a/crates/uselesskey-ssh/Cargo.toml
+++ b/crates/uselesskey-ssh/Cargo.toml
@@ -21,6 +21,7 @@ rand_chacha = { version = "0.3.1", default-features = false }
 
 [dev-dependencies]
 proptest.workspace = true
+uselesskey-test-support = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-ssh/tests/ssh_fixtures.rs
+++ b/crates/uselesskey-ssh/tests/ssh_fixtures.rs
@@ -3,6 +3,7 @@ use uselesskey_core::Factory;
 use uselesskey_ssh::{
     SshCertFactoryExt, SshCertSpec, SshCertType, SshFactoryExt, SshSpec, SshValidity,
 };
+use uselesskey_test_support::{TestResult, ensure, ensure_eq, require_ok};
 
 #[test]
 fn round_trip_parse_openssh_keys() {
@@ -70,4 +71,161 @@ fn cert_principals_and_validity_match_spec() {
 
     let permit_pty = parsed.extensions().get("permit-pty").map(String::as_str);
     assert_eq!(permit_pty, Some(""));
+}
+
+#[test]
+fn host_cert_decodes_with_host_cert_type() -> TestResult<()> {
+    let fx = Factory::deterministic_from_str("ssh-host-cert-seed");
+    let spec = SshCertSpec::host(
+        ["host1.internal", "host2.internal"],
+        SshValidity::new(1_700_000_000, 1_700_001_000),
+    );
+
+    let cert_fx = fx.ssh_cert("host-cert", spec.clone());
+    let parsed = require_ok(
+        Certificate::from_openssh(cert_fx.certificate_openssh()),
+        "host certificate fixture must parse",
+    )?;
+
+    ensure_eq!(parsed.cert_type(), CertType::Host);
+    ensure_eq!(
+        parsed.valid_principals(),
+        &["host1.internal".to_string(), "host2.internal".to_string()][..]
+    );
+    ensure_eq!(parsed.valid_after(), spec.validity.valid_after);
+    ensure_eq!(parsed.valid_before(), spec.validity.valid_before);
+    Ok(())
+}
+
+#[test]
+fn empty_principals_yields_all_principals_valid() -> TestResult<()> {
+    let fx = Factory::deterministic_from_str("ssh-empty-principals-seed");
+    let spec = SshCertSpec {
+        principals: Vec::new(),
+        validity: SshValidity::new(1_700_000_000, 1_700_000_300),
+        cert_type: SshCertType::User,
+        critical_options: Vec::new(),
+        extensions: Vec::new(),
+    };
+
+    let cert_fx = fx.ssh_cert("anyone", spec);
+    let parsed = require_ok(
+        Certificate::from_openssh(cert_fx.certificate_openssh()),
+        "empty-principals certificate fixture must parse",
+    )?;
+
+    ensure!(
+        parsed.valid_principals().is_empty(),
+        "an empty principals list must encode 'all principals valid', got {:?}",
+        parsed.valid_principals()
+    );
+    Ok(())
+}
+
+#[test]
+fn key_pair_accessors_report_label_and_spec() -> TestResult<()> {
+    let fx = Factory::deterministic_from_str("ssh-key-accessors-seed");
+    let key = fx.ssh_key("my-deploy", SshSpec::ed25519());
+
+    ensure_eq!(key.label(), "my-deploy");
+    ensure_eq!(key.spec(), SshSpec::Ed25519);
+
+    let rsa_key = fx.ssh_key("my-rsa", SshSpec::rsa());
+    ensure_eq!(rsa_key.label(), "my-rsa");
+    ensure_eq!(rsa_key.spec(), SshSpec::Rsa);
+    Ok(())
+}
+
+#[test]
+fn cert_fixture_accessors_report_label_and_spec() -> TestResult<()> {
+    let fx = Factory::deterministic_from_str("ssh-cert-accessors-seed");
+    let spec = SshCertSpec::user(["alice"], SshValidity::new(1_700_000_000, 1_700_000_600));
+    let cert_fx = fx.ssh_cert("alice-cert", spec.clone());
+
+    ensure_eq!(cert_fx.label(), "alice-cert");
+    ensure_eq!(cert_fx.spec(), &spec);
+    Ok(())
+}
+
+#[test]
+fn ssh_spec_default_is_ed25519() -> TestResult<()> {
+    ensure_eq!(SshSpec::default(), SshSpec::Ed25519);
+    ensure_eq!(SshCertType::default(), SshCertType::User);
+    Ok(())
+}
+
+#[test]
+fn ssh_cert_type_stable_byte_distinguishes_variants() -> TestResult<()> {
+    ensure!(SshCertType::User.stable_byte() != SshCertType::Host.stable_byte());
+    Ok(())
+}
+
+#[test]
+fn key_pair_debug_omits_key_material() -> TestResult<()> {
+    let fx = Factory::deterministic_from_str("ssh-debug-seed");
+    let key = fx.ssh_key("debug-host", SshSpec::ed25519());
+    let dbg = format!("{key:?}");
+
+    ensure!(dbg.contains("SshKeyPair"));
+    ensure!(dbg.contains("debug-host"));
+    ensure!(
+        !dbg.contains("BEGIN OPENSSH PRIVATE KEY"),
+        "Debug output must not leak private key material: {dbg}"
+    );
+    ensure!(
+        !dbg.contains("ssh-ed25519 "),
+        "Debug output must not leak the public key body: {dbg}"
+    );
+    Ok(())
+}
+
+#[test]
+fn cert_fixture_debug_omits_key_material() -> TestResult<()> {
+    let fx = Factory::deterministic_from_str("ssh-cert-debug-seed");
+    let cert = fx.ssh_cert(
+        "debug-cert",
+        SshCertSpec::user(["alice"], SshValidity::new(1, 2)),
+    );
+    let dbg = format!("{cert:?}");
+
+    ensure!(dbg.contains("SshCertFixture"));
+    ensure!(dbg.contains("debug-cert"));
+    ensure!(
+        !dbg.contains("BEGIN OPENSSH PRIVATE KEY"),
+        "Debug output must not leak private key material: {dbg}"
+    );
+    ensure!(
+        !dbg.contains("ssh-ed25519-cert-v01"),
+        "Debug output must not leak the certificate body: {dbg}"
+    );
+    Ok(())
+}
+
+#[test]
+fn cert_spec_stable_bytes_change_with_critical_options_and_extensions() -> TestResult<()> {
+    let base = SshCertSpec::user(["alice"], SshValidity::new(1, 2));
+    let with_option = SshCertSpec {
+        critical_options: vec![("force-command".to_string(), "/bin/echo".to_string())],
+        ..base.clone()
+    };
+    let with_extension = SshCertSpec {
+        extensions: vec![("permit-pty".to_string(), String::new())],
+        ..base.clone()
+    };
+
+    ensure!(base.stable_bytes() != with_option.stable_bytes());
+    ensure!(base.stable_bytes() != with_extension.stable_bytes());
+    ensure!(with_option.stable_bytes() != with_extension.stable_bytes());
+    Ok(())
+}
+
+#[test]
+fn cert_spec_stable_bytes_change_with_validity_and_cert_type() -> TestResult<()> {
+    let user = SshCertSpec::user(["alice"], SshValidity::new(1, 2));
+    let later = SshCertSpec::user(["alice"], SshValidity::new(10, 20));
+    let host = SshCertSpec::host(["alice"], SshValidity::new(1, 2));
+
+    ensure!(user.stable_bytes() != later.stable_bytes());
+    ensure!(user.stable_bytes() != host.stable_bytes());
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Closes coverage gaps in `uselesskey-ssh` identified by manually walking the public surface against `tests/ssh_fixtures.rs` and the inline `mod tests` blocks. No production code changes.

## Gaps closed

| Area | What was missing | New test |
|---|---|---|
| `SshCertSpec::host` / `to_cert_type(Host)` | Host cert path was only used as a fixture in one test, the cert type was never asserted | `host_cert_decodes_with_host_cert_type` |
| `Builder::all_principals_valid` (empty principals) | Branch never exercised | `empty_principals_yields_all_principals_valid` |
| `SshKeyPair::label() / spec()` accessors | Never read | `key_pair_accessors_report_label_and_spec` |
| `SshCertFixture::label() / spec()` accessors | Never read | `cert_fixture_accessors_report_label_and_spec` |
| `Default` impls on `SshSpec` and `SshCertType` | Compiled but never checked | `ssh_spec_default_is_ed25519` |
| `SshCertType::stable_byte` Host vs User | Only User was tested | `ssh_cert_type_stable_byte_distinguishes_variants` |
| `SshKeyPair`/`SshCertFixture` `Debug` impl | Never asserted; key/cert material could leak | `key_pair_debug_omits_key_material`, `cert_fixture_debug_omits_key_material` |
| `SshCertSpec::stable_bytes` sensitivity | Only principal-change was checked; validity, cert_type, critical_options, extensions all silent on regression | `cert_spec_stable_bytes_change_with_critical_options_and_extensions`, `cert_spec_stable_bytes_change_with_validity_and_cert_type` |

10 new tests, all using `TestResult` + `ensure!`/`ensure_eq!`/`require_ok` so the no-panic-family check stays at zero new debt.

## Test plan

- [x] `cargo test -p uselesskey-ssh --tests` — 13/13 pass (10 new + 3 existing)
- [x] `cargo clippy -p uselesskey-ssh --tests --all-features -- -D warnings`
- [x] `cargo xtask check-no-panic-family` — only the pre-existing `xtask/src/user_path_smoke.rs:126` debt remains, no new debt from this branch
- [x] `cargo fmt --check -p uselesskey-ssh`

https://claude.ai/code/session_01R9SN1o9XoVTaVxj9w4VMzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9SN1o9XoVTaVxj9w4VMzD)_