### PR TITLE
fix(cli): return usage code for audit mode conflicts

### DIFF
--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -112,7 +112,7 @@ struct AuditBundleArgs {
     out: Option<PathBuf>,
     #[arg(long, default_value = "markdown")]
     format: AuditOutputFormat,
-    #[arg(long)]
+    #[arg(long, conflicts_with = "summary")]
     ci: bool,
     #[arg(long)]
     summary: bool,

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -1070,9 +1070,10 @@ fn audit_bundle_summary_rejects_ci_mode() -> TestResult<()> {
         "--summary",
         "--ci",
     ]);
-    audit.assert().failure().stderr(predicate::str::contains(
-        "audit-bundle --summary cannot be combined with --ci",
-    ));
+    audit
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("cannot be used with"));
     Ok(())
 }
 


### PR DESCRIPTION
Summary
- Make `audit-bundle --ci --summary` a Clap usage/config error so it exits with code 2.
- Keep audit failures on the existing CI path as exit 1 and successful audits as exit 0.
- Tighten the regression test for the incompatible audit-mode flags.

Files added/changed
- `crates/uselesskey-cli/src/main.rs`
- `crates/uselesskey-cli/tests/cli.rs`

Validation
- `cargo test -p uselesskey-cli --all-features audit_bundle_summary_rejects_ci_mode`
- Manual reproduction: `cargo run -p uselesskey-cli -- audit-bundle --path target/completion-audit/webhook --ci --summary` exits 2
- `cargo test -p uselesskey-cli --all-features audit_bundle`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo +nightly xtask pr-lite`

Non-goals
- No release prep, version bump, tag, or publish.
- No new contract packs or badges.
- No provider compatibility, production security, or scanner-evasion claims.

What this enables next
- Completes the downstream CI exit-code contract: pass=0, stable audit failure=1, CLI/config usage error=2.