### PR TITLE
xtask: test downstream CI recipes

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -78,7 +78,7 @@ commands = [
 
 [[work_item]]
 id = "external-smoke-ci-recipes"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0013"
 plan = "plans/downstream-ci-polish/implementation-plan.md"
@@ -91,7 +91,7 @@ commands = [
 
 [[work_item]]
 id = "audit-failure-diagnostics"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"

--- a/docs/specs/USELESSKEY-SPEC-0013-external-adoption-smoke.md
+++ b/docs/specs/USELESSKEY-SPEC-0013-external-adoption-smoke.md
@@ -57,6 +57,18 @@ cargo xtask external-adoption-smoke --path .
 cargo xtask external-adoption-smoke --path . --format json
 ```
 
+Downstream CI recipe mode is explicit and opt-in:
+
+```bash
+cargo xtask external-adoption-smoke --path . --ci-recipes
+cargo xtask external-adoption-smoke --path . --ci-recipes --format json
+```
+
+CI recipe mode must execute the documented generate, verify, and
+`audit-bundle --ci` command sequence for supported downstream CI profiles. It
+must not make default external adoption smoke heavier, and it must keep all
+generated fixture payloads and audit receipts under `target/external-adoption-smoke/`.
+
 Local path mode must create clean temporary projects under the repository's
 `target/external-adoption-smoke/` tree, use the current checkout through path
 dependencies or a local CLI binary, and run only documented user-facing
@@ -83,6 +95,7 @@ target/external-adoption-smoke/report.json
 The receipts must summarize:
 
 - command mode (`path` or `version`);
+- whether CI recipe mode ran;
 - repo path or published version used;
 - temp project paths;
 - snippets or examples exercised;
@@ -153,6 +166,7 @@ The initial command implementation should run:
 cargo test -p xtask external_adoption_smoke
 cargo xtask external-adoption-smoke --path .
 cargo xtask external-adoption-smoke --path . --format json
+cargo xtask external-adoption-smoke --path . --ci-recipes --format json
 cargo xtask pr-lite
 git diff --check
 ```
@@ -172,6 +186,7 @@ This spec is accepted when:
 
 - it defines local path mode for clean-project adoption smoke;
 - it defines published-version mode as audit/reference only;
+- it defines `--ci-recipes` as an explicit downstream CI recipe proof mode;
 - it defines Markdown and JSON receipt paths;
 - it names the initial Rust test, scanner-safe, TLS, OIDC/JWKS, and webhook
   adoption jobs;
@@ -253,6 +268,8 @@ External adoption smoke maps to:
 - `cargo xtask external-adoption-smoke --path .` for current-checkout adoption;
 - `cargo xtask external-adoption-smoke --path . --format json` for
   machine-readable receipts;
+- `cargo xtask external-adoption-smoke --path . --ci-recipes --format json` for
+  downstream CI recipe proof;
 - `cargo xtask external-adoption-smoke --version <published>` for crates.io
   audit/reference smoke;
 - generated clean Cargo projects for documented dependency snippets;

--- a/xtask/src/adoption_regression.rs
+++ b/xtask/src/adoption_regression.rs
@@ -258,6 +258,7 @@ fn external_adoption_smoke_step(root: &Path, quiet_stdout: bool) -> Result<()> {
             external_adoption_smoke::RunOptions {
                 path: Some(root.to_path_buf()),
                 version: None,
+                ci_recipes: false,
                 format: external_adoption_smoke::OutputFormat::Human,
             },
         )

--- a/xtask/src/external_adoption_smoke.rs
+++ b/xtask/src/external_adoption_smoke.rs
@@ -15,6 +15,7 @@ const REPORT_JSON: &str = "target/external-adoption-smoke/report.json";
 const REPORT_MD: &str = "target/external-adoption-smoke/report.md";
 
 const CLI_PROFILES: &[&str] = &["scanner-safe", "tls", "oidc", "webhook"];
+const CI_RECIPE_PROFILES: &[&str] = &["webhook", "tls", "oidc"];
 const EXTERNAL_EXAMPLES: &[ExternalExample] = &[
     ExternalExample {
         name: "rust-test-fixtures",
@@ -57,6 +58,7 @@ pub enum OutputFormat {
 pub struct RunOptions {
     pub path: Option<PathBuf>,
     pub version: Option<String>,
+    pub ci_recipes: bool,
     pub format: OutputFormat,
 }
 
@@ -96,6 +98,7 @@ struct ExternalAdoptionSmokeReceipt {
     mode: SmokeMode,
     source: String,
     work_root: String,
+    ci_recipes: bool,
     projects: Vec<ExternalAdoptionProject>,
     steps: Vec<ExternalAdoptionStep>,
     artifacts: Vec<String>,
@@ -142,6 +145,7 @@ pub fn run(root: &Path, options: RunOptions) -> Result<()> {
         mode: source.mode.clone(),
         source: source.label.clone(),
         work_root: relative_artifact(root, &work_dir),
+        ci_recipes: options.ci_recipes,
         projects: Vec::new(),
         steps: Vec::new(),
         artifacts: vec![
@@ -153,7 +157,14 @@ pub fn run(root: &Path, options: RunOptions) -> Result<()> {
         boundaries: BOUNDARIES.to_vec(),
     };
 
-    let result = run_matrix(root, &source, &work_dir, &log_dir, &mut receipt);
+    let result = run_matrix(
+        root,
+        &source,
+        &work_dir,
+        &log_dir,
+        options.ci_recipes,
+        &mut receipt,
+    );
     receipt.status = if result.is_ok() { "pass" } else { "failed" }.to_string();
     write_receipts(&out_dir, &receipt)?;
     match options.format {
@@ -169,6 +180,7 @@ fn run_matrix(
     source: &SmokeSource,
     work_dir: &Path,
     log_dir: &Path,
+    ci_recipes: bool,
     receipt: &mut ExternalAdoptionSmokeReceipt,
 ) -> Result<()> {
     let cli_bin = prepare_cli(root, source, work_dir, log_dir, receipt)?;
@@ -176,6 +188,9 @@ fn run_matrix(
     run_cli_discovery(&cli_bin, work_dir, log_dir, receipt)?;
     for profile in CLI_PROFILES {
         run_cli_profile(&cli_bin, profile, work_dir, log_dir, receipt)?;
+    }
+    if ci_recipes {
+        run_ci_recipes(&cli_bin, work_dir, log_dir, receipt)?;
     }
     Ok(())
 }
@@ -405,6 +420,111 @@ fn run_cli_profile(
         &[bundle_artifact, audit_artifact, inspect_artifact],
     );
 
+    Ok(())
+}
+
+fn run_ci_recipes(
+    cli_bin: &Path,
+    work_dir: &Path,
+    log_dir: &Path,
+    receipt: &mut ExternalAdoptionSmokeReceipt,
+) -> Result<()> {
+    for profile in CI_RECIPE_PROFILES {
+        run_ci_recipe_profile(cli_bin, profile, work_dir, log_dir, receipt)?;
+    }
+    Ok(())
+}
+
+fn run_ci_recipe_profile(
+    cli_bin: &Path,
+    profile: &str,
+    work_dir: &Path,
+    log_dir: &Path,
+    receipt: &mut ExternalAdoptionSmokeReceipt,
+) -> Result<()> {
+    let project_name = format!("ci-recipe-{profile}");
+    let project_dir = work_dir.join(&project_name);
+    let target_dir = project_dir.join("target");
+    let bundle_dir = target_dir.join(format!("uselesskey-{profile}"));
+    let audit_dir = target_dir.join(format!("uselesskey-{profile}-audit"));
+    fs::create_dir_all(&target_dir)
+        .with_context(|| format!("failed to create {}", target_dir.display()))?;
+
+    let bundle_artifact = relative_artifact_from_path(&bundle_dir);
+    let audit_artifact = relative_artifact_from_path(&audit_dir);
+
+    let mut bundle = Command::new(cli_bin);
+    bundle
+        .args(["bundle", "--profile", profile, "--out"])
+        .arg(&bundle_dir)
+        .current_dir(&project_dir);
+    run_command_step(
+        receipt,
+        &format!("ci-recipe-bundle-{profile}"),
+        bundle,
+        &project_dir,
+        log_dir,
+        &[bundle_artifact.as_str()],
+    )?;
+
+    let mut verify = Command::new(cli_bin);
+    verify
+        .args(["verify-bundle", "--path"])
+        .arg(&bundle_dir)
+        .current_dir(&project_dir);
+    run_command_step(
+        receipt,
+        &format!("ci-recipe-verify-{profile}"),
+        verify,
+        &project_dir,
+        log_dir,
+        &[bundle_artifact.as_str()],
+    )?;
+
+    let mut audit = Command::new(cli_bin);
+    audit
+        .args(["audit-bundle", "--path"])
+        .arg(&bundle_dir)
+        .args(["--out"])
+        .arg(&audit_dir)
+        .arg("--ci")
+        .current_dir(&project_dir);
+    run_command_step(
+        receipt,
+        &format!("ci-recipe-audit-{profile}"),
+        audit,
+        &project_dir,
+        log_dir,
+        &[bundle_artifact.as_str(), audit_artifact.as_str()],
+    )?;
+
+    verify_ci_audit_receipt(&audit_dir, profile)?;
+    record_project(
+        receipt,
+        &project_name,
+        &project_dir,
+        &[bundle_artifact, audit_artifact],
+    );
+    Ok(())
+}
+
+fn verify_ci_audit_receipt(audit_dir: &Path, expected_profile: &str) -> Result<()> {
+    let receipt_path = audit_dir.join("bundle-audit.json");
+    let audit = read_json(&receipt_path)?;
+    if audit["status"].as_str() != Some("pass") {
+        bail!(
+            "CI recipe audit status mismatch for {}: {:?}",
+            audit_dir.display(),
+            audit["status"]
+        );
+    }
+    if audit["profile"].as_str() != Some(expected_profile) {
+        bail!(
+            "CI recipe audit profile mismatch for {}: expected {expected_profile}, got {:?}",
+            audit_dir.display(),
+            audit["profile"]
+        );
+    }
     Ok(())
 }
 
@@ -878,6 +998,11 @@ mod tests {
     }
 
     #[test]
+    fn external_adoption_ci_recipe_profiles_are_bounded() {
+        assert_eq!(CI_RECIPE_PROFILES, ["webhook", "tls", "oidc"]);
+    }
+
+    #[test]
     fn external_adoption_examples_are_bounded() {
         let names: Vec<&str> = EXTERNAL_EXAMPLES
             .iter()
@@ -963,6 +1088,7 @@ uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"
             mode: SmokeMode::Path,
             source: ".".to_string(),
             work_root: WORK_DIR.to_string(),
+            ci_recipes: true,
             projects: vec![ExternalAdoptionProject {
                 name: "webhook-cli".to_string(),
                 path: "target/external-adoption-smoke/work/webhook-cli".to_string(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -121,6 +121,9 @@ enum Cmd {
         /// Use a published crates.io version as audit/reference evidence.
         #[arg(long, conflicts_with = "path")]
         version: Option<String>,
+        /// Also run downstream CI recipe commands from the docs.
+        #[arg(long)]
+        ci_recipes: bool,
         /// Output format.
         #[arg(long, value_enum, default_value = "human")]
         format: ExternalAdoptionSmokeFormat,
@@ -639,12 +642,14 @@ fn main() -> Result<()> {
         Cmd::ExternalAdoptionSmoke {
             path,
             version,
+            ci_recipes,
             format,
         } => external_adoption_smoke::run(
             &workspace_root_path(),
             external_adoption_smoke::RunOptions {
                 path,
                 version,
+                ci_recipes,
                 format: format.into(),
             },
         ),
@@ -10494,16 +10499,19 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
             Cmd::ExternalAdoptionSmoke {
                 path,
                 version,
+                ci_recipes,
                 format,
             } => {
                 assert!(path.is_none(), "path should default to None");
                 assert!(version.is_none(), "version should default to None");
+                assert!(!ci_recipes, "ci_recipes should default to false");
                 assert!(matches!(format, ExternalAdoptionSmokeFormat::Human));
                 let err = external_adoption_smoke::run(
                     Path::new("."),
                     external_adoption_smoke::RunOptions {
                         path,
                         version,
+                        ci_recipes,
                         format: format.into(),
                     },
                 );
@@ -10545,6 +10553,20 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
             }
         ));
 
+        let ok_ci_recipes = Cli::try_parse_from([
+            "xtask",
+            "external-adoption-smoke",
+            "--path",
+            ".",
+            "--ci-recipes",
+        ])?;
+        match ok_ci_recipes.cmd {
+            Cmd::ExternalAdoptionSmoke { ci_recipes, .. } => {
+                assert!(ci_recipes, "ci recipe flag should propagate");
+            }
+            _ => bail!("expected Cmd::ExternalAdoptionSmoke"),
+        }
+
         let ok_version = Cli::try_parse_from([
             "xtask",
             "external-adoption-smoke",
@@ -10559,6 +10581,7 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
                 path: None,
                 version: Some(_),
                 format: ExternalAdoptionSmokeFormat::Json,
+                ..
             }
         ));
         Ok(())


### PR DESCRIPTION
Summary
- Adds explicit `cargo xtask external-adoption-smoke --ci-recipes` mode.
- Runs documented downstream CI command sequences for webhook, TLS, and OIDC bundles using `audit-bundle --ci`.
- Records `ci_recipes` in the external-adoption smoke receipt and keeps default external smoke / `adoption-regression --external` bounded.

Files added/changed
- `xtask/src/external_adoption_smoke.rs`
- `xtask/src/main.rs`
- `xtask/src/adoption_regression.rs`
- `docs/specs/USELESSKEY-SPEC-0013-external-adoption-smoke.md`
- `.uselesskey/goals/active.toml`

Validation
- `cargo test -p xtask external_adoption_smoke --no-run`
- `cargo test -p xtask external_adoption_smoke`
- `cargo xtask external-adoption-smoke --path . --ci-recipes --format json`
- `cargo xtask adoption-regression --external`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `cargo +nightly xtask pr-lite`
- `git diff --check`

Non-goals
- No release prep, version bump, tag, publish, new badge, new contract pack, provider compatibility claim, production security claim, or heavier default external smoke.

What this enables next
- Audit failure diagnostics can now target CI users with executable recipe evidence behind the docs.