### PR TITLE
feat(cli): add compact audit bundle summary

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -156,7 +156,7 @@ commands = [
 
 [[work_item]]
 id = "audit-bundle-summary"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
 plan = "plans/downstream-ci-polish/implementation-plan.md"
@@ -168,7 +168,7 @@ commands = [
 
 [[work_item]]
 id = "lane-closeout"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/downstream-ci-polish/implementation-plan.md"

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -114,6 +114,8 @@ struct AuditBundleArgs {
     format: AuditOutputFormat,
     #[arg(long)]
     ci: bool,
+    #[arg(long)]
+    summary: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -444,6 +446,10 @@ fn run_inspect_bundle(args: InspectBundleArgs) -> Result<()> {
 }
 
 fn run_audit_bundle(args: AuditBundleArgs) -> Result<()> {
+    if args.ci && args.summary {
+        bail!("audit-bundle --summary cannot be combined with --ci");
+    }
+
     if args.ci {
         return run_audit_bundle_ci(args);
     }
@@ -462,6 +468,12 @@ fn run_audit_bundle(args: AuditBundleArgs) -> Result<()> {
 
     if let Some(out_dir) = args.out.as_deref() {
         let (json_path, md_path) = write_bundle_audit_receipts(&audit, out_dir)?;
+        if args.summary {
+            return emit_artifact(
+                &Artifact::Text(render_bundle_audit_summary(&audit, Some(out_dir))),
+                None,
+            );
+        }
         return emit_artifact(
             &Artifact::Json(json!({
                 "audit_bundle": {
@@ -472,6 +484,13 @@ fn run_audit_bundle(args: AuditBundleArgs) -> Result<()> {
                     "markdown": md_path,
                 }
             })),
+            None,
+        );
+    }
+
+    if args.summary {
+        return emit_artifact(
+            &Artifact::Text(render_bundle_audit_summary(&audit, None)),
             None,
         );
     }
@@ -1025,6 +1044,35 @@ fn render_bundle_audit_markdown(audit: &BundleAudit) -> String {
         out.push_str(&format!("- {boundary}\n"));
     }
 
+    out
+}
+
+fn render_bundle_audit_summary(audit: &BundleAudit, out_dir: Option<&Path>) -> String {
+    let receipts = if audit.receipt_count == 0 {
+        "none"
+    } else {
+        "present"
+    };
+    let mut out = format!(
+        concat!(
+            "Bundle audit: {}\n",
+            "Profile: {}\n",
+            "Artifacts: {}\n",
+            "Scanner-safe: {}\n",
+            "Runtime material: {}\n",
+            "Receipts: {}\n",
+            "Boundaries: local consistency only\n",
+        ),
+        audit.status,
+        audit.profile,
+        audit.artifact_count,
+        audit.scanner_safe_count,
+        audit.runtime_material_count,
+        receipts
+    );
+    if let Some(out_dir) = out_dir {
+        out.push_str(&format!("Audit receipts: {}\n", display_path(out_dir)));
+    }
     out
 }
 

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -981,6 +981,102 @@ fn audit_bundle_ci_outputs_json_on_success() -> TestResult<()> {
 }
 
 #[test]
+fn audit_bundle_summary_outputs_compact_terminal_report() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("webhook");
+
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    bundle.assert().success();
+
+    let out = run([
+        "audit-bundle",
+        "--path",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--summary",
+    ])?;
+
+    assert!(out.contains("Bundle audit: pass"));
+    assert!(out.contains("Profile: webhook"));
+    assert!(out.contains("Artifacts: 7"));
+    assert!(out.contains("Scanner-safe: 1"));
+    assert!(out.contains("Runtime material: 6"));
+    assert!(out.contains("Receipts: present"));
+    assert!(out.contains("Boundaries: local consistency only"));
+    assert!(!out.contains("requests/valid.json"));
+    assert!(!out.contains("whsec_"));
+    Ok(())
+}
+
+#[test]
+fn audit_bundle_summary_with_out_writes_receipts_and_mentions_output_dir() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("webhook");
+    let audit_dir = dir.path().join("webhook-audit");
+
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    bundle.assert().success();
+
+    let out = run([
+        "audit-bundle",
+        "--path",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--out",
+        audit_dir.to_str().test_context("utf-8")?,
+        "--summary",
+    ])?;
+
+    assert!(out.contains("Bundle audit: pass"));
+    assert!(out.contains("Audit receipts:"));
+    assert!(out.contains("webhook-audit"));
+    assert!(audit_dir.join("bundle-audit.json").is_file());
+    assert!(audit_dir.join("bundle-audit.md").is_file());
+    Ok(())
+}
+
+#[test]
+fn audit_bundle_summary_rejects_ci_mode() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("webhook");
+
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    bundle.assert().success();
+
+    let mut audit = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    audit.args([
+        "audit-bundle",
+        "--path",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--summary",
+        "--ci",
+    ]);
+    audit.assert().failure().stderr(predicate::str::contains(
+        "audit-bundle --summary cannot be combined with --ci",
+    ));
+    Ok(())
+}
+
+#[test]
 fn audit_bundle_json_stdout_reports_scanner_safe_bundle() -> TestResult<()> {
     let dir = tempdir().test_context("tempdir")?;
     let bundle_dir = dir.path().join("scanner-safe");

--- a/docs/how-to/use-uselesskey-in-downstream-ci.md
+++ b/docs/how-to/use-uselesskey-in-downstream-ci.md
@@ -37,6 +37,13 @@ Fail CI if the command exits non-zero. A non-zero exit means the local bundle
 failed a manifest, containment, receipt, scanner-safe/runtime-material, or
 profile validation check.
 
+For compact human CI logs without changing the machine-readable `--ci` path,
+run summary mode in a separate step:
+
+```bash
+uselesskey audit-bundle --path target/uselesskey-webhook --summary
+```
+
 ## Boundaries
 
 This downstream CI recipe proves local bundle consistency. It does not prove

--- a/docs/reference/bundle-inspect-vs-audit.md
+++ b/docs/reference/bundle-inspect-vs-audit.md
@@ -30,6 +30,14 @@ It writes `bundle-audit.json` and `bundle-audit.md` when `--out` is provided.
 Those receipts contain bundle metadata, artifact classifications, stable failure
 classes, checks, and boundaries. They do not copy raw fixture payloads.
 
+Use summary mode when a terminal or CI log only needs the compact decision:
+
+```bash
+uselesskey audit-bundle --path target/uselesskey-webhook --summary
+```
+
+`--summary` is human output. Keep `--ci` for machine-readable failure handling.
+
 ## Boundary
 
 `inspect-bundle` is for a human's immediate read. `audit-bundle` is for durable


### PR DESCRIPTION
Summary
- Add uselesskey audit-bundle --summary for compact human terminal and CI log output.
- Keep --ci as the machine-readable JSON path and reject --ci --summary.
- Document summary mode in downstream CI and inspect-vs-audit reference docs.

Files added/changed
- crates/uselesskey-cli/src/main.rs
- crates/uselesskey-cli/tests/cli.rs
- docs/how-to/use-uselesskey-in-downstream-ci.md
- docs/reference/bundle-inspect-vs-audit.md
- .uselesskey/goals/active.toml

Validation
- cargo test -p uselesskey-cli --all-features audit_bundle
- cargo xtask external-adoption-smoke --path .
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo fmt --all -- --check
- cargo +nightly xtask pr-lite
- git diff --check

Non-goals
- No release prep, version bump, tag, or publish.
- No new contract packs or badges.
- No provider compatibility, production security, or scanner-evasion claims.

What this enables next
- The downstream CI polish lane is ready for closeout with compact audit logs, stable audit JSON/Markdown receipts, and external installed-user examples in place.