### PR TITLE
test(entropy,hmac,ed25519): cover domain constants, JWK shapes, clone/debug invariants

### DIFF
--- a/crates/uselesskey-ed25519/tests/ed25519_extra_coverage.rs
+++ b/crates/uselesskey-ed25519/tests/ed25519_extra_coverage.rs
@@ -1,0 +1,112 @@
+//! Extra coverage for uselesskey-ed25519:
+//!
+//! - Domain constant invariant.
+//! - DER length lower bounds (PKCS#8 / SPKI) for sanity / shape checks.
+//! - JWK `x`/`d` decode to 32 bytes.
+//! - Public JWKS cardinality is exactly 1.
+//! - Clone semantics preserve material.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_ed25519::{DOMAIN_ED25519_KEYPAIR, Ed25519FactoryExt, Ed25519Spec};
+
+fn det_fx(seed_label: &str) -> Factory {
+    Factory::deterministic(Seed::from_env_value(seed_label).unwrap())
+}
+
+#[test]
+fn domain_constant_is_stable() {
+    assert_eq!(DOMAIN_ED25519_KEYPAIR, "uselesskey:ed25519:keypair");
+}
+
+#[test]
+fn der_outputs_meet_minimum_lengths() {
+    let fx = det_fx("ed25519-der-len");
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+
+    // PKCS#8 v1 Ed25519 PrivateKeyInfo is fixed length (48 bytes).
+    assert!(kp.private_key_pkcs8_der().len() >= 48);
+    // SPKI for Ed25519 is fixed length (44 bytes).
+    assert!(kp.public_key_spki_der().len() >= 44);
+}
+
+#[test]
+fn pem_outputs_have_correct_headers() {
+    let fx = det_fx("ed25519-pem-headers");
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+
+    assert!(
+        kp.private_key_pkcs8_pem()
+            .starts_with("-----BEGIN PRIVATE KEY-----")
+    );
+    assert!(
+        kp.public_key_spki_pem()
+            .starts_with("-----BEGIN PUBLIC KEY-----")
+    );
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn public_jwk_has_expected_okp_shape() {
+    let fx = det_fx("ed25519-jwk-shape");
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+    let val = kp.public_jwk().to_value();
+
+    assert_eq!(val["kty"], "OKP");
+    assert_eq!(val["crv"], "Ed25519");
+    assert_eq!(val["use"], "sig");
+    assert_eq!(val["alg"], "EdDSA");
+    assert!(val["kid"].is_string());
+
+    let x = val["x"].as_str().expect("x field");
+    let decoded = URL_SAFE_NO_PAD.decode(x).expect("x is base64url");
+    assert_eq!(decoded.len(), 32, "Ed25519 public key is 32 bytes");
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn private_key_jwk_d_decodes_to_32_bytes() {
+    let fx = det_fx("ed25519-jwk-d");
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+    let val = kp.private_key_jwk().to_value();
+
+    assert_eq!(val["kty"], "OKP");
+    let d = val["d"].as_str().expect("d field");
+    let decoded = URL_SAFE_NO_PAD.decode(d).expect("d is base64url");
+    assert_eq!(decoded.len(), 32, "Ed25519 private scalar is 32 bytes");
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn public_jwks_has_exactly_one_entry() {
+    let fx = det_fx("ed25519-jwks-cardinality");
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+    let jwks = kp.public_jwks().to_value();
+
+    let keys = jwks["keys"].as_array().expect("keys array");
+    assert_eq!(keys.len(), 1);
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn public_jwks_json_matches_public_jwks_to_value() {
+    let fx = det_fx("ed25519-jwks-json");
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+
+    assert_eq!(kp.public_jwks_json(), kp.public_jwks().to_value());
+}
+
+#[test]
+fn clone_preserves_key_material() {
+    let fx = det_fx("ed25519-clone");
+    let original = fx.ed25519("svc", Ed25519Spec::new());
+    let cloned = original.clone();
+
+    assert_eq!(
+        original.private_key_pkcs8_der(),
+        cloned.private_key_pkcs8_der()
+    );
+    assert_eq!(original.public_key_spki_der(), cloned.public_key_spki_der());
+    assert_eq!(original.label(), cloned.label());
+}

--- a/crates/uselesskey-entropy/tests/entropy_extra_coverage.rs
+++ b/crates/uselesskey-entropy/tests/entropy_extra_coverage.rs
@@ -1,0 +1,92 @@
+//! Extra coverage for uselesskey-entropy:
+//!
+//! - Domain constant invariant.
+//! - Zero-length allocation and zero-length `fill_bytes` no-ops.
+//! - `fill_bytes_with_variant` matches `bytes_with_variant`.
+//! - Clone semantics.
+//! - Debug omits byte material.
+
+use uselesskey_core::{Factory, Seed};
+use uselesskey_entropy::{DOMAIN_ENTROPY_FIXTURE, EntropyFactoryExt};
+
+fn det_fx(seed_label: &str) -> Factory {
+    Factory::deterministic(Seed::from_env_value(seed_label).unwrap())
+}
+
+#[test]
+fn domain_constant_is_stable() {
+    // This is part of the cache key; changing it would silently invalidate
+    // every consumer's deterministic entropy. Pin it.
+    assert_eq!(DOMAIN_ENTROPY_FIXTURE, "uselesskey:entropy:fixture");
+}
+
+#[test]
+fn bytes_zero_returns_empty_vec() {
+    let fx = det_fx("entropy-zero");
+    let out = fx.entropy("svc").bytes(0);
+    assert!(out.is_empty());
+}
+
+#[test]
+fn fill_bytes_with_empty_slice_is_noop() {
+    let fx = det_fx("entropy-empty-fill");
+    let mut empty: [u8; 0] = [];
+    fx.entropy("svc").fill_bytes(&mut empty);
+    assert!(empty.is_empty());
+}
+
+#[test]
+fn fill_bytes_with_variant_matches_bytes_with_variant() {
+    let fx = det_fx("entropy-fill-variant");
+    let fixture = fx.entropy("svc");
+
+    let expected = fixture.bytes_with_variant(64, "alt");
+    let mut actual = vec![0u8; 64];
+    fixture.fill_bytes_with_variant(&mut actual, "alt");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn clone_produces_same_bytes() {
+    let fx = det_fx("entropy-clone");
+    let original = fx.entropy("svc");
+    let cloned = original.clone();
+
+    assert_eq!(original.bytes(32), cloned.bytes(32));
+    assert_eq!(original.label(), cloned.label());
+    assert_eq!(original.variant(), cloned.variant());
+}
+
+#[test]
+fn debug_includes_label_and_variant_but_no_byte_material() {
+    let fx = det_fx("entropy-debug-bytes");
+    let fixture = fx.entropy_with_variant("svc", "custom-variant");
+    // Ensure bytes are materialized in the cache so a leak would be visible.
+    let bytes = fixture.bytes(48);
+
+    let dbg = format!("{fixture:?}");
+    assert!(dbg.contains("EntropyFixture"));
+    assert!(dbg.contains("svc"));
+    assert!(dbg.contains("custom-variant"));
+
+    // Debug must not contain any of the actual bytes (hex or decimal).
+    let hex = bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
+    assert!(!dbg.contains(&hex), "debug leaked hex bytes: {dbg}");
+}
+
+#[test]
+fn variants_propagate_through_default_path() {
+    let fx = det_fx("entropy-variant-propagate");
+    let default = fx.entropy("svc");
+    let custom = fx.entropy_with_variant("svc", "custom");
+
+    // The default path uses the variant set on the fixture handle.
+    let default_bytes = default.bytes(32);
+    let custom_bytes = custom.bytes(32);
+    assert_ne!(default_bytes, custom_bytes);
+
+    // And explicit variants match the variant-bound fixtures.
+    let from_default_explicit = default.bytes_with_variant(32, "custom");
+    assert_eq!(custom_bytes, from_default_explicit);
+}

--- a/crates/uselesskey-hmac/tests/hmac_extra_coverage.rs
+++ b/crates/uselesskey-hmac/tests/hmac_extra_coverage.rs
@@ -1,0 +1,77 @@
+//! Extra coverage for uselesskey-hmac:
+//!
+//! - Domain constant invariant.
+//! - Clone semantics produce equal secret bytes and identity.
+//! - Debug omits raw secret bytes (existing test only covers label).
+//! - JWK `use_` field is "sig" (only checked exists today).
+
+use uselesskey_core::{Factory, Seed};
+use uselesskey_hmac::{DOMAIN_HMAC_SECRET, HmacFactoryExt, HmacSpec};
+
+fn det_fx(seed_label: &str) -> Factory {
+    Factory::deterministic(Seed::from_env_value(seed_label).unwrap())
+}
+
+#[test]
+fn domain_constant_is_stable() {
+    assert_eq!(DOMAIN_HMAC_SECRET, "uselesskey:hmac:secret");
+}
+
+#[test]
+fn clone_preserves_secret_and_identity() {
+    let fx = det_fx("hmac-clone");
+    let original = fx.hmac("issuer", HmacSpec::hs256());
+    let cloned = original.clone();
+
+    assert_eq!(original.secret_bytes(), cloned.secret_bytes());
+    assert_eq!(original.label(), cloned.label());
+    assert_eq!(original.spec(), cloned.spec());
+}
+
+#[test]
+fn clone_chain_preserves_secret() {
+    let fx = det_fx("hmac-clone-chain");
+    let original = fx.hmac("issuer", HmacSpec::hs384());
+    let chained = original.clone().clone().clone();
+    assert_eq!(original.secret_bytes(), chained.secret_bytes());
+}
+
+#[test]
+fn debug_omits_raw_secret_bytes() {
+    let fx = det_fx("hmac-debug-secret");
+    let secret = fx.hmac("issuer", HmacSpec::hs256());
+    let bytes_hex = secret
+        .secret_bytes()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+
+    let dbg = format!("{secret:?}");
+    assert!(!dbg.contains(&bytes_hex));
+    // Spot-check: do not leak the raw byte array form either.
+    let bytes_dbg = format!("{:?}", secret.secret_bytes());
+    assert!(!dbg.contains(&bytes_dbg));
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn jwk_use_field_is_sig() {
+    let fx = det_fx("hmac-jwk-use");
+    for spec in [HmacSpec::hs256(), HmacSpec::hs384(), HmacSpec::hs512()] {
+        let secret = fx.hmac("issuer", spec);
+        let val = secret.jwk().to_value();
+        assert_eq!(val["use"], "sig", "use field for {spec:?}");
+        assert_eq!(val["kty"], "oct", "kty field for {spec:?}");
+    }
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn jwks_keys_array_has_exactly_one_entry() {
+    let fx = det_fx("hmac-jwks-cardinality");
+    let secret = fx.hmac("issuer", HmacSpec::hs256());
+
+    let val = secret.jwks().to_value();
+    let keys = val["keys"].as_array().expect("keys array");
+    assert_eq!(keys.len(), 1);
+}


### PR DESCRIPTION
## Summary

Closes small coverage gaps across three sibling fixture crates.

### `uselesskey-entropy`
- Pin `DOMAIN_ENTROPY_FIXTURE` constant (part of every consumer's cache key — silent change would invalidate all deterministic outputs).
- `bytes(0)` returns empty; `fill_bytes(&mut [])` is a no-op.
- `fill_bytes_with_variant` matches `bytes_with_variant` for the same variant.
- `Clone` preserves bytes, label, variant.
- `Debug` includes label/variant but never byte material (hex form check).
- Default variant on the fixture handle propagates through `bytes()` and variant-bound fixtures produce the same material as explicit variant calls on the default fixture.

### `uselesskey-hmac`
- Pin `DOMAIN_HMAC_SECRET` constant.
- `Clone` preserves `secret_bytes`, `label`, `spec` (single + chained clones).
- `Debug` must not contain raw secret bytes (hex form check).
- JWK `use_` field is exactly `"sig"` across HS256/HS384/HS512.
- JWKS keys array has exactly one entry.

### `uselesskey-ed25519`
- Pin `DOMAIN_ED25519_KEYPAIR` constant.
- PKCS#8 / SPKI DER outputs meet minimum-length invariants.
- PEM outputs have the correct `BEGIN` headers.
- `public_jwk()` exercises every OKP field shape; `x` base64url decodes to 32 bytes; `private_key_jwk()` `d` decodes to 32 bytes.
- `public_jwks()` cardinality is exactly 1; `public_jwks_json()` matches `public_jwks().to_value()`.
- `Clone` preserves private/public DER and label.

No production code changes; 3 new test files, all green.

## Test plan

- [x] `cargo test -p uselesskey-entropy -p uselesskey-hmac -p uselesskey-ed25519 --all-features`
- [x] `cargo fmt --check` for each crate
- [x] `cargo clippy --all-features --all-targets -- -D warnings` for each crate

---
_Generated by [Claude Code](https://claude.ai/code/session_015oHchyrZP6euqa5B69NYi9)_