### PR TITLE
test(cli): add coverage for artifact/classifier helpers

### DIFF
--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -1631,7 +1631,6 @@ mod tests {
         assert!(!is_safe_default_output_hint("../target/uselesskey-webhook"));
     }
 
-
     #[test]
     fn helper_formatters_cover_all_branches() {
         assert_eq!(yes_no_unknown(Some(true)), "yes");
@@ -1673,7 +1672,9 @@ mod tests {
             path: "webhook.json".to_string(),
             description: "runtime webhook material".to_string(),
         };
-        assert!(bundle_artifact_contains_symmetric_secret_material(&webhook_secret));
+        assert!(bundle_artifact_contains_symmetric_secret_material(
+            &webhook_secret
+        ));
 
         let jwk_public = BundleArtifactRecord {
             kind: "jwk".to_string(),
@@ -1684,7 +1685,9 @@ mod tests {
             path: "jwk.json".to_string(),
             description: "scanner-safe jwk".to_string(),
         };
-        assert!(!bundle_artifact_contains_symmetric_secret_material(&jwk_public));
+        assert!(!bundle_artifact_contains_symmetric_secret_material(
+            &jwk_public
+        ));
     }
 }
 

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -1630,6 +1630,62 @@ mod tests {
         assert!(!is_safe_default_output_hint("target/../escape"));
         assert!(!is_safe_default_output_hint("../target/uselesskey-webhook"));
     }
+
+
+    #[test]
+    fn helper_formatters_cover_all_branches() {
+        assert_eq!(yes_no_unknown(Some(true)), "yes");
+        assert_eq!(yes_no_unknown(Some(false)), "no");
+        assert_eq!(yes_no_unknown(None), "unknown");
+
+        assert_eq!(yes_no(true), "yes");
+        assert_eq!(yes_no(false), "no");
+
+        assert_eq!(count_or_unknown(Some(3)), "3");
+        assert_eq!(count_or_unknown(None), "unknown");
+    }
+
+    #[test]
+    fn artifact_material_classifiers_follow_scanner_posture() {
+        let rsa_private = BundleArtifactRecord {
+            kind: "rsa".to_string(),
+            format: "pem".to_string(),
+            profile: "runtime".to_string(),
+            lanes: vec!["runtime".to_string()],
+            scanner_safe: false,
+            path: "rsa.pem".to_string(),
+            description: "runtime rsa private key".to_string(),
+        };
+        assert!(bundle_artifact_contains_private_key_material(&rsa_private));
+
+        let rsa_public = BundleArtifactRecord {
+            scanner_safe: true,
+            ..rsa_private.clone()
+        };
+        assert!(!bundle_artifact_contains_private_key_material(&rsa_public));
+
+        let webhook_secret = BundleArtifactRecord {
+            kind: "webhook".to_string(),
+            format: "json".to_string(),
+            profile: "runtime".to_string(),
+            lanes: vec!["runtime".to_string()],
+            scanner_safe: false,
+            path: "webhook.json".to_string(),
+            description: "runtime webhook material".to_string(),
+        };
+        assert!(bundle_artifact_contains_symmetric_secret_material(&webhook_secret));
+
+        let jwk_public = BundleArtifactRecord {
+            kind: "jwk".to_string(),
+            format: "jwk".to_string(),
+            profile: "scanner-safe".to_string(),
+            lanes: vec!["scanner-safe".to_string()],
+            scanner_safe: true,
+            path: "jwk.json".to_string(),
+            description: "scanner-safe jwk".to_string(),
+        };
+        assert!(!bundle_artifact_contains_symmetric_secret_material(&jwk_public));
+    }
 }
 
 fn display_path(path: &Path) -> String {


### PR DESCRIPTION
### Motivation
- Improve code coverage for CLI reporting helpers and artifact classification logic used by bundle inspection and audit summaries to reduce the risk of silent regressions.
- Exercise branch outcomes for formatter helpers and scanner-safe/runtime classification predicates so summary rendering and posture checks remain correct.

### Description
- Add `helper_formatters_cover_all_branches` unit test to exercise `yes_no_unknown`, `yes_no`, and `count_or_unknown` branch behaviors in `crates/uselesskey-cli/src/main.rs`.
- Add `artifact_material_classifiers_follow_scanner_posture` unit test to validate `bundle_artifact_contains_private_key_material` and `bundle_artifact_contains_symmetric_secret_material` behavior across scanner-safe and runtime artifact states.
- Update test initializers to populate `BundleArtifactRecord` fields required by the struct (`profile` and `lanes`) used in the new tests, without changing production logic.

### Testing
- Ran `cargo test -p uselesskey-cli` which executed the unit and integration test suite for the CLI package and completed successfully with all tests passing.
- New tests are included in the `crates/uselesskey-cli/src/main.rs` test module and were validated as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5af8f7e083338893453dee34d5f4)