### PR TITLE
Refactor X.509 self-signed generation into SRP submodules

### DIFF
--- a/crates/uselesskey-x509/src/cert.rs
+++ b/crates/uselesskey-x509/src/cert.rs
@@ -3,30 +3,17 @@
 use std::fmt;
 use std::sync::Arc;
 
-use rand_chacha::ChaCha20Rng;
-use rand_core::RngCore;
-use rand_core::SeedableRng;
-use rcgen::{
-    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-    KeyUsagePurpose, PKCS_RSA_SHA256,
-};
-use rustls_pki_types::PrivatePkcs8KeyDer;
-use time::Duration as TimeDuration;
-use uselesskey_core::negative::CorruptPem;
-use uselesskey_core::sink::TempArtifact;
-use uselesskey_core::{Error, Factory};
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
-
 use crate::chain::X509Chain;
 use crate::negative::{
     corrupt_cert_der_deterministic, corrupt_cert_pem, corrupt_cert_pem_deterministic,
     truncate_cert_der,
 };
-use crate::srp::derive::{
-    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
-};
+use crate::srp::cert_material::generate_self_signed;
 use crate::srp::negative::X509Negative;
-use crate::srp::spec::{ChainSpec, NotBeforeOffset, X509Spec};
+use crate::srp::spec::{ChainSpec, X509Spec};
+use uselesskey_core::negative::CorruptPem;
+use uselesskey_core::sink::TempArtifact;
+use uselesskey_core::{Error, Factory};
 
 /// Cache domain for X.509 certificate fixtures.
 ///
@@ -486,102 +473,13 @@ fn load_inner_with_spec(
     let spec_bytes = spec.stable_bytes();
 
     factory.get_or_init(DOMAIN_X509_CERT, label, &spec_bytes, variant, |seed| {
-        let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
-        // Generate RSA key using uselesskey-rsa for deterministic key generation.
-        // We use the label + variant to derive a unique key.
-        let key_label = format!("{}-key", label);
-        let rsa_spec = RsaSpec::new(spec.rsa_bits);
-        let rsa_keypair = factory.rsa(&key_label, rsa_spec);
-
-        // Get the PKCS#8 DER key and convert it to rcgen's KeyPair
-        let pkcs8_der = rsa_keypair.private_key_pkcs8_der();
-        let pkcs8_key = PrivatePkcs8KeyDer::from(pkcs8_der.to_vec());
-        let key_pair =
-            KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_key, &PKCS_RSA_SHA256).expect("key parse");
-
-        // Build certificate parameters
-        let mut params = CertificateParams::default();
-        params
-            .distinguished_name
-            .push(DnType::CommonName, spec.subject_cn.clone());
-
-        // Set validity period based on spec
-        let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
-        let base_time = deterministic_base_time_from_parts(&[
-            label.as_bytes(),
-            spec.subject_cn.as_bytes(),
-            spec.issuer_cn.as_bytes(),
-            &rsa_bits,
-        ]);
-
-        let not_before = match spec.not_before_offset {
-            NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
-            NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
-        };
-
-        let not_after = not_before + TimeDuration::days(spec.validity_days as i64);
-
-        params.not_before = not_before;
-        params.not_after = not_after;
-        params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        // Set CA status
-        if spec.is_ca {
-            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        } else {
-            params.is_ca = IsCa::NoCa;
-        }
-
-        // Set key usage
-        let mut key_usages = Vec::new();
-        if spec.key_usage.digital_signature {
-            key_usages.push(KeyUsagePurpose::DigitalSignature);
-        }
-        if spec.key_usage.key_encipherment {
-            key_usages.push(KeyUsagePurpose::KeyEncipherment);
-        }
-        if spec.key_usage.key_cert_sign {
-            key_usages.push(KeyUsagePurpose::KeyCertSign);
-        }
-        if spec.key_usage.crl_sign {
-            key_usages.push(KeyUsagePurpose::CrlSign);
-        }
-        params.key_usages = key_usages;
-
-        // Add extended key usage for TLS
-        if !spec.is_ca {
-            params.extended_key_usages = vec![
-                ExtendedKeyUsagePurpose::ServerAuth,
-                ExtendedKeyUsagePurpose::ClientAuth,
-            ];
-        }
-
-        // Add Subject Alternative Names
-        let mut sorted_sans = spec.sans.clone();
-        sorted_sans.sort();
-        sorted_sans.dedup();
-        for san in &sorted_sans {
-            params.subject_alt_names.push(rcgen::SanType::DnsName(
-                san.clone().try_into().expect("valid DNS name"),
-            ));
-        }
-
-        // Generate the self-signed certificate
-        let cert = params.self_signed(&key_pair).expect("cert generation");
-
-        let cert_der: Arc<[u8]> = Arc::from(cert.der().as_ref());
-        let cert_pem = cert.pem();
-
-        let private_key_pkcs8_der: Arc<[u8]> = Arc::from(pkcs8_der);
-        let private_key_pkcs8_pem = rsa_keypair.private_key_pkcs8_pem().to_string();
+        let material = generate_self_signed(factory, label, spec, &seed);
 
         Inner {
-            cert_der,
-            cert_pem,
-            private_key_pkcs8_der,
-            private_key_pkcs8_pem,
+            cert_der: material.cert_der,
+            cert_pem: material.cert_pem,
+            private_key_pkcs8_der: material.private_key_pkcs8_der,
+            private_key_pkcs8_pem: material.private_key_pkcs8_pem,
         }
     })
 }
