### PR TITLE
refactor(cli): split materialized_fixture_bytes into SRP submodules

### DIFF
--- a/crates/uselesskey-cli/src/lib.rs
+++ b/crates/uselesskey-cli/src/lib.rs
@@ -15,10 +15,9 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STD;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use uselesskey_core::{Factory, Seed};
-#[cfg(feature = "rsa-materialize")]
-use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
-use uselesskey_token::{TokenFactoryExt, TokenSpec};
+
+mod materialize;
+use materialize::materialized_fixture_bytes;
 
 /// Bundle manifest describing generated artifacts and handoff metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -419,99 +418,6 @@ fn resolve_fixture_path(out_dir: &Path, target: &Path) -> PathBuf {
     }
 }
 
-fn materialized_fixture_bytes(spec: &MaterializeFixtureSpec) -> Result<Vec<u8>, MaterializeError> {
-    let label = spec
-        .label
-        .clone()
-        .unwrap_or_else(|| fallback_label(&spec.out));
-    let fx = Factory::deterministic_from_str(&spec.seed);
-
-    match spec.kind {
-        MaterializeKind::EntropyBytes => {
-            let len = spec.len.unwrap_or(32);
-            let seed = Seed::from_text(&spec.seed);
-            let mut bytes = vec![0u8; len];
-            seed.fill_bytes(&mut bytes);
-            Ok(bytes)
-        }
-        MaterializeKind::TokenJwtShape => Ok(fx
-            .token(&label, TokenSpec::oauth_access_token())
-            .value()
-            .as_bytes()
-            .to_vec()),
-        MaterializeKind::RsaPkcs8Der => {
-            #[cfg(feature = "rsa-materialize")]
-            {
-                Ok(fx
-                    .rsa(&label, RsaSpec::rs256())
-                    .private_key_pkcs8_der()
-                    .to_vec())
-            }
-            #[cfg(not(feature = "rsa-materialize"))]
-            {
-                Err(MaterializeError::InvalidManifest(
-                    "rsa.pkcs8_der requires uselesskey-cli feature `rsa-materialize`".to_string(),
-                ))
-            }
-        }
-        MaterializeKind::RsaPkcs8Pem => {
-            #[cfg(feature = "rsa-materialize")]
-            {
-                Ok(fx
-                    .rsa(&label, RsaSpec::rs256())
-                    .private_key_pkcs8_pem()
-                    .as_bytes()
-                    .to_vec())
-            }
-            #[cfg(not(feature = "rsa-materialize"))]
-            {
-                Err(MaterializeError::InvalidManifest(
-                    "rsa.pkcs8_pem requires uselesskey-cli feature `rsa-materialize`".to_string(),
-                ))
-            }
-        }
-        MaterializeKind::PemBlockShape => {
-            let len = spec.len.unwrap_or(256);
-            let seed = Seed::from_text(&spec.seed);
-            let mut bytes = vec![0u8; len];
-            seed.fill_bytes(&mut bytes);
-            let payload = BASE64_STD.encode(bytes);
-            let block_label = normalize_pem_label(&label);
-            let mut out = String::new();
-            let _ = writeln!(&mut out, "-----BEGIN {block_label}-----");
-            for chunk in payload.as_bytes().chunks(64) {
-                let _ = writeln!(
-                    &mut out,
-                    "{}",
-                    std::str::from_utf8(chunk).map_err(|err| {
-                        MaterializeError::InvalidManifest(format!(
-                            "generated base64 payload was not utf-8: {err}"
-                        ))
-                    })?
-                );
-            }
-            let _ = writeln!(&mut out, "-----END {block_label}-----");
-            Ok(out.into_bytes())
-        }
-        MaterializeKind::SshPublicKeyShape => {
-            let seed = Seed::from_text(&spec.seed);
-            let mut bytes = [0u8; 32];
-            seed.fill_bytes(&mut bytes);
-            Ok(format!(
-                "ssh-ed25519 {} {}\n",
-                BASE64_STD.encode(bytes),
-                normalize_ssh_comment(&label)
-            )
-            .into_bytes())
-        }
-        MaterializeKind::TokenApiKey => Ok(fx
-            .token(&label, TokenSpec::api_key())
-            .value()
-            .as_bytes()
-            .to_vec()),
-    }
-}
-
 fn verify_fixture_bytes(path: &Path, expected: &[u8]) -> Result<(), MaterializeError> {
     let actual = fs::read(path)?;
     if actual != expected {
@@ -536,42 +442,6 @@ fn fallback_label(path: &Path) -> String {
             }
         })
         .collect()
