### PR TITLE
xtask: wire external adoption into adoption-regression

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -116,7 +116,7 @@ commands = [
 
 [[work_item]]
 id = "adoption-regression-external-mode"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0013"
 plan = "plans/v0.10.0-external-adoption/implementation-plan.md"
@@ -130,7 +130,7 @@ commands = [
 
 [[work_item]]
 id = "lane-closeout"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/v0.10.0-external-adoption/implementation-plan.md"

--- a/xtask/src/adoption_regression.rs
+++ b/xtask/src/adoption_regression.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
-use crate::{bundle_proof, git_head_sha, no_blob_gate, user_path_smoke};
+use crate::{bundle_proof, external_adoption_smoke, git_head_sha, no_blob_gate, user_path_smoke};
 
 const OUT_DIR: &str = "target/adoption-regression";
 const BUNDLE_PROOF_DIR: &str = "target/adoption-regression/bundle-proof";
@@ -17,12 +17,19 @@ const BOUNDARIES: &[&str] = &[
     "scanner-safe metadata is checked for fixture sensitivity, not scanner evasion",
     "contract-pack proofs do not prove downstream verifier correctness",
     "generated fixture payloads stay under target/",
+    "clean-project external adoption smoke runs only when --external is passed",
 ];
 
 #[derive(Clone, Copy, Debug)]
 pub enum OutputFormat {
     Human,
     Json,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RunOptions {
+    pub format: OutputFormat,
+    pub external: bool,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -46,7 +53,7 @@ struct AdoptionRegressionStep {
     artifacts: Vec<String>,
 }
 
-pub fn run(root: &Path, format: OutputFormat) -> Result<()> {
+pub fn run(root: &Path, options: RunOptions) -> Result<()> {
     let out_dir = root.join(OUT_DIR);
     fs::create_dir_all(&out_dir)
         .with_context(|| format!("failed to create {}", out_dir.display()))?;
@@ -57,17 +64,16 @@ pub fn run(root: &Path, format: OutputFormat) -> Result<()> {
         generated_at: chrono::Utc::now().to_rfc3339(),
         git_sha: git_head_sha().ok(),
         steps: Vec::new(),
-        artifacts: vec![
-            "target/adoption-regression/adoption-regression.json".to_string(),
-            "target/adoption-regression/adoption-regression.md".to_string(),
-            "target/user-path-smoke/".to_string(),
-            "target/adoption-regression/runtime-matrix/".to_string(),
-            "target/adoption-regression/bundle-proof/".to_string(),
-        ],
+        artifacts: receipt_artifacts(options.external),
         boundaries: BOUNDARIES.to_vec(),
     };
 
-    let result = run_steps(root, &mut receipt, matches!(format, OutputFormat::Json));
+    let result = run_steps(
+        root,
+        &mut receipt,
+        matches!(options.format, OutputFormat::Json),
+        options.external,
+    );
     if result.is_ok() {
         receipt.status = "pass".to_string();
     } else {
@@ -75,7 +81,7 @@ pub fn run(root: &Path, format: OutputFormat) -> Result<()> {
     }
 
     write_receipts(&out_dir, &receipt)?;
-    match format {
+    match options.format {
         OutputFormat::Human => print_human(&receipt),
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&receipt)?),
     }
@@ -87,6 +93,7 @@ fn run_steps(
     root: &Path,
     receipt: &mut AdoptionRegressionReceipt,
     quiet_stdout: bool,
+    include_external: bool,
 ) -> Result<()> {
     run_step(
         receipt,
@@ -164,8 +171,33 @@ fn run_steps(
         &[],
         || no_blob_step(root, quiet_stdout),
     )?;
+    if include_external {
+        run_step(
+            receipt,
+            "external-adoption-smoke",
+            &["cargo", "xtask", "external-adoption-smoke", "--path", "."],
+            &["target/external-adoption-smoke/"],
+            || external_adoption_smoke_step(root, quiet_stdout),
+        )?;
+    }
 
     Ok(())
+}
+
+fn receipt_artifacts(include_external: bool) -> Vec<String> {
+    let mut artifacts = vec![
+        "target/adoption-regression/adoption-regression.json".to_string(),
+        "target/adoption-regression/adoption-regression.md".to_string(),
+        "target/user-path-smoke/".to_string(),
+        "target/adoption-regression/runtime-matrix/".to_string(),
+        "target/adoption-regression/bundle-proof/".to_string(),
+    ];
+    if include_external {
+        artifacts.push("target/external-adoption-smoke/".to_string());
+        artifacts.push("target/external-adoption-smoke/report.json".to_string());
+        artifacts.push("target/external-adoption-smoke/report.md".to_string());
+    }
+    artifacts
 }
 
 fn user_path_smoke_step(root: &Path, quiet_stdout: bool) -> Result<()> {
@@ -203,6 +235,32 @@ fn no_blob_step(root: &Path, quiet_stdout: bool) -> Result<()> {
         run_command(&mut cmd, true)
     } else {
         no_blob_gate()
+    }
+}
+
+fn external_adoption_smoke_step(root: &Path, quiet_stdout: bool) -> Result<()> {
+    if quiet_stdout {
+        let mut cmd = Command::new("cargo");
+        cmd.args([
+            "xtask",
+            "external-adoption-smoke",
+            "--path",
+            ".",
+            "--format",
+            "json",
+        ])
+        .current_dir(root)
+        .stdin(Stdio::null());
+        run_command(&mut cmd, true)
+    } else {
+        external_adoption_smoke::run(
+            root,
+            external_adoption_smoke::RunOptions {
+                path: Some(root.to_path_buf()),
+                version: None,
+                format: external_adoption_smoke::OutputFormat::Human,
+            },
+        )
     }
 }
 
@@ -453,13 +511,67 @@ mod tests {
 
     #[test]
     fn adoption_regression_artifact_paths_are_target_scoped() {
-        for path in [
-            OUT_DIR,
-            BUNDLE_PROOF_DIR,
-            RUNTIME_MATRIX_DIR,
-            "target/user-path-smoke",
-        ] {
+        for path in receipt_artifacts(true).into_iter().chain([
+            OUT_DIR.to_string(),
+            BUNDLE_PROOF_DIR.to_string(),
+            RUNTIME_MATRIX_DIR.to_string(),
+        ]) {
             assert!(path.starts_with("target/"));
         }
+    }
+
+    #[test]
+    fn adoption_regression_default_artifacts_stay_bounded() {
+        let artifacts = receipt_artifacts(false);
+
+        assert!(artifacts.contains(&"target/user-path-smoke/".to_string()));
+        assert!(
+            !artifacts
+                .iter()
+                .any(|artifact| artifact.starts_with("target/external-adoption-smoke"))
+        );
+    }
+
+    #[test]
+    fn adoption_regression_external_artifacts_include_smoke_receipts() {
+        let artifacts = receipt_artifacts(true);
+
+        assert!(artifacts.contains(&"target/external-adoption-smoke/".to_string()));
+        assert!(artifacts.contains(&"target/external-adoption-smoke/report.json".to_string()));
+        assert!(artifacts.contains(&"target/external-adoption-smoke/report.md".to_string()));
+    }
+
+    #[test]
+    fn adoption_regression_external_step_is_explicit() {
+        let mut receipt = AdoptionRegressionReceipt {
+            schema_version: 1,
+            status: "pass".to_string(),
+            generated_at: "2026-05-16T00:00:00Z".to_string(),
+            git_sha: Some("abc123".to_string()),
+            steps: Vec::new(),
+            artifacts: vec!["target/external-adoption-smoke/".to_string()],
+            boundaries: BOUNDARIES.to_vec(),
+        };
+
+        run_step(
+            &mut receipt,
+            "external-adoption-smoke",
+            &["cargo", "xtask", "external-adoption-smoke", "--path", "."],
+            &["target/external-adoption-smoke/"],
+            || Ok(()),
+        )
+        .expect("external step receipt should record");
+
+        let step = receipt
+            .steps
+            .iter()
+            .find(|step| step.name == "external-adoption-smoke")
+            .expect("external step present");
+        assert_eq!(step.status, "ok");
+        assert_eq!(
+            step.command,
+            ["cargo", "xtask", "external-adoption-smoke", "--path", "."]
+        );
+        assert_eq!(step.artifacts, ["target/external-adoption-smoke/"]);
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -106,6 +106,9 @@ enum Cmd {
     UserPathSmoke,
     /// Run bounded adoption-path regression checks and write receipts.
     AdoptionRegression {
+        /// Also run clean-project external adoption smoke.
+        #[arg(long)]
+        external: bool,
         /// Output format.
         #[arg(long, value_enum, default_value = "human")]
         format: AdoptionRegressionFormat,
@@ -626,9 +629,13 @@ fn main() -> Result<()> {
         Cmd::PublicSurface => public_surface::public_surface_cmd(PUBLISH_CRATES),
         Cmd::ExamplesSmoke { run } => docs_sync::examples_smoke_cmd(run),
         Cmd::UserPathSmoke => user_path_smoke::run(&workspace_root_path()),
-        Cmd::AdoptionRegression { format } => {
-            adoption_regression::run(&workspace_root_path(), format.into())
-        }
+        Cmd::AdoptionRegression { external, format } => adoption_regression::run(
+            &workspace_root_path(),
+            adoption_regression::RunOptions {
+                format: format.into(),
+                external,
+            },
+        ),
         Cmd::ExternalAdoptionSmoke {
             path,
             version,
@@ -10555,6 +10562,38 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
                 format: ExternalAdoptionSmokeFormat::Json,
             }
         ));
+    }
+
+    #[test]
+    fn adoption_regression_external_flag_is_explicit() {
+        let default = Cli::try_parse_from(["xtask", "adoption-regression"]).unwrap();
+        match default.cmd {
+            Cmd::AdoptionRegression {
+                external, format, ..
+            } => {
+                assert!(!external, "external mode must be opt-in");
+                assert!(matches!(format, AdoptionRegressionFormat::Human));
+            }
+            _ => panic!("expected Cmd::AdoptionRegression"),
+        }
+
+        let external = Cli::try_parse_from([
+            "xtask",
+            "adoption-regression",
+            "--external",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        match external.cmd {
+            Cmd::AdoptionRegression {
+                external, format, ..
+            } => {
+                assert!(external, "external flag should propagate");
+                assert!(matches!(format, AdoptionRegressionFormat::Json));
+            }
+            _ => panic!("expected Cmd::AdoptionRegression"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
﻿Summary
- Add explicit `cargo xtask adoption-regression --external` mode that appends clean-project external adoption smoke after the bounded default checks.
- Keep default adoption-regression bounded and record external smoke receipts only when `--external` is requested.
- Mark adoption-regression external mode done and lane closeout ready in the active goal.

Files added/changed
- xtask/src/adoption_regression.rs
- xtask/src/main.rs
- .uselesskey/goals/active.toml

Validation
- cargo xtask fmt
- cargo test -p xtask adoption_regression -- --nocapture
- cargo xtask adoption-regression
- cargo xtask adoption-regression --external
- cargo +nightly xtask pr-lite
- git diff --check

Non-goals
- No v0.10.0 release prep, version bump, tag, or publish.
- No new contract packs, badges, public claims, provider compatibility claims, or production security claims.
- No change to the default bounded adoption-regression behavior beyond receipt metadata factoring.

What this enables next
- The external-adoption lane can close out with a single explicit command that proves clean-project adoption only when maintainers ask for the heavier external path.
