### PR TITLE
test(cli): add audit receipt golden coverage

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -143,7 +143,7 @@ commands = [
 
 [[work_item]]
 id = "audit-receipt-goldens"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"
@@ -156,7 +156,7 @@ commands = [
 
 [[work_item]]
 id = "audit-bundle-summary"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -822,6 +822,69 @@ fn audit_bundle_writes_metadata_only_reviewer_receipts() -> TestResult<()> {
 }
 
 #[test]
+fn audit_bundle_golden_json_preserves_schema_and_boundaries() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("webhook");
+
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    bundle.assert().success();
+
+    let out = run([
+        "audit-bundle",
+        "--path",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--format",
+        "json",
+    ])?;
+    let audit: Value = serde_json::from_str(&out).test_context("audit json")?;
+    let audit = normalize_snapshot_paths(audit, dir.path());
+
+    assert_yaml_snapshot!("audit_bundle_webhook_json_golden", audit);
+    Ok(())
+}
+
+#[test]
+fn audit_bundle_golden_markdown_preserves_metadata_only_posture() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("webhook");
+    let audit_dir = dir.path().join("webhook-audit");
+
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    bundle.assert().success();
+
+    let mut audit = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    audit.args([
+        "audit-bundle",
+        "--path",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--out",
+        audit_dir.to_str().test_context("utf-8")?,
+    ]);
+    audit.assert().success();
+
+    let audit_md =
+        fs::read_to_string(audit_dir.join("bundle-audit.md")).test_context("audit markdown")?;
+    let audit_md = normalize_snapshot_text(&audit_md, dir.path());
+
+    assert_snapshot!("audit_bundle_webhook_markdown_golden", audit_md);
+    Ok(())
+}
+
+#[test]
 fn audit_bundle_json_reports_artifact_runtime_material_flags() -> TestResult<()> {
     let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("webhook");
@@ -861,6 +924,31 @@ fn audit_bundle_json_reports_artifact_runtime_material_flags() -> TestResult<()>
     assert_eq!(evidence["scanner_safe"], true);
     assert_eq!(evidence["runtime_material"], false);
     Ok(())
+}
+
+fn normalize_snapshot_paths(value: Value, temp_root: &std::path::Path) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(|value| normalize_snapshot_paths(value, temp_root))
+                .collect(),
+        ),
+        Value::Object(entries) => Value::Object(
+            entries
+                .into_iter()
+                .map(|(key, value)| (key, normalize_snapshot_paths(value, temp_root)))
+                .collect(),
+        ),
+        Value::String(value) => Value::String(normalize_snapshot_text(&value, temp_root)),
+        other => other,
+    }
+}
+
+fn normalize_snapshot_text(value: &str, temp_root: &std::path::Path) -> String {
+    let normalized = value.replace('\\', "/");
+    let root = temp_root.to_string_lossy().replace('\\', "/");
+    normalized.replace(&root, "<temp>")
 }
 
 #[test]

