### PR TITLE
test(token): add mutant_killers and extra_coverage for derivation pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5052,6 +5052,7 @@ dependencies = [
  "serde",
  "serde_json",
  "uselesskey-core",
+ "uselesskey-test-support",
 ]
 
 [[package]]

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -25,6 +25,7 @@ uselesskey-core = { path = "../uselesskey-core", version = "0.9.0" }
 insta.workspace = true
 proptest.workspace = true
 serde.workspace = true
+uselesskey-test-support = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/uselesskey-token/tests/mutant_killers.rs
+++ b/crates/uselesskey-token/tests/mutant_killers.rs
@@ -1,0 +1,46 @@
+//! Mutation-hardening pins for `TokenSpec`.
+//!
+//! These tests pin the exact-value behaviour of `TokenSpec` constructors,
+//! kind-name strings, stable byte encoding, and authorization scheme
+//! mapping. The values are part of the public derivation contract — a silent
+//! change here would invalidate caches and JWT-shaped fixtures downstream,
+//! so any mutation must be intentional and accompanied by a derivation
+//! version bump (see `crates/uselesskey-core` derivation policy).
+//!
+//! Mirrors the existing pattern in `uselesskey-rsa`, `uselesskey-ecdsa`,
+//! `uselesskey-ed25519`, and `uselesskey-pgp` `tests/mutant_killers.rs`.
+
+use uselesskey_token::TokenSpec;
+
+#[test]
+fn constructors_return_correct_variants() {
+    assert_eq!(TokenSpec::api_key(), TokenSpec::ApiKey);
+    assert_eq!(TokenSpec::bearer(), TokenSpec::Bearer);
+    assert_eq!(TokenSpec::oauth_access_token(), TokenSpec::OAuthAccessToken);
+}
+
+#[test]
+fn kind_names_exact() {
+    assert_eq!(TokenSpec::ApiKey.kind_name(), "api_key");
+    assert_eq!(TokenSpec::Bearer.kind_name(), "bearer");
+    assert_eq!(
+        TokenSpec::OAuthAccessToken.kind_name(),
+        "oauth_access_token"
+    );
+}
+
+#[test]
+fn stable_bytes_exact() {
+    // The exact byte encoding feeds into the per-process cache key and the
+    // deterministic derivation. Treat this as a load-bearing contract.
+    assert_eq!(TokenSpec::ApiKey.stable_bytes(), [0, 0, 0, 1]);
+    assert_eq!(TokenSpec::Bearer.stable_bytes(), [0, 0, 0, 2]);
+    assert_eq!(TokenSpec::OAuthAccessToken.stable_bytes(), [0, 0, 0, 3]);
+}
+
+#[test]
+fn authorization_scheme_exact() {
+    assert_eq!(TokenSpec::ApiKey.authorization_scheme(), "ApiKey");
+    assert_eq!(TokenSpec::Bearer.authorization_scheme(), "Bearer");
+    assert_eq!(TokenSpec::OAuthAccessToken.authorization_scheme(), "Bearer");
+}

