### PR TITLE
test(rustls): cover default-provider mTLS config builders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4979,6 +4979,7 @@ dependencies = [
  "uselesskey-ecdsa",
  "uselesskey-ed25519",
  "uselesskey-rsa",
+ "uselesskey-test-support",
  "uselesskey-x509",
 ]
 

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -47,6 +47,7 @@ uselesskey-x509 = { path = "../uselesskey-x509", version = "0.9.0" }
 uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.0" }
 uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.0" }
 uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.0" }
+uselesskey-test-support.workspace = true
 rustls = { version = "0.23", features = ["ring"] }
 hex = "0.4"
 serde.workspace = true

--- a/crates/uselesskey-rustls/src/config.rs
+++ b/crates/uselesskey-rustls/src/config.rs
@@ -473,6 +473,118 @@ mod tests {
         assert!(!server.is_handshaking());
     }
 
+    // -----------------------------------------------------------------
+    // Default-provider mTLS coverage (no-panic-helper style).
+    //
+    // The non-mTLS default-provider variants (`server_config_rustls`,
+    // `client_config_rustls`) are covered above, but the default-provider
+    // mTLS variants (`server_config_mtls_rustls`,
+    // `client_config_mtls_rustls`) were previously only exercised
+    // indirectly through cross-crate integration tests. These tests pin
+    // those code paths directly and use the `uselesskey-test-support`
+    // no-panic helpers so future migration work need not revisit them.
+    // -----------------------------------------------------------------
+
+    use uselesskey_test_support::{TestResult, ensure, require_ok};
+
+    #[test]
+    fn server_config_mtls_from_chain_default_provider() -> TestResult<()> {
+        install_provider();
+        let fx = super::super::testutil::fx();
+        let chain = fx.x509_chain("mtls-default-server", ChainSpec::new("test.example.com"));
+
+        // Building the config exercises the default-provider mTLS path
+        // including WebPkiClientVerifier::builder. A failure here would
+        // panic on the internal `.expect("valid mTLS server config")`.
+        let cfg = chain.server_config_mtls_rustls();
+
+        // Sanity-check defaults that the builder leaves untouched, to
+        // ensure we're observing a real ServerConfig and not just that
+        // construction didn't panic.
+        ensure!(
+            cfg.alpn_protocols.is_empty(),
+            "default ServerConfig must have no ALPN protocols configured",
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn client_config_mtls_from_chain_default_provider() -> TestResult<()> {
+        install_provider();
+        let fx = super::super::testutil::fx();
+        let chain = fx.x509_chain("mtls-default-client", ChainSpec::new("test.example.com"));
+
+        let cfg = chain.client_config_mtls_rustls();
+
+        ensure!(
+            cfg.alpn_protocols.is_empty(),
+            "default ClientConfig must have no ALPN protocols configured",
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn mtls_default_provider_pair_completes_handshake() -> TestResult<()> {
+        install_provider();
+        let fx = super::super::testutil::fx();
+        let chain = fx.x509_chain("mtls-default-handshake", ChainSpec::new("test.example.com"));
+
+        let server_config = Arc::new(chain.server_config_mtls_rustls());
+        let client_config = Arc::new(chain.client_config_mtls_rustls());
+
+        let server_name: rustls::pki_types::ServerName<'_> = require_ok(
+            "test.example.com".try_into(),
+            "test.example.com must parse as ServerName",
+        )?;
+        let mut server = require_ok(
+            rustls::ServerConnection::new(server_config),
+            "ServerConnection::new",
+        )?;
+        let mut client = require_ok(
+            rustls::ClientConnection::new(client_config, server_name.to_owned()),
+            "ClientConnection::new",
+        )?;
+
+        let mut buf = Vec::new();
+        for iteration in 0..MAX_HANDSHAKE_ITERATIONS {
+            let mut progress = false;
+
+            buf.clear();
+            if client.wants_write() {
+                require_ok(client.write_tls(&mut buf), "client.write_tls")?;
+                if !buf.is_empty() {
+                    require_ok(server.read_tls(&mut &buf[..]), "server.read_tls")?;
+                    require_ok(server.process_new_packets(), "server.process_new_packets")?;
+                    progress = true;
+                }
+            }
+
+            buf.clear();
+            if server.wants_write() {
+                require_ok(server.write_tls(&mut buf), "server.write_tls")?;
+                if !buf.is_empty() {
+                    require_ok(client.read_tls(&mut &buf[..]), "client.read_tls")?;
+                    require_ok(client.process_new_packets(), "client.process_new_packets")?;
+                    progress = true;
+                }
+            }
+
+            if !progress {
+                break;
+            }
+
+            ensure!(
+                iteration < MAX_HANDSHAKE_ITERATIONS - 1,
+                "default-provider mTLS handshake did not complete within {} iterations",
+                MAX_HANDSHAKE_ITERATIONS,
+            );
+        }
+
+        ensure!(!client.is_handshaking(), "client must finish handshaking");
+        ensure!(!server.is_handshaking(), "server must finish handshaking");
+        Ok(())
+    }
+
     #[test]
     fn mtls_roundtrip() {
         let fx = super::super::testutil::fx();


### PR DESCRIPTION
## Summary

Tests-only PR closing a coverage gap in `crates/uselesskey-rustls/src/config.rs`. The non-mTLS default-provider builders (`server_config_rustls`, `client_config_rustls`) were already inline-tested, but the default-provider mTLS variants on `X509Chain` had no direct inline coverage — they were only exercised indirectly through workspace-level integration tests.

The four public-config-method punchlist items from the task brief (`X509Chain`/`X509Cert` `server_config_rustls`/`client_config_rustls`) turned out to already have inline tests on `origin/main`, so this PR pivots to the genuinely-uncovered surface: `RustlsMtlsExt::{server_config_mtls_rustls, client_config_mtls_rustls}` for `X509Chain`.

- `server_config_mtls_from_chain_default_provider` — builds the default-provider mTLS `ServerConfig` and sanity-checks a known default.
- `client_config_mtls_from_chain_default_provider` — builds the default-provider mTLS `ClientConfig` and sanity-checks a known default.
- `mtls_default_provider_pair_completes_handshake` — drives a full mTLS handshake between a default-provider server and client to lock in interop without an explicit `CryptoProvider` argument.

All three new tests use `uselesskey-test-support`'s `TestResult` / `ensure!` / `require_ok` helpers and return `TestResult<()>`, so they add **zero** panic-family debt (`cargo xtask check-no-panic-family` reports `0 new-debt`). `uselesskey-test-support` was added to `dev-dependencies`.

## Test plan

- [x] `cargo test -p uselesskey-rustls --all-features` (24 lib tests pass; previously 21 with `--all-features`)
- [x] `cargo clippy -p uselesskey-rustls --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -p uselesskey-rustls` clean
- [x] `cargo xtask check-no-panic-family` — `0 new-debt`
- [ ] CI green on PR

https://claude.ai/code/session_TODO

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8RKezJEugbwfJc5vd3Twy)_