### PR TITLE
feat(cli): add audit-bundle CI mode

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -53,7 +53,7 @@ commands = [
 
 [[work_item]]
 id = "audit-bundle-ci-policy"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"
@@ -66,7 +66,7 @@ commands = [
 
 [[work_item]]
 id = "downstream-github-actions-recipes"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -110,6 +110,8 @@ struct AuditBundleArgs {
     out: Option<PathBuf>,
     #[arg(long, default_value = "markdown")]
     format: AuditOutputFormat,
+    #[arg(long)]
+    ci: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -417,18 +419,15 @@ fn run_inspect_bundle(args: InspectBundleArgs) -> Result<()> {
 }
 
 fn run_audit_bundle(args: AuditBundleArgs) -> Result<()> {
+    if args.ci {
+        return run_audit_bundle_ci(args);
+    }
+
     let audit = build_bundle_audit(&args.bundle_dir)
         .with_context(|| format!("failed to audit bundle {}", args.bundle_dir.display()))?;
 
     if let Some(out_dir) = args.out.as_deref() {
-        fs::create_dir_all(out_dir)
-            .with_context(|| format!("failed to create audit directory {}", out_dir.display()))?;
-        let json_path = out_dir.join("bundle-audit.json");
-        let md_path = out_dir.join("bundle-audit.md");
-        fs::write(&json_path, serde_json::to_vec_pretty(&audit)?)
-            .with_context(|| format!("failed to write {}", json_path.display()))?;
-        fs::write(&md_path, render_bundle_audit_markdown(&audit))
-            .with_context(|| format!("failed to write {}", md_path.display()))?;
+        let (json_path, md_path) = write_bundle_audit_receipts(&audit, out_dir)?;
         return emit_artifact(
             &Artifact::Json(json!({
                 "audit_bundle": {
@@ -449,6 +448,34 @@ fn run_audit_bundle(args: AuditBundleArgs) -> Result<()> {
         }
         AuditOutputFormat::Json => emit_artifact(&Artifact::Json(json!(audit)), None),
     }
+}
+
+fn run_audit_bundle_ci(args: AuditBundleArgs) -> Result<()> {
+    match build_bundle_audit(&args.bundle_dir) {
+        Ok(audit) => {
+            if let Some(out_dir) = args.out.as_deref() {
+                write_bundle_audit_receipts(&audit, out_dir)?;
+            }
+            emit_artifact(&Artifact::Json(json!(audit)), None)
+        }
+        Err(err) => {
+            let (failure, failure_class) = bundle_audit_failure_json(&args.bundle_dir, &err);
+            emit_artifact(&Artifact::Json(failure), None)?;
+            bail!("audit failed: {failure_class}");
+        }
+    }
+}
+
+fn write_bundle_audit_receipts(audit: &BundleAudit, out_dir: &Path) -> Result<(PathBuf, PathBuf)> {
+    fs::create_dir_all(out_dir)
+        .with_context(|| format!("failed to create audit directory {}", out_dir.display()))?;
+    let json_path = out_dir.join("bundle-audit.json");
+    let md_path = out_dir.join("bundle-audit.md");
+    fs::write(&json_path, serde_json::to_vec_pretty(audit)?)
+        .with_context(|| format!("failed to write {}", json_path.display()))?;
+    fs::write(&md_path, render_bundle_audit_markdown(audit))
+        .with_context(|| format!("failed to write {}", md_path.display()))?;
+    Ok((json_path, md_path))
 }
 
 fn run_export(args: ExportArgs) -> Result<()> {
@@ -1079,6 +1106,80 @@ fn bundle_audit_boundaries(info: &ProfileInfo) -> Vec<String> {
         format!("profile proof/check path: {}", info.proof_command),
         "audit receipts contain metadata only and do not copy generated fixture payloads".to_string(),
     ]
+}
+
+const BUNDLE_AUDIT_FAILURE_CLASSES: [&str; 11] = [
+    "missing_manifest",
+    "invalid_manifest",
+    "path_escape",
+    "missing_artifact",
+    "unexpected_artifact",
+    "missing_receipt",
+    "invalid_receipt",
+    "scanner_safe_mismatch",
+    "runtime_material_mismatch",
+    "profile_validation_failed",
+    "unsupported_profile",
+];
+
+fn bundle_audit_failure_json(
+    bundle_dir: &Path,
+    err: &anyhow::Error,
+) -> (serde_json::Value, String) {
+    let failure_class = bundle_audit_failure_class(err).to_string();
+    let detail = err.to_string();
+    (
+        json!({
+            "version": 1,
+            "status": "fail",
+            "bundle_path": display_path(bundle_dir),
+            "profile": "unknown",
+            "manifest_version": 0,
+            "manifest_path": "manifest.json",
+            "artifact_count": 0,
+            "receipt_count": 0,
+            "scanner_safe_count": 0,
+            "runtime_material_count": 0,
+            "files": [],
+            "artifacts": [],
+            "receipts": [],
+            "missing_files": [],
+            "unexpected_files": [],
+            "checks": [
+                {
+                    "name": "bundle-audit",
+                    "status": "fail",
+                    "failure_class": failure_class.clone(),
+                    "detail": detail,
+                }
+            ],
+            "boundaries": [
+                "audit-bundle proves local bundle consistency and metadata classification",
+                "audit receipts contain metadata only and do not copy generated fixture payloads",
+            ],
+            "does_not_prove": [
+                "repo public claims",
+                "release readiness",
+                "provider compatibility",
+                "production security",
+                "scanner evasion",
+                "downstream verifier correctness",
+            ],
+        }),
+        failure_class,
+    )
+}
+
+fn bundle_audit_failure_class(err: &anyhow::Error) -> &'static str {
+    for source in err.chain() {
+        let message = source.to_string();
+        for failure_class in BUNDLE_AUDIT_FAILURE_CLASSES {
+            if message == failure_class || message.starts_with(&format!("{failure_class}:")) {
+                return failure_class;
+            }
+        }
+    }
+    "profile_validation_failed"
 }
 
 fn display_path(path: &Path) -> String {

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -779,6 +779,35 @@ fn audit_bundle_json_reports_artifact_runtime_material_flags() -> TestResult<()>
 }
 
 #[test]
+fn audit_bundle_ci_outputs_json_on_success() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("webhook");
+
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    bundle.assert().success();
+
+    let out = run([
+        "audit-bundle",
+        "--path",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--ci",
+    ])?;
+    let audit: Value = serde_json::from_str(&out).test_context("audit json")?;
+    assert_eq!(audit["status"], "pass");
+    assert_eq!(audit["profile"], "webhook");
+    assert_eq!(audit["checks"][0]["failure_class"], "invalid_manifest");
+    assert!(!out.contains("whsec_"));
+    Ok(())
+}
+
+#[test]
 fn audit_bundle_json_stdout_reports_scanner_safe_bundle() -> TestResult<()> {
     let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("scanner-safe");
@@ -807,6 +836,54 @@ fn audit_bundle_json_stdout_reports_scanner_safe_bundle() -> TestResult<()> {
     assert_eq!(audit["runtime_material_count"], 0);
     assert!(out.contains("cargo xtask claim-proof --claim scanner-safe-fixtures"));
     assert!(!out.contains("BEGIN PRIVATE KEY"));
+    Ok(())
+}
+
+#[test]
+fn audit_bundle_ci_outputs_failure_json_and_exit_1() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("webhook");
+
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    bundle.assert().success();
+
+    let manifest_path = bundle_dir.join("manifest.json");
+    let mut manifest: Value =
+        serde_json::from_slice(&fs::read(&manifest_path).test_context("manifest")?)
+            .test_context("manifest json")?;
+    let files = manifest["files"]
+        .as_array_mut()
+        .test_context("manifest files")?;
+    let first_file = files.first_mut().test_context("first manifest file")?;
+    *first_file = serde_json::json!("../escape.json");
+    let manifest_bytes = serde_json::to_vec_pretty(&manifest).test_context("manifest bytes")?;
+    fs::write(&manifest_path, manifest_bytes).test_context("mutate manifest")?;
+
+    let mut audit = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    audit.args([
+        "audit-bundle",
+        "--path",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--ci",
+    ]);
+    let assert = audit
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("audit failed: path_escape"));
+    let output = assert.get_output();
+    let audit: Value = serde_json::from_slice(&output.stdout).test_context("audit failure json")?;
+    assert_eq!(audit["status"], "fail");
+    assert_eq!(audit["checks"][0]["status"], "fail");
+    assert_eq!(audit["checks"][0]["failure_class"], "path_escape");
+    assert_eq!(audit["manifest_version"], 0);
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("whsec_"));
     Ok(())
 }
 

--- a/docs/reference/bundle-audit-json.md
+++ b/docs/reference/bundle-audit-json.md
@@ -31,7 +31,7 @@ proof, or scanner-evasion proof.
 | `status` | string | Overall audit result. Current values are `pass` and `fail`. |
 | `bundle_path` | string | Display path of the audited bundle. |
 | `profile` | string | Bundle profile from `manifest.json`. |
-| `manifest_version` | integer | Manifest schema version from `manifest.json`. |
+| `manifest_version` | integer | Manifest schema version from `manifest.json`; failure receipts use `0` when the manifest is unavailable. |
 | `manifest_path` | string | Path to the manifest relative to the bundle root. Currently `manifest.json`. |
 | `artifact_count` | integer | Number of artifacts listed in the audit receipt. |
 | `receipt_count` | integer | Number of receipts listed in the bundle manifest. |
@@ -89,6 +89,10 @@ Each `checks[]` entry has:
 
 Downstream CI should branch on `status`, `profile`, and `failure_class`, not on
 English prose in `detail`, `boundaries`, or `does_not_prove`.
+
+In CI mode, a failed audit emits a receipt with `status: "fail"`, one failing
+check, the relevant stable `failure_class`, and empty artifact/receipt arrays
+when manifest metadata is unavailable.
 
 ## Failure Classes
 

--- a/docs/schemas/bundle-audit.schema.json
+++ b/docs/schemas/bundle-audit.schema.json
@@ -46,8 +46,8 @@
     },
     "manifest_version": {
       "type": "integer",
-      "minimum": 1,
-      "description": "Manifest schema version from manifest.json."
+      "minimum": 0,
+      "description": "Manifest schema version from manifest.json. Failure receipts use 0 when the manifest is unavailable."
     },
     "manifest_path": {
       "type": "string",

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -253,6 +253,15 @@ generated_by = "cargo xtask docs-sync"
 covered_by = ["cargo xtask docs-sync --check"]
 
 [[allow]]
+glob = "docs/schemas/*.json"
+kind = "published_schema"
+owner = "docs/spec"
+surface = "docs"
+classification = "config"
+reason = "Published JSON schemas document stable machine-readable contracts for downstream users."
+covered_by = ["cargo xtask docs-sync --check", "cargo xtask check-file-policy"]
+
+[[allow]]
 glob = "badges/*.json"
 kind = "generated_badge_endpoint"
 owner = "release/ci"


### PR DESCRIPTION
Summary
- Adds `uselesskey audit-bundle --ci` so downstream CI can consume metadata-only audit JSON and rely on process exit status.
- Emits stable failure JSON plus `audit failed: <failure_class>` on stderr when an audit fails.
- Updates the bundle-audit JSON schema/reference docs and file policy for the published schema artifact.

Files added/changed
- `crates/uselesskey-cli/src/main.rs`
- `crates/uselesskey-cli/tests/cli.rs`
- `docs/schemas/bundle-audit.schema.json`
- `docs/reference/bundle-audit-json.md`
- `policy/non-rust-allowlist.toml`
- `.uselesskey/goals/active.toml`

Validation
- `cargo test -p uselesskey-cli --all-features audit_bundle`
- `cargo run -p uselesskey-cli -- bundle --profile webhook --out target/audit-test/ci-webhook`
- `cargo run -p uselesskey-cli -- audit-bundle --path target/audit-test/ci-webhook --ci`
- `cargo xtask external-adoption-smoke --path . --format json`
- `cargo xtask no-blob`
- `cargo xtask check-file-policy`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo +nightly xtask pr-lite`
- `git diff --check`

Non-goals
- No version bump, tag, publish, release prep, new badge, new contract pack, provider compatibility claim, production security claim, or claim-ledger execution from the installed CLI.

What this enables next
- Downstream CI can fail on stable audit failure classes without parsing human output, which sets up GitHub Actions recipes and failure-message polish.