### PR TITLE
Strengthen core proptests for seed parsing and cache semantics

### DIFF
--- a/crates/uselesskey-core/tests/core_prop.rs
+++ b/crates/uselesskey-core/tests/core_prop.rs
@@ -132,6 +132,23 @@ proptest! {
         prop_assert_eq!(seed.bytes(), &hex_bytes);
     }
 
+    /// Seed::from_env_value() rejects 64-byte non-hex payloads (with and without prefix).
+    #[test]
+    fn seed_from_env_value_invalid_64_byte_hex_is_err(
+        s in prop::collection::vec(
+            prop_oneof![Just('g'), Just('z'), Just('!'), Just('_')],
+            64,
+        )
+    ) {
+        let raw: String = s.iter().collect();
+        let prefixed = format!("0x{raw}");
+        let upper_prefixed = format!("0X{raw}");
+
+        prop_assert!(Seed::from_env_value(&raw).is_err());
+        prop_assert!(Seed::from_env_value(&prefixed).is_err());
+        prop_assert!(Seed::from_env_value(&upper_prefixed).is_err());
+    }
+
     // =========================================================================
     // Derivation uniqueness tests
     // =========================================================================
@@ -295,6 +312,15 @@ proptest! {
             std::sync::Arc::ptr_eq(&first, &second),
             "cache hit should return the same Arc pointer"
         );
+
+        fx.clear_cache();
+
+        let third = fx.get_or_init("domain:arc", &label, &spec, "good", seed_array::<32>);
+        prop_assert!(
+            !std::sync::Arc::ptr_eq(&first, &third),
+            "cache clear should force a new Arc allocation"
+        );
+        prop_assert_eq!(*first, *third, "cache clear should not change deterministic value");
     }
 
     // =========================================================================


### PR DESCRIPTION
### Motivation

- Tighten property-test coverage around seed parsing to ensure ambiguous 64-byte inputs are handled strictly. 
- Make cache semantics explicit in tests by verifying pointer identity behavior across cache clears while preserving deterministic values.

### Description

- Add a proptest `seed_from_env_value_invalid_64_byte_hex_is_err` that generates 64-char non-hex payloads and asserts `Seed::from_env_value` returns `Err` for raw, `0x`-prefixed, and `0X`-prefixed forms. 
- Extend `prop_cache_hit_returns_same_arc` to call `fx.clear_cache()` and assert the cached `Arc` pointer is replaced while the dereferenced deterministic value remains equal. 
- Tests live in `crates/uselesskey-core/tests/core_prop.rs` and use existing `proptest` helpers and generators.

### Testing

- Ran `cargo test -p uselesskey-core --test core_prop`, which executed the updated proptests. 
- All tests in that test target passed (17 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5b03ee508333a76e93e8638fc254)