### PR TITLE
test(token): cover negative token variants

### DIFF
--- a/crates/uselesskey-token/src/srp/shape.rs
+++ b/crates/uselesskey-token/src/srp/shape.rs
@@ -594,6 +594,67 @@ mod tests {
         assert_eq!(payload["exp"], 4_100_000_000u64);
     }
 
+    #[test]
+    fn negative_expired_claims_only_rewrites_expiration() {
+        let value = generate_negative_token(
+            "svc",
+            TokenKind::OAuthAccessToken,
+            Seed::new([38u8; 32]),
+            NegativeToken::ExpiredClaims,
+        );
+        let parts = jwt_parts(&value);
+        let header = decode_object_segment(parts[0]);
+        let payload = decode_object_segment(parts[1]);
+
+        assert_eq!(parts.len(), 3);
+        assert_eq!(header["alg"], "RS256");
+        assert_eq!(header["typ"], "JWT");
+        assert_eq!(payload["sub"], "svc");
+        assert_eq!(payload["iss"], "uselesskey");
+        assert_eq!(payload["aud"], "tests");
+        assert_eq!(payload["exp"], 1u64);
+    }
+
+    #[test]
+    fn negative_bad_issuer_only_rewrites_issuer() {
+        let value = generate_negative_token(
+            "svc",
+            TokenKind::OAuthAccessToken,
+            Seed::new([39u8; 32]),
+            NegativeToken::BadIssuer,
+        );
+        let parts = jwt_parts(&value);
+        let header = decode_object_segment(parts[0]);
+        let payload = decode_object_segment(parts[1]);
+
+        assert_eq!(parts.len(), 3);
+        assert_eq!(header["alg"], "RS256");
+        assert_eq!(payload["iss"], "wrong-issuer");
+        assert_eq!(payload["sub"], "svc");
+        assert_eq!(payload["aud"], "tests");
+        assert_eq!(payload["exp"], 2_000_000_000u64);
+    }
+
+    #[test]
+    fn negative_bad_audience_only_rewrites_audience() {
+        let value = generate_negative_token(
+            "svc",
+            TokenKind::OAuthAccessToken,
+            Seed::new([40u8; 32]),
+            NegativeToken::BadAudience,
+        );
+        let parts = jwt_parts(&value);
+        let header = decode_object_segment(parts[0]);
+        let payload = decode_object_segment(parts[1]);
+
+        assert_eq!(parts.len(), 3);
+        assert_eq!(header["alg"], "RS256");
+        assert_eq!(payload["aud"], "wrong-audience");
+        assert_eq!(payload["iss"], "uselesskey");
+        assert_eq!(payload["sub"], "svc");
+        assert_eq!(payload["exp"], 2_000_000_000u64);
+    }
+
     fn jwt_parts(value: &str) -> Vec<&str> {
         value.split('.').collect()
     }

--- a/crates/uselesskey-token/src/token.rs
+++ b/crates/uselesskey-token/src/token.rs
@@ -372,6 +372,47 @@ mod tests {
     }
 
     #[test]
+    fn negative_variants_are_cached_independently() {
+        let fx = Factory::deterministic(Seed::from_env_value("token-negative-variants").unwrap());
+        let token = fx.token("issuer", TokenSpec::oauth_access_token());
+
+        let expired = token.negative_value(NegativeToken::ExpiredClaims);
+        let bad_issuer = token.negative_value(NegativeToken::BadIssuer);
+        let bad_audience = token.negative_value(NegativeToken::BadAudience);
+
+        assert_eq!(expired, token.negative_value(NegativeToken::ExpiredClaims));
+        assert_eq!(bad_issuer, token.negative_value(NegativeToken::BadIssuer));
+        assert_eq!(
+            bad_audience,
+            token.negative_value(NegativeToken::BadAudience)
+        );
+        assert_ne!(expired, bad_issuer);
+        assert_ne!(expired, bad_audience);
+        assert_ne!(bad_issuer, bad_audience);
+        assert_ne!(expired, token.value());
+    }
+
+    #[test]
+    fn negative_values_are_deterministic_across_factories() {
+        let seed = Seed::from_env_value("token-negative-cross-factory").unwrap();
+        let fx1 = Factory::deterministic(seed);
+        let fx2 =
+            Factory::deterministic(Seed::from_env_value("token-negative-cross-factory").unwrap());
+
+        let t1 = fx1.token("issuer", TokenSpec::oauth_access_token());
+        let t2 = fx2.token("issuer", TokenSpec::oauth_access_token());
+
+        for variant in [
+            NegativeToken::ExpiredClaims,
+            NegativeToken::BadIssuer,
+            NegativeToken::BadAudience,
+            NegativeToken::MismatchedKid,
+        ] {
+            assert_eq!(t1.negative_value(variant), t2.negative_value(variant));
+        }
+    }
+
+    #[test]
     fn debug_does_not_include_token_value() {
         let fx = Factory::random();
         let token = fx.token("debug-label", TokenSpec::api_key());


### PR DESCRIPTION
### Motivation
- Increase unit test coverage for `uselesskey-token` negative-token behaviour so negative OAuth variants rewrite only intended claims while preserving JWT shape. 
- Verify negative-value caching and determinism across factories to prevent regressions in per-identity caching and seeded derivation.

### Description
- Add three unit tests in `crates/uselesskey-token/src/srp/shape.rs` that assert `ExpiredClaims`, `BadIssuer`, and `BadAudience` negative variants rewrite only the expected JWT fields and preserve overall JWT shape. 
- Add two `TokenFixture` tests in `crates/uselesskey-token/src/token.rs` that assert negative variants are cached independently and that negative values are deterministic across factories seeded with the same `Seed`. 
- Formatting adjustments applied via the repository lint-fix rules to keep style consistent with the workspace.

### Testing
- Ran `cargo xtask lint-fix --check` which completed successfully. 
- Ran `cargo test -p uselesskey-token` and the package unit tests passed (all token-related tests and doctests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d1c4b19c8333958abfc854634443)