### PR TITLE
docs: decide installed proof handoff boundary

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -103,7 +103,7 @@ commands = [
 
 [[work_item]]
 id = "proof-handoff-boundary"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0012"
 plan = "plans/v0.10.0-external-adoption/implementation-plan.md"
@@ -116,7 +116,7 @@ commands = [
 
 [[work_item]]
 id = "adoption-regression-external-mode"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0013"
 plan = "plans/v0.10.0-external-adoption/implementation-plan.md"

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@ Release-candidate proof and public promise evidence.
 Understanding-oriented material on design and direction.
 
 - [architecture.md](explanation/architecture.md) — Workspace structure and crate map
+- [cli-proof-handoff-boundary.md](explanation/cli-proof-handoff-boundary.md) — Why installed CLI proof remains a handoff instead of an executable proof runner
 - [public-surface.md](architecture/public-surface.md) — Supported public crates versus published internal implementation shards
 - [roadmap.md](explanation/roadmap.md) — Future plans and priorities (Now/Next/Later framework)
 - [requirements.md](explanation/requirements.md) — Problem statement and design requirements

--- a/docs/explanation/cli-proof-handoff-boundary.md
+++ b/docs/explanation/cli-proof-handoff-boundary.md
@@ -1,0 +1,68 @@
+# CLI Proof Handoff Boundary
+
+The v0.10.0 external-adoption buildout keeps proof execution repo-local.
+
+Installed CLI users can discover the relevant proof path:
+
+```bash
+uselesskey profiles
+uselesskey profile webhook --explain
+uselesskey inspect-bundle --path target/uselesskey-webhook
+```
+
+Those commands explain generated files, scanner-safe posture, runtime-material
+posture, proof or check paths, and claim boundaries. They do not execute public
+claim proof.
+
+Reviewers and maintainers who need receipts still use a repo checkout:
+
+```bash
+cargo xtask claim-proof --claim webhook-contract-pack
+cargo xtask verification-pack --out target/uselesskey-verification --claim webhook-contract-pack
+```
+
+## Decision
+
+For this buildout lane, `uselesskey` will not add an installed `prove` command.
+The installed CLI remains a generator, verifier, inspector, and proof handoff
+surface. Executable proof remains in `cargo xtask`.
+
+That means the supported user split is:
+
+| User | Interface |
+| --- | --- |
+| Installed CLI user | `uselesskey profiles`, `bundle`, `verify-bundle`, `inspect-bundle` |
+| Rust test author | crate dependency snippets and library APIs |
+| Reviewer with repo checkout | `cargo xtask verification-pack` |
+| Maintainer or agent | `cargo xtask pr`, `adoption-regression`, `claim-proof`, release evidence |
+
+## Why
+
+The proof system currently depends on repo-owned policy, specs, and `xtask`
+handlers. An installed CLI proof command would be misleading if it shell-ran
+ambient `cargo xtask` commands or executed command strings from policy files in
+whatever directory the user happened to be in.
+
+Keeping proof repo-local avoids:
+
+- arbitrary command execution from ledgers or profile metadata;
+- proof claims that depend on an unrelated current directory;
+- copying generated secret-shaped payloads into reviewer bundles;
+- turning installed CLI convenience into a production security claim.
+
+## Future Promotion Rule
+
+A future installed proof command can be reconsidered only if it has an owned
+proof engine. Acceptable shapes include:
+
+- a reusable proof library/API owned by `uselesskey`;
+- a packaged proof engine that does not rely on ambient repo state;
+- a metadata-only command that writes instructions or bundle-local inspection
+  receipts without claiming repo public-claim proof was executed.
+
+Any future reviewer bundle produced by the installed CLI must remain
+metadata-only and must not copy generated PEM, DER, JWT, key, Kubernetes
+Secret, Vault payload, or webhook request payload files.
+
+The formal boundary is
+[`USELESSKEY-SPEC-0012`](../specs/USELESSKEY-SPEC-0012-cli-proof-handoff.md).

--- a/docs/specs/USELESSKEY-SPEC-0012-cli-proof-handoff.md
+++ b/docs/specs/USELESSKEY-SPEC-0012-cli-proof-handoff.md
@@ -105,6 +105,17 @@ updated.
   until the proof engine has a safe reusable surface.
 - Reviewer evidence remains metadata-only.
 
+## Current v0.10.0 Buildout Decision
+
+The v0.10.0 external-adoption buildout chooses the explanatory handoff path.
+The installed CLI may generate, verify, inspect, and explain bundles, but it
+does not add `uselesskey prove`.
+
+The durable explanation is
+[`docs/explanation/cli-proof-handoff-boundary.md`](../explanation/cli-proof-handoff-boundary.md).
+Executable claim proof remains in repo-local `cargo xtask claim-proof` and
+metadata-only reviewer bundles remain in `cargo xtask verification-pack`.
+
 ## Acceptance Examples
 
 Acceptable:

--- a/plans/v0.10.0-external-adoption/implementation-plan.md
+++ b/plans/v0.10.0-external-adoption/implementation-plan.md
@@ -198,6 +198,9 @@ Do not mix these into this lane:
 7. `docs(design): decide installed proof handoff boundary`
    - Decide whether proof remains repo-local or gets a safe installed CLI
      handoff.
+   - Current lane decision: proof execution remains repo-local for v0.10.0
+     buildout. The installed CLI provides proof discovery and bundle
+     inspection, not an executable `prove` command.
    - If the lane chooses an installed command, the target shape is:
 
      ```bash


### PR DESCRIPTION
﻿Summary
- Record the v0.10.0 buildout decision that installed CLI proof remains an explanatory handoff, not an executable proof runner.
- Add a durable explanation page for the boundary and link it from the docs index and CLI proof-handoff spec.
- Mark proof-handoff-boundary done and adoption-regression external mode ready in the active goal.

Files added/changed
- docs/explanation/cli-proof-handoff-boundary.md
- docs/specs/USELESSKEY-SPEC-0012-cli-proof-handoff.md
- docs/README.md
- plans/v0.10.0-external-adoption/implementation-plan.md
- .uselesskey/goals/active.toml

Validation
- cargo xtask spec-check --strict
- cargo xtask docs-sync --check
- cargo xtask typos
- git diff --check

Non-goals
- No `uselesskey prove` command.
- No v0.10.0 release prep, version bump, tag, or publish.
- No new contract packs, badges, public claims, provider compatibility claims, or production security claims.

What this enables next
- The lane can wire external adoption smoke into adoption-regression with the installed proof boundary already decided.
