### PR TITLE
chore: ignore .claude/worktrees/ from agent isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,8 @@ output.txt
 .gemini/
 gha-creds-*.json
 
+# Claude Code agent worktrees (created by isolation: "worktree")
+.claude/worktrees/
+
 # shipper publish state (plan, receipts, etc.)
 .shipper/


### PR DESCRIPTION
## Summary

Claude Code spawns subagents into ephemeral git worktrees under `.claude/worktrees/<id>/` when invoked with `isolation: "worktree"`. These directories are tooling artifacts — never source — and were showing up as untracked noise in `git status`, tripping the local pre-commit guard.

The peer `.claude/agent-swarm-workflow/` directory remains tracked (workflow docs); only the worktree scratch space is ignored.

## Test plan
- [x] `git status` reports clean tree after a worktree-isolated agent runs
- [x] `.claude/agent-swarm-workflow/` files remain visible to git (`git ls-files .claude/agent-swarm-workflow/` unchanged)

https://claude.ai/code/session_01E8RKezJEugbwfJc5vd3Twy

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8RKezJEugbwfJc5vd3Twy)_