### PR TITLE
test(ssh): cover spec accessors, debug, and fixture round-trips

### DIFF
--- a/crates/uselesskey-ssh/src/spec.rs
+++ b/crates/uselesskey-ssh/src/spec.rs
@@ -160,4 +160,114 @@ mod tests {
         let b = SshCertSpec::user(["bob"], SshValidity::new(1, 2)).stable_bytes();
         assert_ne!(a, b);
     }
+
+    #[test]
+    fn ssh_spec_default_is_ed25519() {
+        assert_eq!(SshSpec::default(), SshSpec::Ed25519);
+    }
+
+    #[test]
+    fn ssh_spec_constructors_return_expected_variants() {
+        assert_eq!(SshSpec::ed25519(), SshSpec::Ed25519);
+        assert_eq!(SshSpec::rsa(), SshSpec::Rsa);
+    }
+
+    #[test]
+    fn ssh_spec_stable_bytes_known_values() {
+        assert_eq!(SshSpec::Ed25519.stable_bytes(), [1]);
+        assert_eq!(SshSpec::Rsa.stable_bytes(), [2]);
+    }
+
+    #[test]
+    fn ssh_cert_type_default_is_user() {
+        assert_eq!(SshCertType::default(), SshCertType::User);
+    }
+
+    #[test]
+    fn ssh_cert_type_stable_byte_known_values() {
+        assert_eq!(SshCertType::User.stable_byte(), 1);
+        assert_eq!(SshCertType::Host.stable_byte(), 2);
+    }
+
+    #[test]
+    fn ssh_validity_new_assigns_fields() {
+        let v = SshValidity::new(100, 200);
+        assert_eq!(v.valid_after, 100);
+        assert_eq!(v.valid_before, 200);
+    }
+
+    #[test]
+    fn cert_spec_user_records_principals_and_type() {
+        let spec = SshCertSpec::user(["alice"], SshValidity::new(0, 1));
+        assert_eq!(spec.principals, vec!["alice".to_string()]);
+        assert_eq!(spec.cert_type, SshCertType::User);
+        assert!(spec.critical_options.is_empty());
+        assert!(spec.extensions.is_empty());
+    }
+
+    #[test]
+    fn cert_spec_user_accepts_empty_principals() {
+        let spec = SshCertSpec::user(std::iter::empty::<&str>(), SshValidity::new(0, 1));
+        assert!(spec.principals.is_empty());
+        assert_eq!(spec.cert_type, SshCertType::User);
+    }
+
+    #[test]
+    fn cert_spec_host_records_principals_and_type() {
+        let spec = SshCertSpec::host(["h1", "h2"], SshValidity::new(0, 1));
+        assert_eq!(spec.principals, vec!["h1".to_string(), "h2".to_string()]);
+        assert_eq!(spec.cert_type, SshCertType::Host);
+    }
+
+    #[test]
+    fn cert_spec_host_accepts_empty_principals() {
+        let spec = SshCertSpec::host(std::iter::empty::<&str>(), SshValidity::new(0, 1));
+        assert!(spec.principals.is_empty());
+        assert_eq!(spec.cert_type, SshCertType::Host);
+    }
+
+    #[test]
+    fn cert_spec_stable_bytes_change_with_cert_type() {
+        let validity = SshValidity::new(1, 2);
+        let user_bytes = SshCertSpec::user(["a"], validity).stable_bytes();
+        let host_bytes = SshCertSpec::host(["a"], validity).stable_bytes();
+        assert_ne!(user_bytes, host_bytes);
+    }
+
+    #[test]
+    fn cert_spec_stable_bytes_change_with_validity() {
+        let a = SshCertSpec::user(["x"], SshValidity::new(1, 2)).stable_bytes();
+        let b = SshCertSpec::user(["x"], SshValidity::new(1, 3)).stable_bytes();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cert_spec_stable_bytes_change_with_critical_options() {
+        let mut a = SshCertSpec::user(["x"], SshValidity::new(1, 2));
+        let mut b = SshCertSpec::user(["x"], SshValidity::new(1, 2));
+        b.critical_options
+            .push(("force-command".to_string(), "/bin/true".to_string()));
+        assert_eq!(a.stable_bytes(), a.stable_bytes());
+        assert_ne!(a.stable_bytes(), b.stable_bytes());
+        a.critical_options
+            .push(("force-command".to_string(), "/bin/true".to_string()));
+        assert_eq!(a.stable_bytes(), b.stable_bytes());
+    }
+
+    #[test]
+    fn cert_spec_stable_bytes_change_with_extensions() {
+        let mut a = SshCertSpec::user(["x"], SshValidity::new(1, 2));
+        let mut b = SshCertSpec::user(["x"], SshValidity::new(1, 2));
+        b.extensions.push(("permit-pty".to_string(), String::new()));
+        assert_ne!(a.stable_bytes(), b.stable_bytes());
+        a.extensions.push(("permit-pty".to_string(), String::new()));
+        assert_eq!(a.stable_bytes(), b.stable_bytes());
+    }
+
+    #[test]
+    fn cert_spec_stable_bytes_with_no_collections_is_deterministic() {
+        let spec = SshCertSpec::user(std::iter::empty::<&str>(), SshValidity::new(0, 1));
+        assert_eq!(spec.stable_bytes(), spec.stable_bytes());
+        assert!(!spec.stable_bytes().is_empty());
+    }
 }

