### PR TITLE
docs: define source-of-truth rails and agent read-order (SPEC_SYSTEM)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,37 +1,45 @@
-## Description
+## Summary
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+What changed?
 
-Fixes # (issue)
+## Source-of-truth links
 
-## Type of change
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
 
-- [ ] `feat`: New feature
-- [ ] `fix`: Bug fix
-- [ ] `docs`: Documentation update
-- [ ] `style`: Code style (formatting, etc)
-- [ ] `refactor`: Refactoring
-- [ ] `perf`: Performance improvement
-- [ ] `test`: Testing
-- [ ] `chore`: Maintenance
-- [ ] `revert`: Revert change
+## Scope
 
-## DevEx Checklist
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
 
-Run these locally before submitting:
+## Non-goals
 
-- [ ] `cargo xtask gate`: Fmt, check, clippy, and test compile pass.
-- [ ] `cargo xtask typos`: No misspellings.
-- [ ] `cargo xtask bdd`: BDD tests pass (if applicable).
-- [ ] `cargo xtask mutants`: Mutation testing passes (if applicable).
+What this PR explicitly does not do.
 
-## Checklist:
+## Proof
 
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules
+```bash
+# commands run
+```
+
+## Results
+
+What passed? What failed? What could not run?
+
+## Claim boundary
+
+What may be claimed after this PR? What may not be claimed yet?
+
+## Rollback
+
+How can this PR be reverted safely?

--- a/.uselesskey/goals/README.md
+++ b/.uselesskey/goals/README.md
@@ -15,6 +15,8 @@ record history; they should not be treated as active instructions.
 Do not create `active.toml` until the lane has an accepted proposal or spec to
 link to.
 
-When resuming agent work, read
-[`docs/handoffs/agent-bootstrap.md`](../../docs/handoffs/agent-bootstrap.md)
-before acting on older chat context.
+When resuming agent work, read these before acting on older chat context:
+
+1. [`docs/reference/SPEC_SYSTEM.md`](../../docs/reference/SPEC_SYSTEM.md) for the source-of-truth roles and stop conditions.
+2. [`docs/handoffs/agent-bootstrap.md`](../../docs/handoffs/agent-bootstrap.md) for the repo-specific startup order.
+3. `active.toml` for the current lane and proof commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,27 @@ Path ignores exist but require ongoing maintenance. This crate replaces "securit
 - Preserve derivation stability: bump version if algorithm changes
 - Extension traits for new key types (not monolithic API growth)
 
+## Repo Source-of-Truth Stack
+
+This repo uses a linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Before changing files for lane or implementation work, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.uselesskey/goals/active.toml`
+3. The linked implementation plan
+4. The linked spec for the selected work item
+5. Any linked ADRs
+
+Work on exactly one ready work item per PR. Do not broaden public claims
+without support/status proof, do not hand-edit generated status, and stop
+instead of guessing when linked source-of-truth files or proof commands are
+missing.
+
 ## Build Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,27 @@ Path ignores exist but require ongoing maintenance. This crate replaces "securit
 - Preserve derivation stability: bump version if algorithm changes
 - Extension traits for new key types (not monolithic API growth)
 
+## Repo Source-of-Truth Stack
+
+This repo uses a linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Before changing files for lane or implementation work, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.uselesskey/goals/active.toml`
+3. The linked implementation plan
+4. The linked spec for the selected work item
+5. Any linked ADRs
+
+Work on exactly one ready work item per PR. Do not broaden public claims
+without support/status proof, do not hand-edit generated status, and stop
+instead of guessing when linked source-of-truth files or proof commands are
+missing.
+
 ## Build Commands
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Architecture Decision Records (ADRs) capture significant design choices and thei
 Repository operating artifacts are split by job so public claims, proof, and
 agent state do not drift into one document.
 
+- [source-of-truth system](reference/SPEC_SYSTEM.md) - Artifact roles, read order, stop conditions, and claim boundaries
 - [proposals](proposals/README.md) - Why a lane exists, who benefits, and what alternatives were considered
 - [specs](specs/README.md) - What behavior is promised, not promised, and how it is proven
 - [status](status/README.md) - Public claim, support tier, and proof mapping indexes
@@ -93,6 +94,7 @@ Understanding-oriented material on design and direction.
 
 Specifications and formal definitions.
 
+- [SPEC_SYSTEM.md](reference/SPEC_SYSTEM.md) — Repo source-of-truth stack, agent workflow, and stop conditions
 - [dependency-economics.md](reference/dependency-economics.md) — Current lane cost receipts
 - [audit-surface.md](reference/audit-surface.md) — Current audit/island receipts
 - [verification-badges.md](reference/verification-badges.md) — Generated README badge endpoint rules and boundaries

