### PR TITLE
release: prepare v0.9.1

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -1,92 +1,94 @@
-id = "uselesskey-adoption-confidence"
-title = "Adoption correctness and fixture confidence"
-status = "archived"
+id = "uselesskey-v0.9.1-release"
+title = "Prepare and cut v0.9.1"
+status = "active"
 owner = "EffortlessMetrics"
-created = "2026-05-16"
+created = "2026-05-17"
 
 objective = """
-Make the copied user paths correct, well-covered, scanner-safe where claimed,
-and hard to overclaim. Users should be able to generate fixtures, inspect
-manifest/audit metadata, trust scanner-safe labels, run proof, and avoid
-committing generated payloads.
+Ship v0.9.1 as a narrow adoption-confidence patch. The release publishes the
+scanner-safe runtime JWK/JWKS metadata correction, adoption-regression receipts,
+fixture-confidence coverage, no-panic new-debt restoration, and current
+copyable how-to snippets without changing the product promise.
 """
 
 end_state = [
-  "Runtime public JWK/JWKS scanner-safe metadata matches material sensitivity.",
-  "Main fixture families have confidence coverage for deterministic identity, negative variants, public JWK/JWKS shape, or redaction-sensitive behavior where relevant.",
-  "Adapter and contract-pack paths have user-visible confidence coverage.",
-  "cargo xtask adoption-regression summarizes copied user-path correctness.",
-  "cargo xtask check-no-panic-family reports 0 new debt.",
-  "Broad generated refactor drafts are closed or parked outside this lane.",
-  "v0.9.1 patch scope is defined if the scanner-safe fix should be published before the next product lane.",
+  "CHANGELOG.md describes v0.9.1 as a bounded adoption-confidence patch.",
+  "docs/release/evidence-matrix-v0.9.1.md maps the patch release story to proof commands.",
+  "Patch release evidence passes for version 0.9.1.",
+  "v0.9.1 is published through cargo xtask publish, not shipper.",
+  "Post-release audit records GitHub, crates.io, docs.rs, adoption-regression, claim-proof, verification-pack, and bundle-proof state honestly.",
+  "The release lane is archived with closeout and learning records before the next product lane starts.",
 ]
 
 [[work_item]]
-id = "scanner-safe-runtime-metadata"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0002"
-plan = "plans/adoption-confidence/closeout.md"
-commands = [
-  "cargo test -p uselesskey-cli --all-features",
-  "cargo xtask no-blob",
-  "cargo xtask user-path-smoke",
-  "cargo xtask pr-lite",
-  "cargo xtask pr",
-]
-
-[[work_item]]
-id = "fixture-confidence-matrix"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0003"
-plan = "plans/adoption-confidence/closeout.md"
-commands = [
-  "cargo test -p uselesskey-token --all-features",
-  "cargo test -p uselesskey-rsa --all-features",
-  "cargo test -p uselesskey-ecdsa --all-features",
-  "cargo test -p uselesskey-pgp",
-  "cargo test -p uselesskey-x509",
-  "cargo xtask check-no-panic-family",
-]
-
-[[work_item]]
-id = "adapter-confidence"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0003"
-plan = "plans/adoption-confidence/closeout.md"
-commands = [
-  "cargo test -p uselesskey-jsonwebtoken --all-features",
-  "cargo test -p uselesskey-rustls --all-features",
-  "cargo xtask pr-lite",
-]
-
-[[work_item]]
-id = "adoption-regression"
+id = "release-notes-evidence-matrix"
 status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0006"