--- a/crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_json_golden.snap
+++ b/crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_json_golden.snap
@@ -1,0 +1,119 @@
+---
+source: crates/uselesskey-cli/tests/cli.rs
+expression: audit
+---
+artifact_count: 7
+artifacts:
+  - description: Webhook valid HMAC request
+    format: json-manifest
+    kind: webhook
+    path: requests/valid.json
+    runtime_material: true
+    scanner_safe: false
+  - description: Webhook negative request with modified body
+    format: json-manifest
+    kind: webhook
+    path: requests/negative-tampered-body.json
+    runtime_material: true
+    scanner_safe: false
+  - description: Webhook negative request signed with the wrong secret
+    format: json-manifest
+    kind: webhook
+    path: requests/negative-wrong-secret.json
+    runtime_material: true
+    scanner_safe: false
+  - description: Webhook negative request outside timestamp tolerance
+    format: json-manifest
+    kind: webhook
+    path: requests/negative-stale-timestamp.json
+    runtime_material: true
+    scanner_safe: false
+  - description: Webhook negative request missing the signature header
+    format: json-manifest
+    kind: webhook
+    path: requests/negative-missing-signature.json
+    runtime_material: true
+    scanner_safe: false
+  - description: Webhook negative request with malformed signature
+    format: json-manifest
+    kind: webhook
+    path: requests/negative-malformed-signature.json
+    runtime_material: true
+    scanner_safe: false
+  - description: Webhook profile verifier expectation evidence
+    format: json-manifest
+    kind: webhook
+    path: evidence/webhook-profile.md
+    runtime_material: false
+    scanner_safe: true
+boundaries:
+  - audit-bundle proves local bundle consistency and metadata classification
+  - audit-bundle does not prove repo public claims; use cargo xtask claim-proof from a repo checkout
+  - audit-bundle does not prove release readiness; use release-evidence for release proof
+  - "profile proof/check path: cargo xtask claim-proof --claim webhook-contract-pack"
+  - audit receipts contain metadata only and do not copy generated fixture payloads
+bundle_path: "<temp>/webhook"
+checks:
+  - detail: manifest parsed
+    failure_class: invalid_manifest
+    name: manifest
+    status: pass
+  - detail: manifest paths are relative and contained by the bundle
+    failure_class: path_escape
+    name: path-containment
+    status: pass
+  - detail: manifest artifacts regenerate and verify
+    failure_class: missing_artifact
+    name: artifact-content
+    status: pass
+  - detail: materialization and audit-surface receipts are present
+    failure_class: missing_receipt
+    name: receipts
+    status: pass
+  - detail: audit-surface receipt matches manifest scanner-safe counts
+    failure_class: scanner_safe_mismatch
+    name: scanner-safe-classification
+    status: pass
+  - detail: audit-surface receipt matches manifest runtime-material counts
+    failure_class: runtime_material_mismatch
+    name: runtime-material-classification
+    status: pass
+  - detail: profile-specific generated files match the manifest
+    failure_class: profile_validation_failed
+    name: profile-validation
+    status: pass
+does_not_prove:
+  - provider compatibility
+  - production secret management
+  - replay protection completeness
+  - delivery retries or transport security
+  - downstream verifier correctness
+files:
+  - requests/valid.json
+  - requests/negative-tampered-body.json
+  - requests/negative-wrong-secret.json
+  - requests/negative-stale-timestamp.json
+  - requests/negative-missing-signature.json
+  - requests/negative-malformed-signature.json
+  - evidence/webhook-profile.md
+  - receipts/materialization.json
+  - receipts/audit-surface.json
+manifest_path: manifest.json
+manifest_version: 1
+missing_files: []
+profile: webhook
+receipt_count: 2
+receipts:
+  - description: deterministic bundle materialization receipt
+    kind: materialization
+    path: receipts/materialization.json
+    profile: webhook
+  - description: scanner-safety and lane metadata receipt
+    kind: audit-surface
+    path: receipts/audit-surface.json
+    profile: webhook
+runtime_material_count: 6
+scanner_safe_count: 1
+status: pass
+unexpected_files: []
+version: 1

