### PR TITLE
Refactor fixture helper code for DRYness

### DIFF
--- a/crates/uselesskey-ssh/src/spec.rs
+++ b/crates/uselesskey-ssh/src/spec.rs
@@ -98,48 +98,39 @@ impl SshCertSpec {
     }
 
     pub fn stable_bytes(&self) -> Vec<u8> {
-        fn push_str(buf: &mut Vec<u8>, s: &str) {
-            let len = u32::try_from(s.len()).unwrap_or(u32::MAX);
-            buf.extend_from_slice(&len.to_be_bytes());
-            buf.extend_from_slice(s.as_bytes());
-        }
-
         let mut out = Vec::new();
         out.push(self.cert_type.stable_byte());
         out.extend_from_slice(&self.validity.valid_after.to_be_bytes());
         out.extend_from_slice(&self.validity.valid_before.to_be_bytes());
-
-        out.extend_from_slice(
-            &u32::try_from(self.principals.len())
-                .unwrap_or(u32::MAX)
-                .to_be_bytes(),
-        );
-        for principal in &self.principals {
-            push_str(&mut out, principal);
-        }
-
-        out.extend_from_slice(
-            &u32::try_from(self.critical_options.len())
-                .unwrap_or(u32::MAX)
-                .to_be_bytes(),
-        );
-        for (name, value) in &self.critical_options {
-            push_str(&mut out, name);
-            push_str(&mut out, value);
-        }
-
-        out.extend_from_slice(
-            &u32::try_from(self.extensions.len())
-                .unwrap_or(u32::MAX)
-                .to_be_bytes(),
-        );
-        for (name, value) in &self.extensions {
-            push_str(&mut out, name);
-            push_str(&mut out, value);
-        }
-
+        push_strings(&mut out, &self.principals);
+        push_string_pairs(&mut out, &self.critical_options);
+        push_string_pairs(&mut out, &self.extensions);
         out
     }
+}
+
+fn push_strings(buf: &mut Vec<u8>, values: &[String]) {
+    push_len(buf, values.len());
+    for value in values {
+        push_str(buf, value);
+    }
+}
+
+fn push_string_pairs(buf: &mut Vec<u8>, values: &[(String, String)]) {
+    push_len(buf, values.len());
+    for (name, value) in values {
+        push_str(buf, name);
+        push_str(buf, value);
+    }
+}
+
+fn push_str(buf: &mut Vec<u8>, value: &str) {
+    push_len(buf, value.len());
+    buf.extend_from_slice(value.as_bytes());
+}
+
+fn push_len(buf: &mut Vec<u8>, len: usize) {
+    buf.extend_from_slice(&u32::try_from(len).unwrap_or(u32::MAX).to_be_bytes());
 }
 
 #[cfg(test)]

