### PR TITLE
test(core): add PEM corruption edge-case coverage

### DIFF
--- a/crates/uselesskey-core/src/srp/negative/pem.rs
+++ b/crates/uselesskey-core/src/srp/negative/pem.rs
@@ -187,6 +187,25 @@ mod tests {
         assert!(out.starts_with("-----BEGIN CORRUPTED KEY-----\n"));
     }
 
+
+    #[test]
+    fn bad_header_on_empty_input_is_single_replacement_line() {
+        let out = corrupt_pem("", CorruptPem::BadHeader);
+        assert_eq!(out, "-----BEGIN CORRUPTED KEY-----\n");
+    }
+
+    #[test]
+    fn truncate_utf8_exact_boundary_keeps_full_character() {
+        let pem = "éx"; // 'é' is two bytes
+        let out = corrupt_pem(pem, CorruptPem::Truncate { bytes: 2 });
+        assert_eq!(out, "é");
+    }
+
+    #[test]
+    fn truncate_utf8_zero_budget_returns_empty() {
+        let out = corrupt_pem("abc", CorruptPem::Truncate { bytes: 0 });
+        assert_eq!(out, "");
+    }
     #[test]
     fn bad_footer_replaces_last_line() {
         let pem = "-----BEGIN TEST-----\nAAA=\n-----END TEST-----\n";

--- a/crates/uselesskey-core/src/srp/negative/pem.rs
+++ b/crates/uselesskey-core/src/srp/negative/pem.rs
@@ -187,7 +187,6 @@ mod tests {
         assert!(out.starts_with("-----BEGIN CORRUPTED KEY-----\n"));
     }
 
-
     #[test]
     fn bad_header_on_empty_input_is_single_replacement_line() {
         let out = corrupt_pem("", CorruptPem::BadHeader);


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for PEM negative-fixture helpers to exercise empty-input and UTF-8 truncation edge cases and reduce uncovered branches in `corrupt_pem` behavior.

### Description
- Add three unit tests in `crates/uselesskey-core/src/srp/negative/pem.rs` to cover: `CorruptPem::BadHeader` on empty input, UTF-8 truncation when the byte budget lands exactly on a multi-byte character boundary, and zero-byte truncation returning an empty string.

### Testing
- Ran `cargo test -p uselesskey-core negative::pem -- --nocapture` and the test suite completed successfully with `28 passed; 0 failed` for the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5af8f7e083338893453dee34d5f4)