### PR TITLE
test(cli): cover runtime JWKS scanner-safe metadata

### DIFF
--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -381,6 +381,68 @@ fn bundle_profile_runtime_jwk_marks_public_key_artifacts_scanner_safe() -> TestR
 }
 
 #[test]
+fn bundle_profile_runtime_jwks_marks_public_key_artifacts_scanner_safe() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("bundle");
+
+    let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    cmd.args([
+        "bundle",
+        "--profile",
+        "runtime",
+        "--format",
+        "jwks",
+        "--seed",
+        "det-seed",
+        "--label",
+        "issuer",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    cmd.assert().success();
+
+    let manifest_path = bundle_dir.join("manifest.json");
+    let manifest: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("read manifest")?)
+            .test_context("manifest json")?;
+    let artifacts = manifest["artifacts"]
+        .as_array()
+        .test_context("artifacts array")?;
+
+    let public_jwks_kinds = ["rsa", "ecdsa", "ed25519"];
+    for kind in public_jwks_kinds {
+        let artifact = artifacts
+            .iter()
+            .find(|a| a["kind"].as_str() == Some(kind) && a["format"].as_str() == Some("jwks"))
+            .test_context(format!("{kind} jwks artifact"))?;
+        assert_eq!(
+            artifact["scanner_safe"], true,
+            "{kind} JWKS only contains public components and must be scanner-safe",
+        );
+    }
+
+    let hmac = artifacts
+        .iter()
+        .find(|a| a["kind"].as_str() == Some("hmac"))
+        .test_context("hmac artifact")?;
+    assert_eq!(
+        hmac["scanner_safe"], false,
+        "hmac JWKS includes the symmetric `k` secret",
+    );
+
+    let audit: Value = serde_json::from_slice(
+        &fs::read(bundle_dir.join("receipts/audit-surface.json"))
+            .test_context("read audit surface")?,
+    )
+    .test_context("audit json")?;
+    assert_eq!(
+        audit["runtime_material_count"], 2,
+        "only hmac + token carry secret material in runtime+jwks bundles",
+    );
+    Ok(())
+}
+
+#[test]
 fn bundle_profile_oidc_writes_contract_pack() -> TestResult<()> {
     let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("oidc");

--- a/xtask/src/user_path_smoke.rs
+++ b/xtask/src/user_path_smoke.rs
@@ -108,21 +108,26 @@ mod tests {
     }
 
     #[test]
-    fn user_path_smoke_rejects_non_target_output() {
+    fn user_path_smoke_rejects_non_target_output() -> Result<()> {
         let root = std::env::temp_dir().join("uselesskey-user-path-smoke-test");
         let outside = root
             .parent()
-            .unwrap_or_else(|| Path::new("/"))
+            .context("temp-dir test root has no parent")?
             .join("outside-user-path-smoke");
-        let err = ensure_target_child(&root, &outside).unwrap_err();
+        let err = match ensure_target_child(&root, &outside) {
+            Ok(()) => bail!("non-target output was accepted"),
+            Err(err) => err,
+        };
 
         assert!(err.to_string().contains("outside target"));
+        Ok(())
     }
 
     #[test]
-    fn user_path_smoke_accepts_target_output() {
+    fn user_path_smoke_accepts_target_output() -> Result<()> {
         let root = std::env::temp_dir().join("uselesskey-user-path-smoke-test");
 
-        ensure_target_child(&root, &root.join("target/user-path-smoke")).unwrap();
+        ensure_target_child(&root, &root.join("target/user-path-smoke"))?;
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Adds an end-to-end `runtime --format jwks` bundle test for scanner-safe metadata.
- Verifies RSA/ECDSA/Ed25519 JWKS artifacts are scanner-safe while HMAC/token runtime material remains counted as secret-bearing.
- Removes a no-panic-family test debt site in `xtask user_path_smoke` surfaced by the requested validation.

## Files added/changed
- `crates/uselesskey-cli/tests/cli.rs`
- `xtask/src/user_path_smoke.rs`

## Validation
- `cargo test -p uselesskey-cli --test cli --all-features bundle_profile_runtime_jwks_marks_public_key_artifacts_scanner_safe`
- `cargo test -p uselesskey-cli --all-features`
- `cargo clippy -p uselesskey-cli --all-features --tests -- -D warnings`
- `cargo xtask no-blob`
- `cargo xtask user-path-smoke`
- `cargo test -p xtask user_path_smoke`
- `cargo xtask check-no-panic-family`
- `cargo +nightly xtask pr-lite`
- `cargo xtask pr`
- `git diff --check`

## Non-goals
- No new fixture family or contract pack.
- No scanner-evasion or provider-compatibility claim changes.
- No release machinery or badge changes.

## What this enables next
- Closes the reviewer-identified JWKS integration coverage gap after the runtime scanner-safe metadata fix.
- Keeps adoption-smoke/no-panic validation green for the next queue item.