### PR TITLE
examples: add downstream CI bundle audit example

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -131,7 +131,7 @@ commands = [
 
 [[work_item]]
 id = "downstream-ci-example"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0013"
 plan = "plans/downstream-ci-polish/implementation-plan.md"
@@ -143,7 +143,7 @@ commands = [
 
 [[work_item]]
 id = "audit-receipt-goldens"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"

--- a/examples/external/downstream-ci-bundle-audit/.github/workflows/uselesskey-audit.yml.example
+++ b/examples/external/downstream-ci-bundle-audit/.github/workflows/uselesskey-audit.yml.example
@@ -1,0 +1,40 @@
+name: uselesskey bundle audit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  bundle-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install uselesskey CLI
+        run: cargo install uselesskey-cli --version 0.9.1 --locked
+
+      - name: Generate webhook fixtures
+        run: uselesskey bundle --profile webhook --out target/uselesskey-webhook
+
+      - name: Verify webhook bundle
+        run: uselesskey verify-bundle --path target/uselesskey-webhook
+
+      - name: Audit webhook bundle
+        run: |
+          uselesskey audit-bundle \
+            --path target/uselesskey-webhook \
+            --out target/uselesskey-webhook-audit \
+            --ci
+
+      - name: Upload uselesskey audit receipts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: uselesskey-webhook-audit
+          path: |
+            target/uselesskey-webhook-audit/bundle-audit.json
+            target/uselesskey-webhook-audit/bundle-audit.md
+          if-no-files-found: error

--- a/examples/external/downstream-ci-bundle-audit/Cargo.toml
+++ b/examples/external/downstream-ci-bundle-audit/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "uselesskey-external-downstream-ci-bundle-audit"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]

--- a/examples/external/downstream-ci-bundle-audit/README.md
+++ b/examples/external/downstream-ci-bundle-audit/README.md
@@ -1,0 +1,40 @@
+# Downstream CI Bundle Audit
+
+Use this clean-project example when a downstream repository wants to generate a
+fixture bundle in CI, verify it, and upload metadata-only audit receipts.
+
+The installed CLI path is the product surface:
+
+```bash
+uselesskey bundle --profile webhook --out target/uselesskey-webhook
+uselesskey verify-bundle --path target/uselesskey-webhook
+uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit --ci
+```
+
+The reviewable files are:
+
+```text
+target/uselesskey-webhook-audit/bundle-audit.json
+target/uselesskey-webhook-audit/bundle-audit.md
+```
+
+Keep generated fixture payloads under `target/`. The audit receipts are
+metadata-only and do not copy raw webhook request bodies, key material, tokens,
+or secret-shaped payloads.
+
+## GitHub Actions
+
+The example workflow is stored as:
+
+```text
+.github/workflows/uselesskey-audit.yml.example
+```
+
+Rename it to `.github/workflows/uselesskey-audit.yml` in a downstream project if
+you want GitHub Actions to run it.
+
+## Boundary
+
+This proves local generated bundle consistency in downstream CI. It does not
+prove repo public claims, production security, provider compatibility, scanner
+evasion, release readiness, or downstream verifier correctness.

--- a/examples/external/downstream-ci-bundle-audit/src/lib.rs
+++ b/examples/external/downstream-ci-bundle-audit/src/lib.rs
@@ -1,0 +1,20 @@
+#![forbid(unsafe_code)]
+
+/// Marker for the downstream CI bundle audit example.
+///
+/// The example's primary behavior lives in the workflow file. This crate exists
+/// so external-adoption smoke can copy the example into a clean project and
+/// compile it like the other external examples.
+pub fn example_name() -> &'static str {
+    "downstream-ci-bundle-audit"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_downstream_ci_bundle_audit_example() {
+        assert_eq!(example_name(), "downstream-ci-bundle-audit");
+    }
+}

--- a/xtask/src/external_adoption_smoke.rs
+++ b/xtask/src/external_adoption_smoke.rs
@@ -33,6 +33,10 @@ const EXTERNAL_EXAMPLES: &[ExternalExample] = &[
         name: "tls-chain-validation",
         source_dir: "examples/external/tls-chain-validation",
     },
+    ExternalExample {
+        name: "downstream-ci-bundle-audit",
+        source_dir: "examples/external/downstream-ci-bundle-audit",
+    },
 ];
 const BOUNDARIES: &[&str] = &[
     "external-adoption-smoke proves clean-project user paths, not release readiness",
@@ -1015,6 +1019,7 @@ mod tests {
                 "webhook-verifier",
                 "oidc-jwks-validation",
                 "tls-chain-validation",
+                "downstream-ci-bundle-audit",
             ]
         );
     }


### PR DESCRIPTION
Summary
- Add a clean-project downstream CI bundle audit example with a copyable GitHub Actions workflow.
- Register the example in external-adoption-smoke so it compiles in the clean-project matrix.
- Advance the downstream CI polish goal from example work to audit receipt golden coverage.

Files added/changed
- examples/external/downstream-ci-bundle-audit/Cargo.toml
- examples/external/downstream-ci-bundle-audit/README.md
- examples/external/downstream-ci-bundle-audit/.github/workflows/uselesskey-audit.yml.example
- examples/external/downstream-ci-bundle-audit/src/lib.rs
- xtask/src/external_adoption_smoke.rs
- .uselesskey/goals/active.toml

Validation
- cargo test -p xtask external_adoption_smoke
- cargo xtask external-adoption-smoke --path .
- cargo xtask adoption-regression --external
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo fmt --all -- --check
- git diff --check

Non-goals
- No release prep, version bump, tag, or publish.
- No new contract packs or badges.
- No provider compatibility, production security, or scanner-evasion claims.

What this enables next
- The audit receipt golden slice can protect stable bundle-audit JSON/Markdown shape now that downstream CI has a concrete installed-user example.