### PR TITLE
Refactor X.509 self-signed generation into SRP helpers

### DIFF
--- a/crates/uselesskey-x509/src/cert.rs
+++ b/crates/uselesskey-x509/src/cert.rs
@@ -3,30 +3,18 @@
 use std::fmt;
 use std::sync::Arc;
 
-use rand_chacha::ChaCha20Rng;
-use rand_core::RngCore;
-use rand_core::SeedableRng;
-use rcgen::{
-    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-    KeyUsagePurpose, PKCS_RSA_SHA256,
-};
-use rustls_pki_types::PrivatePkcs8KeyDer;
-use time::Duration as TimeDuration;
 use uselesskey_core::negative::CorruptPem;
 use uselesskey_core::sink::TempArtifact;
 use uselesskey_core::{Error, Factory};
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
 
 use crate::chain::X509Chain;
 use crate::negative::{
     corrupt_cert_der_deterministic, corrupt_cert_pem, corrupt_cert_pem_deterministic,
     truncate_cert_der,
 };
-use crate::srp::derive::{
-    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
-};
+use crate::srp::cert::build_self_signed_cert_material;
 use crate::srp::negative::X509Negative;
-use crate::srp::spec::{ChainSpec, NotBeforeOffset, X509Spec};
+use crate::srp::spec::{ChainSpec, X509Spec};
 
 /// Cache domain for X.509 certificate fixtures.
 ///
@@ -486,102 +474,13 @@ fn load_inner_with_spec(
     let spec_bytes = spec.stable_bytes();
 
     factory.get_or_init(DOMAIN_X509_CERT, label, &spec_bytes, variant, |seed| {
-        let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
-        // Generate RSA key using uselesskey-rsa for deterministic key generation.
-        // We use the label + variant to derive a unique key.
-        let key_label = format!("{}-key", label);
-        let rsa_spec = RsaSpec::new(spec.rsa_bits);
-        let rsa_keypair = factory.rsa(&key_label, rsa_spec);
-
-        // Get the PKCS#8 DER key and convert it to rcgen's KeyPair
-        let pkcs8_der = rsa_keypair.private_key_pkcs8_der();
-        let pkcs8_key = PrivatePkcs8KeyDer::from(pkcs8_der.to_vec());
-        let key_pair =
-            KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_key, &PKCS_RSA_SHA256).expect("key parse");
-
-        // Build certificate parameters
-        let mut params = CertificateParams::default();
-        params
-            .distinguished_name
-            .push(DnType::CommonName, spec.subject_cn.clone());
-
-        // Set validity period based on spec
-        let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
-        let base_time = deterministic_base_time_from_parts(&[
-            label.as_bytes(),
-            spec.subject_cn.as_bytes(),
-            spec.issuer_cn.as_bytes(),
-            &rsa_bits,
-        ]);
-
-        let not_before = match spec.not_before_offset {
-            NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
-            NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
-        };
-
-        let not_after = not_before + TimeDuration::days(spec.validity_days as i64);
-
-        params.not_before = not_before;
-        params.not_after = not_after;
-        params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        // Set CA status
-        if spec.is_ca {
-            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        } else {
-            params.is_ca = IsCa::NoCa;
-        }
-
-        // Set key usage
-        let mut key_usages = Vec::new();
-        if spec.key_usage.digital_signature {
-            key_usages.push(KeyUsagePurpose::DigitalSignature);
-        }
-        if spec.key_usage.key_encipherment {
-            key_usages.push(KeyUsagePurpose::KeyEncipherment);
-        }
-        if spec.key_usage.key_cert_sign {
-            key_usages.push(KeyUsagePurpose::KeyCertSign);
-        }
-        if spec.key_usage.crl_sign {
-            key_usages.push(KeyUsagePurpose::CrlSign);
-        }
-        params.key_usages = key_usages;
-
-        // Add extended key usage for TLS
-        if !spec.is_ca {
-            params.extended_key_usages = vec![
-                ExtendedKeyUsagePurpose::ServerAuth,
-                ExtendedKeyUsagePurpose::ClientAuth,
-            ];
-        }
-
-        // Add Subject Alternative Names
-        let mut sorted_sans = spec.sans.clone();
-        sorted_sans.sort();
-        sorted_sans.dedup();
-        for san in &sorted_sans {
-            params.subject_alt_names.push(rcgen::SanType::DnsName(
-                san.clone().try_into().expect("valid DNS name"),
-            ));
-        }
-
-        // Generate the self-signed certificate
-        let cert = params.self_signed(&key_pair).expect("cert generation");
-
-        let cert_der: Arc<[u8]> = Arc::from(cert.der().as_ref());
-        let cert_pem = cert.pem();
-
-        let private_key_pkcs8_der: Arc<[u8]> = Arc::from(pkcs8_der);
-        let private_key_pkcs8_pem = rsa_keypair.private_key_pkcs8_pem().to_string();
+        let material = build_self_signed_cert_material(factory, label, spec, seed);
 
         Inner {
-            cert_der,
-            cert_pem,
-            private_key_pkcs8_der,
-            private_key_pkcs8_pem,
+            cert_der: material.cert_der,
+            cert_pem: material.cert_pem,
+            private_key_pkcs8_der: material.private_key_pkcs8_der,
+            private_key_pkcs8_pem: material.private_key_pkcs8_pem,
         }
     })
 }
