### PR TITLE
test(core): strengthen error unit test coverage

### DIFF
--- a/crates/uselesskey-core/src/error.rs
+++ b/crates/uselesskey-core/src/error.rs
@@ -22,9 +22,10 @@ pub enum Error {
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::Error;
+    use std::error::Error as _;
 
     #[test]
-    fn error_messages_are_readable() {
+    fn missing_env_var_message_is_readable() {
         let missing = Error::MissingEnvVar {
             var: "MY_VAR".to_string(),
         };
@@ -32,7 +33,11 @@ mod tests {
             missing.to_string(),
             "environment variable `MY_VAR` is not set"
         );
+        assert!(missing.source().is_none());
+    }
 
+    #[test]
+    fn invalid_seed_message_is_readable() {
         let invalid = Error::InvalidSeed {
             var: "MY_VAR".to_string(),
             message: "bad seed".to_string(),
@@ -41,11 +46,15 @@ mod tests {
             invalid.to_string(),
             "failed to parse seed from environment variable `MY_VAR`: bad seed"
         );
+        assert!(invalid.source().is_none());
+    }
 
-        #[cfg(feature = "std")]
-        {
-            let io_err: Error = std::io::Error::other("io-fail").into();
-            assert_eq!(io_err.to_string(), "io-fail");
-        }
+    #[test]
+    fn io_error_variant_preserves_inner_error() {
+        let inner = std::io::Error::other("io-fail");
+        let io_err: Error = inner.into();
+
+        assert_eq!(io_err.to_string(), "io-fail");
+        assert!(io_err.source().is_none());
     }
 }


### PR DESCRIPTION
### Motivation

- Make `Error`-related unit tests more focused and actionable by verifying both `Display` output and current `source()` semantics for each variant.

### Description

- Split the single `error_messages_are_readable` test into three focused tests: `missing_env_var_message_is_readable`, `invalid_seed_message_is_readable`, and `io_error_variant_preserves_inner_error`.
- Add `use std::error::Error as _;` and explicit `source()` assertions to lock in the current error-chaining semantics (non-IO variants and the current IO conversion return no `source`).
- Rename and adjust assertions to reflect observed behavior of the `Io(#[from] std::io::Error)` conversion.

### Testing

- Ran `cargo test -p uselesskey-core error::tests --features std` and verified `3 passed; 0 failed` for the targeted tests.
- Executed the crate test harness where applicable; other test binaries were filtered by the selection and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5afcbd9c8333b7ca1ee227aacde8)