### PR TITLE
test(entropy,hmac,ed25519): cover fixture invariants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4760,6 +4760,7 @@ dependencies = [
  "serde_json",
  "uselesskey-core",
  "uselesskey-jwk",
+ "uselesskey-test-support",
 ]
 
 [[package]]
@@ -4790,6 +4791,7 @@ dependencies = [
  "serde",
  "uselesskey-core",
  "uselesskey-jwk",
+ "uselesskey-test-support",
 ]
 
 [[package]]

--- a/crates/uselesskey-ed25519/Cargo.toml
+++ b/crates/uselesskey-ed25519/Cargo.toml
@@ -36,6 +36,7 @@ insta.workspace = true
 proptest.workspace = true
 rstest.workspace = true
 serde.workspace = true
+uselesskey-test-support = { workspace = true }
 
 
 [lints]

--- a/crates/uselesskey-ed25519/tests/ed25519_extra_coverage.rs
+++ b/crates/uselesskey-ed25519/tests/ed25519_extra_coverage.rs
@@ -1,0 +1,125 @@
+//! Extra coverage for uselesskey-ed25519:
+//!
+//! - Domain constant invariant.
+//! - DER length lower bounds (PKCS#8 / SPKI) for sanity / shape checks.
+//! - JWK `x`/`d` decode to 32 bytes.
+//! - Public JWKS cardinality is exactly 1.
+//! - Clone semantics preserve material.
+
+#[cfg(feature = "jwk")]
+use base64::Engine as _;
+#[cfg(feature = "jwk")]
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use uselesskey_core::{Factory, Seed};
+use uselesskey_ed25519::{DOMAIN_ED25519_KEYPAIR, Ed25519FactoryExt, Ed25519Spec};
+use uselesskey_test_support::{TestResult, require_ok, require_some};
+
+fn det_fx(seed_label: &str) -> TestResult<Factory> {
+    Ok(Factory::deterministic(require_ok(
+        Seed::from_env_value(seed_label),
+        "valid deterministic seed",
+    )?))
+}
+
+#[test]
+fn domain_constant_is_stable() {
+    assert_eq!(DOMAIN_ED25519_KEYPAIR, "uselesskey:ed25519:keypair");
+}
+
+#[test]
+fn der_outputs_meet_minimum_lengths() -> TestResult<()> {
+    let fx = det_fx("ed25519-der-len")?;
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+
+    // PKCS#8 v1 Ed25519 PrivateKeyInfo is fixed length (48 bytes).
+    assert!(kp.private_key_pkcs8_der().len() >= 48);
+    // SPKI for Ed25519 is fixed length (44 bytes).
+    assert!(kp.public_key_spki_der().len() >= 44);
+    Ok(())
+}
+
+#[test]
+fn pem_outputs_have_correct_headers() -> TestResult<()> {
+    let fx = det_fx("ed25519-pem-headers")?;
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+
+    assert!(
+        kp.private_key_pkcs8_pem()
+            .starts_with("-----BEGIN PRIVATE KEY-----")
+    );
+    assert!(
+        kp.public_key_spki_pem()
+            .starts_with("-----BEGIN PUBLIC KEY-----")
+    );
+    Ok(())
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn public_jwk_has_expected_okp_shape() -> TestResult<()> {
+    let fx = det_fx("ed25519-jwk-shape")?;
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+    let val = kp.public_jwk().to_value();
+
+    assert_eq!(val["kty"], "OKP");
+    assert_eq!(val["crv"], "Ed25519");
+    assert_eq!(val["use"], "sig");
+    assert_eq!(val["alg"], "EdDSA");
+    assert!(val["kid"].is_string());
+
+    let x = require_some(val["x"].as_str(), "x field")?;
+    let decoded = require_ok(URL_SAFE_NO_PAD.decode(x), "x is base64url")?;
+    assert_eq!(decoded.len(), 32, "Ed25519 public key is 32 bytes");
+    Ok(())
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn private_key_jwk_d_decodes_to_32_bytes() -> TestResult<()> {
+    let fx = det_fx("ed25519-jwk-d")?;
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+    let val = kp.private_key_jwk().to_value();
+
+    assert_eq!(val["kty"], "OKP");
+    let d = require_some(val["d"].as_str(), "d field")?;
+    let decoded = require_ok(URL_SAFE_NO_PAD.decode(d), "d is base64url")?;
+    assert_eq!(decoded.len(), 32, "Ed25519 private scalar is 32 bytes");
+    Ok(())
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn public_jwks_has_exactly_one_entry() -> TestResult<()> {
+    let fx = det_fx("ed25519-jwks-cardinality")?;
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+    let jwks = kp.public_jwks().to_value();
+
+    let keys = require_some(jwks["keys"].as_array(), "keys array")?;
+    assert_eq!(keys.len(), 1);
+    Ok(())
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn public_jwks_json_matches_public_jwks_to_value() -> TestResult<()> {
+    let fx = det_fx("ed25519-jwks-json")?;
+    let kp = fx.ed25519("svc", Ed25519Spec::new());
+
+    assert_eq!(kp.public_jwks_json(), kp.public_jwks().to_value());
+    Ok(())
+}
+
+#[test]
+fn clone_preserves_key_material() -> TestResult<()> {
+    let fx = det_fx("ed25519-clone")?;
+    let original = fx.ed25519("svc", Ed25519Spec::new());
+    let cloned = original.clone();
+
+    assert_eq!(
+        original.private_key_pkcs8_der(),
+        cloned.private_key_pkcs8_der()
+    );
+    assert_eq!(original.public_key_spki_der(), cloned.public_key_spki_der());
+    assert_eq!(original.label(), cloned.label());
+    Ok(())
+}

--- a/crates/uselesskey-entropy/tests/entropy_extra_coverage.rs
+++ b/crates/uselesskey-entropy/tests/entropy_extra_coverage.rs
@@ -1,0 +1,102 @@
+//! Extra coverage for uselesskey-entropy:
+//!
+//! - Domain constant invariant.
+//! - Zero-length allocation and zero-length `fill_bytes` no-ops.
+//! - `fill_bytes_with_variant` matches `bytes_with_variant`.
+//! - Clone semantics.
+//! - Debug omits byte material.
+
+use uselesskey_core::{Factory, Seed};
+use uselesskey_entropy::{DOMAIN_ENTROPY_FIXTURE, EntropyFactoryExt};
+use uselesskey_test_support::{TestResult, require_ok};
+
+fn det_fx(seed_label: &str) -> TestResult<Factory> {
+    Ok(Factory::deterministic(require_ok(
+        Seed::from_env_value(seed_label),
+        "valid deterministic seed",
+    )?))
+}
+
+#[test]
+fn domain_constant_is_stable() {
+    // This is part of the cache key; changing it would silently invalidate
+    // every consumer's deterministic entropy. Pin it.
+    assert_eq!(DOMAIN_ENTROPY_FIXTURE, "uselesskey:entropy:fixture");
+}
+
+#[test]
+fn bytes_zero_returns_empty_vec() -> TestResult<()> {
+    let fx = det_fx("entropy-zero")?;
+    let out = fx.entropy("svc").bytes(0);
+    assert!(out.is_empty());
+    Ok(())
+}
+
+#[test]
+fn fill_bytes_with_empty_slice_is_noop() -> TestResult<()> {
+    let fx = det_fx("entropy-empty-fill")?;
+    let mut empty: [u8; 0] = [];
+    fx.entropy("svc").fill_bytes(&mut empty);
+    assert!(empty.is_empty());
+    Ok(())
+}
+
+#[test]
+fn fill_bytes_with_variant_matches_bytes_with_variant() -> TestResult<()> {
+    let fx = det_fx("entropy-fill-variant")?;
+    let fixture = fx.entropy("svc");
+
+    let expected = fixture.bytes_with_variant(64, "alt");
+    let mut actual = vec![0u8; 64];
+    fixture.fill_bytes_with_variant(&mut actual, "alt");
+
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn clone_produces_same_bytes() -> TestResult<()> {
+    let fx = det_fx("entropy-clone")?;
+    let original = fx.entropy("svc");
+    let cloned = original.clone();
+
+    assert_eq!(original.bytes(32), cloned.bytes(32));
+    assert_eq!(original.label(), cloned.label());
+    assert_eq!(original.variant(), cloned.variant());
+    Ok(())
+}
+
+#[test]
+fn debug_includes_label_and_variant_but_no_byte_material() -> TestResult<()> {
+    let fx = det_fx("entropy-debug-bytes")?;
+    let fixture = fx.entropy_with_variant("svc", "custom-variant");
+    // Ensure bytes are materialized in the cache so a leak would be visible.
+    let bytes = fixture.bytes(48);
+
+    let dbg = format!("{fixture:?}");
+    assert!(dbg.contains("EntropyFixture"));
+    assert!(dbg.contains("svc"));
+    assert!(dbg.contains("custom-variant"));
+
+    // Debug must not contain the materialized byte stream as contiguous hex.
+    let hex = bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
+    assert!(!dbg.contains(&hex), "debug leaked hex bytes: {dbg}");
+    Ok(())
+}
+
+#[test]
+fn variants_propagate_through_default_path() -> TestResult<()> {
+    let fx = det_fx("entropy-variant-propagate")?;
+    let default = fx.entropy("svc");
+    let custom = fx.entropy_with_variant("svc", "custom");
+
+    // The default path uses the variant set on the fixture handle.
+    let default_bytes = default.bytes(32);
+    let custom_bytes = custom.bytes(32);
+    assert_ne!(default_bytes, custom_bytes);
+
+    // And explicit variants match the variant-bound fixtures.
+    let from_default_explicit = default.bytes_with_variant(32, "custom");
+    assert_eq!(custom_bytes, from_default_explicit);
+    Ok(())
+}

--- a/crates/uselesskey-hmac/Cargo.toml
+++ b/crates/uselesskey-hmac/Cargo.toml
@@ -31,6 +31,7 @@ base64 = { workspace = true }
 insta.workspace = true
 proptest.workspace = true
 serde.workspace = true
+uselesskey-test-support = { workspace = true }
 
 [features]
 default = []

--- a/crates/uselesskey-hmac/tests/hmac_extra_coverage.rs
+++ b/crates/uselesskey-hmac/tests/hmac_extra_coverage.rs
@@ -1,0 +1,86 @@
+//! Extra coverage for uselesskey-hmac:
+//!
+//! - Domain constant invariant.
+//! - Clone semantics produce equal secret bytes and identity.
+//! - Debug omits common raw secret byte renderings (existing test only covers label).
+//! - JWK `use_` field is "sig" (only checked exists today).
+
+use uselesskey_core::{Factory, Seed};
+use uselesskey_hmac::{DOMAIN_HMAC_SECRET, HmacFactoryExt, HmacSpec};
+use uselesskey_test_support::{TestResult, require_ok, require_some};
+
+fn det_fx(seed_label: &str) -> TestResult<Factory> {
+    Ok(Factory::deterministic(require_ok(
+        Seed::from_env_value(seed_label),
+        "valid deterministic seed",
+    )?))
+}
+
+#[test]
+fn domain_constant_is_stable() {
+    assert_eq!(DOMAIN_HMAC_SECRET, "uselesskey:hmac:secret");
+}
+
+#[test]
+fn clone_preserves_secret_and_identity() -> TestResult<()> {
+    let fx = det_fx("hmac-clone")?;
+    let original = fx.hmac("issuer", HmacSpec::hs256());
+    let cloned = original.clone();
+
+    assert_eq!(original.secret_bytes(), cloned.secret_bytes());
+    assert_eq!(original.label(), cloned.label());
+    assert_eq!(original.spec(), cloned.spec());
+    Ok(())
+}
+
+#[test]
+fn clone_chain_preserves_secret() -> TestResult<()> {
+    let fx = det_fx("hmac-clone-chain")?;
+    let original = fx.hmac("issuer", HmacSpec::hs384());
+    let chained = original.clone().clone().clone();
+    assert_eq!(original.secret_bytes(), chained.secret_bytes());
+    Ok(())
+}
+
+#[test]
+fn debug_omits_raw_secret_bytes() -> TestResult<()> {
+    let fx = det_fx("hmac-debug-secret")?;
+    let secret = fx.hmac("issuer", HmacSpec::hs256());
+    let bytes_hex = secret
+        .secret_bytes()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+
+    let dbg = format!("{secret:?}");
+    assert!(!dbg.contains(&bytes_hex));
+    // Spot-check: do not leak the raw byte array form either.
+    let bytes_dbg = format!("{:?}", secret.secret_bytes());
+    assert!(!dbg.contains(&bytes_dbg));
+    Ok(())
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn jwk_use_field_is_sig() -> TestResult<()> {
+    let fx = det_fx("hmac-jwk-use")?;
+    for spec in [HmacSpec::hs256(), HmacSpec::hs384(), HmacSpec::hs512()] {
+        let secret = fx.hmac("issuer", spec);
+        let val = secret.jwk().to_value();
+        assert_eq!(val["use"], "sig", "use field for {spec:?}");
+        assert_eq!(val["kty"], "oct", "kty field for {spec:?}");
+    }
+    Ok(())
+}
+
+#[cfg(feature = "jwk")]
+#[test]
+fn jwks_keys_array_has_exactly_one_entry() -> TestResult<()> {
+    let fx = det_fx("hmac-jwks-cardinality")?;
+    let secret = fx.hmac("issuer", HmacSpec::hs256());
+
+    let val = secret.jwks().to_value();
+    let keys = require_some(val["keys"].as_array(), "keys array")?;
+    assert_eq!(keys.len(), 1);
+    Ok(())
+}


### PR DESCRIPTION
Summary
- Ports the useful entropy/HMAC/Ed25519 confidence coverage from stale #703 onto current main.
- Covers domain constants, deterministic clone/debug invariants, JWK/JWKS public/secret material shapes, and zeroization-sensitive HMAC behavior.
- Converts the new tests to no-panic-family style with uselesskey-test-support helpers.

Files added/changed
- crates/uselesskey-entropy/tests/entropy_extra_coverage.rs
- crates/uselesskey-ed25519/tests/ed25519_extra_coverage.rs
- crates/uselesskey-hmac/tests/hmac_extra_coverage.rs
- crates/uselesskey-ed25519/Cargo.toml
- crates/uselesskey-hmac/Cargo.toml
- Cargo.lock

Validation
- cargo xtask fmt
- cargo test -p uselesskey-ed25519 --test ed25519_extra_coverage --no-default-features
- cargo test -p uselesskey-ed25519 --test ed25519_extra_coverage --features jwk
- cargo test -p uselesskey-hmac --test hmac_extra_coverage --no-default-features
- cargo test -p uselesskey-hmac --test hmac_extra_coverage --features jwk
- cargo test -p uselesskey-entropy --test entropy_extra_coverage --all-features
- cargo test -p uselesskey-ed25519 --all-features
- cargo test -p uselesskey-hmac --all-features
- cargo clippy -p uselesskey-ed25519 --tests --all-features -- -D warnings
- cargo clippy -p uselesskey-entropy --tests --all-features -- -D warnings
- cargo clippy -p uselesskey-hmac --tests --all-features -- -D warnings
- cargo xtask check-no-panic-family: no new entropy/HMAC/Ed25519 debt; still reports the three pre-existing X.509 sites already on main
- cargo +nightly xtask pr-lite
- git diff --check HEAD~1..HEAD

Non-goals
- No new fixture families.
- No scanner-safe claim changes.
- No public API changes.
- No release machinery changes.

What this enables next
- Replaces the stale #703 draft with a current-main coverage slice that supports the adoption-correctness lane without reopening broad product or infrastructure work.