@@ -589,6 +488,7 @@ fn load_inner_with_spec(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::NotBeforeOffset;
     use crate::testutil::fx;
     use uselesskey_core::Seed;
 

--- a/crates/uselesskey-x509/src/srp/cert.rs
+++ b/crates/uselesskey-x509/src/srp/cert.rs
@@ -1,0 +1,148 @@
+//! Single-responsibility helpers for self-signed certificate material.
+
+use std::sync::Arc;
+
+use rand_chacha::ChaCha20Rng;
+use rand_core::{RngCore, SeedableRng};
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
+    KeyUsagePurpose, PKCS_RSA_SHA256,
+};
+use rustls_pki_types::PrivatePkcs8KeyDer;
+use time::Duration as TimeDuration;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+use crate::srp::derive::{
+    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
+};
+use crate::srp::spec::{NotBeforeOffset, X509Spec};
+
+/// Generated certificate and private-key bytes for one self-signed fixture.
+pub(crate) struct SelfSignedCertMaterial {
+    pub(crate) cert_der: Arc<[u8]>,
+    pub(crate) cert_pem: String,
+    pub(crate) private_key_pkcs8_der: Arc<[u8]>,
+    pub(crate) private_key_pkcs8_pem: String,
+}
+
+/// Build deterministic self-signed certificate material for an already-derived artifact seed.
+pub(crate) fn build_self_signed_cert_material(
+    factory: &Factory,
+    label: &str,
+    spec: &X509Spec,
+    seed: Seed,
+) -> SelfSignedCertMaterial {
+    let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
+    let rsa_keypair = deterministic_rsa_keypair(factory, label, spec);
+    let pkcs8_der = rsa_keypair.private_key_pkcs8_der();
+    let key_pair = rcgen_key_pair_from_pkcs8(pkcs8_der);
+
+    let params = certificate_params(label, spec, &mut rng);
+    let cert = params.self_signed(&key_pair).expect("cert generation");
+
+    SelfSignedCertMaterial {
+        cert_der: Arc::from(cert.der().as_ref()),
+        cert_pem: cert.pem(),
+        private_key_pkcs8_der: Arc::from(pkcs8_der),
+        private_key_pkcs8_pem: rsa_keypair.private_key_pkcs8_pem().to_string(),
+    }
+}
+
+fn deterministic_rsa_keypair(
+    factory: &Factory,
+    label: &str,
+    spec: &X509Spec,
+) -> uselesskey_rsa::RsaKeyPair {
+    // Generate RSA key using uselesskey-rsa for deterministic key generation.
+    // The certificate cache variant is intentionally not part of the key identity so
+    // negative certificate variants keep the same key while changing certificate metadata.
+    let key_label = format!("{}-key", label);
+    factory.rsa(&key_label, RsaSpec::new(spec.rsa_bits))
+}
+
+fn rcgen_key_pair_from_pkcs8(pkcs8_der: &[u8]) -> KeyPair {
+    let pkcs8_key = PrivatePkcs8KeyDer::from(pkcs8_der.to_vec());
+    KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_key, &PKCS_RSA_SHA256).expect("key parse")
+}
+
+fn certificate_params(label: &str, spec: &X509Spec, rng: &mut ChaCha20Rng) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.subject_cn.clone());
+
+    set_validity(label, spec, &mut params);
+    params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
+        rng.fill_bytes(bytes);
+    }));
+    set_ca_status(spec, &mut params);
+    set_key_usages(spec, &mut params);
+    set_extended_key_usages(spec, &mut params);
+    set_subject_alt_names(spec, &mut params);
+
+    params
+}
+
+fn set_validity(label: &str, spec: &X509Spec, params: &mut CertificateParams) {
+    let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
+    let base_time = deterministic_base_time_from_parts(&[
+        label.as_bytes(),
+        spec.subject_cn.as_bytes(),
+        spec.issuer_cn.as_bytes(),
+        &rsa_bits,
+    ]);
+
+    let not_before = match spec.not_before_offset {
+        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
+        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
+    };
+
+    params.not_before = not_before;
+    params.not_after = not_before + TimeDuration::days(spec.validity_days as i64);
+}
+
+fn set_ca_status(spec: &X509Spec, params: &mut CertificateParams) {
+    params.is_ca = if spec.is_ca {
+        IsCa::Ca(BasicConstraints::Unconstrained)
+    } else {
+        IsCa::NoCa
+    };
+}
+
+fn set_key_usages(spec: &X509Spec, params: &mut CertificateParams) {
+    let mut key_usages = Vec::new();
+    if spec.key_usage.digital_signature {
+        key_usages.push(KeyUsagePurpose::DigitalSignature);
+    }
+    if spec.key_usage.key_encipherment {
+        key_usages.push(KeyUsagePurpose::KeyEncipherment);
+    }
+    if spec.key_usage.key_cert_sign {
+        key_usages.push(KeyUsagePurpose::KeyCertSign);
+    }
+    if spec.key_usage.crl_sign {
+        key_usages.push(KeyUsagePurpose::CrlSign);
+    }
+    params.key_usages = key_usages;
+}
+
+fn set_extended_key_usages(spec: &X509Spec, params: &mut CertificateParams) {
+    if !spec.is_ca {
+        params.extended_key_usages = vec![
+            ExtendedKeyUsagePurpose::ServerAuth,
+            ExtendedKeyUsagePurpose::ClientAuth,
+        ];
+    }
+}
+
+fn set_subject_alt_names(spec: &X509Spec, params: &mut CertificateParams) {
+    let mut sorted_sans = spec.sans.clone();
+    sorted_sans.sort();
+    sorted_sans.dedup();
+    for san in &sorted_sans {
+        params.subject_alt_names.push(rcgen::SanType::DnsName(
+            san.clone().try_into().expect("valid DNS name"),
+        ));
+    }
+}