--- a/crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_markdown_golden.snap
+++ b/crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_markdown_golden.snap
@@ -1,0 +1,62 @@
+---
+source: crates/uselesskey-cli/tests/cli.rs
+expression: audit_md
+---
+# uselesskey Bundle Audit
+
+- Status: pass
+- Bundle: <temp>/webhook
+- Profile: webhook
+- Receipt type: durable metadata-only reviewer/CI receipt
+- Quick summary: uselesskey inspect-bundle --path <bundle-dir>
+- Payload posture: raw generated fixture payloads are not copied into this receipt
+- Manifest: manifest.json (version 1)
+- Artifacts: 7
+- Receipts: 2
+- Scanner-safe artifacts: 1
+- Runtime material artifacts: 6
+
+## Checks
+
+| Check | Status | Failure class | Detail |
+|---|---|---|---|
+| manifest | pass | invalid_manifest | manifest parsed |
+| path-containment | pass | path_escape | manifest paths are relative and contained by the bundle |
+| artifact-content | pass | missing_artifact | manifest artifacts regenerate and verify |
+| receipts | pass | missing_receipt | materialization and audit-surface receipts are present |
+| scanner-safe-classification | pass | scanner_safe_mismatch | audit-surface receipt matches manifest scanner-safe counts |
+| runtime-material-classification | pass | runtime_material_mismatch | audit-surface receipt matches manifest runtime-material counts |
+| profile-validation | pass | profile_validation_failed | profile-specific generated files match the manifest |
+
+## Artifacts
+
+| Path | Kind | Format | Scanner-safe | Runtime material |
+|---|---|---|---|---|
+| requests/valid.json | webhook | json-manifest | no | yes |
+| requests/negative-tampered-body.json | webhook | json-manifest | no | yes |
+| requests/negative-wrong-secret.json | webhook | json-manifest | no | yes |
+| requests/negative-stale-timestamp.json | webhook | json-manifest | no | yes |
+| requests/negative-missing-signature.json | webhook | json-manifest | no | yes |
+| requests/negative-malformed-signature.json | webhook | json-manifest | no | yes |
+| evidence/webhook-profile.md | webhook | json-manifest | yes | no |
+
+## Receipts
+
+- materialization: receipts/materialization.json
+- audit-surface: receipts/audit-surface.json
+
+## Boundaries
+
+- audit-bundle proves local bundle consistency and metadata classification
+- audit-bundle does not prove repo public claims; use cargo xtask claim-proof from a repo checkout
+- audit-bundle does not prove release readiness; use release-evidence for release proof
+- profile proof/check path: cargo xtask claim-proof --claim webhook-contract-pack
+- audit receipts contain metadata only and do not copy generated fixture payloads
+
+## Does Not Prove
+
+- provider compatibility
+- production secret management
+- replay protection completeness
+- delivery retries or transport security
+- downstream verifier correctness

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -274,6 +274,15 @@ covered_by = ["cargo xtask badges --check"]
 # === Example reference outputs =============================================
 
 [[allow]]
+glob = "examples/external/downstream-ci-bundle-audit/.github/workflows/*.yml.example"
+kind = "external_example_ci_workflow"
+owner = "cli"
+surface = "examples"
+classification = "docs"
+reason = "Downstream-shaped GitHub Actions workflow example for installed CLI bundle audit. It is inert until copied by a downstream project."
+covered_by = ["cargo xtask external-adoption-smoke --path .", "cargo xtask check-file-policy"]
+
+[[allow]]
 glob = "examples/scanner-safe-bundle/expected/**/*"
 kind = "scanner_safe_bundle_reference"
 owner = "cli"


### PR DESCRIPTION
Summary
- Add golden coverage for webhook bundle audit JSON and Markdown receipts with volatile temp paths normalized.
- Protect stable audit schema shape, failure classes, boundary language, and metadata-only posture.
- Add a narrow non-Rust file-policy allowlist entry for the already-landed inert downstream CI workflow example.

Files added/changed
- crates/uselesskey-cli/tests/cli.rs
- crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_json_golden.snap
- crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_markdown_golden.snap
- policy/non-rust-allowlist.toml
- .uselesskey/goals/active.toml

Validation
- cargo test -p uselesskey-cli --all-features audit_bundle
- cargo xtask check-file-policy
- cargo xtask no-blob
- cargo +nightly xtask pr-lite
- cargo fmt --all -- --check
- git diff --check

Non-goals
- No release prep, version bump, tag, or publish.
- No new contract packs or badges.
- No provider compatibility, production security, or scanner-evasion claims.

What this enables next
- The compact audit summary slice can build on protected JSON/Markdown receipt shape and boundary wording.