### PR TITLE
ops: start downstream CI polish lane

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -1,24 +1,28 @@
-id = "uselesskey-installed-bundle-audit"
-title = "Installed bundle audit and reviewer handoff"
-status = "archived"
+id = "uselesskey-downstream-ci-polish"
+title = "Downstream CI and installed-user polish"
+status = "active"
 owner = "EffortlessMetrics"
 created = "2026-05-18"
 
 objective = """
-Make installed CLI-generated bundles locally auditable and reviewer-friendly.
-Users should be able to generate scanner-safe/TLS/OIDC/webhook fixtures,
-inspect and verify the bundle, and attach metadata-only audit receipts without
-cloning the repo or learning xtask.
+Make the installed bundle loop boring to run in downstream CI. Users should be
+able to install uselesskey, generate fixtures, verify and inspect bundles, audit
+the bundle with stable JSON/Markdown receipts, fail CI on meaningful drift, and
+understand each failure without learning repo-local proof machinery.
 """
 
 end_state = [
-  "Installed bundle audit behavior and boundaries are specified.",
-  "The installed CLI writes deterministic JSON and Markdown bundle-audit receipts.",
-  "Audit receipts prove local bundle consistency and metadata classification without copying raw fixture payloads.",
-  "Scanner-safe, TLS, OIDC, webhook, and runtime bundles have bounded audit coverage.",
-  "External adoption smoke runs bundle, verify-bundle, audit-bundle, and inspect-bundle for installed-style bundle paths.",
-  "Reviewer handoff and downstream CI docs explain what audit-bundle proves and does not prove.",
-  "The lane closes without a version bump, tag, publish, new badge, or new contract pack.",
+  "Bundle audit JSON has a documented stable schema and reference.",
+  "Installed audit commands expose CI-oriented behavior without shell parsing fragile prose.",
+  "Downstream GitHub Actions recipes show generate, verify, audit, and artifact handoff.",
+  "External adoption smoke can exercise documented downstream CI recipes explicitly.",
+  "Audit failure diagnostics are actionable while preserving stable machine-readable classes.",
+  "Installed CLI doctor covers user-local environment checks without repo-local proof tools.",
+  "Inspect and audit wording clearly separate quick summaries from durable receipts.",
+  "A downstream CI example proves the installed-user audit loop end to end.",
+  "Audit receipt golden tests protect schema shape, boundary language, and metadata-only posture.",
+  "Compact audit summaries keep terminal and CI logs readable.",
+  "The lane closes without release prep, version bump, tag, publish, new contract pack, or provider/security overclaims.",
 ]
 
 [[work_item]]
@@ -26,7 +30,7 @@ id = "lane-open"
 status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/installed-bundle-audit/implementation-plan.md"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
@@ -35,72 +39,145 @@ commands = [
 ]
 
 [[work_item]]