--- a/crates/uselesskey-x509/src/srp/mod.rs
+++ b/crates/uselesskey-x509/src/srp/mod.rs
@@ -1,5 +1,6 @@
 //! Single-responsibility internals for X.509 fixture generation.
 
+pub(crate) mod cert;
 pub mod chain_negative;
 pub mod derive;
 pub mod negative;


### PR DESCRIPTION
### Motivation
- Reduce complexity in the public X.509 facade by extracting large self-signed certificate construction logic into a focused SRP helper module for clearer single-responsibility structure.
- Improve testability and readability by splitting certificate material creation (key derivation, rcgen conversion, params assembly) into small helpers without changing deterministic derivation semantics.

### Description
- Move self-signed certificate material generation into a new internal module at `crates/uselesskey-x509/src/srp/cert.rs` exposing `build_self_signed_cert_material` and small helpers for RSA key lookup, PKCS#8→`rcgen` conversion, validity, CA flags, key usages, EKU, and SAN handling.
- Replace the large inlined generation code in `crates/uselesskey-x509/src/cert.rs` with a call to `build_self_signed_cert_material` inside `load_inner_with_spec` so caching and public API remain unchanged.
- Register the new helper with `srp` internals by adding `pub(crate) mod cert;` to `crates/uselesskey-x509/src/srp/mod.rs`.
- Preserve deterministic behavior, cache keys, and public surface (`X509Cert`, `X509FactoryExt`) while moving implementation details into the `srp` submodule.

### Testing
- Ran `cargo test -p uselesskey-x509` which executed the crate unit/integration/doctests and completed successfully with all tests passing.
- Ran lint/format checks via `cargo xtask lint-fix --check` which completed successfully (no formatting or clippy warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bd59e3888333aa9d9adf29fe9a88)