### PR TITLE
docs: add downstream GitHub Actions audit recipes

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -66,7 +66,7 @@ commands = [
 
 [[work_item]]
 id = "downstream-github-actions-recipes"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"
@@ -78,7 +78,7 @@ commands = [
 
 [[work_item]]
 id = "external-smoke-ci-recipes"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0013"
 plan = "plans/downstream-ci-polish/implementation-plan.md"

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@ Task-oriented instructions for common workflows.
 - [release.md](how-to/release.md) — Cutting a release
 - [choose-features.md](how-to/choose-features.md) — Choosing feature sets by need
 - [downstream-fixture-policy.md](how-to/downstream-fixture-policy.md) — Policy pack for downstream bots and reviewers
+- [use-uselesskey-in-downstream-ci.md](how-to/use-uselesskey-in-downstream-ci.md) — Installed CLI bundle audit in downstream CI
+- [use-uselesskey-in-github-actions.md](how-to/use-uselesskey-in-github-actions.md) — GitHub Actions recipes for bundle audit receipts
 - [adapter-template.md](how-to/adapter-template.md) — Scaffolding and validating new adapter crates
 - [test-oidc-jwks-validation.md](how-to/test-oidc-jwks-validation.md) — Using the OIDC/JWKS contract pack in validator tests
 - [test-jwt-negative-validation.md](how-to/test-jwt-negative-validation.md) — Using JWT-shaped negatives for policy rejection tests

--- a/docs/how-to/use-uselesskey-in-downstream-ci.md
+++ b/docs/how-to/use-uselesskey-in-downstream-ci.md
@@ -3,12 +3,15 @@
 Use this recipe when a downstream project wants deterministic fixtures plus a
 metadata-only audit receipt during CI.
 
+For GitHub Actions-specific workflow files, see
+[use-uselesskey-in-github-actions.md](use-uselesskey-in-github-actions.md).
+
 ```yaml
 steps:
   - run: cargo install uselesskey-cli --version 0.9.1
   - run: uselesskey bundle --profile webhook --out target/uselesskey-webhook
   - run: uselesskey verify-bundle --path target/uselesskey-webhook
-  - run: uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit
+  - run: uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit --ci
 ```
 
 The audit files are safe reviewer metadata:
@@ -27,7 +30,7 @@ unless your project has a separate reviewed policy for those artifacts.
 Use JSON mode when CI needs a machine-readable decision point:
 
 ```bash
-uselesskey audit-bundle --path target/uselesskey-webhook --format json
+uselesskey audit-bundle --path target/uselesskey-webhook --ci
 ```
 
 Fail CI if the command exits non-zero. A non-zero exit means the local bundle

--- a/docs/how-to/use-uselesskey-in-github-actions.md
+++ b/docs/how-to/use-uselesskey-in-github-actions.md
@@ -1,0 +1,150 @@
+# Use uselesskey in GitHub Actions
+
+Use these recipes when a downstream repository wants deterministic fixture
+bundles plus metadata-only audit receipts in GitHub Actions.
+
+The installed CLI path is the product surface here. Repo-local `cargo xtask`
+proof remains for maintainers and public-claim reviewers with a repo checkout.
+
+## Webhook Fixtures
+
+This workflow generates a webhook contract-pack bundle, verifies it, and fails
+CI if the installed bundle audit reports a stable failure class.
+
+```yaml
+name: uselesskey webhook fixtures
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  webhook-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install uselesskey CLI
+        run: cargo install uselesskey-cli --version 0.9.1 --locked
+
+      - name: Generate webhook fixtures
+        run: uselesskey bundle --profile webhook --out target/uselesskey-webhook
+
+      - name: Verify webhook bundle
+        run: uselesskey verify-bundle --path target/uselesskey-webhook
+
+      - name: Audit webhook bundle
+        run: |
+          uselesskey audit-bundle \
+            --path target/uselesskey-webhook \
+            --out target/uselesskey-webhook-audit \
+            --ci
+```
+
+`--ci` emits machine-readable audit JSON on stdout and exits non-zero when the
+bundle fails a stable audit class such as `missing_manifest`, `path_escape`,
+`missing_artifact`, `scanner_safe_mismatch`, or `runtime_material_mismatch`.
+
+## TLS and OIDC Fixtures
+
+Use separate output paths for each profile so audit receipts stay attached to
+one local bundle.
+
+```yaml
+name: uselesskey verifier fixtures
+
+on:
+  pull_request:
+
+jobs:
+  verifier-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install uselesskey CLI
+        run: cargo install uselesskey-cli --version 0.9.1 --locked
+
+      - name: Generate TLS fixtures
+        run: uselesskey bundle --profile tls --out target/uselesskey-tls
+
+      - name: Verify TLS bundle
+        run: uselesskey verify-bundle --path target/uselesskey-tls
+
+      - name: Audit TLS bundle
+        run: |
+          uselesskey audit-bundle \
+            --path target/uselesskey-tls \
+            --out target/uselesskey-tls-audit \
+            --ci
+
+      - name: Generate OIDC fixtures
+        run: uselesskey bundle --profile oidc --out target/uselesskey-oidc
+
+      - name: Verify OIDC bundle
+        run: uselesskey verify-bundle --path target/uselesskey-oidc
+
+      - name: Audit OIDC bundle
+        run: |
+          uselesskey audit-bundle \
+            --path target/uselesskey-oidc \
+            --out target/uselesskey-oidc-audit \
+            --ci
+```
+
+## Upload Audit Receipts
+
+Upload only metadata-only audit receipts unless your downstream policy
+explicitly asks for raw fixture payloads. Keep generated bundles under
+`target/`.
+
+```yaml
+      - name: Upload uselesskey audit receipts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: uselesskey-audit-receipts
+          path: |
+            target/uselesskey-webhook-audit/bundle-audit.json
+            target/uselesskey-webhook-audit/bundle-audit.md
+            target/uselesskey-tls-audit/bundle-audit.json
+            target/uselesskey-tls-audit/bundle-audit.md
+            target/uselesskey-oidc-audit/bundle-audit.json
+            target/uselesskey-oidc-audit/bundle-audit.md
+          if-no-files-found: ignore
+```
+
+## What This Proves
+
+These recipes prove local generated bundle consistency in the downstream CI
+job:
+
+- the bundle manifest parses;
+- listed artifacts and receipts exist;
+- files stay under the bundle path;
+- scanner-safe and runtime-material metadata match the bundle receipts;
+- profile-specific bundle validation passes.
+
+## What This Does Not Prove
+
+These recipes do not prove:
+
+- production security;
+- production key management;
+- provider compatibility;
+- scanner evasion;
+- repo public claims;
+- release readiness;
+- downstream verifier correctness.
+
+Use repo-local proof only when a reviewer needs public-claim evidence:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification
+```
+


### PR DESCRIPTION
Summary
- Adds a GitHub Actions how-to for installed CLI bundle audit workflows.
- Shows webhook, TLS, and OIDC generate/verify/audit jobs using `audit-bundle --ci`.
- Updates the generic downstream CI guide and docs index, and advances the downstream CI polish goal to the next slice.

Files added/changed
- `docs/how-to/use-uselesskey-in-github-actions.md`
- `docs/how-to/use-uselesskey-in-downstream-ci.md`
- `docs/README.md`
- `.uselesskey/goals/active.toml`

Validation
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `git diff --check`

Non-goals
- No version bump, tag, publish, release prep, new badge, new contract pack, provider compatibility claim, production security claim, or repo-local proof requirement for installed users.

What this enables next
- `external-adoption-smoke --ci-recipes` can make these documented CI snippets executable evidence instead of doc-only guidance.