### PR TITLE
test(core): expand TempArtifact unit coverage

### DIFF
--- a/crates/uselesskey-core/src/sink/mod.rs
+++ b/crates/uselesskey-core/src/sink/mod.rs
@@ -75,7 +75,10 @@ mod tests {
             let artifact = TempArtifact::new_string("uselesskey-", ".unit.cleanup", "cleanup")
                 .expect("create TempArtifact");
             let path = artifact.path().to_path_buf();
-            assert!(path.exists(), "temp file should exist while artifact is alive");
+            assert!(
+                path.exists(),
+                "temp file should exist while artifact is alive"
+            );
             path
         };
 

--- a/crates/uselesskey-core/src/sink/mod.rs
+++ b/crates/uselesskey-core/src/sink/mod.rs
@@ -43,6 +43,8 @@ impl TempArtifact {
 #[cfg(test)]
 mod tests {
     use super::TempArtifact;
+    use std::thread;
+    use std::time::Duration;
 
     #[test]
     fn temp_artifact_string_round_trips_and_debug_mentions_path() {
@@ -65,5 +67,35 @@ mod tests {
 
         let read = artifact.read_to_bytes().expect("read_to_bytes");
         assert_eq!(read, bytes);
+    }
+
+    #[test]
+    fn temp_artifact_exposes_live_path_and_deletes_on_drop() {
+        let path = {
+            let artifact = TempArtifact::new_string("uselesskey-", ".unit.cleanup", "cleanup")
+                .expect("create TempArtifact");
+            let path = artifact.path().to_path_buf();
+            assert!(path.exists(), "temp file should exist while artifact is alive");
+            path
+        };
+
+        let mut attempts = 0;
+        loop {
+            thread::sleep(Duration::from_millis(10));
+            attempts += 1;
+            if !path.exists() || attempts >= 5 {
+                break;
+            }
+        }
+
+        assert!(!path.exists(), "temp file should be deleted after drop");
+    }
+
+    #[test]
+    fn temp_artifact_read_to_string_replaces_invalid_utf8() {
+        let artifact = TempArtifact::new_bytes("uselesskey-", ".unit.utf8", &[0xFF, 0xFE, 0xFD])
+            .expect("create TempArtifact");
+        let text = artifact.read_to_string().expect("read_to_string");
+        assert!(text.contains('\u{FFFD}'));
     }
 }


### PR DESCRIPTION
### Motivation
- Improve unit-test coverage for the public `sink::TempArtifact` wrapper to exercise lifecycle behavior and encoding edge-cases.
- Ensure the wrapper's behavior mirrors the internal tempfile-backed implementation: file exists while the artifact lives and is deleted on drop, and `read_to_string()` preserves replacement-character semantics for invalid UTF-8.

### Description
- Added imports for `std::thread` and `std::time::Duration` to support polling of filesystem cleanup in tests.
- Added `temp_artifact_exposes_live_path_and_deletes_on_drop` test that asserts `TempArtifact::path()` points to an existing file while alive and that the tempfile is removed after the wrapper is dropped.
- Added `temp_artifact_read_to_string_replaces_invalid_utf8` test that verifies `read_to_string()` surfaces the Unicode replacement character for invalid UTF-8 bytes via the public `sink::TempArtifact` API.
- Kept existing round-trip tests (`new_string` and `new_bytes`) intact to preserve basic coverage.

### Testing
- Ran the targeted unit test with `cargo test -p uselesskey-core temp_artifact_exposes_live_path_and_deletes_on_drop -- --nocapture`, which passed.
- Ran the module-level test filter with `cargo test -p uselesskey-core sink::mod::tests -- --nocapture`; the command executed in the CI-like workspace (initially produced zero selected tests due to filter matching), and the follow-up exact test run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5afcbd9c8333b7ca1ee227aacde8)