### PR TITLE
Refactor X.509 self-signed cert generation into SRP submodules

### DIFF
--- a/crates/uselesskey-x509/src/cert.rs
+++ b/crates/uselesskey-x509/src/cert.rs
@@ -4,29 +4,21 @@ use std::fmt;
 use std::sync::Arc;
 
 use rand_chacha::ChaCha20Rng;
-use rand_core::RngCore;
 use rand_core::SeedableRng;
-use rcgen::{
-    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-    KeyUsagePurpose, PKCS_RSA_SHA256,
-};
-use rustls_pki_types::PrivatePkcs8KeyDer;
-use time::Duration as TimeDuration;
 use uselesskey_core::negative::CorruptPem;
 use uselesskey_core::sink::TempArtifact;
 use uselesskey_core::{Error, Factory};
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
 
 use crate::chain::X509Chain;
 use crate::negative::{
     corrupt_cert_der_deterministic, corrupt_cert_pem, corrupt_cert_pem_deterministic,
     truncate_cert_der,
 };
-use crate::srp::derive::{
-    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
-};
 use crate::srp::negative::X509Negative;
-use crate::srp::spec::{ChainSpec, NotBeforeOffset, X509Spec};
+use crate::srp::spec::{ChainSpec, X509Spec};
+
+mod material;
+mod params;
 
 /// Cache domain for X.509 certificate fixtures.
 ///
@@ -487,108 +479,22 @@ fn load_inner_with_spec(
 
     factory.get_or_init(DOMAIN_X509_CERT, label, &spec_bytes, variant, |seed| {
         let mut rng = ChaCha20Rng::from_seed(*seed.bytes());
-        // Generate RSA key using uselesskey-rsa for deterministic key generation.
-        // We use the label + variant to derive a unique key.
-        let key_label = format!("{}-key", label);
-        let rsa_spec = RsaSpec::new(spec.rsa_bits);
-        let rsa_keypair = factory.rsa(&key_label, rsa_spec);
-
-        // Get the PKCS#8 DER key and convert it to rcgen's KeyPair
-        let pkcs8_der = rsa_keypair.private_key_pkcs8_der();
-        let pkcs8_key = PrivatePkcs8KeyDer::from(pkcs8_der.to_vec());
-        let key_pair =
-            KeyPair::from_pkcs8_der_and_sign_algo(&pkcs8_key, &PKCS_RSA_SHA256).expect("key parse");
-
-        // Build certificate parameters
-        let mut params = CertificateParams::default();
-        params
-            .distinguished_name
-            .push(DnType::CommonName, spec.subject_cn.clone());
-
-        // Set validity period based on spec
-        let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
-        let base_time = deterministic_base_time_from_parts(&[
-            label.as_bytes(),
-            spec.subject_cn.as_bytes(),
-            spec.issuer_cn.as_bytes(),
-            &rsa_bits,
-        ]);
-
-        let not_before = match spec.not_before_offset {
-            NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
-            NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
-        };
-
-        let not_after = not_before + TimeDuration::days(spec.validity_days as i64);
-
-        params.not_before = not_before;
-        params.not_after = not_after;
-        params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
-            rng.fill_bytes(bytes);
-        }));
-
-        // Set CA status
-        if spec.is_ca {
-            params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        } else {
-            params.is_ca = IsCa::NoCa;
-        }
-
-        // Set key usage
-        let mut key_usages = Vec::new();
-        if spec.key_usage.digital_signature {
-            key_usages.push(KeyUsagePurpose::DigitalSignature);
-        }
-        if spec.key_usage.key_encipherment {
-            key_usages.push(KeyUsagePurpose::KeyEncipherment);
-        }
-        if spec.key_usage.key_cert_sign {
-            key_usages.push(KeyUsagePurpose::KeyCertSign);
-        }
-        if spec.key_usage.crl_sign {
-            key_usages.push(KeyUsagePurpose::CrlSign);
-        }
-        params.key_usages = key_usages;
-
-        // Add extended key usage for TLS
-        if !spec.is_ca {
-            params.extended_key_usages = vec![
-                ExtendedKeyUsagePurpose::ServerAuth,
-                ExtendedKeyUsagePurpose::ClientAuth,
-            ];
-        }
-
-        // Add Subject Alternative Names
-        let mut sorted_sans = spec.sans.clone();
-        sorted_sans.sort();
-        sorted_sans.dedup();
-        for san in &sorted_sans {
-            params.subject_alt_names.push(rcgen::SanType::DnsName(
-                san.clone().try_into().expect("valid DNS name"),
-            ));
-        }
-
-        // Generate the self-signed certificate
-        let cert = params.self_signed(&key_pair).expect("cert generation");
-
-        let cert_der: Arc<[u8]> = Arc::from(cert.der().as_ref());
-        let cert_pem = cert.pem();
-
-        let private_key_pkcs8_der: Arc<[u8]> = Arc::from(pkcs8_der);
-        let private_key_pkcs8_pem = rsa_keypair.private_key_pkcs8_pem().to_string();
+        let keys = material::generate(factory, label, spec.rsa_bits);
+        let params = params::self_signed_params(label, spec, &mut rng);
+        let cert = params.self_signed(&keys.key_pair).expect("cert generation");
 
         Inner {
-            cert_der,
-            cert_pem,
-            private_key_pkcs8_der,
-            private_key_pkcs8_pem,
+            cert_der: Arc::from(cert.der().as_ref()),
+            cert_pem: cert.pem(),
+            private_key_pkcs8_der: Arc::from(keys.rsa.private_key_pkcs8_der()),
+            private_key_pkcs8_pem: keys.rsa.private_key_pkcs8_pem().to_string(),
         }
     })
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::NotBeforeOffset;
     use crate::testutil::fx;
     use uselesskey_core::Seed;
 