--- a/crates/uselesskey-ssh/tests/ssh_accessors.rs
+++ b/crates/uselesskey-ssh/tests/ssh_accessors.rs
@@ -1,0 +1,132 @@
+use ssh_key::{Certificate, PrivateKey};
+use uselesskey_core::Factory;
+use uselesskey_ssh::{SshCertFactoryExt, SshCertSpec, SshFactoryExt, SshSpec, SshValidity};
+
+#[test]
+fn key_pair_getters_return_label_and_spec() {
+    let fx = Factory::deterministic_from_str("ssh-accessor-seed");
+    let key = fx.ssh_key("deploy", SshSpec::ed25519());
+
+    assert_eq!(key.label(), "deploy");
+    assert_eq!(key.spec(), SshSpec::Ed25519);
+}
+
+#[test]
+fn key_pair_debug_omits_key_material() {
+    let fx = Factory::deterministic_from_str("ssh-debug-seed");
+    let key = fx.ssh_key("deploy", SshSpec::ed25519());
+
+    let dbg = format!("{key:?}");
+    assert!(dbg.contains("SshKeyPair"));
+    assert!(dbg.contains("deploy"));
+    assert!(!dbg.contains(key.private_key_openssh()));
+}
+
+#[test]
+fn key_pair_private_key_is_openssh_pem() {
+    let fx = Factory::deterministic_from_str("ssh-pem-seed");
+    let key = fx.ssh_key("deploy", SshSpec::ed25519());
+
+    let pem = key.private_key_openssh();
+    assert!(pem.starts_with("-----BEGIN OPENSSH PRIVATE KEY-----"));
+    assert!(pem.contains("-----END OPENSSH PRIVATE KEY-----"));
+}
+
+#[test]
+fn key_pair_authorized_key_line_has_algorithm_prefix() {
+    let fx = Factory::deterministic_from_str("ssh-authz-line-seed");
+
+    let ed = fx.ssh_key("ed", SshSpec::ed25519());
+    assert!(ed.authorized_key_line().starts_with("ssh-ed25519 "));
+
+    let rsa = fx.ssh_key("rsa", SshSpec::rsa());
+    assert!(rsa.authorized_key_line().starts_with("ssh-rsa "));
+}
+
+#[test]
+fn different_specs_produce_different_keys() {
+    let fx = Factory::deterministic_from_str("ssh-spec-diff-seed");
+    let ed = fx.ssh_key("same-label", SshSpec::ed25519());
+    let rsa = fx.ssh_key("same-label", SshSpec::rsa());
+
+    assert_ne!(ed.private_key_openssh(), rsa.private_key_openssh());
+    assert_ne!(ed.authorized_key_line(), rsa.authorized_key_line());
+}
+
+#[test]
+fn cert_fixture_getters_return_label_and_spec() {
+    let fx = Factory::deterministic_from_str("ssh-cert-accessor-seed");
+    let spec = SshCertSpec::user(["alice"], SshValidity::new(0, 100));
+    let cert = fx.ssh_cert("cert-label", spec.clone());
+
+    assert_eq!(cert.label(), "cert-label");
+    assert_eq!(cert.spec(), &spec);
+}
+
+#[test]
+fn cert_fixture_debug_omits_key_material() {
+    let fx = Factory::deterministic_from_str("ssh-cert-debug-seed");
+    let spec = SshCertSpec::user(["alice"], SshValidity::new(0, 100));
+    let cert = fx.ssh_cert("cert-label", spec);
+
+    let dbg = format!("{cert:?}");
+    assert!(dbg.contains("SshCertFixture"));
+    assert!(dbg.contains("cert-label"));
+    assert!(!dbg.contains(cert.private_key_openssh()));
+}
+
+#[test]
+fn cert_fixture_private_key_is_openssh_pem() {
+    let fx = Factory::deterministic_from_str("ssh-cert-pem-seed");
+    let spec = SshCertSpec::user(["alice"], SshValidity::new(0, 100));
+    let cert = fx.ssh_cert("cert-pem", spec);
+
+    let pem = cert.private_key_openssh();
+    assert!(pem.starts_with("-----BEGIN OPENSSH PRIVATE KEY-----"));
+
+    PrivateKey::from_openssh(pem).expect("cert private key fixture must parse");
+}
+
+#[test]
+fn cert_fixture_certificate_helper_matches_openssh() {
+    let fx = Factory::deterministic_from_str("ssh-cert-helper-seed");
+    let spec = SshCertSpec::user(["alice"], SshValidity::new(0, 100));
+    let cert_fx = fx.ssh_cert("cert", spec);
+
+    let from_helper = cert_fx.certificate();
+    let from_string = Certificate::from_openssh(cert_fx.certificate_openssh()).unwrap();
+
+    assert_eq!(
+        from_helper.to_openssh().unwrap(),
+        from_string.to_openssh().unwrap()
+    );
+}
+
+#[test]
+fn cert_with_no_principals_marks_all_valid() {
+    let fx = Factory::deterministic_from_str("ssh-cert-empty-seed");
+    let spec = SshCertSpec::user(std::iter::empty::<&str>(), SshValidity::new(0, 100));
+    let cert = fx.ssh_cert("any-principal", spec).certificate();
+
+    assert!(cert.valid_principals().is_empty());
+}
+
+#[test]
+fn cert_with_different_validity_produces_different_material() {
+    let fx = Factory::deterministic_from_str("ssh-cert-validity-seed");
+    let a = fx
+        .ssh_cert(
+            "label",
+            SshCertSpec::user(["alice"], SshValidity::new(0, 100)),
+        )
+        .certificate_openssh()
+        .to_string();
+    let b = fx
+        .ssh_cert(
+            "label",
+            SshCertSpec::user(["alice"], SshValidity::new(0, 200)),
+        )
+        .certificate_openssh()
+        .to_string();
+    assert_ne!(a, b);
+}