--- a/docs/handoffs/agent-bootstrap.md
+++ b/docs/handoffs/agent-bootstrap.md
@@ -5,13 +5,15 @@ lane state lives in the repo, not in chat history.
 
 ## Startup Order
 
-1. Read `.uselesskey/goals/active.toml`.
-2. Read the `plan` paths linked from ready or active work items.
-3. Read the linked proposal, specs, and ADRs for the work item.
-4. Run `cargo xtask spec-check --strict` before changing source-of-truth files.
-5. Run `cargo xtask claim-report` when public claims, badges, contract packs, or
+1. Read `AGENTS.md` or `CLAUDE.md`.
+2. Read `docs/reference/SPEC_SYSTEM.md`.
+3. Read `.uselesskey/goals/active.toml`.
+4. Read the `plan` paths linked from ready or active work items.
+5. Read the linked proposal, specs, and ADRs for the work item.
+6. Run `cargo xtask spec-check --strict` before changing source-of-truth files.
+7. Run `cargo xtask claim-report` when public claims, badges, contract packs, or
    release evidence change.
-6. Use chat instructions as current operator intent, but do not treat old chat
+8. Use chat instructions as current operator intent, but do not treat old chat
    prompts as source-of-truth state.
 
 ## PR Body Contract

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,197 @@
+# Repo Source-of-Truth System
+
+`uselesskey` uses a linked source-of-truth stack so humans and agents can find
+why work exists, what behavior is required, what decisions constrain it, what
+lands next, and what proof supports public claims without relying on chat
+history.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact Roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| Roadmap | Release direction, milestone framing, lane discovery | Detailed PR queue, live proof receipts |
+| Proposal | Why a lane exists, affected users, alternatives, risks, success criteria | Behavior contract, PR ordering |
+| Spec | Required behavior, acceptance examples, evidence, test and CI mapping | Product rationale, implementation sequence |
+| ADR | Durable architecture or operating decision, context, consequences | Current task list, metric state |
+| Plan | Work-item sequence, dependencies, proof commands, rollback, closeout | Product strategy, durable architecture decisions |
+| Active goal | Current machine-readable lane state, work items, proof commands, claim boundaries | Generated status, long-form rationale, historical closeout |
+| Support/status docs | Public claims, tiering, known limitations, promotion proof | Feature design, task queue |
+| Policy ledgers | Exceptions, owners, reasons, coverage, review dates | Broad architecture rationale |
+| Handoffs/learnings | Session facts, proof run, durable lessons | Active execution source of truth |
+
+## Source-of-Truth Locations
+
+| Question | Source of truth |
+| --- | --- |
+| Why are we doing this? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What decision constrains it? | `docs/adr/` |
+| What PR lands next? | `plans/<lane>/implementation-plan.md` |
+| What is the agent actively executing? | `.uselesskey/goals/active.toml` |
+| What proves the claim? | `docs/status/`, receipts, CI output |
+| What exceptions exist? | `policy/*.toml` |
+
+## Rules
+
+1. Keep one kind of truth per artifact.
+2. Work on one semantic artifact or one implementation work item per PR unless
+   the selected plan item explicitly says otherwise.
+3. Proposals explain why; specs define behavior; ADRs record durable decisions;
+   plans define sequencing; active goals define current execution.
+4. Public claims require support/status proof or an equivalent claim-ledger
+   pointer.
+5. Policy exceptions require an owner, reason, coverage, and review date.
+6. Generated status and receipts are updated by their generator/checker command,
+   not by hand.
+7. Proof commands must run before success is claimed; unavailable proof must be
+   reported with the command, reason, substitute evidence if any, and whether it
+   blocks merge.
+8. Claim boundaries are part of the artifact contract. Do not broaden support,
+   security, or provider-compatibility claims without the matching spec and
+   proof update.
+
+## Required Metadata
+
+New source-of-truth proposals, specs, ADRs, and plans should include metadata for
+these fields, using `n/a` or an empty list where a field does not apply:
+
+- `Status`
+- `Owner`
+- `Created`
+- `Linked proposal`
+- `Linked specs`
+- `Linked ADRs`
+- `Linked plan`
+- `Linked issues`
+- `Linked PRs`
+- `Support-tier impact`
+- `Policy impact`
+
+The existing repository templates in `docs/templates/` encode these as TOML
+front matter for proposals, specs, and ADRs.
+
+## Agent Workflow
+
+Agents must begin by reading repo instructions and then this stack in order:
+
+1. `AGENTS.md` or `CLAUDE.md`.
+2. `docs/reference/SPEC_SYSTEM.md`.
+3. `.uselesskey/goals/active.toml`.
+4. The linked implementation plan for the selected ready work item.
+5. The linked proposal only for why-level context.
+6. The linked spec for behavior and acceptance.
+7. Any linked ADRs for constraints.
+8. Current `git status` before editing.
+
+After startup, agents should pick exactly one ready work item, implement only
+that item, run the listed proof commands plus `git diff --check`, and update
+only the docs, status, receipts, or policy files required by that work item.
+
+## Stop Conditions
+
+Stop and report instead of guessing when:
+
+- `.uselesskey/goals/active.toml` is missing, stale, or paused without a selected
+  lane;
+- linked proposals, specs, ADRs, or plans do not exist;
+- the selected work item is missing proof commands;
+- proof commands cannot run and no substitute evidence is defined;
+- generated status differs from committed status before the work item begins;
+- unrelated staged changes are present;
+- the requested work conflicts with an ADR or spec;
+- a public claim lacks a support/status proof pointer.
+
+## Active Goal Lifecycle
+
+The active goal manifest lives at `.uselesskey/goals/active.toml`.
+
+- `status = "active"` means agents may select ready work items from it.
+- `status = "paused"` must include a reason and means agents should not invent a
+  new lane.
+- Completed or superseded manifests move to
+  `.uselesskey/goals/archive/YYYY-MM-DD-<lane>.toml` before a new active manifest
+  is created.
+
+Do not leave multiple active goals.
+
+## Closeout Format
+
+At the end of a lane, write `plans/<lane>/closeout.md` with:
+
+- shipped work;
+- proof commands and receipts;
+- PRs and CI runs;
+- generated status, support-tier, and policy updates;
+- deferred work;
+- claim boundary;
+- next lane recommendation.
+
+Closeout prevents future agents from rediscovering old work.
+
+## Common Failure Modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<lane>/implementation-plan.md`; keep the spec to
+behavior, examples, and proof.
+
+### Plan becomes product rationale
+
+Move why-level prose to `docs/proposals/`; keep the plan to work items,
+acceptance, proof, and rollback.
+
+### Active goal becomes prose
+
+Keep `.uselesskey/goals/active.toml` machine-readable and link out to docs for
+long explanations or generated tables.
+
+### Agent hand-edits generated status
+
+Run the generator/checker named in the selected plan item instead of editing
+receipts or generated endpoints by hand.
+
+### Support claims drift
+
+Add or update support/status proof before broadening README, how-to, badge, or
+CLI claims.
+
+### Policy exceptions become silent debt
+
+Every exception needs owner, reason, `covered_by`, `review_after`, and optional
+`expires` metadata.
+
+### Mega PR
+
+Split the change so one PR owns one semantic artifact or one implementation work
+item.
+
+## What Good Looks Like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the source-of-truth
+system is working.


