### PR TITLE
test(x509): tolerate CRLF blank-line corruption

### DIFF
--- a/crates/uselesskey-x509/tests/negative_x509.rs
+++ b/crates/uselesskey-x509/tests/negative_x509.rs
@@ -544,7 +544,8 @@ fn corrupt_cert_pem_extra_blank_line_on_real_cert() {
     let corrupted = cert.corrupt_cert_pem(CorruptPem::ExtraBlankLine);
     assert_ne!(corrupted, cert.cert_pem());
     // Should have an empty line injected.
-    assert!(corrupted.contains("\n\n"));
+    let normalized = corrupted.replace("\r\n", "\n");
+    assert!(normalized.contains("\n\n"));
 }
 
 #[test]


### PR DESCRIPTION
Summary
- Normalize CRLF to LF in the ExtraBlankLine PEM corruption assertion so Windows line endings do not hide the intended blank-line check.

Files changed
- crates/uselesskey-x509/tests/negative_x509.rs

Validation
- cargo test -p uselesskey-x509 --test negative_x509 corrupt_cert_pem_extra_blank_line_on_real_cert

Non-goals
- No fixture behavior change.
- No release, badge, or contract-pack changes.

What this enables next
- Keeps adoption-regression / X.509 negative fixture checks portable while the installed bundle audit lane lands separately.