--- a/crates/uselesskey-token/src/srp/shape.rs
+++ b/crates/uselesskey-token/src/srp/shape.rs
@@ -209,15 +209,11 @@ fn bad_base64url_segment(label: &str, seed: Seed) -> String {
 }
 
 fn invalid_jwt_header_shape(label: &str, seed: Seed) -> String {
-    let [_header, payload, signature] = oauth_parts(label, seed);
-    let header = encode_json(&json!(["not-a-header"]));
-    format!("{header}.{payload}.{signature}")
+    token_with_header(label, seed, encode_json(&json!(["not-a-header"])))
 }
 
 fn missing_alg(label: &str, seed: Seed) -> String {
-    let [_header, payload, signature] = oauth_parts(label, seed);
-    let header = encode_json(&json!({ "typ": "JWT" }));
-    format!("{header}.{payload}.{signature}")
+    token_with_header(label, seed, encode_json(&json!({ "typ": "JWT" })))
 }
 
 fn alg_none(label: &str, seed: Seed) -> String {
@@ -225,54 +221,59 @@ fn alg_none(label: &str, seed: Seed) -> String {
 }
 
 fn mismatched_kid(label: &str, seed: Seed) -> String {
-    let [_header, payload, signature] = oauth_parts(label, seed);
-    let mut header = jwt_header();
-    header.insert("kid".to_string(), json!("unknown-kid"));
-
-    let mut payload = decode_object(&payload);
-    payload.insert("kid".to_string(), json!("expected-kid"));
-
-    format!(
-        "{}.{}.{}",
-        encode_object(&header),
-        encode_object(&payload),
-        signature
-    )
+    token_with_header_and_payload(label, seed, |header, claims| {
+        header.insert("kid".to_string(), json!("unknown-kid"));
+        claims.insert("kid".to_string(), json!("expected-kid"));
+    })
 }
 
 fn not_yet_valid_claims(label: &str, seed: Seed) -> String {
-    let [_header, payload, signature] = oauth_parts(label, seed);
-    let mut claims = decode_object(&payload);
-    claims.insert("nbf".to_string(), json!(4_000_000_000u64));
-    claims.insert("exp".to_string(), json!(4_100_000_000u64));
-
-    format!(
-        "{}.{}.{}",
-        encode_object(&jwt_header()),
-        encode_object(&claims),
-        signature
-    )
+    token_with_payload(label, seed, |claims| {
+        claims.insert("nbf".to_string(), json!(4_000_000_000u64));
+        claims.insert("exp".to_string(), json!(4_100_000_000u64));
+    })
 }
 
 fn token_with_header_claim(label: &str, seed: Seed, claim: &str, value: Value) -> String {
-    let [_header, payload, signature] = oauth_parts(label, seed);
-    let mut header = jwt_header();
-    header.insert(claim.to_string(), value);
-
-    format!("{}.{}.{}", encode_object(&header), payload, signature)
+    token_with_header_and_payload(label, seed, |header, _claims| {
+        header.insert(claim.to_string(), value);
+    })
 }
 
 fn token_with_payload_claim(label: &str, seed: Seed, claim: &str, value: Value) -> String {
-    let [_header, payload, signature] = oauth_parts(label, seed);
-    let mut claims = decode_object(&payload);
-    claims.insert(claim.to_string(), value);
+    token_with_payload(label, seed, |claims| {
+        claims.insert(claim.to_string(), value);
+    })
+}
 
-    format!(
-        "{}.{}.{}",
-        encode_object(&jwt_header()),
-        encode_object(&claims),
-        signature
-    )
+fn token_with_header(label: &str, seed: Seed, header: String) -> String {
+    let [_header, payload, signature] = oauth_parts(label, seed);
+    encode_token(&header, &payload, &signature)
+}
+
+fn token_with_payload(
+    label: &str,
+    seed: Seed,
+    mutate: impl FnOnce(&mut Map<String, Value>),
+) -> String {
+    token_with_header_and_payload(label, seed, |_header, claims| mutate(claims))
+}
+
+fn token_with_header_and_payload(
+    label: &str,
+    seed: Seed,
+    mutate: impl FnOnce(&mut Map<String, Value>, &mut Map<String, Value>),
+) -> String {
+    let [_header, payload, signature] = oauth_parts(label, seed);
+    let mut header = jwt_header();
+    let mut claims = decode_object(&payload);
+    mutate(&mut header, &mut claims);
+
+    encode_token(&encode_object(&header), &encode_object(&claims), &signature)
+}
+
+fn encode_token(header: &str, payload: &str, signature: &str) -> String {
+    format!("{header}.{payload}.{signature}")
 }
 
 fn malformed_bearer(seed: Seed) -> String {


### PR DESCRIPTION
### Motivation
- Reduce duplicated logic in token negative-fixture assembly and SSH stable-byte encoding by extracting small, reusable helpers to make the code more DRY and easier to maintain.
- Improve readability and centralize formatting/encoding behaviour so future variants can be implemented with minimal repetition.

### Description
- Consolidated JWT/token negative-fixture construction in `crates/uselesskey-token/src/srp/shape.rs` by adding shared helpers: `token_with_header`, `token_with_payload`, `token_with_header_and_payload`, `token_with_header_claim`, `token_with_payload_claim`, and `encode_token`, and by replacing repeated segment extraction/formatting with calls to those helpers.
- Replaced ad-hoc header/payload formatting occurrences with calls to the new token helpers so negative-variant functions now express only the mutation they need.
- Extracted length-prefixed string encoding helpers in `crates/uselesskey-ssh/src/spec.rs`: `push_strings`, `push_string_pairs`, `push_str`, and `push_len`, and updated `SshCertSpec::stable_bytes` to use them to avoid repeating the same encoding boilerplate.

### Testing
- Ran `cargo test -p uselesskey-token -p uselesskey-ssh` and all targeted unit tests passed. 
- Test runs included unit, doctest and property tests exercised by the two packages and completed successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b8a15e6c8333bd02e222e2d3cbcb)