@@ -589,6 +487,7 @@ fn load_inner_with_spec(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::srp::spec::NotBeforeOffset;
     use crate::testutil::fx;
     use uselesskey_core::Seed;
 

--- a/crates/uselesskey-x509/src/srp/cert_material.rs
+++ b/crates/uselesskey-x509/src/srp/cert_material.rs
@@ -1,0 +1,55 @@
+//! Self-signed certificate material generation.
+
+use std::sync::Arc;
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use rcgen::{KeyPair, PKCS_RSA_SHA256};
+use rustls_pki_types::PrivatePkcs8KeyDer;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+use crate::srp::cert_params::self_signed_params;
+use crate::srp::spec::X509Spec;
+
+pub(crate) struct SelfSignedMaterial {
+    pub(crate) cert_der: Arc<[u8]>,
+    pub(crate) cert_pem: String,
+    pub(crate) private_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) private_key_pkcs8_pem: String,
+}
+
+pub(crate) fn generate_self_signed(
+    factory: &Factory,
+    label: &str,
+    spec: &X509Spec,
+    seed: &Seed,
+) -> SelfSignedMaterial {
+    let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
+    let rsa_keypair = certificate_keypair(factory, label, spec);
+    let pkcs8_der = rsa_keypair.private_key_pkcs8_der();
+    let key_pair = rcgen_keypair(pkcs8_der);
+    let params = self_signed_params(label, spec, &mut rng);
+    let cert = params.self_signed(&key_pair).expect("cert generation");
+
+    SelfSignedMaterial {
+        cert_der: Arc::from(cert.der().as_ref()),
+        cert_pem: cert.pem(),
+        private_key_pkcs8_der: Arc::from(pkcs8_der),
+        private_key_pkcs8_pem: rsa_keypair.private_key_pkcs8_pem().to_string(),
+    }
+}
+
+fn certificate_keypair(
+    factory: &Factory,
+    label: &str,
+    spec: &X509Spec,
+) -> uselesskey_rsa::RsaKeyPair {
+    let key_label = format!("{}-key", label);
+    factory.rsa(&key_label, RsaSpec::new(spec.rsa_bits))
+}
+
+fn rcgen_keypair(pkcs8_der: &[u8]) -> KeyPair {
+    let pkcs8_key = PrivatePkcs8KeyDer::from(pkcs8_der.to_vec());
+    KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_key, &PKCS_RSA_SHA256).expect("key parse")
+}

