### PR TITLE
xtask: add external adoption smoke

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -50,7 +50,7 @@ commands = [
 
 [[work_item]]
 id = "external-adoption-smoke"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0013"
 plan = "plans/v0.10.0-external-adoption/implementation-plan.md"
@@ -64,7 +64,7 @@ commands = [
 
 [[work_item]]
 id = "installed-cli-docs"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0012"
 plan = "plans/v0.10.0-external-adoption/implementation-plan.md"

--- a/xtask/src/external_adoption_smoke.rs
+++ b/xtask/src/external_adoption_smoke.rs
@@ -1,0 +1,811 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+
+use crate::git_head_sha;
+
+const OUT_DIR: &str = "target/external-adoption-smoke";
+const WORK_DIR: &str = "target/external-adoption-smoke/work";
+const LOG_DIR: &str = "target/external-adoption-smoke/logs";
+const REPORT_JSON: &str = "target/external-adoption-smoke/report.json";
+const REPORT_MD: &str = "target/external-adoption-smoke/report.md";
+
+const CLI_PROFILES: &[&str] = &["scanner-safe", "tls", "oidc", "webhook"];
+const BOUNDARIES: &[&str] = &[
+    "external-adoption-smoke proves clean-project user paths, not release readiness",
+    "published-version mode is audit/reference evidence, not a release trigger",
+    "installed-style CLI smoke does not claim provider compatibility",
+    "repo-local claim-proof and verification-pack remain separate proof surfaces",
+    "generated fixture payloads and temp projects stay under target/external-adoption-smoke/",
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputFormat {
+    Human,
+    Json,
+}
+
+#[derive(Debug)]
+pub struct RunOptions {
+    pub path: Option<PathBuf>,
+    pub version: Option<String>,
+    pub format: OutputFormat,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum SmokeMode {
+    Path,
+    Version,
+}
+
+#[derive(Debug)]
+struct SmokeSource {
+    mode: SmokeMode,
+    label: String,
+    facade_dep: FacadeDependency,
+    cli_source: CliSource,
+}
+
+#[derive(Debug)]
+enum FacadeDependency {
+    Path(PathBuf),
+    Version(String),
+}
+
+#[derive(Debug)]
+enum CliSource {
+    LocalPath(PathBuf),
+    Version(String),
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ExternalAdoptionSmokeReceipt {
+    schema_version: u32,
+    status: String,
+    generated_at: String,
+    git_sha: Option<String>,
+    mode: SmokeMode,
+    source: String,
+    work_root: String,
+    projects: Vec<ExternalAdoptionProject>,
+    steps: Vec<ExternalAdoptionStep>,
+    artifacts: Vec<String>,
+    boundaries: Vec<&'static str>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ExternalAdoptionProject {
+    name: String,
+    path: String,
+    status: String,
+    outputs: Vec<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ExternalAdoptionStep {
+    name: String,
+    command: Vec<String>,
+    cwd: String,
+    status: String,
+    duration_ms: u64,
+    stdout: String,
+    stderr: String,
+    details: Option<String>,
+    artifacts: Vec<String>,
+}
+
+pub fn run(root: &Path, options: RunOptions) -> Result<()> {
+    let source = resolve_source(&options)?;
+    let out_dir = root.join(OUT_DIR);
+    reset_target_output(root, &out_dir)?;
+    let work_dir = root.join(WORK_DIR);
+    let log_dir = root.join(LOG_DIR);
+    fs::create_dir_all(&work_dir)
+        .with_context(|| format!("failed to create {}", work_dir.display()))?;
+    fs::create_dir_all(&log_dir)
+        .with_context(|| format!("failed to create {}", log_dir.display()))?;
+
+    let mut receipt = ExternalAdoptionSmokeReceipt {
+        schema_version: 1,
+        status: "running".to_string(),
+        generated_at: chrono::Utc::now().to_rfc3339(),
+        git_sha: git_head_sha().ok(),
+        mode: source.mode.clone(),
+        source: source.label.clone(),
+        work_root: relative_artifact(root, &work_dir),
+        projects: Vec::new(),
+        steps: Vec::new(),
+        artifacts: vec![
+            REPORT_JSON.to_string(),
+            REPORT_MD.to_string(),
+            WORK_DIR.to_string(),
+            LOG_DIR.to_string(),
+        ],
+        boundaries: BOUNDARIES.to_vec(),
+    };
+
+    let result = run_matrix(root, &source, &work_dir, &log_dir, &mut receipt);
+    receipt.status = if result.is_ok() { "pass" } else { "failed" }.to_string();
+    write_receipts(&out_dir, &receipt)?;
+    match options.format {
+        OutputFormat::Human => print_human(&receipt),
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&receipt)?),
+    }
+
+    result
+}
+
+fn run_matrix(
+    root: &Path,
+    source: &SmokeSource,
+    work_dir: &Path,
+    log_dir: &Path,
+    receipt: &mut ExternalAdoptionSmokeReceipt,
+) -> Result<()> {
+    let cli_bin = prepare_cli(root, source, work_dir, log_dir, receipt)?;
+    run_rust_test_project(source, work_dir, log_dir, receipt)?;
+    run_cli_discovery(&cli_bin, work_dir, log_dir, receipt)?;
+    for profile in CLI_PROFILES {
+        run_cli_profile(&cli_bin, profile, work_dir, log_dir, receipt)?;
+    }
+    Ok(())
+}
+
+fn prepare_cli(
+    root: &Path,
+    source: &SmokeSource,
+    work_dir: &Path,
+    log_dir: &Path,
+    receipt: &mut ExternalAdoptionSmokeReceipt,
+) -> Result<PathBuf> {
+    match &source.cli_source {
+        CliSource::LocalPath(cli_dir) => {
+            let target_dir = work_dir.join("cargo-target/local-cli");
+            fs::create_dir_all(&target_dir)
+                .with_context(|| format!("failed to create {}", target_dir.display()))?;
+            let mut cmd = Command::new("cargo");
+            cmd.args(["build", "--quiet", "--bin", "uselesskey", "--manifest-path"])
+                .arg(cli_dir.join("Cargo.toml"))
+                .env("CARGO_TARGET_DIR", &target_dir);
+            run_command_step(
+                receipt,
+                "build-local-cli",
+                cmd,
+                root,
+                log_dir,
+                &["target/external-adoption-smoke/work/cargo-target/local-cli/"],
+            )?;
+            let bin = target_dir.join("debug").join(cli_binary_name());
+            if !bin.is_file() {
+                bail!("expected local CLI binary at {}", bin.display());
+            }
+            Ok(bin)
+        }
+        CliSource::Version(version) => {
+            let cli_root = work_dir.join("cli-root");
+            let mut cmd = Command::new("cargo");
+            cmd.args(["install", "uselesskey-cli", "--version", version, "--root"])
+                .arg(&cli_root)
+                .arg("--locked");
+            run_command_step(
+                receipt,
+                "install-published-cli",
+                cmd,
+                root,
+                log_dir,
+                &["target/external-adoption-smoke/work/cli-root/"],
+            )?;
+            let bin = cli_root.join("bin").join(cli_binary_name());
+            if !bin.is_file() {
+                bail!("expected installed CLI binary at {}", bin.display());
+            }
+            Ok(bin)
+        }
+    }
+}
+
+fn run_rust_test_project(
+    source: &SmokeSource,
+    work_dir: &Path,
+    log_dir: &Path,
+    receipt: &mut ExternalAdoptionSmokeReceipt,
+) -> Result<()> {
+    let project_dir = work_dir.join("rust-test-fixtures");
+    write_rust_test_project(&project_dir, &source.facade_dep)?;
+    let mut cmd = Command::new("cargo");
+    cmd.args(["test", "--quiet"])
+        .current_dir(&project_dir)
+        .env("CARGO_TARGET_DIR", project_dir.join("target"));
+    run_command_step(
+        receipt,
+        "rust-test-fixtures",
+        cmd,
+        &project_dir,
+        log_dir,
+        &["target/external-adoption-smoke/work/rust-test-fixtures/"],
+    )?;
+    record_project(
+        receipt,
+        "rust-test-fixtures",
+        &project_dir,
+        &["target/external-adoption-smoke/work/rust-test-fixtures/target/".to_string()],
+    );
+    Ok(())
+}
+
+fn run_cli_discovery(
+    cli_bin: &Path,
+    work_dir: &Path,
+    log_dir: &Path,
+    receipt: &mut ExternalAdoptionSmokeReceipt,
+) -> Result<()> {
+    let project_dir = work_dir.join("cli-discovery");
+    fs::create_dir_all(project_dir.join("target"))
+        .with_context(|| format!("failed to create {}", project_dir.display()))?;
+
+    let mut profiles = Command::new(cli_bin);
+    profiles.arg("profiles").current_dir(&project_dir);
+    run_command_step(
+        receipt,
+        "cli-profiles",
+        profiles,
+        &project_dir,
+        log_dir,
+        &[],
+    )?;
+
+    let mut explain = Command::new(cli_bin);
+    explain
+        .args(["profile", "webhook", "--explain"])
+        .current_dir(&project_dir);
+    run_command_step(
+        receipt,
+        "cli-profile-webhook-explain",
+        explain,
+        &project_dir,
+        log_dir,
+        &[],
+    )?;
+
+    Ok(())
+}
+
+fn run_cli_profile(
+    cli_bin: &Path,
+    profile: &str,
+    work_dir: &Path,
+    log_dir: &Path,
+    receipt: &mut ExternalAdoptionSmokeReceipt,
+) -> Result<()> {
+    let project_name = format!("{profile}-cli");
+    let project_dir = work_dir.join(&project_name);
+    let target_dir = project_dir.join("target");
+    let bundle_dir = target_dir.join(format!("uselesskey-{profile}"));
+    let inspect_out = target_dir.join(format!("inspect-{profile}.txt"));
+    fs::create_dir_all(&target_dir)
+        .with_context(|| format!("failed to create {}", target_dir.display()))?;
+
+    let bundle_artifact = relative_artifact_from_path(&bundle_dir);
+    let inspect_artifact = relative_artifact_from_path(&inspect_out);
+
+    let mut bundle = Command::new(cli_bin);
+    bundle
+        .args(["bundle", "--profile", profile, "--out"])
+        .arg(&bundle_dir)
+        .current_dir(&project_dir);
+    run_command_step(
+        receipt,
+        &format!("cli-bundle-{profile}"),
+        bundle,
+        &project_dir,
+        log_dir,
+        &[bundle_artifact.as_str()],
+    )?;
+
+    let mut verify = Command::new(cli_bin);
+    verify
+        .args(["verify-bundle", "--path"])
+        .arg(&bundle_dir)
+        .current_dir(&project_dir);
+    run_command_step(
+        receipt,
+        &format!("cli-verify-{profile}"),
+        verify,
+        &project_dir,
+        log_dir,
+        &[bundle_artifact.as_str()],
+    )?;
+
+    let mut inspect = Command::new(cli_bin);
+    inspect
+        .args(["inspect-bundle", "--path"])
+        .arg(&bundle_dir)
+        .args(["--out"])
+        .arg(&inspect_out)
+        .current_dir(&project_dir);
+    run_command_step(
+        receipt,
+        &format!("cli-inspect-{profile}"),
+        inspect,
+        &project_dir,
+        log_dir,
+        &[bundle_artifact.as_str(), inspect_artifact.as_str()],
+    )?;
+
+    verify_bundle_shape(&bundle_dir, profile)?;
+    record_project(
+        receipt,
+        &project_name,
+        &project_dir,
+        &[bundle_artifact, inspect_artifact],
+    );
+
+    Ok(())
+}
+
+fn write_rust_test_project(project_dir: &Path, dep: &FacadeDependency) -> Result<()> {
+    fs::create_dir_all(project_dir.join("src"))
+        .with_context(|| format!("failed to create {}/src", project_dir.display()))?;
+    let dependency = match dep {
+        FacadeDependency::Path(path) => format!(
+            "uselesskey = {{ path = \"{}\", default-features = false, features = [\"rsa\", \"jwk\", \"token\"] }}",
+            toml_escape(&path.display().to_string())
+        ),
+        FacadeDependency::Version(version) => format!(
+            "uselesskey = {{ version = \"{}\", default-features = false, features = [\"rsa\", \"jwk\", \"token\"] }}",
+            toml_escape(version)
+        ),
+    };
+    fs::write(
+        project_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "uselesskey-external-adoption"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+{dependency}
+
+[workspace]
+"#
+        ),
+    )
+    .with_context(|| {
+        format!(
+            "failed to write {}",
+            project_dir.join("Cargo.toml").display()
+        )
+    })?;
+    fs::write(
+        project_dir.join("src/lib.rs"),
+        r#"use uselesskey::{Factory, RsaFactoryExt, RsaSpec, TokenFactoryExt, TokenSpec};
+
+#[test]
+fn deterministic_fixtures_work_from_clean_project() {
+    let fx = Factory::deterministic_from_str("external-adoption-smoke");
+    let rsa = fx.rsa("issuer", RsaSpec::rs256());
+    let rsa_again = fx.rsa("issuer", RsaSpec::rs256());
+    assert_eq!(rsa.kid(), rsa_again.kid());
+
+    let jwk = rsa.public_jwk().to_value();
+    assert_eq!(jwk["kty"], "RSA");
+    assert_eq!(jwk["alg"], "RS256");
+
+    let token = fx.token("api", TokenSpec::api_key());
+    assert!(token.value().starts_with("uk_test_"));
+}
+"#,
+    )
+    .with_context(|| {
+        format!(
+            "failed to write {}",
+            project_dir.join("src/lib.rs").display()
+        )
+    })?;
+    Ok(())
+}
+
+fn verify_bundle_shape(bundle_dir: &Path, expected_profile: &str) -> Result<()> {
+    let manifest_path = bundle_dir.join("manifest.json");
+    let manifest: Value = read_json(&manifest_path)?;
+    if manifest["profile"].as_str() != Some(expected_profile) {
+        bail!(
+            "bundle profile mismatch for {}: expected {expected_profile}, got {:?}",
+            bundle_dir.display(),
+            manifest["profile"]
+        );
+    }
+    let artifacts = manifest["artifacts"]
+        .as_array()
+        .context("manifest artifacts is not an array")?;
+    if artifacts.is_empty() {
+        bail!("bundle {} has no artifacts", bundle_dir.display());
+    }
+    for required in [
+        "receipts/materialization.json",
+        "receipts/audit-surface.json",
+    ] {
+        if !bundle_dir.join(required).is_file() {
+            bail!(
+                "bundle {} is missing expected file {required}",
+                bundle_dir.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn resolve_source(options: &RunOptions) -> Result<SmokeSource> {
+    match (&options.path, &options.version) {
+        (Some(path), None) => {
+            let source_root = resolve_existing_path(path)?;
+            let facade_dir = if source_root.join("crates/uselesskey/Cargo.toml").exists() {
+                source_root.join("crates/uselesskey")
+            } else {
+                source_root.clone()
+            };
+            let cli_dir = if source_root
+                .join("crates/uselesskey-cli/Cargo.toml")
+                .exists()
+            {
+                source_root.join("crates/uselesskey-cli")
+            } else {
+                source_root.clone()
+            };
+            if !facade_dir.join("Cargo.toml").is_file() {
+                bail!(
+                    "external-adoption-smoke --path could not find uselesskey facade Cargo.toml under {}",
+                    source_root.display()
+                );
+            }
+            if !cli_dir.join("Cargo.toml").is_file() {
+                bail!(
+                    "external-adoption-smoke --path could not find uselesskey-cli Cargo.toml under {}",
+                    source_root.display()
+                );
+            }
+            Ok(SmokeSource {
+                mode: SmokeMode::Path,
+                label: source_root.display().to_string(),
+                facade_dep: FacadeDependency::Path(facade_dir),
+                cli_source: CliSource::LocalPath(cli_dir),
+            })
+        }
+        (None, Some(version)) if !version.trim().is_empty() => Ok(SmokeSource {
+            mode: SmokeMode::Version,
+            label: version.clone(),
+            facade_dep: FacadeDependency::Version(version.clone()),
+            cli_source: CliSource::Version(version.clone()),
+        }),
+        (None, Some(_)) => bail!("external-adoption-smoke --version must not be empty"),
+        (None, None) => {
+            bail!("external-adoption-smoke requires exactly one of --path or --version")
+        }
+        (Some(_), Some(_)) => {
+            bail!("external-adoption-smoke: --path and --version are mutually exclusive")
+        }
+    }
+}
+
+fn resolve_existing_path(path: &Path) -> Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("failed to read current dir")?
+            .join(path)
+    };
+    if !absolute.exists() {
+        bail!("path does not exist: {}", absolute.display());
+    }
+    Ok(absolute)
+}
+
+fn run_command_step(
+    receipt: &mut ExternalAdoptionSmokeReceipt,
+    name: &str,
+    mut cmd: Command,
+    cwd: &Path,
+    log_dir: &Path,
+    artifacts: &[&str],
+) -> Result<()> {
+    eprintln!("==> {name}");
+    cmd.stdin(Stdio::null());
+    let command = command_to_vec(&cmd);
+    let stdout_path = log_dir.join(format!("{name}.stdout.txt"));
+    let stderr_path = log_dir.join(format!("{name}.stderr.txt"));
+    let start = Instant::now();
+    let output = cmd
+        .output()
+        .with_context(|| format!("failed to spawn {name}"))?;
+    let duration_ms = start.elapsed().as_millis() as u64;
+    fs::write(&stdout_path, &output.stdout)
+        .with_context(|| format!("failed to write {}", stdout_path.display()))?;
+    fs::write(&stderr_path, &output.stderr)
+        .with_context(|| format!("failed to write {}", stderr_path.display()))?;
+
+    let stdout = relative_artifact_from_path(&stdout_path);
+    let stderr = relative_artifact_from_path(&stderr_path);
+    if output.status.success() {
+        eprintln!("==> {name} [ok]");
+        receipt.steps.push(ExternalAdoptionStep {
+            name: name.to_string(),
+            command,
+            cwd: cwd.display().to_string(),
+            status: "ok".to_string(),
+            duration_ms,
+            stdout,
+            stderr,
+            details: None,
+            artifacts: artifacts
+                .iter()
+                .map(|artifact| (*artifact).to_string())
+                .collect(),
+        });
+        Ok(())
+    } else {
+        let details = format!("command failed with {}", output.status);
+        eprintln!("==> {name} [FAILED]");
+        eprintln!("    {details}");
+        receipt.steps.push(ExternalAdoptionStep {
+            name: name.to_string(),
+            command,
+            cwd: cwd.display().to_string(),
+            status: "failed".to_string(),
+            duration_ms,
+            stdout,
+            stderr,
+            details: Some(details.clone()),
+            artifacts: artifacts
+                .iter()
+                .map(|artifact| (*artifact).to_string())
+                .collect(),
+        });
+        bail!("{name}: {details}")
+    }
+}
+
+fn command_to_vec(cmd: &Command) -> Vec<String> {
+    let mut command = Vec::new();
+    command.push(cmd.get_program().to_string_lossy().into_owned());
+    command.extend(cmd.get_args().map(|arg| arg.to_string_lossy().into_owned()));
+    command
+}
+
+fn record_project(
+    receipt: &mut ExternalAdoptionSmokeReceipt,
+    name: &str,
+    path: &Path,
+    outputs: &[String],
+) {
+    receipt.projects.push(ExternalAdoptionProject {
+        name: name.to_string(),
+        path: relative_artifact_from_path(path),
+        status: "ok".to_string(),
+        outputs: outputs.to_vec(),
+    });
+}
+
+fn reset_target_output(root: &Path, out_root: &Path) -> Result<()> {
+    ensure_target_child(root, out_root)?;
+    if out_root.exists() {
+        fs::remove_dir_all(out_root)
+            .with_context(|| format!("failed to remove {}", out_root.display()))?;
+    }
+    fs::create_dir_all(out_root).with_context(|| format!("failed to create {}", out_root.display()))
+}
+
+fn ensure_target_child(root: &Path, path: &Path) -> Result<()> {
+    let absolute = absolute_path(root, path);
+    let target_root = absolute_path(root, &root.join("target"));
+    if !absolute.starts_with(&target_root) {
+        bail!(
+            "external-adoption-smoke refuses to write outside target/: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn absolute_path(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+fn write_receipts(out_dir: &Path, receipt: &ExternalAdoptionSmokeReceipt) -> Result<()> {
+    fs::write(
+        out_dir.join("report.json"),
+        serde_json::to_string_pretty(receipt).context("failed to serialize adoption smoke")?,
+    )
+    .with_context(|| format!("failed to write {}", out_dir.join("report.json").display()))?;
+    fs::write(out_dir.join("report.md"), render_markdown(receipt))
+        .with_context(|| format!("failed to write {}", out_dir.join("report.md").display()))
+}
+
+fn render_markdown(receipt: &ExternalAdoptionSmokeReceipt) -> String {
+    let mut md = String::new();
+    md.push_str("# External Adoption Smoke Receipt\n\n");
+    md.push_str(&format!("Status: `{}`\n\n", receipt.status));
+    md.push_str(&format!("Mode: `{:?}`\n\n", receipt.mode));
+    md.push_str(&format!("Source: `{}`\n\n", receipt.source));
+    if let Some(git_sha) = &receipt.git_sha {
+        md.push_str(&format!("Git SHA: `{git_sha}`\n\n"));
+    }
+
+    md.push_str("## Projects\n\n");
+    md.push_str("| Project | Status | Path | Outputs |\n");
+    md.push_str("| --- | --- | --- | --- |\n");
+    for project in &receipt.projects {
+        md.push_str(&format!(
+            "| {} | `{}` | `{}` | `{}` |\n",
+            project.name,
+            project.status,
+            project.path,
+            project.outputs.join("<br>")
+        ));
+    }
+
+    md.push_str("\n## Steps\n\n");
+    md.push_str("| Step | Status | Command | Logs | Details |\n");
+    md.push_str("| --- | --- | --- | --- | --- |\n");
+    for step in &receipt.steps {
+        let details = step.details.as_deref().unwrap_or("");
+        md.push_str(&format!(
+            "| {} | `{}` | `{}` | `{}` / `{}` | {} |\n",
+            step.name,
+            step.status,
+            step.command.join(" "),
+            step.stdout,
+            step.stderr,
+            details
+        ));
+    }
+
+    md.push_str("\n## Boundaries\n\n");
+    for boundary in &receipt.boundaries {
+        md.push_str(&format!("- {boundary}\n"));
+    }
+
+    md
+}
+
+fn print_human(receipt: &ExternalAdoptionSmokeReceipt) {
+    println!(
+        "external-adoption-smoke: {} (projects={}, steps={})",
+        receipt.status,
+        receipt.projects.len(),
+        receipt.steps.len()
+    );
+    println!("external-adoption-smoke: wrote {REPORT_JSON} and {REPORT_MD}");
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let raw =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn cli_binary_name() -> &'static str {
+    if cfg!(windows) {
+        "uselesskey.exe"
+    } else {
+        "uselesskey"
+    }
+}
+
+fn relative_artifact(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn relative_artifact_from_path(path: &Path) -> String {
+    if let Ok(cwd) = std::env::current_dir()
+        && let Ok(stripped) = path.strip_prefix(&cwd)
+    {
+        return stripped.to_string_lossy().replace('\\', "/");
+    }
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn toml_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn external_adoption_profiles_are_bounded() {
+        assert_eq!(CLI_PROFILES, ["scanner-safe", "tls", "oidc", "webhook"]);
+    }
+
+    #[test]
+    fn external_adoption_rejects_non_target_output() -> Result<()> {
+        let root = std::env::temp_dir().join("uselesskey-external-adoption-test");
+        let outside = root
+            .parent()
+            .context("temp-dir test root has no parent")?
+            .join("outside-external-adoption");
+        let err = match ensure_target_child(&root, &outside) {
+            Ok(()) => bail!("non-target output was accepted"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("outside target"));
+        Ok(())
+    }
+
+    #[test]
+    fn external_adoption_accepts_target_output() -> Result<()> {
+        let root = std::env::temp_dir().join("uselesskey-external-adoption-test");
+
+        ensure_target_child(&root, &root.join("target/external-adoption-smoke"))?;
+        Ok(())
+    }
+
+    #[test]
+    fn external_adoption_toml_escape_handles_windows_paths() {
+        assert_eq!(
+            toml_escape(r#"C:\Code\Rust\uselesskey\crates\uselesskey"#),
+            r#"C:\\Code\\Rust\\uselesskey\\crates\\uselesskey"#
+        );
+    }
+
+    #[test]
+    fn external_adoption_markdown_lists_boundaries() {
+        let receipt = ExternalAdoptionSmokeReceipt {
+            schema_version: 1,
+            status: "pass".to_string(),
+            generated_at: "2026-05-17T00:00:00Z".to_string(),
+            git_sha: Some("abc123".to_string()),
+            mode: SmokeMode::Path,
+            source: ".".to_string(),
+            work_root: WORK_DIR.to_string(),
+            projects: vec![ExternalAdoptionProject {
+                name: "webhook-cli".to_string(),
+                path: "target/external-adoption-smoke/work/webhook-cli".to_string(),
+                status: "ok".to_string(),
+                outputs: vec![
+                    "target/external-adoption-smoke/work/webhook-cli/target/uselesskey-webhook"
+                        .to_string(),
+                ],
+            }],
+            steps: vec![ExternalAdoptionStep {
+                name: "cli-bundle-webhook".to_string(),
+                command: vec![
+                    "uselesskey".to_string(),
+                    "bundle".to_string(),
+                    "--profile".to_string(),
+                    "webhook".to_string(),
+                ],
+                cwd: ".".to_string(),
+                status: "ok".to_string(),
+                duration_ms: 1,
+                stdout: "target/external-adoption-smoke/logs/stdout.txt".to_string(),
+                stderr: "target/external-adoption-smoke/logs/stderr.txt".to_string(),
+                details: None,
+                artifacts: Vec::new(),
+            }],
+            artifacts: vec![REPORT_JSON.to_string(), REPORT_MD.to_string()],
+            boundaries: BOUNDARIES.to_vec(),
+        };
+
+        let markdown = render_markdown(&receipt);
+        assert!(markdown.contains("External Adoption Smoke Receipt"));
+        assert!(markdown.contains("installed-style CLI smoke does not claim provider"));
+        assert!(markdown.contains("cli-bundle-webhook"));
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -24,6 +24,7 @@ mod contract_packs;
 mod docs_sync;
 mod doctor;
 mod economics;
+mod external_adoption_smoke;
 mod plan;
 mod policy;
 mod pr_bundles;
@@ -108,6 +109,18 @@ enum Cmd {
         /// Output format.
         #[arg(long, value_enum, default_value = "human")]
         format: AdoptionRegressionFormat,
+    },
+    /// Prove clean-project external adoption paths and write receipts.
+    ExternalAdoptionSmoke {
+        /// Use a local workspace or crate path. Pass "." for the current checkout.
+        #[arg(long, conflicts_with = "version")]
+        path: Option<PathBuf>,
+        /// Use a published crates.io version as audit/reference evidence.
+        #[arg(long, conflicts_with = "path")]
+        version: Option<String>,
+        /// Output format.
+        #[arg(long, value_enum, default_value = "human")]
+        format: ExternalAdoptionSmokeFormat,
     },
     /// Run publish dry-runs for crates in dependency order.
     PublishCheck,
@@ -519,6 +532,12 @@ enum AdoptionRegressionFormat {
     Json,
 }
 
+#[derive(Clone, Debug, ValueEnum)]
+enum ExternalAdoptionSmokeFormat {
+    Human,
+    Json,
+}
+
 impl From<SpecCheckFormat> for spec_check::OutputFormat {
     fn from(value: SpecCheckFormat) -> Self {
         match value {
@@ -564,6 +583,15 @@ impl From<AdoptionRegressionFormat> for adoption_regression::OutputFormat {
     }
 }
 
+impl From<ExternalAdoptionSmokeFormat> for external_adoption_smoke::OutputFormat {
+    fn from(value: ExternalAdoptionSmokeFormat) -> Self {
+        match value {
+            ExternalAdoptionSmokeFormat::Human => external_adoption_smoke::OutputFormat::Human,
+            ExternalAdoptionSmokeFormat::Json => external_adoption_smoke::OutputFormat::Json,
+        }
+    }
+}
+
 impl MutationNightlyScope {
     fn as_str(self) -> &'static str {
         match self {
@@ -601,6 +629,18 @@ fn main() -> Result<()> {
         Cmd::AdoptionRegression { format } => {
             adoption_regression::run(&workspace_root_path(), format.into())
         }
+        Cmd::ExternalAdoptionSmoke {
+            path,
+            version,
+            format,
+        } => external_adoption_smoke::run(
+            &workspace_root_path(),
+            external_adoption_smoke::RunOptions {
+                path,
+                version,
+                format: format.into(),
+            },
+        ),
         Cmd::PublishCheck => publish_check(),
         Cmd::Pr { with_mutants } => pr(with_mutants),
         Cmd::PrLite { format } => pr_lite(format),
@@ -10438,6 +10478,83 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
             } => assert!(skip_install_cli),
             _ => panic!("expected Cmd::CratesioSmoke"),
         }
+    }
+
+    #[test]
+    fn external_adoption_smoke_clap_validation() {
+        let parsed = Cli::try_parse_from(["xtask", "external-adoption-smoke"]);
+        assert!(
+            parsed.is_ok(),
+            "bare external-adoption-smoke should parse; runtime guard rejects missing source"
+        );
+        match parsed.unwrap().cmd {
+            Cmd::ExternalAdoptionSmoke {
+                path,
+                version,
+                format,
+            } => {
+                assert!(path.is_none(), "path should default to None");
+                assert!(version.is_none(), "version should default to None");
+                assert!(matches!(format, ExternalAdoptionSmokeFormat::Human));
+                let err = external_adoption_smoke::run(
+                    Path::new("."),
+                    external_adoption_smoke::RunOptions {
+                        path,
+                        version,
+                        format: format.into(),
+                    },
+                )
+                .expect_err("external-adoption-smoke without --path or --version must error");
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("--path") && msg.contains("--version"),
+                    "error must mention both --path and --version: {msg}"
+                );
+            }
+            _ => panic!("expected Cmd::ExternalAdoptionSmoke"),
+        }
+
+        let conflict = Cli::try_parse_from([
+            "xtask",
+            "external-adoption-smoke",
+            "--path",
+            ".",
+            "--version",
+            "0.9.1",
+        ]);
+        assert!(
+            conflict.is_err(),
+            "clap must reject --path + --version together"
+        );
+
+        let ok_path =
+            Cli::try_parse_from(["xtask", "external-adoption-smoke", "--path", "."]).unwrap();
+        assert!(matches!(
+            ok_path.cmd,
+            Cmd::ExternalAdoptionSmoke {
+                path: Some(_),
+                version: None,
+                ..
+            }
+        ));
+
+        let ok_version = Cli::try_parse_from([
+            "xtask",
+            "external-adoption-smoke",
+            "--version",
+            "0.9.1",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        assert!(matches!(
+            ok_version.cmd,
+            Cmd::ExternalAdoptionSmoke {
+                path: None,
+                version: Some(_),
+                format: ExternalAdoptionSmokeFormat::Json,
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `cargo xtask external-adoption-smoke` with `--path`, `--version`, and `--format json` modes.
- Exercise clean-project Rust dependency usage plus installed-style CLI profile discovery and bundle/verify/inspect paths for scanner-safe, TLS, OIDC, and webhook profiles.
- Write Markdown/JSON receipts under `target/external-adoption-smoke/` and advance the active goal to the installed CLI docs slice.

## Files added/changed
- `.uselesskey/goals/active.toml`
- `xtask/src/external_adoption_smoke.rs`
- `xtask/src/main.rs`

## Validation
- `cargo test -p xtask external_adoption_smoke -- --nocapture`
- `cargo xtask spec-check --strict`
- `cargo xtask external-adoption-smoke --path . --format json`
- `cargo xtask external-adoption-smoke --path .`
- `cargo xtask pr-lite`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo test -p xtask`
- `cargo xtask pr`
- `git diff --check`

## Non-goals
- No v0.10.0 release prep, version bump, tag, or publish.
- No new contract packs, badges, shipper work, provider compatibility claims, production security claims, broad refactors, or dependency churn.
- No installed CLI proof runner; repo-local claim-proof and verification-pack remain separate proof surfaces.

## What this enables next
- Separating installed CLI docs from repo-local proof docs against a runnable external-adoption contract.
- Adding clean-project external examples and wiring them into the smoke command.
- Optionally adding `adoption-regression --external` later without making external smoke part of the default bounded gate.