### PR DESCRIPTION
### Motivation

- Provide a single, durable reference for the repo's source-of-truth stack so humans and agents know where each kind of truth belongs and what to read first. 
- Prevent agents and contributors from drifting by encoding read order, stop conditions, claim boundaries, and artifact roles in a canonical doc. 
- Make the agent bootstrap and PR workflow explicit so repository automation and reviewers can rely on consistent proof commands. 

### Description

- Added `docs/reference/SPEC_SYSTEM.md` documenting the Source-of-Truth stack (Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof), artifact roles, source locations, rules, required metadata, agent workflow, stop conditions, active-goal lifecycle, closeout format, and common failure modes. 
- Updated agent guidance files (`AGENTS.md` and `CLAUDE.md`) to include the repo source-of-truth read order and a short summary of the stack so implementers/agents read `SPEC_SYSTEM.md` and the active manifest first. 
- Updated `.uselesskey/goals/README.md`, `docs/handoffs/agent-bootstrap.md`, and `docs/README.md` to link to the new reference and to clarify the recommended agent startup/read order. 
- Replaced the repository PR template at `.github/PULL_REQUEST_TEMPLATE.md` with a source-of-truth-aware template (source-of-truth links, scope checklist, proof/results, claim boundary, rollback). 
- All changes are documentation-only and do not modify runtime behavior or release artifacts. 

### Testing

- Ran `cargo xtask spec-check --strict`, which passed and reported `spec-check: pass (artifacts=36, claims=9, warnings=0, errors=0)`. 
- Ran `cargo xtask docs-sync --check`, which passed and reported the docs-sync inventory as expected. 
- Ran `cargo xtask check-file-policy`, which passed (file-policy matched all tracked files). 
- Ran `git diff --check`, which passed (no diff-check failures). 
- Attempted `cargo xtask typos` but the `typos` binary was not available in the environment, so spell-check could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a17f0c7608333b8f00dcc97e31e0e)