--- a/crates/uselesskey-x509/src/cert/material.rs
+++ b/crates/uselesskey-x509/src/cert/material.rs
@@ -1,0 +1,27 @@
+use rcgen::{KeyPair, PKCS_RSA_SHA256};
+use rustls_pki_types::PrivatePkcs8KeyDer;
+use uselesskey_core::Factory;
+use uselesskey_rsa::{RsaFactoryExt, RsaKeyPair, RsaSpec};
+
+pub(super) struct CertKeyMaterial {
+    pub(super) rsa: RsaKeyPair,
+    pub(super) key_pair: KeyPair,
+}
+
+pub(super) fn generate(factory: &Factory, label: &str, rsa_bits: usize) -> CertKeyMaterial {
+    let key_label = format!("{}-key", label);
+    let rsa = factory.rsa(&key_label, RsaSpec::new(rsa_bits));
+
+    CertKeyMaterial {
+        key_pair: parse_key_pair(&rsa),
+        rsa,
+    }
+}
+
+fn parse_key_pair(key_pair: &RsaKeyPair) -> KeyPair {
+    KeyPair::from_pkcs8_der_and_sign_algo(
+        &PrivatePkcs8KeyDer::from(key_pair.private_key_pkcs8_der().to_vec()),
+        &PKCS_RSA_SHA256,
+    )
+    .expect("key parse")
+}