-}
-
-fn normalize_pem_label(label: &str) -> String {
-    let normalized: String = label
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_uppercase()
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    if normalized.is_empty() {
-        "SECRET".to_string()
-    } else {
-        normalized
-    }
-}
-
-fn normalize_ssh_comment(label: &str) -> String {
-    let normalized: String = label
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '.' || ch == '_' || ch == '-' {
-                ch
-            } else {
-                '-'
-            }
-        })
-        .collect();
-    if normalized.is_empty() {
-        "fixture".to_string()
-    } else {
-        normalized
-    }
 }
 
 fn fixture_const_name(spec: &MaterializeFixtureSpec) -> String {

--- a/crates/uselesskey-cli/src/materialize/entropy.rs
+++ b/crates/uselesskey-cli/src/materialize/entropy.rs
@@ -1,0 +1,9 @@
+use uselesskey_core::Seed;
+
+pub(super) fn entropy_bytes(seed: &str, len: Option<usize>) -> Vec<u8> {
+    let len = len.unwrap_or(32);
+    let seed = Seed::from_text(seed);
+    let mut bytes = vec![0u8; len];
+    seed.fill_bytes(&mut bytes);
+    bytes
+}

--- a/crates/uselesskey-cli/src/materialize/mod.rs
+++ b/crates/uselesskey-cli/src/materialize/mod.rs
@@ -1,0 +1,31 @@
+use uselesskey_core::Factory;
+
+use crate::{MaterializeError, MaterializeFixtureSpec, MaterializeKind, fallback_label};
+
+mod entropy;
+mod pem_shape;
+mod rsa;
+mod ssh_shape;
+mod token;
+
+pub(crate) fn materialized_fixture_bytes(
+    spec: &MaterializeFixtureSpec,
+) -> Result<Vec<u8>, MaterializeError> {
+    let label = spec
+        .label
+        .clone()
+        .unwrap_or_else(|| fallback_label(&spec.out));
+    let fx = Factory::deterministic_from_str(&spec.seed);
+
+    match spec.kind {
+        MaterializeKind::EntropyBytes => Ok(entropy::entropy_bytes(&spec.seed, spec.len)),
+        MaterializeKind::TokenJwtShape => Ok(token::jwt_shape(&fx, &label)),
+        MaterializeKind::RsaPkcs8Der => rsa::pkcs8_der(&fx, &label),
+        MaterializeKind::RsaPkcs8Pem => rsa::pkcs8_pem(&fx, &label),
+        MaterializeKind::PemBlockShape => pem_shape::pem_block_shape(&spec.seed, &label, spec.len),
+        MaterializeKind::SshPublicKeyShape => {
+            Ok(ssh_shape::ssh_public_key_shape(&spec.seed, &label))
+        }
+        MaterializeKind::TokenApiKey => Ok(token::api_key(&fx, &label)),
+    }
+}

--- a/crates/uselesskey-cli/src/materialize/pem_shape.rs
+++ b/crates/uselesskey-cli/src/materialize/pem_shape.rs
@@ -1,0 +1,53 @@
+use std::fmt::Write as _;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STD;
+use uselesskey_core::Seed;
+
+use crate::MaterializeError;
+
+pub(super) fn pem_block_shape(
+    seed: &str,
+    label: &str,
+    len: Option<usize>,
+) -> Result<Vec<u8>, MaterializeError> {
+    let len = len.unwrap_or(256);
+    let seed = Seed::from_text(seed);
+    let mut bytes = vec![0u8; len];
+    seed.fill_bytes(&mut bytes);
+    let payload = BASE64_STD.encode(bytes);
+    let block_label = normalize_pem_label(label);
+    let mut out = String::new();
+    let _ = writeln!(&mut out, "-----BEGIN {block_label}-----");
+    for chunk in payload.as_bytes().chunks(64) {
+        let _ = writeln!(
+            &mut out,
+            "{}",
+            std::str::from_utf8(chunk).map_err(|err| {
+                MaterializeError::InvalidManifest(format!(
+                    "generated base64 payload was not utf-8: {err}"
+                ))
+            })?
+        );
+    }
+    let _ = writeln!(&mut out, "-----END {block_label}-----");
+    Ok(out.into_bytes())
+}
+
+fn normalize_pem_label(label: &str) -> String {
+    let normalized: String = label
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if normalized.is_empty() {
+        "SECRET".to_string()
+    } else {
+        normalized
+    }
+}

--- a/crates/uselesskey-cli/src/materialize/rsa.rs
+++ b/crates/uselesskey-cli/src/materialize/rsa.rs
@@ -1,0 +1,40 @@
+use uselesskey_core::Factory;
+#[cfg(feature = "rsa-materialize")]
+use uselesskey_rsa::{RsaFactoryExt, RsaSpec};
+
+use crate::MaterializeError;
+
+pub(super) fn pkcs8_der(fx: &Factory, label: &str) -> Result<Vec<u8>, MaterializeError> {
+    #[cfg(feature = "rsa-materialize")]
+    {
+        Ok(fx
+            .rsa(label, RsaSpec::rs256())
+            .private_key_pkcs8_der()
+            .to_vec())
+    }
+    #[cfg(not(feature = "rsa-materialize"))]
+    {
+        let _ = (fx, label);
+        Err(MaterializeError::InvalidManifest(
+            "rsa.pkcs8_der requires uselesskey-cli feature `rsa-materialize`".to_string(),
+        ))
+    }
+}
+
+pub(super) fn pkcs8_pem(fx: &Factory, label: &str) -> Result<Vec<u8>, MaterializeError> {
+    #[cfg(feature = "rsa-materialize")]
+    {
+        Ok(fx
+            .rsa(label, RsaSpec::rs256())
+            .private_key_pkcs8_pem()
+            .as_bytes()
+            .to_vec())
+    }
+    #[cfg(not(feature = "rsa-materialize"))]
+    {
+        let _ = (fx, label);
+        Err(MaterializeError::InvalidManifest(
+            "rsa.pkcs8_pem requires uselesskey-cli feature `rsa-materialize`".to_string(),
+        ))
+    }
+}

--- a/crates/uselesskey-cli/src/materialize/ssh_shape.rs
+++ b/crates/uselesskey-cli/src/materialize/ssh_shape.rs
@@ -1,0 +1,33 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STD;
+use uselesskey_core::Seed;
+
+pub(super) fn ssh_public_key_shape(seed: &str, label: &str) -> Vec<u8> {
+    let seed = Seed::from_text(seed);
+    let mut bytes = [0u8; 32];
+    seed.fill_bytes(&mut bytes);
+    format!(
+        "ssh-ed25519 {} {}\n",
+        BASE64_STD.encode(bytes),
+        normalize_ssh_comment(label)
+    )
+    .into_bytes()
+}
+
+fn normalize_ssh_comment(label: &str) -> String {
+    let normalized: String = label
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '.' || ch == '_' || ch == '-' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if normalized.is_empty() {
+        "fixture".to_string()
+    } else {
+        normalized
+    }
+}

--- a/crates/uselesskey-cli/src/materialize/token.rs
+++ b/crates/uselesskey-cli/src/materialize/token.rs
@@ -1,0 +1,16 @@
+use uselesskey_core::Factory;
+use uselesskey_token::{TokenFactoryExt, TokenSpec};
+
+pub(super) fn jwt_shape(fx: &Factory, label: &str) -> Vec<u8> {
+    fx.token(label, TokenSpec::oauth_access_token())
+        .value()
+        .as_bytes()
+        .to_vec()
+}
+
+pub(super) fn api_key(fx: &Factory, label: &str) -> Vec<u8> {
+    fx.token(label, TokenSpec::api_key())
+        .value()
+        .as_bytes()
+        .to_vec()
+}


### PR DESCRIPTION
## Summary

`materialized_fixture_bytes` in `crates/uselesskey-cli/src/lib.rs` was a 92-line `match` over `MaterializeKind` that mixed seed handling, factory dispatch, base64/PEM framing, and SSH formatting across 7 variants. This PR extracts each handler into its own focused module under `crates/uselesskey-cli/src/materialize/`, leaving the top-level function as a thin dispatcher.

### Layout

- `materialize/mod.rs` — dispatcher; resolves the label and `Factory` once, then routes by kind.
- `materialize/entropy.rs` — raw seeded entropy bytes.
- `materialize/token.rs` — JWT-shape and API-key token wrappers around `TokenFactoryExt`.
- `materialize/rsa.rs` — feature-gated PKCS#8 DER/PEM; returns the same `InvalidManifest` errors when the `rsa-materialize` feature is off.
- `materialize/pem_shape.rs` — PEM envelope assembly + `normalize_pem_label` (now scoped where it's used).
- `materialize/ssh_shape.rs` — ssh-ed25519 line + `normalize_ssh_comment`.

### Invariants preserved

- Public surface unchanged. `materialized_fixture_bytes` is still `pub(crate)` and reachable from `lib.rs`.
- Byte-for-byte output identical for every kind, including PEM line-chunking and trailing newlines.
- Error strings for the disabled-feature paths match exactly, so the existing `rsa_materialize_requires_feature` test passes unmodified.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p uselesskey-cli --all-features -- -D warnings`
- [x] `cargo clippy -p uselesskey-cli --no-default-features --lib -- -D warnings`
- [x] `cargo test -p uselesskey-cli` (default + `--all-features` + `--no-default-features --lib`) — all green, including `ssh_public_key_shape_stays_shape_only` and `rsa_materialize_requires_feature`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011jWGH1uMNTmtKqEhujoZ8q)_