### PR DESCRIPTION
## Summary

Closes coverage gaps in `uselesskey-ssh`:

- `SshSpec` / `SshCertType`: `Default`, named constructors, known-value `stable_bytes()` (verifies the wire format that backs cache keys).
- `SshValidity::new` field assignment.
- `SshCertSpec`: explicit construction with single/multiple/empty principals for both `user` and `host`; `stable_bytes()` variation across `cert_type`, `validity`, `critical_options`, and `extensions`.
- `SshKeyPair`: `label()`, `spec()`, `Debug` non-leak invariant, `private_key_openssh()` PEM header, `authorized_key_line()` algorithm prefix, different specs → different material.
- `SshCertFixture`: `label()`, `spec()`, `Debug` non-leak invariant, PEM round-trip parses, `certificate()` matches `certificate_openssh()`, empty-principals path marks `all_principals_valid`, validity differences propagate to material.

35 tests pass (`cargo test -p uselesskey-ssh --all-features`).

## Test plan

- [x] `cargo test -p uselesskey-ssh --all-features`
- [x] `cargo fmt -p uselesskey-ssh --check`
- [x] `cargo clippy -p uselesskey-ssh --all-features --all-targets -- -D warnings`

---
_Generated by [Claude Code](https://claude.ai/code/session_015oHchyrZP6euqa5B69NYi9)_