--- a/crates/uselesskey-x509/src/cert/params.rs
+++ b/crates/uselesskey-x509/src/cert/params.rs
@@ -1,0 +1,101 @@
+use rand_core::RngCore;
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+};
+use time::Duration as TimeDuration;
+use time::OffsetDateTime;
+
+use crate::srp::derive::{
+    deterministic_base_time_from_parts, deterministic_serial_number_with_rng,
+};
+use crate::srp::spec::{KeyUsage, NotBeforeOffset, X509Spec};
+
+pub(super) fn self_signed_params(
+    label: &str,
+    spec: &X509Spec,
+    rng: &mut impl RngCore,
+) -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, spec.subject_cn.clone());
+
+    let base_time = deterministic_base_time(label, spec);
+    params.not_before = apply_not_before(base_time, spec.not_before_offset);
+    params.not_after = params.not_before + TimeDuration::days(spec.validity_days as i64);
+    params.serial_number = Some(deterministic_serial_number_with_rng(|bytes| {
+        rng.fill_bytes(bytes);
+    }));
+
+    params.is_ca = ca_constraint(spec.is_ca);
+    params.key_usages = key_usage_purposes(spec.key_usage);
+    params.extended_key_usages = extended_key_usages(spec.is_ca);
+    add_sorted_dns_sans(&mut params, &spec.sans);
+
+    params
+}
+
+fn deterministic_base_time(label: &str, spec: &X509Spec) -> OffsetDateTime {
+    let rsa_bits = (spec.rsa_bits as u32).to_be_bytes();
+    deterministic_base_time_from_parts(&[
+        label.as_bytes(),
+        spec.subject_cn.as_bytes(),
+        spec.issuer_cn.as_bytes(),
+        &rsa_bits,
+    ])
+}
+
+fn apply_not_before(base_time: OffsetDateTime, offset: NotBeforeOffset) -> OffsetDateTime {
+    match offset {
+        NotBeforeOffset::DaysAgo(days) => base_time - TimeDuration::days(days as i64),
+        NotBeforeOffset::DaysFromNow(days) => base_time + TimeDuration::days(days as i64),
+    }
+}
+
+fn ca_constraint(is_ca: bool) -> IsCa {
+    if is_ca {
+        IsCa::Ca(BasicConstraints::Unconstrained)
+    } else {
+        IsCa::NoCa
+    }
+}
+
+fn key_usage_purposes(key_usage: KeyUsage) -> Vec<KeyUsagePurpose> {
+    let mut purposes = Vec::new();
+    if key_usage.digital_signature {
+        purposes.push(KeyUsagePurpose::DigitalSignature);
+    }
+    if key_usage.key_encipherment {
+        purposes.push(KeyUsagePurpose::KeyEncipherment);
+    }
+    if key_usage.key_cert_sign {
+        purposes.push(KeyUsagePurpose::KeyCertSign);
+    }
+    if key_usage.crl_sign {
+        purposes.push(KeyUsagePurpose::CrlSign);
+    }
+    purposes
+}
+
+fn extended_key_usages(is_ca: bool) -> Vec<ExtendedKeyUsagePurpose> {
+    if is_ca {
+        Vec::new()
+    } else {
+        vec![
+            ExtendedKeyUsagePurpose::ServerAuth,
+            ExtendedKeyUsagePurpose::ClientAuth,
+        ]
+    }
+}
+
+fn add_sorted_dns_sans(params: &mut CertificateParams, sans: &[String]) {
+    let mut sorted_sans = sans.to_vec();
+    sorted_sans.sort();
+    sorted_sans.dedup();
+
+    for san in &sorted_sans {
+        params.subject_alt_names.push(rcgen::SanType::DnsName(
+            san.clone().try_into().expect("valid DNS name"),
+        ));
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce complexity in `cert.rs` by isolating key-material creation and certificate-parameter construction into dedicated SRP submodules for better readability and maintainability.
- Improve testability and reusability by giving deterministic RSA key material and parameter construction their own responsibilities.
- Preserve deterministic derivation semantics and cache identity while making the orchestration in the loader simpler.

### Description
- Extracted deterministic RSA/key parsing logic into `crates/uselesskey-x509/src/cert/material.rs` with `generate()` producing `CertKeyMaterial` and an `rcgen::KeyPair` converter.
- Extracted certificate-parameter construction into `crates/uselesskey-x509/src/cert/params.rs` with `self_signed_params()` that builds `rcgen::CertificateParams` (validity, serial, CA constraints, key usages, EKU, SAN normalization, etc.).
- Simplified `load_inner_with_spec()` in `crates/uselesskey-x509/src/cert.rs` to orchestrate: derive RNG, call `material::generate()`, call `params::self_signed_params()`, sign, and assemble outputs; no behavioral changes to public APIs or cache keys.
- Kept deterministic inputs/stable-bytes/versioning and negative fixtures unchanged.

### Testing
- Ran unit tests for the crate with `cargo test -p uselesskey-x509 cert::tests` and all `cert` unit tests passed (`19` tests passed).
- Ran the full crate test suite with `cargo test -p uselesskey-x509` and the suite passed (`87` tests for unit/integration + additional test groups; overall all tests passed).
- Ran lints and formatting checks with `cargo clippy -p uselesskey-x509 --all-targets -- -D warnings` and `cargo fmt --check`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bd59ae688333a4f0ba550d6e9529)