-id = "installed-bundle-audit-spec"
-status = "done"
+id = "bundle-audit-json-schema"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
-plan = "plans/installed-bundle-audit/implementation-plan.md"
-commands = [
-  "cargo xtask spec-check --strict",
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "audit-bundle-cli"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0014"
-plan = "plans/installed-bundle-audit/implementation-plan.md"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
 commands = [
   "cargo test -p uselesskey-cli --all-features audit_bundle",
-  "cargo xtask external-adoption-smoke --path .",
-  "cargo xtask adoption-regression --external",
-  "cargo xtask no-blob",
-  "cargo xtask pr-lite",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "external-adoption-audit"
-status = "done"
+id = "audit-bundle-ci-policy"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
-plan = "plans/installed-bundle-audit/implementation-plan.md"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
 commands = [
-  "cargo test -p xtask external_adoption_smoke",
-  "cargo xtask external-adoption-smoke --path .",
+  "cargo test -p uselesskey-cli --all-features audit_bundle",
   "cargo xtask external-adoption-smoke --path . --format json",
-  "cargo xtask adoption-regression --external",
-  "cargo xtask pr-lite",
+  "cargo +nightly xtask pr-lite",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "reviewer-handoff-docs"
-status = "done"
+id = "downstream-github-actions-recipes"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
-plan = "plans/installed-bundle-audit/implementation-plan.md"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
 commands = [
   "cargo xtask docs-sync --check",
   "cargo xtask typos",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "external-smoke-ci-recipes"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0013"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
+commands = [
+  "cargo test -p xtask external_adoption_smoke",
+  "cargo xtask external-adoption-smoke --path . --ci-recipes --format json",
+  "cargo xtask adoption-regression --external",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "audit-failure-diagnostics"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0014"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
+commands = [
+  "cargo test -p uselesskey-cli --all-features audit_bundle",
+  "cargo xtask no-blob",
+  "cargo +nightly xtask pr-lite",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "installed-cli-doctor"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0012"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
+commands = [
+  "cargo test -p uselesskey-cli --all-features doctor",
+  "cargo run -p uselesskey-cli -- doctor",
+  "cargo run -p uselesskey-cli -- doctor --format json",
+  "cargo +nightly xtask pr-lite",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "inspect-audit-alignment"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0014"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
+commands = [
+  "cargo test -p uselesskey-cli --all-features inspect audit_bundle",
+  "cargo xtask external-adoption-smoke --path .",
+  "cargo xtask docs-sync --check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "downstream-ci-example"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0013"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
+commands = [
+  "cargo xtask external-adoption-smoke --path .",
+  "cargo xtask adoption-regression --external",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "audit-receipt-goldens"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0014"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
+commands = [
+  "cargo test -p uselesskey-cli --all-features audit_bundle",
+  "cargo xtask no-blob",
+  "cargo +nightly xtask pr-lite",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "audit-bundle-summary"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0014"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
+commands = [
+  "cargo test -p uselesskey-cli --all-features audit_bundle",
   "cargo xtask external-adoption-smoke --path .",
   "git diff --check",
 ]
 
 [[work_item]]
 id = "lane-closeout"
-status = "done"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/installed-bundle-audit/closeout.md"
+plan = "plans/downstream-ci-polish/implementation-plan.md"
 commands = [
-  "cargo xtask external-adoption-smoke --path .",
+  "cargo xtask external-adoption-smoke --path . --format json",
   "cargo xtask adoption-regression --external",
   "cargo xtask claim-report --check-public-claims",
   "cargo xtask contract-packs --check",
+  "cargo xtask check-no-panic-family",
   "cargo xtask docs-sync --check",
   "cargo xtask typos",
   "cargo +nightly xtask pr-lite",

--- a/plans/README.md
+++ b/plans/README.md
@@ -18,6 +18,7 @@ Plans do not define product truth. Link to proposals for why and specs for what.
 - [v0.9.1-release](v0.9.1-release/README.md) - v0.9.1 adoption-confidence patch release
 - [v0.10.0-external-adoption](v0.10.0-external-adoption/README.md) - External adoption and installed-user workflow buildout
 - [installed-bundle-audit](installed-bundle-audit/README.md) - Installed CLI bundle audit and reviewer handoff
+- [downstream-ci-polish](downstream-ci-polish/README.md) - Downstream CI and installed-user polish
 
 ## Templates
 

--- a/plans/downstream-ci-polish/README.md
+++ b/plans/downstream-ci-polish/README.md
@@ -1,0 +1,12 @@
+# Downstream CI Polish
+
+This plan area owns the downstream CI and installed-user polish lane.
+
+The lane starts after the installed bundle audit and reviewer handoff lane
+closed. Its job is to make the installed bundle loop quiet, stable, and useful
+for downstream CI without turning installed-user commands into repo-local claim
+proof or release evidence.
+
+## Plan Files
+
+- [implementation-plan.md](implementation-plan.md) - PR sequence, proof commands, non-goals, and stop conditions

--- a/plans/downstream-ci-polish/implementation-plan.md
+++ b/plans/downstream-ci-polish/implementation-plan.md
@@ -1,0 +1,379 @@
++++
+id = "USELESSKEY-PLAN-0022"
+kind = "plan"
+title = "Downstream CI and installed-user polish"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-18"
+milestone = "v0.10.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0003",
+  "USELESSKEY-SPEC-0005",
+  "USELESSKEY-SPEC-0009",
+  "USELESSKEY-SPEC-0012",
+  "USELESSKEY-SPEC-0013",
+  "USELESSKEY-SPEC-0014",
+]
+linked_adrs = [
+  "USELESSKEY-ADR-0001",
+  "USELESSKEY-ADR-0002",
+  "USELESSKEY-ADR-0003",
+]
++++
+
+# Downstream CI and Installed-User Polish
+
+## Objective
+
+Make the installed bundle loop boring to run every day in downstream CI.
+
+The target experience is:
+
+```text
+install
+  -> generate
+    -> verify
+      -> inspect
+        -> audit
+          -> fail CI on stable failure classes
+            -> attach metadata-only evidence
+```
+
+This is a v0.10.0 product-quality buildout lane. It is not release
+preparation.
+
+## Scope
+
+This lane covers:
+
+- a documented stable JSON contract for installed bundle audit receipts;
+- CI-oriented audit behavior that downstream users can rely on without parsing
+  prose;
+- downstream GitHub Actions recipes for generate, verify, audit, and artifact
+  upload;
+- explicit external-adoption smoke for documented CI recipes;
+- clearer `audit-bundle` failure diagnostics with stable failure classes;
+- a small installed-user `uselesskey doctor` command;
+- consistent `inspect-bundle` and `audit-bundle` wording;
+- one downstream-shaped CI example for bundle audit;
+- golden coverage for stable audit receipt shape and boundary language;
+- compact audit summaries for terminal and CI logs;
+- closeout with no release action.
+
+## Non-goals
+
+Do not mix these into this lane:
+
+- v0.10.0 release prep;
+- version bumps;
+- tags or crates.io publish;
+- new contract packs;
+- new README badges;
+- badge work except generated endpoint drift caused by this lane's checks;
+- shipper migration work;
+- provider compatibility claims;
+- production security claims;
+- scanner-evasion language;
+- broad refactors;
+- dependency churn.
+
+## PR Sequence
+
+1. `ops: start downstream CI polish lane`
+   - Open `.uselesskey/goals/active.toml` for this lane.
+   - Add this plan area.
+   - Validation:
+
+     ```bash
+     cargo xtask spec-check --strict
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+2. `docs(spec): define bundle audit JSON schema`
+   - Add:
+
+     ```text
+     docs/schemas/bundle-audit.schema.json
+     docs/reference/bundle-audit-json.md
+     ```
+
+   - Document stable fields including schema version, status, bundle path,
+     profile, artifacts, checks, failure classes, and boundaries.
+   - Keep failure classes stable:
+
+     ```text
+     missing_manifest
+     invalid_manifest
+     path_escape
+     missing_artifact
+     unexpected_artifact
+     missing_receipt
+     invalid_receipt
+     scanner_safe_mismatch
+     runtime_material_mismatch
+     profile_validation_failed
+     unsupported_profile
+     ```
+
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-cli --all-features audit_bundle
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+3. `feat(cli): add audit-bundle CI policy controls`
+   - Add CI-oriented behavior such as:
+
+     ```bash
+     uselesskey audit-bundle --path target/uselesskey-webhook --ci
+     ```
+
+   - Preserve:
+
+     ```text
+     exit 0: bundle audit passed
+     exit 1: audit failed by stable class
+     exit 2: CLI/config usage error
+     ```
+
+   - Avoid requiring downstream shell parsing of human prose.
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-cli --all-features audit_bundle
+     cargo run -p uselesskey-cli -- audit-bundle --path target/audit-test/webhook --ci
+     cargo xtask external-adoption-smoke --path . --format json
+     cargo +nightly xtask pr-lite
+     git diff --check
+     ```
+
+4. `docs: add downstream CI recipes for bundle audit`
+   - Add:
+
+     ```text
+     docs/how-to/use-uselesskey-in-github-actions.md
+     ```
+
+   - Include recipes for webhook fixtures, TLS/OIDC fixtures, and uploading
+     `bundle-audit.json` plus `bundle-audit.md` as CI artifacts.
+   - State that installed audit proves local generated bundle consistency, not
+     production security or provider compatibility.
+   - Validation:
+
+     ```bash
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+5. `xtask: test downstream CI snippets`
+   - Extend external adoption smoke with explicit documented recipe mode:
+
+     ```bash
+     cargo xtask external-adoption-smoke --path . --ci-recipes
+     ```
+
+   - Keep default external smoke bounded.
+   - Validation:
+
+     ```bash
+     cargo test -p xtask external_adoption_smoke
+     cargo xtask external-adoption-smoke --path . --ci-recipes --format json
+     cargo xtask adoption-regression --external
+     git diff --check
+     ```
+
+6. `feat(cli): improve audit-bundle failure diagnostics`
+   - Make human failures copyable and actionable while preserving stable JSON
+     failure classes.
+   - Do not print raw fixture payloads.
+   - Keep paths relative where possible.
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-cli --all-features audit_bundle
+     cargo xtask no-blob
+     cargo +nightly xtask pr-lite
+     git diff --check
+     ```
+
+7. `feat(cli): add installed CLI doctor`
+   - Add:
+
+     ```bash
+     uselesskey doctor
+     uselesskey doctor --format json
+     ```
+
+   - Check installed-user concerns only: CLI version, current working
+     directory, `target/` write access, bundle output path safety, JSON output
+     support, and known profiles.
+   - Do not check repo-local proof tools.
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-cli --all-features doctor
+     cargo run -p uselesskey-cli -- doctor
+     cargo run -p uselesskey-cli -- doctor --format json
+     cargo +nightly xtask pr-lite
+     git diff --check
+     ```
+
+8. `feat(cli): align inspect-bundle and audit-bundle summaries`
+   - Keep `inspect-bundle` as a quick human summary.
+   - Keep `audit-bundle` as durable metadata-only reviewer and CI receipts.
+   - Add:
+
+     ```text
+     docs/reference/bundle-inspect-vs-audit.md
+     ```
+
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-cli --all-features inspect audit_bundle
+     cargo xtask external-adoption-smoke --path .
+     cargo xtask docs-sync --check
+     git diff --check
+     ```
+
+9. `examples: add downstream CI bundle audit example`
+   - Add:
+
+     ```text
+     examples/external/downstream-ci-bundle-audit/
+       Cargo.toml
+       README.md
+       .github/workflows/uselesskey-audit.yml.example
+     ```
+
+   - Model the installed loop:
+
+     ```bash
+     uselesskey bundle --profile webhook --out target/uselesskey-webhook
+     uselesskey verify-bundle --path target/uselesskey-webhook
+     uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit
+     ```
+
+   - Validation:
+
+     ```bash
+     cargo xtask external-adoption-smoke --path .
+     cargo xtask adoption-regression --external
+     git diff --check
+     ```
+
+10. `test(cli): add audit receipt golden coverage`
+    - Golden-test stable parts of:
+
+      ```text
+      bundle-audit.md
+      bundle-audit.json
+      ```
+
+    - Normalize volatile paths.
+    - Protect schema shape, boundary language, and metadata-only posture.
+    - Validation:
+
+      ```bash
+      cargo test -p uselesskey-cli --all-features audit_bundle
+      cargo xtask no-blob
+      cargo +nightly xtask pr-lite
+      git diff --check
+      ```
+
+11. `feat(cli): add compact audit summary output`
+    - Add:
+
+      ```bash
+      uselesskey audit-bundle --path target/uselesskey-webhook --summary
+      ```
+
+    - Keep output compact for terminals and CI logs.
+    - Validation:
+
+      ```bash
+      cargo test -p uselesskey-cli --all-features audit_bundle
+      cargo xtask external-adoption-smoke --path .
+      git diff --check
+      ```
+
+12. `docs: close out downstream CI polish lane`
+    - Add closeout and learning record.
+    - Archive `.uselesskey/goals/active.toml`.
+    - Validation:
+
+      ```bash
+      cargo xtask external-adoption-smoke --path . --format json
+      cargo xtask adoption-regression --external
+      cargo xtask claim-report --check-public-claims
+      cargo xtask contract-packs --check
+      cargo xtask check-no-panic-family
+      cargo xtask docs-sync --check
+      cargo xtask typos
+      cargo +nightly xtask pr-lite
+      cargo xtask pr
+      git diff --check
+      ```
+
+## Acceptance
+
+A downstream team can:
+
+- install `uselesskey-cli`;
+- generate scanner-safe, TLS, OIDC, or webhook fixtures;
+- verify and inspect the bundle;
+- audit the bundle with installed CLI commands;
+- fail CI on stable failure classes;
+- upload metadata-only audit receipts;
+- understand what audit proves and what remains out of scope.
+
+## Proof Commands
+
+Docs-only lane setup:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+External and CI-loop proof:
+
+```bash
+cargo xtask external-adoption-smoke --path . --format json
+cargo xtask adoption-regression --external
+cargo +nightly xtask pr-lite
+cargo xtask pr
+git diff --check
+```
+
+## Rollback
+
+Before code lands, revert the lane-open PR or archive the active goal with a
+superseded closeout note.
+
+After CLI or xtask changes land, revert the smallest failing PR. Do not loosen
+audit boundaries, scanner-safe classification, or failure-class stability to
+keep the lane moving.
+
+## Stop Conditions
+
+Pause or split the lane if:
+
+- the work starts preparing or cutting v0.10.0;
+- a change requires a version bump, tag, publish, or shipper migration;
+- a CI recipe implies provider compatibility, production security, or scanner
+  evasion;
+- installed CLI commands need to execute repo-local `xtask` or claim-ledger
+  command strings;
+- audit receipts need to copy raw generated fixture payloads;
+- a new contract pack, new badge, dependency churn, or broad refactor becomes
+  necessary.


### PR DESCRIPTION
## Summary
- Opens the downstream CI and installed-user polish lane.
- Replaces the archived installed bundle audit active goal with the new active lane goal.
- Adds the downstream-ci-polish plan area and indexes it from plans/README.md.

## Files added/changed
- .uselesskey/goals/active.toml
- plans/downstream-ci-polish/README.md
- plans/downstream-ci-polish/implementation-plan.md
- plans/README.md

## Validation
- cargo xtask spec-check --strict
- cargo xtask docs-sync --check
- cargo xtask typos
- git diff --check

## Non-goals
- No v0.10.0 release prep, version bump, tag, or publish.
- No new contract packs, badges, provider compatibility claims, production security claims, broad refactors, or dependency churn.

## What this enables next
- The next ready slice is the bundle audit JSON schema and reference docs for downstream CI consumers.