### PR TITLE
docs: refresh adoption how-to version snippets

### DIFF
--- a/docs/how-to/choose-features.md
+++ b/docs/how-to/choose-features.md
@@ -98,7 +98,7 @@ If you need every key family, use `all-keys`.
 - Use `uselesskey-cli verify` in CI to prove generated outputs still match the
   manifest.
 - If `build.rs` calls the library directly, use:
-  `uselesskey-cli = { version = "0.7.0", default-features = false }`
+  `uselesskey-cli = { version = "0.9.0", default-features = false }`
   for the common shape-only path.
 - Add `features = ["rsa-materialize"]` only when the build-time path needs RSA
   PKCS#8 fixtures.

--- a/docs/how-to/choose-lane.md
+++ b/docs/how-to/choose-lane.md
@@ -35,14 +35,14 @@ For shape-only build-time fixtures, depend on the slim library surface:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.7.0", default-features = false }
+uselesskey-cli = { version = "0.9.0", default-features = false }
 ```
 
 For RSA PKCS#8 build-time fixtures, opt into the specialized RSA materialize support:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.7.0", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.9.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 See `crates/materialize-shape-buildrs-example/` for the common shape-only pattern and `crates/materialize-buildrs-example/` for the specialized RSA pattern.

--- a/docs/how-to/downstream-fixture-policy.md
+++ b/docs/how-to/downstream-fixture-policy.md
@@ -53,14 +53,14 @@ Shape-only common lane:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.7.0", default-features = false }
+uselesskey-cli = { version = "0.9.0", default-features = false }
 ```
 
 Specialized RSA build-time lane:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.7.0", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.9.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 ## Materialize in CI or build scripts

--- a/docs/how-to/test-jwt-negative-validation.md
+++ b/docs/how-to/test-jwt-negative-validation.md
@@ -34,7 +34,7 @@ For runtime test generation:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7", default-features = false, features = ["token"] }
+uselesskey = { version = "0.9.0", default-features = false, features = ["token"] }
 ```
 
 ```rust

--- a/docs/how-to/test-oidc-jwks-validation.md
+++ b/docs/how-to/test-oidc-jwks-validation.md
@@ -49,7 +49,7 @@ For Rust tests that do not need files, use the public fixture surface directly:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7", default-features = false, features = ["rsa", "jwk"] }
+uselesskey = { version = "0.9.0", default-features = false, features = ["rsa", "jwk"] }
 ```
 
 ```rust

--- a/docs/how-to/test-webauthn-validation.md
+++ b/docs/how-to/test-webauthn-validation.md
@@ -14,8 +14,8 @@ Add the crate as a dev-dependency alongside the core factory:
 
 ```toml
 [dev-dependencies]
-uselesskey-core = "0.7"
-uselesskey-webauthn = "0.7"
+uselesskey-core = "0.9.0"
+uselesskey-webauthn = "0.9.0"
 ```
 
 Then derive a registration and an assertion fixture from the same seed

--- a/docs/how-to/test-webhook-signature-validation.md
+++ b/docs/how-to/test-webhook-signature-validation.md
@@ -14,7 +14,7 @@ should enforce.
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7", default-features = false, features = ["webhook"] }
+uselesskey = { version = "0.9.0", default-features = false, features = ["webhook"] }
 ```
 
 Or depend on `uselesskey-webhook` directly if you only need this
@@ -22,8 +22,8 @@ surface:
 
 ```toml
 [dev-dependencies]
-uselesskey-webhook = "0.7"
-uselesskey-core = "0.7"
+uselesskey-webhook = "0.9.0"
+uselesskey-core = "0.9.0"
 ```
 
 ## Generate the contract pack

--- a/docs/how-to/use-pkcs11-mock-fixtures.md
+++ b/docs/how-to/use-pkcs11-mock-fixtures.md
@@ -14,8 +14,8 @@ under test consumes; the cryptography is deliberately mock.
 
 ```toml
 [dev-dependencies]
-uselesskey-core = { version = "0.7", default-features = false }
-uselesskey-pkcs11-mock = { version = "0.7" }
+uselesskey-core = { version = "0.9.0", default-features = false }
+uselesskey-pkcs11-mock = { version = "0.9.0" }
 ```
 
 ```rust


### PR DESCRIPTION
Summary
- Refresh current task-first how-to dependency snippets to v0.9.0.
- Keep historical migration and release docs at their documented older versions.

Files added/changed
- docs/how-to/choose-features.md
- docs/how-to/choose-lane.md
- docs/how-to/downstream-fixture-policy.md
- docs/how-to/test-jwt-negative-validation.md
- docs/how-to/test-oidc-jwks-validation.md
- docs/how-to/test-webauthn-validation.md
- docs/how-to/test-webhook-signature-validation.md
- docs/how-to/use-pkcs11-mock-fixtures.md

Validation
- cargo xtask docs-sync --check
- cargo xtask typos
- git diff --check

Non-goals
- No code changes, no new claims, no release action, no dependency churn, and no historical migration doc rewrite.

What this enables next
- The adoption-confidence closeout is backed by current copyable task docs, not only README/start-here snippets.