### PR TITLE
docs(spec): define bundle audit JSON schema

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -40,7 +40,7 @@ commands = [
 
 [[work_item]]
 id = "bundle-audit-json-schema"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"
@@ -53,7 +53,7 @@ commands = [
 
 [[work_item]]
 id = "audit-bundle-ci-policy"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"

--- a/docs/reference/bundle-audit-json.md
+++ b/docs/reference/bundle-audit-json.md
@@ -1,0 +1,136 @@
+# Bundle Audit JSON
+
+`uselesskey audit-bundle --format json` emits a metadata-only bundle audit
+receipt. `uselesskey audit-bundle --out <dir>` writes the same shape to
+`<dir>/bundle-audit.json`.
+
+The schema is published at
+[`docs/schemas/bundle-audit.schema.json`](../schemas/bundle-audit.schema.json).
+
+## What It Is For
+
+Use this JSON in downstream CI when you need a stable machine-readable answer
+to:
+
+- which profile was generated;
+- which files and receipts the bundle claims;
+- which artifacts are scanner-safe;
+- which artifacts are runtime material;
+- which local consistency checks passed;
+- which stable failure class applies if the audit fails.
+
+The JSON receipt is for installed-user bundle audit. It is not repo public-claim
+proof, release evidence, provider compatibility proof, production security
+proof, or scanner-evasion proof.
+
+## Stable Fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `version` | integer | Bundle audit receipt schema version. Version `1` is the current schema. |
+| `status` | string | Overall audit result. Current values are `pass` and `fail`. |
+| `bundle_path` | string | Display path of the audited bundle. |
+| `profile` | string | Bundle profile from `manifest.json`. |
+| `manifest_version` | integer | Manifest schema version from `manifest.json`. |
+| `manifest_path` | string | Path to the manifest relative to the bundle root. Currently `manifest.json`. |
+| `artifact_count` | integer | Number of artifacts listed in the audit receipt. |
+| `receipt_count` | integer | Number of receipts listed in the bundle manifest. |
+| `scanner_safe_count` | integer | Number of artifacts classified as scanner-safe. |
+| `runtime_material_count` | integer | Number of artifacts classified as runtime material. |
+| `files` | string array | Bundle files relative to the audited bundle root. |
+| `artifacts` | object array | Artifact metadata. Does not include payload contents. |
+| `receipts` | object array | Receipt metadata. Does not include receipt payload contents. |
+| `missing_files` | string array | Files expected from the manifest but not found. |
+| `unexpected_files` | string array | Files found in the bundle tree but not expected from the manifest. |
+| `checks` | object array | Local audit checks and their stable failure classes. |
+| `boundaries` | string array | Human-readable statements for what audit does prove. |
+| `does_not_prove` | string array | Human-readable statements for out-of-scope claims. |
+
+## Artifact Objects
+
+Each `artifacts[]` entry has:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `path` | string | Artifact path relative to the audited bundle root. |
+| `kind` | string | Artifact kind from the bundle manifest. |
+| `format` | string | Artifact format from the bundle manifest. |
+| `scanner_safe` | boolean | Whether manifest metadata classifies the artifact as scanner-safe. |
+| `runtime_material` | boolean | Whether audit classifies the artifact as generated runtime material. |
+| `description` | string | Human-facing artifact description from the manifest. |
+
+Artifact objects intentionally omit PEM, DER, JWK, JWKS, JWT, token, HMAC key,
+webhook body, certificate, and other raw fixture payload contents.
+
+## Receipt Objects
+
+Each `receipts[]` entry has:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `path` | string | Receipt path relative to the audited bundle root. |
+| `kind` | string | Receipt kind, such as `materialization` or `audit-surface`. |
+| `profile` | string | Bundle profile associated with the receipt. |
+| `description` | string | Human-facing receipt description. |
+
+The audit receipt lists receipt metadata. It does not copy receipt payloads into
+the JSON object.
+
+## Check Objects
+
+Each `checks[]` entry has:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `name` | string | Stable audit check name. |
+| `status` | string | Check result, currently `pass` or `fail`. |
+| `failure_class` | string | Stable class to use in CI branching and docs. |
+| `detail` | string | Human-facing detail. Treat as diagnostic text, not a stable parser target. |
+
+Downstream CI should branch on `status`, `profile`, and `failure_class`, not on
+English prose in `detail`, `boundaries`, or `does_not_prove`.
+
+## Failure Classes
+
+The stable failure class set is:
+
+| Failure class | Meaning |
+| --- | --- |
+| `missing_manifest` | `manifest.json` is missing. |
+| `invalid_manifest` | `manifest.json` could not be parsed or did not match the expected shape. |
+| `path_escape` | A manifest path is absolute or escapes the bundle root. |
+| `missing_artifact` | A manifest-listed file is missing from the bundle. |
+| `unexpected_artifact` | A file exists in the bundle tree but is not listed by the manifest. |
+| `missing_receipt` | A required receipt entry is missing. |
+| `invalid_receipt` | A required receipt exists but could not be parsed or reconciled. |
+| `scanner_safe_mismatch` | Scanner-safe counts differ between manifest metadata and audit-surface receipt metadata. |
+| `runtime_material_mismatch` | Runtime-material counts differ between manifest metadata and audit-surface receipt metadata. |
+| `profile_validation_failed` | Profile-specific deterministic validation failed. |
+| `unsupported_profile` | The bundle profile is not supported by installed bundle audit. |
+
+## Stability Contract
+
+For schema version `1`, downstream users can rely on the required field names,
+basic types, and failure class strings documented here.
+
+Fields may gain new values only when the command can do so without weakening the
+metadata-only boundary. New schema versions must update the schema file and this
+reference page.
+
+Human-facing strings are useful for logs and reviews, but only field names,
+types, booleans, counts, paths, `status`, and `failure_class` are intended for
+machine decisions.
+
+## Boundary
+
+`audit-bundle` proves local bundle consistency and metadata classification for
+the bundle being audited.
+
+It does not prove:
+
+- repo public claims;
+- release readiness;
+- production security;
+- webhook, OIDC, TLS, or other provider compatibility;
+- scanner evasion;
+- downstream verifier correctness.

--- a/docs/schemas/bundle-audit.schema.json
+++ b/docs/schemas/bundle-audit.schema.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.rs/uselesskey-cli/bundle-audit.schema.json",
+  "title": "uselesskey bundle audit receipt",
+  "description": "Metadata-only receipt emitted by `uselesskey audit-bundle --format json` and written to bundle-audit.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "status",
+    "bundle_path",
+    "profile",
+    "manifest_version",
+    "manifest_path",
+    "artifact_count",
+    "receipt_count",
+    "scanner_safe_count",
+    "runtime_material_count",
+    "files",
+    "artifacts",
+    "receipts",
+    "missing_files",
+    "unexpected_files",
+    "checks",
+    "boundaries",
+    "does_not_prove"
+  ],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Bundle audit receipt schema version."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "fail"],
+      "description": "Overall audit result."
+    },
+    "bundle_path": {
+      "type": "string",
+      "description": "Display path of the audited bundle."
+    },
+    "profile": {
+      "type": "string",
+      "description": "Bundle profile from manifest.json."
+    },
+    "manifest_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Manifest schema version from manifest.json."
+    },
+    "manifest_path": {
+      "type": "string",
+      "const": "manifest.json",
+      "description": "Path to the audited manifest relative to the bundle root."
+    },
+    "artifact_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "receipt_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "scanner_safe_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "runtime_material_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "files": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Bundle file paths relative to the audited bundle."
+    },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" }
+    },
+    "receipts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/receipt" }
+    },
+    "missing_files": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "unexpected_files": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "checks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/check" }
+    },
+    "boundaries": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Human-readable audit boundaries."
+    },
+    "does_not_prove": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Human-readable statements for out-of-scope claims."
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "kind",
+        "format",
+        "scanner_safe",
+        "runtime_material",
+        "description"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Artifact path relative to the audited bundle."
+        },
+        "kind": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string"
+        },
+        "scanner_safe": {
+          "type": "boolean"
+        },
+        "runtime_material": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "kind", "profile", "description"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Receipt path relative to the audited bundle."
+        },
+        "kind": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "status", "failure_class", "detail"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pass", "fail"]
+        },
+        "failure_class": {
+          "$ref": "#/$defs/failure_class"
+        },
+        "detail": {
+          "type": "string"
+        }
+      }
+    },
+    "failure_class": {
+      "type": "string",
+      "enum": [
+        "missing_manifest",
+        "invalid_manifest",
+        "path_escape",
+        "missing_artifact",
+        "unexpected_artifact",
+        "missing_receipt",
+        "invalid_receipt",
+        "scanner_safe_mismatch",
+        "runtime_material_mismatch",
+        "profile_validation_failed",
+        "unsupported_profile"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a JSON Schema for installed bundle audit receipts.
- Adds reference docs for stable fields, check objects, failure classes, and machine-readable CI boundaries.
- Advances the active downstream CI polish goal from bundle-audit-json-schema to audit-bundle-ci-policy.

## Files added/changed
- docs/schemas/bundle-audit.schema.json
- docs/reference/bundle-audit-json.md
- .uselesskey/goals/active.toml

## Validation
- powershell JSON parse for docs/schemas/bundle-audit.schema.json
- cargo test -p uselesskey-cli --all-features audit_bundle
- cargo xtask docs-sync --check
- cargo xtask typos
- git diff --check

## Non-goals
- No CLI behavior change.
- No release prep, version bump, tag, publish, new contract pack, or badge.
- No provider compatibility, production security, or scanner-evasion claim.

## What this enables next
- Downstream CI can target a documented audit receipt shape before the lane adds CI policy controls.