-plan = "plans/adoption-confidence/closeout.md"
+plan = "plans/v0.9.1-release/implementation-plan.md"
 commands = [
-  "cargo xtask adoption-regression",
-  "cargo xtask adoption-regression --format json",
-]
-
-[[work_item]]
-id = "lane-closeout"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0005"
-plan = "plans/adoption-confidence/closeout.md"
-commands = [
-  "cargo xtask adoption-regression",
-  "cargo xtask adoption-regression --format json",
-  "cargo xtask check-no-panic-family",
+  "cargo xtask spec-check --strict",
   "cargo xtask claim-report --check-public-claims",
   "cargo xtask contract-packs --check",
   "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "release-candidate-proof"
+status = "ready"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0006"
+plan = "plans/v0.9.1-release/implementation-plan.md"
+commands = [
+  "cargo xtask release-evidence --version 0.9.1 --patch --dry-run --summary",
+  "cargo xtask adoption-regression",
+  "cargo xtask adoption-regression --format json",
+  "cargo xtask claim-proof --all-stable",
+  "cargo xtask user-path-smoke",
+  "cargo xtask check-no-panic-family",
+  "cargo xtask claim-report --check-public-claims",
+  "cargo xtask contract-packs --check",
   "cargo +nightly xtask pr-lite",
   "cargo xtask pr",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "cut-v0.9.1"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0006"
+plan = "plans/v0.9.1-release/implementation-plan.md"
+commands = [
+  "cargo xtask release-evidence --version 0.9.1 --patch --dry-run --summary",
+  "cargo xtask publish-preflight",
+  "cargo xtask publish-check",
+  "cargo xtask no-blob",
+  "cargo xtask check-no-panic-family",
+  "cargo xtask badges --check",
+  "cargo xtask docs-sync --check",
+  "cargo xtask pr",
+  "git diff --check",
+  "cargo xtask publish",
+]
+
+[[work_item]]
+id = "post-release-audit"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0006"
+plan = "plans/v0.9.1-release/implementation-plan.md"
+commands = [
+  "cargo xtask cratesio-smoke --version 0.9.1",
+  "cargo xtask adoption-regression",
+  "cargo xtask claim-proof --all-stable",
+  "cargo xtask verification-pack --out target/uselesskey-verification",
+  "cargo xtask bundle-proof --profile tls --out target/release-evidence/tls",
+  "cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc",
+  "cargo xtask bundle-proof --profile webhook --out target/release-evidence/webhook",
+  "cargo xtask no-blob",
+  "cargo xtask check-no-panic-family",
   "git diff --check",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-17
+
+v0.9.1 is an adoption-confidence patch. It publishes the runtime scanner-safe
+metadata correction for public asymmetric JWK/JWKS outputs, adds
+adoption-regression receipts for copied user paths, and carries fixture and
+adapter confidence coverage that makes v0.9.0's first-run path safer to trust.
+
+This release does not add product claims, profiles, contract packs, README
+badges, provider compatibility promises, or production security assurances.
+
+### Added
+
+- Added `cargo xtask adoption-regression` with Markdown and JSON receipts for
+  copied user-path confidence across user-path smoke, runtime scanner-safe
+  matrix, webhook profile tests, TLS/OIDC bundle proofs, and no-blob checks.
+- Added fixture and adapter confidence coverage for scanner-safe metadata,
+  negative variants, deterministic identity pins, debug/redaction-sensitive
+  output, and copied contract-pack paths.
+
+### Changed
+
+- Refreshed first-run and how-to snippets so current copyable examples point at
+  the v0.9 release line.
+
+### Fixed
+
+- Corrected runtime bundle metadata so public asymmetric RSA/ECDSA/Ed25519
+  JWK/JWKS artifacts are scanner-safe while secret-bearing HMAC, token, and
+  private key outputs remain outside that claim.
+- Restored the no-panic-family new-debt posture after the adoption-confidence
+  coverage and X.509 refactor work.
+
 ## [0.9.0] - 2026-05-14
 
 v0.9.0 is the command-backed fixture-platform release. It turns public

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@ Validation lanes and the claim boundaries behind them.
 Release-candidate proof and public promise evidence.
 
 - [evidence-matrix-v0.9.0.md](release/evidence-matrix-v0.9.0.md) — v0.9.0 command-backed claim, verification-pack, PR-lite, and webhook proof matrix
+- [evidence-matrix-v0.9.1.md](release/evidence-matrix-v0.9.1.md) — v0.9.1 adoption-confidence patch proof matrix
 - [evidence-matrix-v0.7.0.md](release/evidence-matrix-v0.7.0.md) — v0.7.0 public fixture promise evidence matrix
 - [v0.7.0-checklist.md](release/v0.7.0-checklist.md) — Release-governance issue map for v0.7.0 checklist lines
 - [v0.7.0-category-notes.md](release/v0.7.0-category-notes.md) — Release note category map and draft-audit guidance for v0.7.0

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -127,14 +127,14 @@ verifier correctness.
 Patch release evidence records the public claim index:
 
 ```bash
-cargo xtask release-evidence --version 0.8.1 --patch --dry-run --summary
+cargo xtask release-evidence --version <PATCH_VERSION> --patch --dry-run --summary
 ```
 
 Minor release evidence records both public claims and contract-pack registry
 state:
 
 ```bash
-cargo xtask release-evidence --version 0.9.0 --dry-run --summary
+cargo xtask release-evidence --version <MINOR_VERSION> --dry-run --summary
 ```
 
 Non-dry release evidence writes these receipts:

--- a/docs/how-to/migration.md
+++ b/docs/how-to/migration.md
@@ -1,6 +1,7 @@
-# Migrating to `uselesskey` 0.7.0: deterministic crypto fixtures without committed blobs
+# Migrating to `uselesskey`: deterministic crypto fixtures without committed blobs
 
-This guide shows how to replace committed PEM/DER/JWK/token blobs with runtime-generated fixtures using `uselesskey` **0.7.0**.
+This guide shows how to replace committed PEM/DER/JWK/token blobs with
+runtime-generated fixtures using the current v0.9 release line.
 
 ## What this repo is for
 
@@ -18,7 +19,7 @@ Use `uselesskey` as a `dev-dependency`, then opt into only the fixture families 
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.7.0", default-features = false, features = ["rsa", "jwk"] }
+uselesskey = { version = "0.9.0", default-features = false, features = ["rsa", "jwk"] }
 ```
 
 ### Minimal feature examples
@@ -26,22 +27,21 @@ uselesskey = { version = "0.7.0", default-features = false, features = ["rsa", "
 ```toml
 # token-only tests
 [dev-dependencies]
-uselesskey = { version = "0.7.0", default-features = false, features = ["token"] }
+uselesskey = { version = "0.9.0", default-features = false, features = ["token"] }
 ```
 
 ```toml
 # TLS chain + rustls adapter
 [dev-dependencies]
-uselesskey = { version = "0.7.0", default-features = false, features = ["x509"] }
-uselesskey-rustls = { version = "0.7.0" }
+uselesskey = { version = "0.9.0", default-features = false, features = ["x509"] }
+uselesskey-rustls = { version = "0.9.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```toml
-# JWT + JOSE/OpenID style conversions
+# JWT signing and verification helpers
 [dev-dependencies]
-uselesskey = { version = "0.7.0", default-features = false, features = ["rsa", "hmac", "jwk"] }
-uselesskey-jsonwebtoken = { version = "0.7.0" }
-uselesskey-jose-openid = { version = "0.7.0" }
+uselesskey = { version = "0.9.0", default-features = false, features = ["rsa", "hmac", "jwk"] }
+uselesskey-jsonwebtoken = { version = "0.9.0" }
 ```
 
 > Prefer adapter crates (`uselesskey-rustls`, `uselesskey-jsonwebtoken`, etc.) over broad feature bundles to keep compile and dependency surface small.
@@ -173,7 +173,7 @@ Use `Factory::random()` when fixture values should vary across runs (e.g., explo
 
 ## Migration checklist
 
-1. Add `uselesskey` 0.7.0 to `[dev-dependencies]`
+1. Add `uselesskey` to `[dev-dependencies]`
 2. Enable only needed features (`rsa`, `ecdsa`, `ed25519`, `hmac`, `token`, `x509`, `pgp`, `jwk`)
 3. Replace committed PEM/DER/JWK/token fixtures with `Factory` calls
 4. Centralize seed strategy (`USELESSKEY_SEED` in CI)

--- a/docs/how-to/release.md
+++ b/docs/how-to/release.md
@@ -65,9 +65,12 @@ Before tagging, make sure the release PR has already:
 - prepared the post-release audit checklist in
   [`docs/release/post-release-audit.md`](../release/post-release-audit.md)
 
-For v0.9.0, use
-[`docs/release/evidence-matrix-v0.9.0.md`](../release/evidence-matrix-v0.9.0.md)
-as the release-specific proof map.
+For version-specific proof maps, use the matching release matrix:
+
+- [`docs/release/evidence-matrix-v0.9.1.md`](../release/evidence-matrix-v0.9.1.md)
+  for the v0.9.1 adoption-confidence patch
+- [`docs/release/evidence-matrix-v0.9.0.md`](../release/evidence-matrix-v0.9.0.md)
+  for the v0.9.0 command-backed fixture-platform release
 
 ## Publish
 

--- a/docs/release/evidence-matrix-v0.9.1.md
+++ b/docs/release/evidence-matrix-v0.9.1.md
@@ -1,0 +1,145 @@
+# v0.9.1 Release Evidence Matrix
+
+This matrix maps the v0.9.1 patch release story to the proof commands that must
+carry it.
+
+v0.9.1 is an adoption-confidence patch. It publishes confidence work already
+landed on `main` after v0.9.0:
+
+```text
+runtime metadata correction
+  -> copied user-path smoke
+    -> adoption-regression receipts
+      -> claim-proof and verification-pack checks
+        -> patch release evidence
+```
+
+This document is the release-prep proof map. It names the required proof, the
+receipt surface, and the planned v0.9.1 candidate status. Generated receipts
+stay under `target/` unless a later PR explicitly adds a tracked receipt path.
+
+## Patch Scope
+
+v0.9.1 is scoped to:
+
+- runtime public asymmetric JWK/JWKS scanner-safe metadata correction;
+- `cargo xtask adoption-regression` Markdown and JSON receipts;
+- fixture-confidence coverage for copied user paths;
+- no-panic new-debt restoration;
+- current copyable how-to snippets.
+
+It does not add product claims, profiles, contract packs, README badges,
+provider compatibility promises, production security promises, shipper
+migration work, historical no-panic baseline work, or broad dependency churn.
+
+## Required Release Gates
+
+| Gate | Command or artifact | Patch claim covered | v0.9.1 candidate status |
+| --- | --- | --- | --- |
+| Source-of-truth proof | `cargo xtask spec-check --strict` | Specs, plans, active goals, and claim ledgers are parseable and linked. | Planned. |
+| Public claim drift check | `cargo xtask claim-report --check-public-claims` | Public claim index matches `policy/claim-ledger.toml`. | Planned. |
+| Contract-pack registry | `cargo xtask contract-packs --check` | Existing stable contract packs remain registered and bounded. | Planned. |
+| Patch release evidence | `cargo xtask release-evidence --version 0.9.1 --patch --dry-run --summary` | Patch lane carries publish-system and user-path smoke evidence without full minor-release expansion. | Planned. |
+| Adoption regression | `cargo xtask adoption-regression` and `cargo xtask adoption-regression --format json` | Copied user paths, runtime scanner-safe matrix, webhook profile tests, TLS/OIDC proofs, and no-blob pass. | Planned. |
+| Stable claim proof | `cargo xtask claim-proof --all-stable` | Stable public claims still have whitelisted proof handlers. | Planned. |
+| User-path smoke | `cargo xtask user-path-smoke` | Scanner-safe, TLS, OIDC, and webhook copyable paths still work. | Planned. |
+| No-panic family | `cargo xtask check-no-panic-family` | Stage A.5 new-debt posture remains clean. | Planned. |
+| PR-lite local evidence | `cargo +nightly xtask pr-lite` | Local contributor evidence remains bounded and receipt-backed. | Planned. |
+| Full PR gate | `cargo xtask pr` | Fast PR evidence, docs, examples, public-surface, and receipts pass. | Planned. |
+| Publish preflight | `cargo xtask publish-preflight` | Metadata, package, and snippet checks are ready before publish. | Pre-tag only. |
+| Publish dry run | `cargo xtask publish-check` | Publishable crates dry-run in dependency order. | Pre-tag only. |
+| Secret-shaped blob gate | `cargo xtask no-blob` | No committed secret-shaped fixture blobs were introduced. | Pre-tag and audit. |
+| Badge endpoint drift | `cargo xtask badges --check` | Existing generated badge endpoints remain current; v0.9.1 adds no badge. | Pre-tag only. |
+| Post-release crates.io smoke | `cargo xtask cratesio-smoke --version 0.9.1` | External registry install view works after publish. | Post-release audit only. |
+| docs.rs state | `docs/release/post-release-audit-v0.9.1.md` | docs.rs is complete, queued, failed, or not found; queued is not a republish reason. | Post-release audit only. |
+
+## Scanner-Safe Metadata Proof
+
+The patch's user-visible fix is runtime public JWK/JWKS scanner-safe metadata.
+The candidate proof must show that public asymmetric JWK/JWKS artifacts are
+treated as scanner-safe while secret-bearing HMAC, token, and private key
+outputs remain outside that claim.
+
+The direct proof path is:
+
+```bash
+cargo xtask adoption-regression
+cargo xtask adoption-regression --format json
+cargo xtask user-path-smoke
+cargo xtask no-blob
+```
+
+## Public Claim Matrix
+
+| Public claim | Surfaces | Required evidence | Artifact or command | v0.9.1 status |
+| --- | --- | --- | --- | --- |
+| Scanner-safe fixtures | README badge, `badges/scanner-safe.json`, `docs/status/PUBLIC_CLAIMS.md`, bundle manifests | Scanner-safe reference, runtime matrix, no-blob gate, generated badge drift check | `cargo xtask claim-proof --claim scanner-safe-fixtures`; `cargo xtask adoption-regression`; `cargo xtask no-blob` | Planned. |
+| TLS contract pack | `uselesskey bundle --profile tls`, TLS how-to, contract-pack registry | Existing bundle proof and contract-pack registry row remain valid | `cargo xtask bundle-proof --profile tls --out target/release-evidence/tls`; `cargo xtask claim-proof --claim tls-contract-pack` | Post-release audit repeat. |
+| OIDC/JWKS contract pack | OIDC/JWKS docs and contract-pack registry | Existing bundle proof and contract-pack registry row remain valid | `cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc`; `cargo xtask claim-proof --claim oidc-jwks-contract-pack` | Post-release audit repeat. |
+| Webhook contract pack | `uselesskey bundle --profile webhook`, webhook how-to, contract-pack registry | Existing bundle proof, claim-proof handler, and verification-pack inclusion remain valid | `cargo xtask bundle-proof --profile webhook --out target/release-evidence/webhook`; `cargo xtask claim-proof --claim webhook-contract-pack` | Post-release audit repeat. |
+| Public crate-surface stability | README, docs metadata, support matrix, publish plan | Public-surface and publish preflight checks | `cargo xtask public-surface`; `cargo xtask publish-preflight`; `cargo xtask publish-check` | Pre-tag and audit. |
+| External crates.io install smoke | Post-release audit, release evidence | External install against published registry version | `cargo xtask cratesio-smoke --version 0.9.1` | Post-release only. |
+
+## Verification-Pack Proof
+
+The metadata-only review bundle must remain buildable:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification
+cargo xtask verification-pack --out target/uselesskey-verification --claim scanner-safe-fixtures
+```
+
+The verification pack contains receipts and metadata. It must not copy generated
+secret-shaped fixture payloads into a shareable review bundle.
+
+## Claim Boundaries
+
+Scanner-safe fixtures mean repository automation found no committed
+secret-shaped fixture blobs under the configured fixture policy and that bundle
+metadata classifies fixture material by sensitivity. This does not mean every
+derived encoded export is safe to commit, and it does not prove scanner evasion.
+
+TLS contract-pack proof covers deterministic verifier-path fixtures. It does
+not prove production PKI, revocation, CT, mTLS, browser trust-store behavior,
+or operational certificate management.
+
+OIDC/JWKS contract-pack proof covers deterministic discovery/JWKS verifier
+fixtures. It does not prove production identity-provider compatibility, token
+lifetime policy, key rotation policy, or network security.
+
+Webhook contract-pack proof covers deterministic HMAC webhook verifier fixtures
+for positive and negative request cases. It does not prove production webhook
+provider compatibility, secret rotation, delivery retries, timestamp-policy
+suitability, replay protection completeness, transport security, or production
+secret management.
+
+PR evidence is diff-scoped and advisory. It belongs in summaries, annotations,
+and artifacts, not public README badges.
+
+## Candidate Proof Command Set
+
+The release-candidate proof PR should run:
+
+```bash
+cargo xtask release-evidence --version 0.9.1 --patch --dry-run --summary
+cargo xtask adoption-regression
+cargo xtask adoption-regression --format json
+cargo xtask claim-proof --all-stable
+cargo xtask user-path-smoke
+cargo xtask check-no-panic-family
+cargo xtask claim-report --check-public-claims
+cargo xtask contract-packs --check
+cargo +nightly xtask pr-lite
+cargo xtask pr
+git diff --check
+```
+
+The pre-tag proof PR should additionally run:
+
+```bash
+cargo xtask publish-preflight
+cargo xtask publish-check
+cargo xtask no-blob
+cargo xtask badges --check
+cargo xtask docs-sync --check
+```

--- a/plans/README.md
+++ b/plans/README.md
@@ -15,6 +15,7 @@ Plans do not define product truth. Link to proposals for why and specs for what.
 - [v0.9.0-release](v0.9.0-release/README.md) - v0.9.0 release preparation, proof, publish, and audit
 - [first-run-ux](first-run-ux/README.md) - First-run task routing and contract-pack adoption UX
 - [adoption-confidence](adoption-confidence/README.md) - Copied user-path correctness, fixture confidence, and adoption-regression closeout
+- [v0.9.1-release](v0.9.1-release/README.md) - v0.9.1 adoption-confidence patch release
 
 ## Templates
 

--- a/plans/v0.9.1-release/README.md
+++ b/plans/v0.9.1-release/README.md
@@ -1,0 +1,11 @@
+# v0.9.1 Release
+
+This plan area owns the v0.9.1 patch release lane.
+
+The lane starts after v0.9.0, first-run UX, and adoption-confidence have
+closed. Its job is to publish the already-landed confidence fixes, not to add
+another product pack or broaden the public promise.
+
+## Plan Files
+
+- [implementation-plan.md](implementation-plan.md) - PR sequence, proof commands, non-goals, and stop conditions

--- a/plans/v0.9.1-release/implementation-plan.md
+++ b/plans/v0.9.1-release/implementation-plan.md
@@ -1,0 +1,205 @@
++++
+id = "USELESSKEY-PLAN-0016"
+kind = "plan"
+title = "v0.9.1 release"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-17"
+milestone = "v0.9.1"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0002",
+  "USELESSKEY-SPEC-0003",
+  "USELESSKEY-SPEC-0005",
+  "USELESSKEY-SPEC-0006",
+  "USELESSKEY-SPEC-0008",
+  "USELESSKEY-SPEC-0009",
+  "USELESSKEY-SPEC-0010",
+  "USELESSKEY-SPEC-0011",
+  "USELESSKEY-SPEC-0012",
+]
+linked_adrs = [
+  "USELESSKEY-ADR-0002",
+  "USELESSKEY-ADR-0004",
+]
++++
+
+# v0.9.1 Release
+
+## Objective
+
+Ship v0.9.1 as a narrow adoption-confidence patch.
+
+The release story is:
+
+```text
+v0.9.0 adoption path
+  -> scanner-safe runtime JWK/JWKS metadata correction
+    -> adoption-regression receipt
+      -> fixture-confidence coverage
+        -> no-panic new-debt restoration
+          -> patch release audit
+```
+
+## Scope
+
+This lane covers:
+
+- v0.9.1 changelog and patch evidence matrix;
+- patch release proof for the adoption-confidence surface;
+- publish preflight and publish-check proof;
+- v0.9.1 publish through `cargo xtask publish`;
+- post-release audit for GitHub, crates.io, docs.rs, adoption-regression,
+  claim-proof, verification-pack, and contract-pack proofs.
+
+## Non-goals
+
+Do not mix these into the v0.9.1 release lane:
+
+- new contract packs;
+- new README badges;
+- provider compatibility claims;
+- production security claims;
+- shipper migration work;
+- TLS mTLS, revocation, CT, or browser trust-store expansion;
+- historical no-panic baseline burndown;
+- broad dependency churn;
+- broad SRP refactors.
+
+## PR Sequence
+
+1. `release: prepare v0.9.1`
+   - Update `CHANGELOG.md`.
+   - Add `docs/release/evidence-matrix-v0.9.1.md`.
+   - Open this active release goal and plan.
+   - Verify current user-facing version snippets do not leave stale v0.7/v0.8
+     copyable install guidance outside historical migration docs.
+   - Validation:
+
+     ```bash
+     cargo xtask spec-check --strict
+     cargo xtask claim-report --check-public-claims
+     cargo xtask contract-packs --check
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+2. `release: prove v0.9.1 candidate`
+   - Run patch-release proof.
+   - Do not commit generated `target/` receipts unless a tracked receipt path is
+     explicitly added.
+   - Validation:
+
+     ```bash
+     cargo xtask release-evidence --version 0.9.1 --patch --dry-run --summary
+     cargo xtask adoption-regression
+     cargo xtask adoption-regression --format json
+     cargo xtask claim-proof --all-stable
+     cargo xtask user-path-smoke
+     cargo xtask check-no-panic-family
+     cargo xtask claim-report --check-public-claims
+     cargo xtask contract-packs --check
+     cargo +nightly xtask pr-lite
+     cargo xtask pr
+     git diff --check
+     ```
+
+3. `release: cut v0.9.1`
+   - Bump publishable crate versions where required.
+   - Re-run pre-tag proof.
+   - Publish through `cargo xtask publish`.
+   - Do not switch to shipper for this release.
+   - Validation:
+
+     ```bash
+     cargo xtask release-evidence --version 0.9.1 --patch --dry-run --summary
+     cargo xtask publish-preflight
+     cargo xtask publish-check
+     cargo xtask no-blob
+     cargo xtask check-no-panic-family
+     cargo xtask badges --check
+     cargo xtask docs-sync --check
+     cargo xtask pr
+     git diff --check
+     ```
+
+4. `release(v0.9.1): post-release audit record`
+   - Verify GitHub release visibility.
+   - Verify intended public crates on crates.io.
+   - Verify removed shims were not republished.
+   - Run `cargo xtask cratesio-smoke --version 0.9.1`.
+   - Record docs.rs state honestly. Queued docs.rs builds are not a republish
+     reason; failed builds require build-log inspection.
+   - Re-run adoption-regression, claim-proof, verification-pack, and
+     TLS/OIDC/webhook bundle proofs.
+
+5. `docs: close out v0.9.1 release lane`
+   - Archive the active goal.
+   - Add release closeout and learning records.
+   - Leave the repo ready for the next product lane.
+
+## Proof Commands
+
+Release setup:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask claim-report --check-public-claims
+cargo xtask contract-packs --check
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Release candidate:
+
+```bash
+cargo xtask release-evidence --version 0.9.1 --patch --dry-run --summary
+cargo xtask adoption-regression
+cargo xtask adoption-regression --format json
+cargo xtask claim-proof --all-stable
+cargo xtask user-path-smoke
+cargo xtask check-no-panic-family
+cargo xtask claim-report --check-public-claims
+cargo xtask contract-packs --check
+cargo +nightly xtask pr-lite
+cargo xtask pr
+git diff --check
+```
+
+Pre-publish:
+
+```bash
+cargo xtask release-evidence --version 0.9.1 --patch --dry-run --summary
+cargo xtask publish-preflight
+cargo xtask publish-check
+cargo xtask no-blob
+cargo xtask check-no-panic-family
+cargo xtask badges --check
+cargo xtask docs-sync --check
+cargo xtask pr
+git diff --check
+```
+
+## Rollback
+
+Before tagging or publishing, this lane is ordinary release-candidate work:
+revert the release PR or split the failed proof into a fix PR.
+
+After publishing starts, use the existing publish-recovery and post-release
+audit docs. Do not rewrite tags, yank crates, or republish without an explicit
+operator decision and a written recovery record.
+
+## Stop Conditions
+
+Pause before irreversible release actions if:
+
+- a proof command fails and the failure is not understood;
+- `cargo xtask publish-check` or `publish-preflight` fails;
+- `no-blob` or scanner-safe proof fails;
+- generated badge endpoints drift without explanation;
+- docs.rs returns failed build logs instead of queue lag;
+- a request asks to switch to shipper for this release;
+- the release scope expands into a new contract pack, badge, TLS expansion,
+  dependency churn, or historical no-panic baseline work.


### PR DESCRIPTION
## Summary
- opens the v0.9.1 release lane as a narrow adoption-confidence patch
- adds the v0.9.1 release plan and evidence matrix
- updates changelog, release docs, and stale current migration snippets to the v0.9 line

## Files added/changed
- .uselesskey/goals/active.toml
- plans/v0.9.1-release/README.md
- plans/v0.9.1-release/implementation-plan.md
- docs/release/evidence-matrix-v0.9.1.md
- CHANGELOG.md
- docs/README.md
- docs/VERIFICATION.md
- docs/how-to/release.md
- docs/how-to/migration.md
- plans/README.md

## Validation
- cargo xtask spec-check --strict
- cargo xtask claim-report --check-public-claims
- cargo xtask contract-packs --check
- cargo xtask docs-sync --check
- cargo xtask typos
- git diff --check

## Non-goals
- no version bump, tag, publish, or GitHub release creation
- no new product claims, profiles, contract packs, or badges
- no shipper migration, TLS expansion, dependency churn, historical no-panic baseline work, or broad SRP refactors

## What this enables next
- run and merge the v0.9.1 release-candidate proof slice
- then cut, publish, audit, and close the patch release lane