### PR TITLE
xtask: add adoption-regression receipt

### DIFF
--- a/xtask/src/adoption_regression.rs
+++ b/xtask/src/adoption_regression.rs
@@ -1,0 +1,465 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+
+use crate::{bundle_proof, git_head_sha, no_blob_gate, user_path_smoke};
+
+const OUT_DIR: &str = "target/adoption-regression";
+const BUNDLE_PROOF_DIR: &str = "target/adoption-regression/bundle-proof";
+const RUNTIME_MATRIX_DIR: &str = "target/adoption-regression/runtime-matrix";
+
+const BOUNDARIES: &[&str] = &[
+    "adoption-regression checks copied user paths; it is not release evidence",
+    "scanner-safe metadata is checked for fixture sensitivity, not scanner evasion",
+    "contract-pack proofs do not prove downstream verifier correctness",
+    "generated fixture payloads stay under target/",
+];
+
+#[derive(Clone, Copy, Debug)]
+pub enum OutputFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct AdoptionRegressionReceipt {
+    schema_version: u32,
+    status: String,
+    generated_at: String,
+    git_sha: Option<String>,
+    steps: Vec<AdoptionRegressionStep>,
+    artifacts: Vec<String>,
+    boundaries: Vec<&'static str>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct AdoptionRegressionStep {
+    name: String,
+    command: Vec<String>,
+    status: String,
+    duration_ms: u64,
+    details: Option<String>,
+    artifacts: Vec<String>,
+}
+
+pub fn run(root: &Path, format: OutputFormat) -> Result<()> {
+    let out_dir = root.join(OUT_DIR);
+    fs::create_dir_all(&out_dir)
+        .with_context(|| format!("failed to create {}", out_dir.display()))?;
+
+    let mut receipt = AdoptionRegressionReceipt {
+        schema_version: 1,
+        status: "running".to_string(),
+        generated_at: chrono::Utc::now().to_rfc3339(),
+        git_sha: git_head_sha().ok(),
+        steps: Vec::new(),
+        artifacts: vec![
+            "target/adoption-regression/adoption-regression.json".to_string(),
+            "target/adoption-regression/adoption-regression.md".to_string(),
+            "target/user-path-smoke/".to_string(),
+            "target/adoption-regression/runtime-matrix/".to_string(),
+            "target/adoption-regression/bundle-proof/".to_string(),
+        ],
+        boundaries: BOUNDARIES.to_vec(),
+    };
+
+    let result = run_steps(root, &mut receipt, matches!(format, OutputFormat::Json));
+    if result.is_ok() {
+        receipt.status = "pass".to_string();
+    } else {
+        receipt.status = "failed".to_string();
+    }
+
+    write_receipts(&out_dir, &receipt)?;
+    match format {
+        OutputFormat::Human => print_human(&receipt),
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&receipt)?),
+    }
+
+    result
+}
+
+fn run_steps(
+    root: &Path,
+    receipt: &mut AdoptionRegressionReceipt,
+    quiet_stdout: bool,
+) -> Result<()> {
+    run_step(
+        receipt,
+        "user-path-smoke",
+        &["cargo", "xtask", "user-path-smoke"],
+        &[
+            "target/user-path-smoke/",
+            "target/release-evidence/webhook/",
+            "target/claim-report/",
+            "target/contract-packs/",
+            "target/claim-proof/webhook-contract-pack/",
+        ],
+        || user_path_smoke_step(root, quiet_stdout),
+    )?;
+    run_step(
+        receipt,
+        "runtime-scanner-safe-matrix",
+        &["internal", "runtime-scanner-safe-matrix"],
+        &["target/adoption-regression/runtime-matrix/"],
+        || runtime_scanner_safe_matrix(root, quiet_stdout),
+    )?;
+    run_step(
+        receipt,
+        "webhook-profile-tests",
+        &[
+            "cargo",
+            "test",
+            "-p",
+            "uselesskey-webhook",
+            "--all-features",
+        ],
+        &[],
+        || {
+            let mut cmd = Command::new("cargo");
+            cmd.args(["test", "-p", "uselesskey-webhook", "--all-features"])
+                .current_dir(root)
+                .stdin(Stdio::null());
+            run_command(&mut cmd, quiet_stdout)
+        },
+    )?;
+    run_step(
+        receipt,
+        "tls-bundle-proof",
+        &[
+            "cargo",
+            "xtask",
+            "bundle-proof",
+            "--profile",
+            "tls",
+            "--out",
+            "target/adoption-regression/bundle-proof/tls",
+        ],
+        &["target/adoption-regression/bundle-proof/tls/"],
+        || bundle_proof_step(root, "tls", quiet_stdout),
+    )?;
+    run_step(
+        receipt,
+        "oidc-bundle-proof",
+        &[
+            "cargo",
+            "xtask",
+            "bundle-proof",
+            "--profile",
+            "oidc",
+            "--out",
+            "target/adoption-regression/bundle-proof/oidc",
+        ],
+        &["target/adoption-regression/bundle-proof/oidc/"],
+        || bundle_proof_step(root, "oidc", quiet_stdout),
+    )?;
+    run_step(
+        receipt,
+        "no-blob",
+        &["cargo", "xtask", "no-blob"],
+        &[],
+        || no_blob_step(root, quiet_stdout),
+    )?;
+
+    Ok(())
+}
+
+fn user_path_smoke_step(root: &Path, quiet_stdout: bool) -> Result<()> {
+    if quiet_stdout {
+        let mut cmd = Command::new("cargo");
+        cmd.args(["xtask", "user-path-smoke"])
+            .current_dir(root)
+            .stdin(Stdio::null());
+        run_command(&mut cmd, true)
+    } else {
+        user_path_smoke::run(root)
+    }
+}
+
+fn bundle_proof_step(root: &Path, profile: &str, quiet_stdout: bool) -> Result<()> {
+    let out = root.join(BUNDLE_PROOF_DIR).join(profile);
+    if quiet_stdout {
+        let mut cmd = Command::new("cargo");
+        cmd.args(["xtask", "bundle-proof", "--profile", profile, "--out"])
+            .arg(&out)
+            .current_dir(root)
+            .stdin(Stdio::null());
+        run_command(&mut cmd, true)
+    } else {
+        bundle_proof::run(profile, Some(&out))
+    }
+}
+
+fn no_blob_step(root: &Path, quiet_stdout: bool) -> Result<()> {
+    if quiet_stdout {
+        let mut cmd = Command::new("cargo");
+        cmd.args(["xtask", "no-blob"])
+            .current_dir(root)
+            .stdin(Stdio::null());
+        run_command(&mut cmd, true)
+    } else {
+        no_blob_gate()
+    }
+}
+
+fn runtime_scanner_safe_matrix(root: &Path, quiet_stdout: bool) -> Result<()> {
+    let out_root = root.join(RUNTIME_MATRIX_DIR);
+    if out_root.exists() {
+        fs::remove_dir_all(&out_root)
+            .with_context(|| format!("failed to remove {}", out_root.display()))?;
+    }
+    fs::create_dir_all(&out_root)
+        .with_context(|| format!("failed to create {}", out_root.display()))?;
+
+    for format in ["jwk", "jwks"] {
+        let bundle_dir = out_root.join(format);
+        let mut cmd = Command::new("cargo");
+        cmd.args([
+            "run",
+            "--quiet",
+            "-p",
+            "uselesskey-cli",
+            "--",
+            "bundle",
+            "--profile",
+            "runtime",
+            "--format",
+            format,
+            "--seed",
+            "adoption-regression-seed",
+            "--label",
+            "issuer",
+            "--out",
+        ])
+        .arg(&bundle_dir)
+        .current_dir(root)
+        .stdin(Stdio::null());
+        run_command(&mut cmd, quiet_stdout)
+            .with_context(|| format!("runtime scanner-safe {format} bundle failed"))?;
+        verify_runtime_manifest(&bundle_dir, format)?;
+    }
+
+    Ok(())
+}
+
+fn verify_runtime_manifest(bundle_dir: &Path, expected_format: &str) -> Result<()> {
+    let manifest: Value = read_json(&bundle_dir.join("manifest.json"))?;
+    let artifacts = manifest["artifacts"]
+        .as_array()
+        .context("manifest artifacts is not an array")?;
+
+    for kind in ["rsa", "ecdsa", "ed25519"] {
+        let artifact = find_artifact(artifacts, kind, expected_format)?;
+        if artifact["scanner_safe"] != true {
+            bail!("{kind} {expected_format} artifact is not scanner-safe");
+        }
+    }
+
+    for kind in ["hmac", "token"] {
+        let artifact = artifacts
+            .iter()
+            .find(|artifact| artifact["kind"].as_str() == Some(kind))
+            .with_context(|| format!("missing {kind} artifact"))?;
+        if artifact["scanner_safe"] != false {
+            bail!("{kind} runtime artifact should remain secret-bearing");
+        }
+    }
+
+    let audit: Value = read_json(&bundle_dir.join("receipts/audit-surface.json"))?;
+    if audit["runtime_material_count"] != 2 {
+        bail!("runtime_material_count drifted for {expected_format}");
+    }
+
+    Ok(())
+}
+
+fn find_artifact<'a>(artifacts: &'a [Value], kind: &str, format: &str) -> Result<&'a Value> {
+    artifacts
+        .iter()
+        .find(|artifact| {
+            artifact["kind"].as_str() == Some(kind) && artifact["format"].as_str() == Some(format)
+        })
+        .with_context(|| format!("missing {kind} {format} artifact"))
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn run_step<F>(
+    receipt: &mut AdoptionRegressionReceipt,
+    name: &str,
+    command: &[&str],
+    artifacts: &[&str],
+    f: F,
+) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    eprintln!("==> {name}");
+    let start = Instant::now();
+    match f() {
+        Ok(()) => {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            eprintln!("==> {name} [ok]");
+            receipt.steps.push(AdoptionRegressionStep {
+                name: name.to_string(),
+                command: command_to_strings(command),
+                status: "ok".to_string(),
+                duration_ms,
+                details: None,
+                artifacts: artifacts_to_strings(artifacts),
+            });
+            Ok(())
+        }
+        Err(err) => {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            let details = err.to_string();
+            eprintln!("==> {name} [FAILED]");
+            eprintln!("    {details}");
+            receipt.steps.push(AdoptionRegressionStep {
+                name: name.to_string(),
+                command: command_to_strings(command),
+                status: "failed".to_string(),
+                duration_ms,
+                details: Some(details),
+                artifacts: artifacts_to_strings(artifacts),
+            });
+            Err(err)
+        }
+    }
+}
+
+fn run_command(cmd: &mut Command, quiet_stdout: bool) -> Result<()> {
+    if quiet_stdout {
+        cmd.stdout(Stdio::null());
+    }
+    let status = cmd.status().context("failed to spawn command")?;
+    if !status.success() {
+        bail!("command failed with {status}");
+    }
+    Ok(())
+}
+
+fn write_receipts(out_dir: &Path, receipt: &AdoptionRegressionReceipt) -> Result<()> {
+    fs::create_dir_all(out_dir)
+        .with_context(|| format!("failed to create {}", out_dir.display()))?;
+    fs::write(
+        out_dir.join("adoption-regression.json"),
+        serde_json::to_string_pretty(receipt).context("failed to serialize adoption receipt")?,
+    )
+    .with_context(|| {
+        format!(
+            "failed to write {}",
+            out_dir.join("adoption-regression.json").display()
+        )
+    })?;
+    fs::write(
+        out_dir.join("adoption-regression.md"),
+        render_markdown(receipt),
+    )
+    .with_context(|| {
+        format!(
+            "failed to write {}",
+            out_dir.join("adoption-regression.md").display()
+        )
+    })
+}
+
+fn render_markdown(receipt: &AdoptionRegressionReceipt) -> String {
+    let mut md = String::new();
+    md.push_str("# Adoption Regression Receipt\n\n");
+    md.push_str(&format!("Status: `{}`\n\n", receipt.status));
+    if let Some(git_sha) = &receipt.git_sha {
+        md.push_str(&format!("Git SHA: `{git_sha}`\n\n"));
+    }
+
+    md.push_str("## Steps\n\n");
+    md.push_str("| Step | Status | Command | Details |\n");
+    md.push_str("| --- | --- | --- | --- |\n");
+    for step in &receipt.steps {
+        let command = step.command.join(" ");
+        let details = step.details.as_deref().unwrap_or("");
+        md.push_str(&format!(
+            "| {} | `{}` | `{}` | {} |\n",
+            step.name, step.status, command, details
+        ));
+    }
+
+    md.push_str("\n## Boundaries\n\n");
+    for boundary in &receipt.boundaries {
+        md.push_str(&format!("- {boundary}\n"));
+    }
+
+    md
+}
+
+fn print_human(receipt: &AdoptionRegressionReceipt) {
+    println!(
+        "adoption-regression: {} (steps={})",
+        receipt.status,
+        receipt.steps.len()
+    );
+    println!(
+        "adoption-regression: wrote target/adoption-regression/adoption-regression.json and target/adoption-regression/adoption-regression.md"
+    );
+}
+
+fn command_to_strings(command: &[&str]) -> Vec<String> {
+    command.iter().map(|part| (*part).to_string()).collect()
+}
+
+fn artifacts_to_strings(artifacts: &[&str]) -> Vec<String> {
+    artifacts.iter().map(|path| (*path).to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adoption_regression_receipt_markdown_lists_boundaries() {
+        let receipt = AdoptionRegressionReceipt {
+            schema_version: 1,
+            status: "pass".to_string(),
+            generated_at: "2026-05-16T00:00:00Z".to_string(),
+            git_sha: Some("abc123".to_string()),
+            steps: vec![AdoptionRegressionStep {
+                name: "no-blob".to_string(),
+                command: vec![
+                    "cargo".to_string(),
+                    "xtask".to_string(),
+                    "no-blob".to_string(),
+                ],
+                status: "ok".to_string(),
+                duration_ms: 1,
+                details: None,
+                artifacts: Vec::new(),
+            }],
+            artifacts: Vec::new(),
+            boundaries: BOUNDARIES.to_vec(),
+        };
+
+        let markdown = render_markdown(&receipt);
+        assert!(markdown.contains("adoption-regression checks copied user paths"));
+        assert!(markdown.contains("| no-blob | `ok` | `cargo xtask no-blob` |  |"));
+    }
+
+    #[test]
+    fn adoption_regression_artifact_paths_are_target_scoped() {
+        for path in [
+            OUT_DIR,
+            BUNDLE_PROOF_DIR,
+            RUNTIME_MATRIX_DIR,
+            "target/user-path-smoke",
+        ] {
+            assert!(path.starts_with("target/"));
+        }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,6 +15,7 @@ use owo_colors::OwoColorize;
 use regex::Regex;
 use uselesskey_feature_grid::{BDD_FEATURE_MATRIX, CORE_FEATURE_MATRIX};
 
+mod adoption_regression;
 mod audit_surface;
 mod bundle_proof;
 mod claim_proof;
@@ -102,6 +103,12 @@ enum Cmd {
     },
     /// Run bounded first-run user-path smoke checks.
     UserPathSmoke,
+    /// Run bounded adoption-path regression checks and write receipts.
+    AdoptionRegression {
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: AdoptionRegressionFormat,
+    },
     /// Run publish dry-runs for crates in dependency order.
     PublishCheck,
     /// Run PR-scoped tests based on git diff.
@@ -506,6 +513,12 @@ enum DoctorFormat {
     Json,
 }
 
+#[derive(Clone, Debug, ValueEnum)]
+enum AdoptionRegressionFormat {
+    Human,
+    Json,
+}
+
 impl From<SpecCheckFormat> for spec_check::OutputFormat {
     fn from(value: SpecCheckFormat) -> Self {
         match value {
@@ -538,6 +551,15 @@ impl From<DoctorFormat> for doctor::OutputFormat {
         match value {
             DoctorFormat::Human => doctor::OutputFormat::Human,
             DoctorFormat::Json => doctor::OutputFormat::Json,
+        }
+    }
+}
+
+impl From<AdoptionRegressionFormat> for adoption_regression::OutputFormat {
+    fn from(value: AdoptionRegressionFormat) -> Self {
+        match value {
+            AdoptionRegressionFormat::Human => adoption_regression::OutputFormat::Human,
+            AdoptionRegressionFormat::Json => adoption_regression::OutputFormat::Json,
         }
     }
 }
@@ -576,6 +598,9 @@ fn main() -> Result<()> {
         Cmd::PublicSurface => public_surface::public_surface_cmd(PUBLISH_CRATES),
         Cmd::ExamplesSmoke { run } => docs_sync::examples_smoke_cmd(run),
         Cmd::UserPathSmoke => user_path_smoke::run(&workspace_root_path()),
+        Cmd::AdoptionRegression { format } => {
+            adoption_regression::run(&workspace_root_path(), format.into())
+        }
         Cmd::PublishCheck => publish_check(),
         Cmd::Pr { with_mutants } => pr(with_mutants),
         Cmd::PrLite { format } => pr_lite(format),


### PR DESCRIPTION
## Summary
- add cargo xtask adoption-regression with human and JSON receipt output
- run bounded copied-user-path checks: user-path-smoke, runtime scanner-safe matrix, webhook tests, TLS/OIDC bundle proofs, and no-blob
- write metadata receipts under target/adoption-regression/ while keeping generated fixture payloads under target/

## Files added/changed
- xtask/src/main.rs: registers the adoption-regression command and --format json option
- xtask/src/adoption_regression.rs: implements the receipt runner, runtime scanner-safe matrix, markdown/json receipts, and focused tests

## Validation
- cargo test -p xtask adoption_regression
- cargo clippy -p xtask --all-targets -- -D warnings
- cargo xtask adoption-regression
- cargo xtask adoption-regression --format json with stdout parsed as JSON
- cargo +nightly xtask pr-lite
- cargo xtask pr
- git diff --check

## Non-goals
- no new fixture families or contract packs
- no release machinery changes
- no new public claims or badges
- no arbitrary command execution from TOML

## What this enables next
- gives the adoption-correctness lane a single bounded receipt for copied user paths, scanner-safe runtime metadata, and stable contract-pack proof coverage