### PR TITLE
test(webauthn): improve coverage for JSON payload and length-prefix boundary

### DIFF
--- a/crates/uselesskey-webauthn/src/lib.rs
+++ b/crates/uselesskey-webauthn/src/lib.rs
@@ -567,6 +567,36 @@ mod tests {
         );
     }
 
+
+    #[test]
+    fn client_data_json_sets_expected_type_and_cross_origin_false() {
+        let bytes = build_client_data_json("webauthn.get", b"xyz", "login.example.com");
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("parse clientDataJSON");
+
+        assert_eq!(parsed["type"], "webauthn.get");
+        assert_eq!(parsed["origin"], "https://login.example.com");
+        assert_eq!(parsed["challenge"], base64url(b"xyz"));
+        assert_eq!(parsed["crossOrigin"], false);
+    }
+
+    #[test]
+    fn write_field_uses_u16_prefix_for_max_legacy_length() {
+        let mut out = Vec::new();
+        let value = vec![0xAA; u16::MAX as usize];
+
+        write_field(&mut out, "challenge", &value);
+
+        let marker = b"challenge";
+        let at = out
+            .windows(marker.len())
+            .position(|window| window == marker)
+            .expect("challenge marker present");
+        let len_offset = at + marker.len();
+
+        assert_eq!(&out[len_offset..len_offset + 2], &u16::MAX.to_be_bytes());
+        assert_eq!(out.len(), marker.len() + 2 + value.len());
+    }
+
     fn assert_contains_bytes(haystack: &[u8], needle: &[u8]) {
         assert!(
             haystack

--- a/crates/uselesskey-webauthn/src/lib.rs
+++ b/crates/uselesskey-webauthn/src/lib.rs
@@ -567,11 +567,11 @@ mod tests {
         );
     }
 
-
     #[test]
     fn client_data_json_sets_expected_type_and_cross_origin_false() {
         let bytes = build_client_data_json("webauthn.get", b"xyz", "login.example.com");
-        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("parse clientDataJSON");
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("parse clientDataJSON");
 
         assert_eq!(parsed["type"], "webauthn.get");
         assert_eq!(parsed["origin"], "https://login.example.com");


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for WebAuthn fixture shape generation and exercise an edge case in `write_field` length-prefix encoding to prevent regressions.

### Description
- Add two tests in `crates/uselesskey-webauthn/src/lib.rs`: one verifying `build_client_data_json` encodes `type`, `origin`, base64url `challenge`, and `crossOrigin: false`, and another asserting `write_field` uses the 2-byte `u16` prefix when the value length is exactly `u16::MAX`.

### Testing
- Ran `cargo test -p uselesskey-webauthn` and all tests passed (`22 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5af8f7e083338893453dee34d5f4)