--- a/crates/uselesskey-token/tests/token_extra_coverage.rs
+++ b/crates/uselesskey-token/tests/token_extra_coverage.rs
@@ -1,0 +1,123 @@
+//! Extra coverage for `uselesskey-token`:
+//!
+//! - Pin `DOMAIN_TOKEN_FIXTURE` so accidental renames flip a test rather than
+//!   silently re-key every cached and deterministic token fixture downstream.
+//! - Pin `TokenFixture::spec()` / `label()` accessors which are otherwise only
+//!   exercised by doctests.
+//! - Pin `authorization_header()` shape for every supported spec.
+//! - Pin negative-fixture cache identity by variant (different `NegativeToken`
+//!   variants must produce distinct cached values from the same base token).
+//! - Pin `Clone` semantics: cloning preserves label/spec/value.
+//!
+//! Follows the established `<crate>_extra_coverage.rs` pattern used by
+//! `uselesskey-hmac`, `uselesskey-ed25519`, `uselesskey-entropy`, and
+//! `uselesskey-jwk`.
+
+use uselesskey_core::{Factory, Seed};
+use uselesskey_test_support::{TestResult, ensure, ensure_eq, require_ok};
+use uselesskey_token::{DOMAIN_TOKEN_FIXTURE, NegativeToken, TokenFactoryExt, TokenSpec};
+
+fn det_fx(seed_label: &str) -> TestResult<Factory> {
+    Ok(Factory::deterministic(require_ok(
+        Seed::from_env_value(seed_label),
+        "valid deterministic seed",
+    )?))
+}
+
+#[test]
+fn domain_constant_is_stable() {
+    assert_eq!(DOMAIN_TOKEN_FIXTURE, "uselesskey:token:fixture");
+}
+
+#[test]
+fn spec_accessor_returns_construction_spec() -> TestResult<()> {
+    let fx = det_fx("token-spec-accessor")?;
+    for spec in [
+        TokenSpec::api_key(),
+        TokenSpec::bearer(),
+        TokenSpec::oauth_access_token(),
+    ] {
+        let tok = fx.token("svc", spec);
+        ensure_eq!(tok.spec(), spec);
+    }
+    Ok(())
+}
+
+#[test]
+fn label_accessor_returns_construction_label() -> TestResult<()> {
+    let fx = det_fx("token-label-accessor")?;
+    let tok = fx.token("my-service", TokenSpec::api_key());
+    ensure_eq!(tok.label(), "my-service");
+    Ok(())
+}
+
+#[test]
+fn authorization_header_uses_api_key_scheme_for_api_key_spec() -> TestResult<()> {
+    let fx = det_fx("token-auth-header-api")?;
+    let tok = fx.token("svc", TokenSpec::api_key());
+    let header = tok.authorization_header();
+    ensure!(header.starts_with("ApiKey "));
+    ensure!(header.ends_with(tok.value()));
+    Ok(())
+}
+
+#[test]
+fn authorization_header_uses_bearer_scheme_for_oauth_spec() -> TestResult<()> {
+    let fx = det_fx("token-auth-header-oauth")?;
+    let tok = fx.token("svc", TokenSpec::oauth_access_token());
+    let header = tok.authorization_header();
+    ensure!(header.starts_with("Bearer "));
+    ensure!(header.ends_with(tok.value()));
+    Ok(())
+}
+
+#[test]
+fn negative_variants_have_distinct_cached_values() -> TestResult<()> {
+    let fx = det_fx("token-negative-distinct")?;
+    let tok = fx.token("svc", TokenSpec::oauth_access_token());
+
+    let expired = tok.negative_value(NegativeToken::ExpiredClaims);
+    let bad_issuer = tok.negative_value(NegativeToken::BadIssuer);
+    let bad_aud = tok.negative_value(NegativeToken::BadAudience);
+    let alg_none = tok.negative_value(NegativeToken::AlgNone);
+
+    // Each variant must reach its own cache bucket.
+    ensure!(expired != bad_issuer);
+    ensure!(expired != bad_aud);
+    ensure!(expired != alg_none);
+    ensure!(bad_issuer != bad_aud);
+    ensure!(bad_issuer != alg_none);
+    ensure!(bad_aud != alg_none);
+
+    // And none of them should equal the positive fixture.
+    let good = tok.value();
+    ensure!(expired != good);
+    ensure!(bad_issuer != good);
+    ensure!(bad_aud != good);
+    ensure!(alg_none != good);
+
+    Ok(())
+}
+
+#[test]
+fn negative_variant_value_is_cached_within_token_fixture() -> TestResult<()> {
+    let fx = det_fx("token-negative-cache")?;
+    let tok = fx.token("svc", TokenSpec::oauth_access_token());
+
+    let first = tok.negative_value(NegativeToken::BadIssuer);
+    let second = tok.negative_value(NegativeToken::BadIssuer);
+    ensure_eq!(first, second);
+    Ok(())
+}
+
+#[test]
+fn clone_preserves_label_spec_and_value() -> TestResult<()> {
+    let fx = det_fx("token-clone")?;
+    let original = fx.token("clone-svc", TokenSpec::bearer());
+    let cloned = original.clone();
+
+    ensure_eq!(original.label(), cloned.label());
+    ensure_eq!(original.spec(), cloned.spec());
+    ensure_eq!(original.value(), cloned.value());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`uselesskey-token` was the only crypto-fixture crate without a `tests/mutant_killers.rs` or a `<crate>_extra_coverage.rs` file. Both pinning patterns are well-established across the workspace (rsa/ecdsa/ed25519/pgp ship `mutant_killers.rs`; hmac/ed25519/entropy/jwk ship `*_extra_coverage.rs`), and the derivation-critical surface of `TokenSpec` and `TokenFixture` was not pinned anywhere.

This PR closes that gap. **Tests only — no production code changes.**

### `tests/mutant_killers.rs`

Pins values that participate in cache identity and deterministic derivation:

- `TokenSpec` constructor variants (`api_key`/`bearer`/`oauth_access_token` → correct enum)
- `kind_name()` exact strings
- `stable_bytes()` exact byte arrays (`[0,0,0,1]`/`[0,0,0,2]`/`[0,0,0,3]`)
- `authorization_scheme()` exact strings

A silent change to any of these would invalidate every cached and deterministic token fixture downstream without warning. The byte-exact pin matches `uselesskey-pgp/tests/mutant_killers.rs::stable_bytes_exact` so the policy is uniform.

### `tests/token_extra_coverage.rs`

Pins the rest of the token public surface that was either doctest-only or had partial coverage:

- `DOMAIN_TOKEN_FIXTURE` value (`"uselesskey:token:fixture"`)
- `TokenFixture::spec()` / `label()` accessors (previously only exercised via doctests)
- `authorization_header()` for `ApiKey` and `OAuth` (the inline test only covers `bearer`)
- Negative-variant cache uniqueness (4 different `NegativeToken` arms produce distinct values, and none equal the positive fixture)
- Negative-variant intra-fixture caching (same variant → same cached value)
- `Clone` preserves `label`/`spec`/`value`

Returns `TestResult<()>` and routes assertions through `uselesskey-test-support`'s `ensure!`/`ensure_eq!`/`require_ok` helpers so this PR adds **zero** new panic-family debt.

## Test plan

- [x] `cargo test -p uselesskey-token --test mutant_killers --test token_extra_coverage` — all 12 new tests pass
- [x] `cargo clippy -p uselesskey-token --all-targets -- -D warnings` clean
- [x] `cargo fmt -p uselesskey-token` clean
- [x] `cargo xtask check-no-panic-family` reports the same 3 pre-existing x509 debt sites — no new debt from this PR
- [ ] CI green on PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01EW3aTamLseQScPtQH42Xjp)_