### PR TITLE
Improve proptest distinct-label generation in ECDSA property tests

### DIFF
--- a/crates/uselesskey-ecdsa/tests/ecdsa_prop.rs
+++ b/crates/uselesskey-ecdsa/tests/ecdsa_prop.rs
@@ -7,6 +7,13 @@ mod testutil;
 use proptest::prelude::*;
 
 use uselesskey_core::{Factory, Seed};
+
+#[cfg(feature = "jwk")]
+fn distinct_labels() -> impl Strategy<Value = (String, String)> {
+    ("[a-zA-Z0-9]{1,16}", "[a-zA-Z0-9]{1,16}")
+        .prop_filter("labels must be distinct", |(a, b)| a != b)
+}
+
 use uselesskey_ecdsa::{EcdsaFactoryExt, EcdsaSpec};
 
 proptest! {
@@ -108,11 +115,8 @@ proptest! {
     #[cfg(feature = "jwk")]
     fn different_labels_produce_different_kids(
         seed in any::<[u8; 32]>(),
-        label1 in "[a-zA-Z0-9]{1,16}",
-        label2 in "[a-zA-Z0-9]{1,16}",
+        (label1, label2) in distinct_labels(),
     ) {
-        prop_assume!(label1 != label2);
-
         let fx = Factory::deterministic(Seed::new(seed));
         let k1 = fx.ecdsa(&label1, EcdsaSpec::es256());
         let k2 = fx.ecdsa(&label2, EcdsaSpec::es256());


### PR DESCRIPTION
### Motivation
- Replace assumption-based input rejection in a proptest with a generator that yields only valid (distinct) label pairs to make the property clearer and avoid runtime `prop_assume!` filtering.

### Description
- Add a `distinct_labels()` helper that returns a `(String, String)` pair strategy and uses `.prop_filter()` to ensure the two labels differ.
- Gate the helper with `#[cfg(feature = "jwk")]` to avoid dead-code warnings when the `jwk` feature is not enabled.
- Update the `different_labels_produce_different_kids` property to consume `(label1, label2) in distinct_labels()` and remove the inline `prop_assume!`.

### Testing
- Ran `cargo test -p uselesskey-ecdsa --test ecdsa_prop` and the proptest suite completed successfully (`4 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5b03ee508333a76e93e8638fc254)