### PR TITLE
test(core): strengthen deterministic_from_str unit coverage

### DIFF
--- a/crates/uselesskey-core/src/srp/factory.rs
+++ b/crates/uselesskey-core/src/srp/factory.rs
@@ -462,4 +462,29 @@ mod tests {
             "seed must be redacted in debug output: {dbg}"
         );
     }
+
+    #[test]
+    fn deterministic_from_str_preserves_whitespace() {
+        let exact = Factory::deterministic_from_str(" seed-value ");
+        let trimmed = Factory::deterministic_from_str("seed-value");
+
+        let a: Arc<u64> = exact.get_or_init("domain:text", "label", b"spec", "good", draw_u64);
+        let b: Arc<u64> = trimmed.get_or_init("domain:text", "label", b"spec", "good", draw_u64);
+
+        assert_ne!(
+            *a, *b,
+            "deterministic_from_str should hash the text verbatim, including whitespace"
+        );
+    }
+
+    #[test]
+    fn deterministic_from_str_matches_seed_from_text() {
+        let from_str = Factory::deterministic_from_str("seed-value");
+        let from_seed = Factory::deterministic(Seed::from_text("seed-value"));
+
+        let a: Arc<u64> = from_str.get_or_init("domain:text", "label", b"spec", "good", draw_u64);
+        let b: Arc<u64> = from_seed.get_or_init("domain:text", "label", b"spec", "good", draw_u64);
+
+        assert_eq!(*a, *b);
+    }
 }


### PR DESCRIPTION
### Motivation
- Improve confidence in deterministic seed construction semantics for `Factory::deterministic_from_str` by exercising whitespace handling and parity with `Seed::from_text` in unit tests.

### Description
- Added two unit tests to `crates/uselesskey-core/src/srp/factory.rs`: `deterministic_from_str_preserves_whitespace` to assert surrounding whitespace is significant, and `deterministic_from_str_matches_seed_from_text` to assert equivalence with `Factory::deterministic(Seed::from_text(...))`.

### Testing
- Ran `cargo test -p uselesskey-core deterministic_from_` and both new tests (`deterministic_from_str_preserves_whitespace` and `deterministic_from_str_matches_seed_from_text`) passed; the package test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5afcbd9c8333b7ca1ee227aacde8)