### PR TITLE
Ensure cache initializers run once under contention

### DIFF
--- a/crates/uselesskey-core/Cargo.toml
+++ b/crates/uselesskey-core/Cargo.toml
@@ -34,7 +34,7 @@ dashmap = { workspace = true, optional = true }
 rand10.workspace = true
 rand_chacha10.workspace = true
 rand_core10.workspace = true
-spin = { version = "0.10.0", default-features = false, features = ["mutex", "spin_mutex"] }
+spin = { version = "0.10.0", default-features = false, features = ["mutex", "once", "spin_mutex"] }
 tempfile = { workspace = true, optional = true }
 thiserror = { version = "2.0.18", default-features = false }
 

--- a/crates/uselesskey-core/src/srp/cache.rs
+++ b/crates/uselesskey-core/src/srp/cache.rs
@@ -15,16 +15,18 @@ use core::fmt;
 use dashmap::DashMap;
 #[cfg(not(feature = "std"))]
 use spin::Mutex;
+use spin::Once;
 
 use crate::srp::identity::ArtifactId;
 
 type CacheValue = Arc<dyn Any + Send + Sync>;
+type CacheCell = Arc<Once<CacheValue>>;
 
 #[cfg(feature = "std")]
-type Cache = DashMap<ArtifactId, CacheValue>;
+type Cache = DashMap<ArtifactId, CacheCell>;
 
 #[cfg(not(feature = "std"))]
-type Cache = Mutex<BTreeMap<ArtifactId, CacheValue>>;
+type Cache = Mutex<BTreeMap<ArtifactId, CacheCell>>;
 
 /// Cache keyed by [`ArtifactId`] that stores typed values behind `Arc<dyn Any>`.
 ///
@@ -94,7 +96,29 @@ impl ArtifactCache {
         T: Any + Send + Sync + 'static,
     {
         let value_any: CacheValue = value;
-        let winner = cache_insert_if_absent(&self.inner, id.clone(), value_any);
+        self.insert_cache_value_if_absent(id, || value_any)
+    }
+
+    /// Initialize a typed value if the id is vacant and return the winning cached value.
+    ///
+    /// The initializer runs at most once for a given cache identity, even when
+    /// multiple threads race to populate the same entry. Panics if an existing
+    /// value for the same id has a different concrete type.
+    pub fn insert_if_absent_with_typed<T, F>(&self, id: ArtifactId, init: F) -> Arc<T>
+    where
+        T: Any + Send + Sync + 'static,
+        F: FnOnce() -> T,
+    {
+        self.insert_cache_value_if_absent(id, || Arc::new(init()) as CacheValue)
+    }
+
+    fn insert_cache_value_if_absent<T, F>(&self, id: ArtifactId, init: F) -> Arc<T>
+    where
+        T: Any + Send + Sync + 'static,
+        F: FnOnce() -> CacheValue,
+    {
+        let cell = cache_cell_for(&self.inner, id.clone());
+        let winner = cell.call_once(init).clone();
         downcast_or_panic::<T>(winner, &id)
     }
 }
@@ -137,26 +161,32 @@ fn cache_clear(cache: &Cache) {
 
 #[cfg(feature = "std")]
 fn cache_get(cache: &Cache, id: &ArtifactId) -> Option<CacheValue> {
-    cache.get(id).map(|entry| entry.value().clone())
+    cache
+        .get(id)
+        .and_then(|entry| entry.value().get().cloned())
 }
 
 #[cfg(not(feature = "std"))]
 fn cache_get(cache: &Cache, id: &ArtifactId) -> Option<CacheValue> {
-    cache.lock().get(id).cloned()
+    cache.lock().get(id).and_then(|cell| cell.get().cloned())
 }
 
 #[cfg(feature = "std")]
-fn cache_insert_if_absent(cache: &Cache, id: ArtifactId, value: CacheValue) -> CacheValue {
-    cache.entry(id).or_insert(value).value().clone()
+fn cache_cell_for(cache: &Cache, id: ArtifactId) -> CacheCell {
+    cache
+        .entry(id)
+        .or_insert_with(|| Arc::new(Once::new()))
+        .value()
+        .clone()
 }
 
 #[cfg(not(feature = "std"))]
-fn cache_insert_if_absent(cache: &Cache, id: ArtifactId, value: CacheValue) -> CacheValue {
+fn cache_cell_for(cache: &Cache, id: ArtifactId) -> CacheCell {
     use alloc::collections::btree_map::Entry;
 
     let mut guard = cache.lock();
     match guard.entry(id) {
-        Entry::Vacant(slot) => slot.insert(value).clone(),
+        Entry::Vacant(slot) => slot.insert(Arc::new(Once::new())).clone(),
         Entry::Occupied(slot) => slot.get().clone(),
     }
 }
@@ -221,6 +251,45 @@ mod tests {
 
         assert!(Arc::ptr_eq(&first, &second));
         assert_eq!(*second, 11u32);
+    }
+
+    #[test]
+    fn racing_initializers_for_same_id_run_only_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc as StdArc, Barrier};
+        use std::thread;
+        use std::time::Duration;
+
+        let cache = StdArc::new(ArtifactCache::new());
+        let starts = StdArc::new(AtomicUsize::new(0));
+        let barrier = StdArc::new(Barrier::new(16));
+
+        let handles: Vec<_> = (0..16)
+            .map(|_| {
+                let cache = StdArc::clone(&cache);
+                let starts = StdArc::clone(&starts);
+                let barrier = StdArc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    cache.insert_if_absent_with_typed(sample_id(), || {
+                        starts.fetch_add(1, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(25));
+                        91u32
+                    })
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            let value = handle.join().expect("worker should not panic");
+            assert_eq!(*value, 91);
+        }
+
+        assert_eq!(
+            starts.load(Ordering::SeqCst),
+            1,
+            "same cache id should not run duplicate expensive initializers"
+        );
     }
 
     #[test]

--- a/crates/uselesskey-core/src/srp/factory.rs
+++ b/crates/uselesskey-core/src/srp/factory.rs
@@ -135,15 +135,10 @@ impl Factory {
             DerivationVersion::V1,
         );
 
-        if let Some(entry) = self.inner.cache.get_typed::<T>(&id) {
-            return entry;
-        }
-
-        let seed = self.seed_for(&id);
-        let value = init(seed);
-        let arc: Arc<T> = Arc::new(value);
-
-        self.inner.cache.insert_if_absent_typed(id, arc)
+        self.inner.cache.insert_if_absent_with_typed(id.clone(), || {
+            let seed = self.seed_for(&id);
+            init(seed)
+        })
     }
 
     fn seed_for(&self, id: &ArtifactId) -> Seed {
@@ -239,6 +234,44 @@ mod tests {
         });
 
         assert_eq!(*outer, "outer-42");
+    }
+
+    #[test]
+    fn concurrent_get_or_init_same_identity_runs_initializer_once() {
+        use std::sync::Barrier;
+        use std::thread;
+        use std::time::Duration;
+
+        let fx = Factory::deterministic(Seed::new([9u8; 32]));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(16));
+
+        let handles: Vec<_> = (0..16)
+            .map(|_| {
+                let fx = fx.clone();
+                let starts = Arc::clone(&starts);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    fx.get_or_init("domain:race", "label", b"spec", "good", |_seed| {
+                        starts.fetch_add(1, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(25));
+                        1234u64
+                    })
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            let value = handle.join().expect("worker should not panic");
+            assert_eq!(*value, 1234);
+        }
+
+        assert_eq!(
+            starts.load(Ordering::SeqCst),
+            1,
+            "same artifact identity should run the expensive initializer once"
+        );
     }
 
     #[test]