--- a/crates/uselesskey-x509/src/srp/cert_params.rs
+++ b/crates/uselesskey-x509/src/srp/cert_params.rs
@@ -1,0 +1,104 @@
+//! Certificate parameter assembly for self-signed X.509 fixtures.
+
+use rand_core::RngCore;
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+    SerialNumber,
+};
+use time::Duration as TimeDuration;
+use time::OffsetDateTime;
+
+use crate::srp::derive::{
+    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
+};
+use crate::srp::spec::{KeyUsage, NotBeforeOffset, X509Spec};
+
+pub(crate) fn self_signed_params(
+    label: &str,
+    spec: &X509Spec,
+    rng: &mut impl RngCore,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.subject_cn.clone());
+    params.not_before = not_before(label, spec);
+    params.not_after = params.not_before + TimeDuration::days(spec.validity_days as i64);
+    params.serial_number = Some(next_serial_number(rng));
+    params.is_ca = ca_status(spec.is_ca);
+    params.key_usages = key_usage_purposes(spec.key_usage);
+
+    if !spec.is_ca {
+        params.extended_key_usages = leaf_extended_key_usages();
+    }
+
+    add_sorted_dns_sans(&mut params, &spec.sans);
+    params
+}
+
+fn not_before(label: &str, spec: &X509Spec) -> OffsetDateTime {
+    let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
+    let base_time = deterministic_base_time_from_parts(&[
+        label.as_bytes(),
+        spec.subject_cn.as_bytes(),
+        spec.issuer_cn.as_bytes(),
+        &rsa_bits,
+    ]);
+
+    apply_not_before(base_time, spec.not_before_offset)
+}
+
+fn apply_not_before(base_time: OffsetDateTime, offset: NotBeforeOffset) -> OffsetDateTime {
+    match offset {
+        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
+        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
+    }
+}
+
+fn ca_status(is_ca: bool) -> IsCa {
+    if is_ca {
+        IsCa::Ca(BasicConstraints::Unconstrained)
+    } else {
+        IsCa::NoCa
+    }
+}
+
+fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
+    let mut purposes = Vec::new();
+    if key_usage.digital_signature {
+        purposes.push(KeyUsagePurpose::DigitalSignature);
+    }
+    if key_usage.key_encipherment {
+        purposes.push(KeyUsagePurpose::KeyEncipherment);
+    }
+    if key_usage.key_cert_sign {
+        purposes.push(KeyUsagePurpose::KeyCertSign);
+    }
+    if key_usage.crl_sign {
+        purposes.push(KeyUsagePurpose::CrlSign);
+    }
+    purposes
+}
+
+fn leaf_extended_key_usages() -> Vec<ExtendedKeyUsagePurpose> {
+    vec![
+        ExtendedKeyUsagePurpose::ServerAuth,
+        ExtendedKeyUsagePurpose::ClientAuth,
+    ]
+}
+
+fn add_sorted_dns_sans(params: &mut CertificateParams, sans: &[String]) {
+    let mut sorted_sans = sans.to_vec();
+    sorted_sans.sort();
+    sorted_sans.dedup();
+
+    for san in &sorted_sans {
+        params.subject_alt_names.push(rcgen::SanType::DnsName(
+            san.clone().try_into().expect("valid DNS name"),
+        ));
+    }
+}
+
+fn next_serial_number(rng: &mut impl RngCore) -> SerialNumber {
+    deterministic_serial_number_with_rng(|bytes| rng.fill_bytes(bytes))
+}

--- a/crates/uselesskey-x509/src/srp/mod.rs
+++ b/crates/uselesskey-x509/src/srp/mod.rs
@@ -1,5 +1,7 @@
 //! Single-responsibility internals for X.509 fixture generation.
 
+pub(crate) mod cert_material;
+pub(crate) mod cert_params;
 pub mod chain_negative;
 pub mod derive;
 pub mod negative;


### PR DESCRIPTION
### Motivation
- Reduce complexity in `cert.rs` by moving self-signed certificate assembly and parameter logic into small, single-responsibility SRP submodules.  
- Improve maintainability and testability while preserving the public X.509 fixture API and deterministic/cached behavior.  

### Description
- Extracted self-signed certificate material generation into `crates/uselesskey-x509/src/srp/cert_material.rs` as `generate_self_signed` which returns a `SelfSignedMaterial`.  
- Extracted certificate parameter assembly (validity, CA status, key usage, EKU, SAN normalization, deterministic serials) into `crates/uselesskey-x509/src/srp/cert_params.rs` via `self_signed_params`.  
- Updated `crates/uselesskey-x509/src/cert.rs` to delegate to `generate_self_signed` inside the cache loader and map returned material into the existing `Inner` shape so the public API is unchanged.  
- Added `pub(crate)` module entries in `crates/uselesskey-x509/src/srp/mod.rs` to expose the new SRP helpers internally and kept visibility confined to the crate.  

### Testing
- Ran `cargo check -p uselesskey-x509` and it completed successfully.  
- Ran `cargo test -p uselesskey-x509` and the crate tests succeeded (all tests passed).  
- Ran the lint/fmt check via `cargo xtask lint-fix --check` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bd59e3888333aa9d9adf29fe9a88)