### PR TITLE
docs: separate installed CLI and proof paths

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -64,7 +64,7 @@ commands = [
 
 [[work_item]]
 id = "installed-cli-docs"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0012"
 plan = "plans/v0.10.0-external-adoption/implementation-plan.md"
@@ -76,7 +76,7 @@ commands = [
 
 [[work_item]]
 id = "clean-project-examples"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0003"
 plan = "plans/v0.10.0-external-adoption/implementation-plan.md"

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Pick the job first; the proof machinery is there when you need it.
 | The smallest feature lane for my test | `docs/how-to/start-here.md` |
 | A deterministic webhook verifier pack | `uselesskey bundle --profile webhook --out target/uselesskey-webhook` |
 | TLS or OIDC/JWKS verifier fixtures | `uselesskey profiles` |
-| Proof for a security/platform reviewer | `cargo xtask verification-pack --out target/uselesskey-verification` |
+| Proof for a security/platform reviewer with a repo checkout | `cargo xtask verification-pack --out target/uselesskey-verification` |
 
-CLI contract packs start with:
+Installed CLI users start with:
 
 ```bash
 cargo install uselesskey-cli --version 0.9.1
@@ -54,8 +54,15 @@ uselesskey bundle --profile webhook --out target/uselesskey-webhook
 uselesskey verify-bundle --path target/uselesskey-webhook
 ```
 
-Public claims are command-backed. For reviewer handoff, generate a
-metadata-only proof bundle:
+Rust test authors start with a dependency snippet:
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.9.1", features = ["rsa"] }
+```
+
+Reviewer and maintainer proof is repo-local. From a checkout, public claims are
+command-backed and can be packaged as a metadata-only proof bundle:
 
 ```bash
 cargo xtask verification-pack --out target/uselesskey-verification
@@ -176,6 +183,10 @@ uselesskey = { version = "0.9.1", features = ["rsa", "jwk"] }
 [dev-dependencies]
 uselesskey = { version = "0.9.1", features = ["x509"] }
 ```
+
+The following materialization commands are repo-checkout examples. Installed
+CLI users can run the same subcommands as `uselesskey materialize ...` and
+`uselesskey verify ...`.
 
 ```bash
 # Build-time materialization, shape-only common lane
@@ -400,22 +411,22 @@ The `uselesskey-cli` bundle workflow generates a deterministic directory of fixt
 
 ```bash
 # Generate a scanner-safe fixture bundle (default profile)
-cargo run -p uselesskey-cli -- bundle --profile scanner-safe --out target/uselesskey-bundle
+uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle
 
 # Verify the bundle against its recorded manifest and receipts
-cargo run -p uselesskey-cli -- verify-bundle --path target/uselesskey-bundle
+uselesskey verify-bundle --path target/uselesskey-bundle
 
 # Print a human-readable summary without exposing fixture payloads
-cargo run -p uselesskey-cli -- inspect-bundle --path target/uselesskey-bundle
+uselesskey inspect-bundle --path target/uselesskey-bundle
 
 # Render Kubernetes / Vault payloads from the verified bundle
-cargo run -p uselesskey-cli -- export k8s \
+uselesskey export k8s \
     --bundle-dir target/uselesskey-bundle \
     --name uselesskey-fixtures \
     --namespace tests \
     --out target/uselesskey-bundle/secret.yaml
 
-cargo run -p uselesskey-cli -- export vault-kv-json \
+uselesskey export vault-kv-json \
     --bundle-dir target/uselesskey-bundle \
     --out target/uselesskey-bundle/kv-v2.json
 ```
@@ -423,7 +434,7 @@ cargo run -p uselesskey-cli -- export vault-kv-json \
 The `oidc` profile emits an OIDC/JWKS contract pack with valid JWKS and JWT-shape fixtures plus duplicate-`kid`, missing-`kid`, `alg: none`, and bad-audience negatives:
 
 ```bash
-cargo run -p uselesskey-cli -- bundle --profile oidc --out target/uselesskey-oidc
+uselesskey bundle --profile oidc --out target/uselesskey-oidc
 ```
 
 For the reference manifest, receipts, and payload shapes see [`examples/scanner-safe-bundle/README.md`](examples/scanner-safe-bundle/README.md). For OIDC/JWT validator-test recipes see [`docs/how-to/test-oidc-jwks-validation.md`](docs/how-to/test-oidc-jwks-validation.md) and [`docs/how-to/test-jwt-negative-validation.md`](docs/how-to/test-jwt-negative-validation.md).

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -9,6 +9,11 @@
 Badges are the front panel. The generated evidence, CI receipts, and release
 artifacts remain the source of truth.
 
+This page is repo-checkout proof documentation. Installed CLI users should use
+`uselesskey profiles`, `uselesskey bundle`, `uselesskey verify-bundle`, and
+`uselesskey inspect-bundle` from the task docs first; `cargo xtask` commands
+here are reviewer, maintainer, and release evidence commands.
+
 For the public claim index and local proof path, see
 [`docs/status/PUBLIC_CLAIMS.md`](status/PUBLIC_CLAIMS.md) and
 [`docs/how-to/verify-uselesskey-public-claims.md`](how-to/verify-uselesskey-public-claims.md).

--- a/docs/contract-packs/README.md
+++ b/docs/contract-packs/README.md
@@ -23,9 +23,17 @@ uselesskey profile webhook --explain
 uselesskey bundle --profile webhook --explain
 ```
 
+Interface split:
+
+- installed CLI users generate, verify, and inspect bundles with `uselesskey`;
+- Rust test authors use crate dependency snippets in the linked how-to docs;
+- reviewers with a repo checkout use `cargo xtask verification-pack`;
+- maintainers use `cargo xtask claim-proof`, `bundle-proof`, and release
+  evidence commands.
+
 ## Quick Index
 
-| Profile | Use when you need | Generate | Proof |
+| Profile | Use when you need | Installed CLI | Repo-checkout proof |
 | --- | --- | --- | --- |
 | `scanner-safe` | scanner-safe baseline fixtures and export receipts | `uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle` | `cargo xtask claim-proof --claim scanner-safe-fixtures` |
 | `tls` | TLS chain and certificate rejection fixtures | `uselesskey bundle --profile tls --out target/uselesskey-tls` | `cargo xtask claim-proof --claim tls-contract-pack` |
@@ -39,20 +47,15 @@ Vault payload files.
 
 ## Scanner-Safe Baseline
 
-Generate:
+Installed CLI:
 
 ```bash
 uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle
-```
-
-Verify:
-
-```bash
 uselesskey verify-bundle --path target/uselesskey-bundle
 uselesskey inspect-bundle --path target/uselesskey-bundle
 ```
 
-Prove:
+Repo-checkout proof:
 
 ```bash
 cargo xtask claim-proof --claim scanner-safe-fixtures
@@ -78,20 +81,15 @@ Docs:
 
 ## TLS
 
-Generate:
+Installed CLI:
 
 ```bash
 uselesskey bundle --profile tls --out target/uselesskey-tls
-```
-
-Verify:
-
-```bash
 uselesskey verify-bundle --path target/uselesskey-tls
 uselesskey inspect-bundle --path target/uselesskey-tls
 ```
 
-Prove:
+Repo-checkout proof:
 
 ```bash
 cargo xtask claim-proof --claim tls-contract-pack
@@ -119,20 +117,15 @@ Docs:
 
 ## OIDC/JWKS
 
-Generate:
+Installed CLI:
 
 ```bash
 uselesskey bundle --profile oidc --out target/uselesskey-oidc
-```
-
-Verify:
-
-```bash
 uselesskey verify-bundle --path target/uselesskey-oidc
 uselesskey inspect-bundle --path target/uselesskey-oidc
 ```
 
-Prove:
+Repo-checkout proof:
 
 ```bash
 cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc
@@ -159,20 +152,15 @@ Docs:
 
 ## Webhook
 
-Generate:
+Installed CLI:
 
 ```bash
 uselesskey bundle --profile webhook --out target/uselesskey-webhook
-```
-
-Verify:
-
-```bash
 uselesskey verify-bundle --path target/uselesskey-webhook
 uselesskey inspect-bundle --path target/uselesskey-webhook
 ```
 
-Prove:
+Repo-checkout proof:
 
 ```bash
 cargo xtask claim-proof --claim webhook-contract-pack
@@ -201,7 +189,8 @@ Docs:
 
 ## Reviewer Bundle
 
-When a reviewer needs all public-claim receipts in one metadata-only directory:
+When a reviewer needs all public-claim receipts in one metadata-only directory,
+run this from a repo checkout:
 
 ```bash
 cargo xtask verification-pack --out target/uselesskey-verification

--- a/docs/how-to/export-vault-kv-fixtures.md
+++ b/docs/how-to/export-vault-kv-fixtures.md
@@ -10,16 +10,19 @@ Vault KV-v2 read response uses.
 ## Generate the bundle
 
 ```bash
-cargo run -p uselesskey-cli -- bundle \
+uselesskey bundle \
   --profile scanner-safe \
   --out target/uselesskey-bundle
 
-cargo run -p uselesskey-cli -- verify-bundle \
+uselesskey verify-bundle \
   --path target/uselesskey-bundle
 
-cargo run -p uselesskey-cli -- inspect-bundle \
+uselesskey inspect-bundle \
   --path target/uselesskey-bundle
 ```
+
+From a repo checkout while changing the CLI, prefix those subcommands with
+`cargo run -p uselesskey-cli --`.
 
 `inspect-bundle` prints the profile, artifact count, scanner-safety
 posture, runtime material count, private/symmetric material flags,
@@ -29,7 +32,7 @@ fixture payloads.
 ## Export to Vault KV-v2 JSON
 
 ```bash
-cargo run -p uselesskey-cli -- export vault-kv-json \
+uselesskey export vault-kv-json \
   --bundle-dir target/uselesskey-bundle \
   --out target/uselesskey-bundle/kv-v2.json
 ```
@@ -124,6 +127,8 @@ for the registry-truth analogue: that doc covers the publish-side
 "don't trust local state, regenerate from upstream" pattern.
 
 ## Evidence
+
+Repo-checkout proof:
 
 ```bash
 cargo xtask bundle-proof --profile scanner-safe --out target/release-evidence/scanner-safe

--- a/docs/how-to/generate-scanner-safe-k8s-secret.md
+++ b/docs/how-to/generate-scanner-safe-k8s-secret.md
@@ -6,16 +6,19 @@ without committing runtime private key material or symmetric secret material.
 ## Generate and verify the bundle
 
 ```bash
-cargo run -p uselesskey-cli -- bundle \
+uselesskey bundle \
   --profile scanner-safe \
   --out target/uselesskey-bundle
 
-cargo run -p uselesskey-cli -- verify-bundle \
+uselesskey verify-bundle \
   --path target/uselesskey-bundle
 
-cargo run -p uselesskey-cli -- inspect-bundle \
+uselesskey inspect-bundle \
   --path target/uselesskey-bundle
 ```
+
+From a repo checkout while changing the CLI, prefix those subcommands with
+`cargo run -p uselesskey-cli --`.
 
 The inspection step prints the profile, artifact count, scanner-safety posture,
 runtime material count, private/symmetric material flags, exports, verification
@@ -24,13 +27,13 @@ status, and receipt kinds. It does not print fixture payloads.
 ## Export Kubernetes and Vault-shaped payloads
 
 ```bash
-cargo run -p uselesskey-cli -- export k8s \
+uselesskey export k8s \
   --bundle-dir target/uselesskey-bundle \
   --name uselesskey-fixtures \
   --namespace tests \
   --out target/uselesskey-bundle/secret.yaml
 
-cargo run -p uselesskey-cli -- export vault-kv-json \
+uselesskey export vault-kv-json \
   --bundle-dir target/uselesskey-bundle \
   --out target/uselesskey-bundle/kv-v2.json
 ```
@@ -67,6 +70,8 @@ symmetric fixture material.
   usable committed secret material.
 
 ## Evidence
+
+Repo-checkout proof:
 
 ```bash
 cargo xtask bundle-proof --profile scanner-safe --out target/release-evidence/scanner-safe

--- a/docs/how-to/start-here.md
+++ b/docs/how-to/start-here.md
@@ -17,7 +17,7 @@ or cryptographic assurance.
 | test TLS verifier behavior | TLS contract pack | `uselesskey bundle --profile tls --out target/uselesskey-tls` |
 | test OIDC/JWKS validator behavior | OIDC/JWKS contract pack | `uselesskey bundle --profile oidc --out target/uselesskey-oidc` |
 | test webhook signature negatives | webhook contract pack | `uselesskey bundle --profile webhook --out target/uselesskey-webhook` |
-| prove public claims for a reviewer | verification pack | `cargo xtask verification-pack --out target/uselesskey-verification` |
+| prove public claims for a reviewer with a repo checkout | verification pack | `cargo xtask verification-pack --out target/uselesskey-verification` |
 
 Install the CLI when you want bundle commands outside this workspace:
 
@@ -27,11 +27,15 @@ uselesskey profiles
 uselesskey bundle --profile webhook --explain
 ```
 
-Inside the workspace, use:
+Inside this workspace, maintainers may run the same CLI subcommands through
+Cargo while changing the CLI itself:
 
 ```bash
 cargo run -p uselesskey-cli -- bundle --profile webhook --out target/uselesskey-webhook
 ```
+
+Reviewer proof and release evidence use `cargo xtask` from a repo checkout.
+They are not required before a new user gets a working fixture.
 
 ## Rust Test Fixtures
 
@@ -94,9 +98,16 @@ For the product-family view, see
 
 ### TLS
 
+Installed CLI:
+
 ```bash
 uselesskey bundle --profile tls --out target/uselesskey-tls
 uselesskey verify-bundle --path target/uselesskey-tls
+```
+
+Repo-checkout proof:
+
+```bash
 cargo xtask claim-proof --claim tls-contract-pack
 ```
 
@@ -106,9 +117,16 @@ trust-store behavior, or downstream verifier correctness.
 
 ### OIDC/JWKS
 
+Installed CLI:
+
 ```bash
 uselesskey bundle --profile oidc --out target/uselesskey-oidc
 uselesskey verify-bundle --path target/uselesskey-oidc
+```
+
+Repo-checkout proof:
+
+```bash
 cargo xtask claim-report --claim oidc-jwks-contract-pack
 ```
 
@@ -117,9 +135,16 @@ not prove provider compatibility, issuer policy, or production token security.
 
 ### Webhook
 
+Installed CLI:
+
 ```bash
 uselesskey bundle --profile webhook --out target/uselesskey-webhook
 uselesskey verify-bundle --path target/uselesskey-webhook
+```
+
+Repo-checkout proof:
+
+```bash
 cargo xtask claim-proof --claim webhook-contract-pack
 ```
 
@@ -130,7 +155,7 @@ completeness, delivery behavior, or transport security.
 
 ## Reviewer Proof
 
-Build a metadata-only review bundle:
+Build a metadata-only review bundle from a repo checkout:
 
 ```bash
 cargo xtask verification-pack --out target/uselesskey-verification

--- a/docs/how-to/test-oidc-jwks-validation.md
+++ b/docs/how-to/test-oidc-jwks-validation.md
@@ -6,16 +6,19 @@ JWKS contract pack with both valid and negative key-set shapes.
 ## Generate the pack
 
 ```bash
-cargo run -p uselesskey-cli -- bundle \
+uselesskey bundle \
   --profile oidc \
   --out target/oidc-fixtures
 
-cargo run -p uselesskey-cli -- verify-bundle \
+uselesskey verify-bundle \
   --path target/oidc-fixtures
 
-cargo run -p uselesskey-cli -- inspect-bundle \
+uselesskey inspect-bundle \
   --path target/oidc-fixtures
 ```
+
+From a repo checkout while changing the CLI, prefix those subcommands with
+`cargo run -p uselesskey-cli --`.
 
 The profile writes:
 
@@ -82,6 +85,8 @@ under `target/` and verify them in CI instead of committing generated payloads.
   adds runtime signing fixtures and adapter-specific assertions.
 
 ## Evidence
+
+Repo-checkout proof:
 
 ```bash
 cargo xtask bundle-proof --profile oidc --out target/release-evidence/oidc

--- a/docs/how-to/test-tls-chain-validation.md
+++ b/docs/how-to/test-tls-chain-validation.md
@@ -12,16 +12,19 @@ from the bundle seed: re-running it produces byte-identical files.
 ## Generate the bundle
 
 ```bash
-cargo run -p uselesskey-cli -- bundle \
+uselesskey bundle \
   --profile tls \
   --out target/tls-fixtures
 
-cargo run -p uselesskey-cli -- verify-bundle \
+uselesskey verify-bundle \
   --path target/tls-fixtures
 
-cargo run -p uselesskey-cli -- inspect-bundle \
+uselesskey inspect-bundle \
   --path target/tls-fixtures
 ```
+
+From a repo checkout while changing the CLI, prefix those subcommands with
+`cargo run -p uselesskey-cli --`.
 
 The profile writes:
 
@@ -149,7 +152,7 @@ behavior; the rejection paths are the verifier's own.
 
 ## Evidence
 
-For release-grade evidence that the bundle still reproduces:
+Repo-checkout proof that the bundle still reproduces:
 
 ```bash
 cargo xtask bundle-proof --profile tls --out target/release-evidence/tls

--- a/docs/how-to/test-webhook-signature-validation.md
+++ b/docs/how-to/test-webhook-signature-validation.md
@@ -28,20 +28,23 @@ uselesskey-core = "0.9.1"
 
 ## Generate the contract pack
 
-Use the bundle profile when you want filesystem fixtures plus receipts
-that a reviewer can inspect:
+Use the installed CLI when you want filesystem fixtures plus receipts that a
+reviewer can inspect:
 
 ```bash
-cargo run -p uselesskey-cli -- bundle \
+uselesskey bundle \
   --profile webhook \
   --out target/webhook-fixtures
 
-cargo run -p uselesskey-cli -- verify-bundle \
+uselesskey verify-bundle \
   --path target/webhook-fixtures
 
-cargo run -p uselesskey-cli -- inspect-bundle \
+uselesskey inspect-bundle \
   --path target/webhook-fixtures
 ```
+
+From a repo checkout while changing the CLI, prefix those subcommands with
+`cargo run -p uselesskey-cli --`.
 
 The contract pack writes:
 
@@ -60,7 +63,7 @@ Each request fixture records `method`, `path`, `timestamp`, `body`,
 `headers`, `expected_result`, `rejection_class`, and
 `verifier_secret`.
 
-For release-grade evidence that the bundle still reproduces:
+Repo-checkout proof that the bundle still reproduces:
 
 ```bash
 cargo xtask bundle-proof --profile webhook --out target/release-evidence/webhook


### PR DESCRIPTION
Summary
- Label installed CLI, Rust dependency, reviewer evidence, and maintainer proof paths separately in first-run and contract-pack docs.
- Lead downstream how-to docs with installed `uselesskey ...` commands, while keeping `cargo run -p uselesskey-cli --` as a repo-checkout equivalent.
- Mark the installed CLI docs work item done and move clean-project examples to ready.

Files added/changed
- README.md
- docs/VERIFICATION.md
- docs/contract-packs/README.md
- docs/how-to/start-here.md
- docs/how-to/test-webhook-signature-validation.md
- docs/how-to/test-tls-chain-validation.md
- docs/how-to/test-oidc-jwks-validation.md
- docs/how-to/generate-scanner-safe-k8s-secret.md
- docs/how-to/export-vault-kv-fixtures.md
- .uselesskey/goals/active.toml

Validation
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask spec-check --strict
- git diff --check

Non-goals
- No v0.10.0 release prep, version bump, tag, or publish.
- No new contract packs, badges, provider compatibility claims, or production security claims.
- No CLI behavior changes or dependency churn.

What this enables next
- Clean-project adoption examples can now build from docs that clearly separate installed-user commands from repo-local proof machinery.