--- a/crates/uselesskey-core/tests/edge_cases.rs
+++ b/crates/uselesskey-core/tests/edge_cases.rs
@@ -8,6 +8,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
+use std::time::Duration;
 
 use uselesskey_core::{Factory, Mode, Seed};
 
@@ -48,6 +49,7 @@ fn concurrent_get_or_init_same_key_calls_init_once() {
                 bar.wait();
                 let v = fx.get_or_init("domain:conc", "shared", b"spec", "good", |_rng| {
                     count.fetch_add(1, Ordering::SeqCst);
+                    thread::sleep(Duration::from_millis(25));
                     42u64
                 });
                 assert_eq!(*v, 42u64);
@@ -59,10 +61,11 @@ fn concurrent_get_or_init_same_key_calls_init_once() {
         h.join().unwrap();
     }
 
-    // init should be called a small number of times (ideally 1, but DashMap
-    // may race on insert; the important thing is all threads see the same value)
-    let count = init_count.load(Ordering::SeqCst);
-    assert!((1..=8).contains(&count), "init called {count} times");
+    assert_eq!(
+        init_count.load(Ordering::SeqCst),
+        1,
+        "same cache identity should run exactly one initializer"
+    );
 }
 
 // ===========================================================================


### PR DESCRIPTION
### Motivation

- Prevent duplicate expensive artifact generation when many threads race to populate the same cache identity while preserving deterministic seed derivation. 
- Provide a one-time initialization primitive usable in both `std` and `no_std` builds so cache behavior is consistent across feature sets.

### Description

- Store cache entries as one-time initialization cells (`CacheCell = Arc<Once<CacheValue>>`) and switch the cache to hold those cells instead of raw values, enabling atomic `call_once` initialization. (changes in `crates/uselesskey-core/src/srp/cache.rs` and `crates/uselesskey-core/Cargo.toml` to enable `spin` `once` feature)
- Add `insert_if_absent_with_typed` / `insert_cache_value_if_absent` helpers that run an initializer exactly once per `ArtifactId` and downcast the winning value, and keep `insert_if_absent_typed` as a convenience wrapper. (`crates/uselesskey-core/src/srp/cache.rs`)
- Route `Factory::get_or_init` through the new cache-initializer path so the derived-seed initializer runs at most once for a given `(domain, label, spec, variant)`. (`crates/uselesskey-core/src/srp/factory.rs`)
- Strengthen concurrency edge tests and add explicit racing initializer tests that assert a single initializer runs under contention. (`crates/uselesskey-core/tests/edge_cases.rs`, `crates/uselesskey-core/src/srp/cache.rs` tests, `crates/uselesskey-core/src/srp/factory.rs` tests)

### Testing

- Ran `cargo test -p uselesskey-core` and all unit/doc tests passed (existing and newly added concurrency tests included). ✅
- Ran `cargo check -p uselesskey-core --no-default-features` to validate the no-`std` configuration and it succeeded. ✅
- Ran `cargo clippy -p uselesskey-core --all-targets -- -D warnings` with no warnings. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1ff0fdc833385d2ca5412f77ddf)