### PR TITLE
ops: start real workflow closure lane

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -1,28 +1,26 @@
-id = "uselesskey-downstream-ci-polish"
-title = "Downstream CI and installed-user polish"
-status = "archived"
+id = "uselesskey-real-workflow-closure"
+title = "Real workflow closure"
+status = "active"
 owner = "EffortlessMetrics"
 created = "2026-05-18"
 
 objective = """
-Make the installed bundle loop boring to run in downstream CI. Users should be
-able to install uselesskey, generate fixtures, verify and inspect bundles, audit
-the bundle with stable JSON/Markdown receipts, fail CI on meaningful drift, and
-understand each failure without learning repo-local proof machinery.
+Make uselesskey prove real user workflows, not just repo proof machinery.
+Downstream users should be able to solve deterministic valid/invalid fixture
+jobs for Rust tests, scanner-safe CI/platform bundles, and explicit
+materialization paths without learning the repo operating system.
 """
 
 end_state = [
-  "Bundle audit JSON has a documented stable schema and reference.",
-  "Installed audit commands expose CI-oriented behavior without shell parsing fragile prose.",
-  "Downstream GitHub Actions recipes show generate, verify, audit, and artifact handoff.",
-  "External adoption smoke can exercise documented downstream CI recipes explicitly.",
-  "Audit failure diagnostics are actionable while preserving stable machine-readable classes.",
-  "Installed CLI doctor covers user-local environment checks without repo-local proof tools.",
-  "Inspect and audit wording clearly separate quick summaries from durable receipts.",
-  "A downstream CI example proves the installed-user audit loop end to end.",
-  "Audit receipt golden tests protect schema shape, boundary language, and metadata-only posture.",
-  "Compact audit summaries keep terminal and CI logs readable.",
-  "The lane closes without release prep, version bump, tag, publish, new contract pack, or provider/security overclaims.",
+  "Real user workflows are specified for Rust developers, CI/platform users, and explicit materialization users.",
+  "Negative fixtures are a first-class taxonomy with deterministic shape, scanner-safety posture, downstream failure intent, tests, and task docs.",
+  "JWK/JWKS and token-shape negative fixture gaps are closed through taxonomy-backed implementation.",
+  "An OIDC/JWKS validator example proves a downstream auth-validation workflow with positive and negative cases.",
+  "The bundle product surface has a documented manifest and receipt contract before broad emitter expansion.",
+  "Bundle verification/scanner-safety/negative-coverage receipts are tightened without copying generated payloads.",
+  "Task-first fixture workflow docs route by user job instead of crate layout.",
+  "Public crate promises are audited so public crates have a direct downstream import story or candidate-internal status.",
+  "The lane closes without release prep, version bump, tag, publish, new contract packs, provider/security overclaims, scanner-evasion language, or broad refactors.",
 ]
 
 [[work_item]]
@@ -30,7 +28,7 @@ id = "lane-open"
 status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
+plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
@@ -39,102 +37,63 @@ commands = [
 ]
 
 [[work_item]]
-id = "bundle-audit-json-schema"
-status = "done"
+id = "real-user-workflow-spec"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0014"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-cli --all-features audit_bundle",
+  "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
   "cargo xtask typos",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "audit-bundle-ci-policy"
-status = "done"
+id = "negative-fixture-taxonomy-spec"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0014"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-cli --all-features audit_bundle",
-  "cargo xtask external-adoption-smoke --path . --format json",
-  "cargo +nightly xtask pr-lite",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "downstream-github-actions-recipes"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0014"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
-commands = [
+  "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
   "cargo xtask typos",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "external-smoke-ci-recipes"
-status = "done"
+id = "jwk-jwks-negative-wave"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0013"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
-  "cargo test -p xtask external_adoption_smoke",
-  "cargo xtask external-adoption-smoke --path . --ci-recipes --format json",
-  "cargo xtask adoption-regression --external",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "audit-failure-diagnostics"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0014"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
-commands = [
-  "cargo test -p uselesskey-cli --all-features audit_bundle",
-  "cargo xtask no-blob",
+  "cargo test -p uselesskey-jwk --all-features",
+  "cargo test -p uselesskey --all-features",
   "cargo +nightly xtask pr-lite",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "installed-cli-doctor"
-status = "done"
+id = "token-shape-negatives"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0012"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-cli --all-features doctor",
-  "cargo run -p uselesskey-cli -- doctor",
-  "cargo run -p uselesskey-cli -- doctor --format json",
+  "cargo test -p uselesskey-token --all-features",
+  "cargo test -p uselesskey --all-features",
   "cargo +nightly xtask pr-lite",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "inspect-audit-alignment"
-status = "done"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0014"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
-commands = [
-  "cargo test -p uselesskey-cli --all-features inspect audit_bundle",
-  "cargo xtask external-adoption-smoke --path .",
-  "cargo xtask docs-sync --check",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "downstream-ci-example"
-status = "done"
+id = "oidc-jwks-validator-example"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0013"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
+plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
   "cargo xtask external-adoption-smoke --path .",
   "cargo xtask adoption-regression --external",
@@ -142,36 +101,64 @@ commands = [
 ]
 
 [[work_item]]
-id = "audit-receipt-goldens"
-status = "done"
+id = "bundle-product-surface-spec"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/real-workflow-closure/implementation-plan.md"
+commands = [
+  "cargo xtask spec-check --strict",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "bundle-manifest-receipts"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0014"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
+plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-cli --all-features audit_bundle",
+  "cargo test -p uselesskey-cli --all-features bundle verify_bundle audit_bundle",
+  "cargo xtask external-adoption-smoke --path .",
   "cargo xtask no-blob",
   "cargo +nightly xtask pr-lite",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "audit-bundle-summary"
-status = "done"
+id = "task-first-docs-spec-and-guides"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0014"
-plan = "plans/downstream-ci-polish/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0005"
+plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-cli --all-features audit_bundle",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
   "cargo xtask external-adoption-smoke --path .",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "public-surface-discipline"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0002"
+plan = "plans/real-workflow-closure/implementation-plan.md"
+commands = [
+  "cargo xtask public-surface",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
   "git diff --check",
 ]
 
 [[work_item]]
 id = "lane-closeout"
-status = "done"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/downstream-ci-polish/closeout.md"
+plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
   "cargo xtask external-adoption-smoke --path . --format json",
   "cargo xtask adoption-regression --external",

--- a/plans/README.md
+++ b/plans/README.md
@@ -19,6 +19,7 @@ Plans do not define product truth. Link to proposals for why and specs for what.
 - [v0.10.0-external-adoption](v0.10.0-external-adoption/README.md) - External adoption and installed-user workflow buildout
 - [installed-bundle-audit](installed-bundle-audit/README.md) - Installed CLI bundle audit and reviewer handoff
 - [downstream-ci-polish](downstream-ci-polish/README.md) - Downstream CI and installed-user polish
+- [real-workflow-closure](real-workflow-closure/README.md) - Real user workflow closure for negative fixtures, bundle rails, task docs, and public surface discipline
 
 ## Templates
 

--- a/plans/real-workflow-closure/README.md
+++ b/plans/real-workflow-closure/README.md
@@ -1,0 +1,7 @@
+# Real Workflow Closure
+
+This lane makes `uselesskey` prove task-shaped downstream workflows instead of
+adding more proof machinery.
+
+- [implementation-plan.md](implementation-plan.md) - PR sequence, proof
+  commands, rollback notes, and stop conditions

--- a/plans/real-workflow-closure/implementation-plan.md
+++ b/plans/real-workflow-closure/implementation-plan.md
@@ -1,0 +1,334 @@
++++
+id = "USELESSKEY-PLAN-0024"
+kind = "plan"
+title = "Real workflow closure"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-18"
+milestone = "v0.10.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0002",
+  "USELESSKEY-SPEC-0003",
+  "USELESSKEY-SPEC-0005",
+  "USELESSKEY-SPEC-0009",
+  "USELESSKEY-SPEC-0011",
+  "USELESSKEY-SPEC-0013",
+  "USELESSKEY-SPEC-0014",
+]
+linked_adrs = [
+  "USELESSKEY-ADR-0001",
+  "USELESSKEY-ADR-0002",
+  "USELESSKEY-ADR-0003",
+  "USELESSKEY-ADR-0004",
+]
++++
+
+# Real Workflow Closure
+
+## Objective
+
+Make `uselesskey` feel less like a well-governed fixture repo and more like a
+tool users reach for when auth, TLS, token, webhook, or secret-shaped tests need
+deterministic valid and invalid artifacts.
+
+The target experience is:
+
+```text
+pick a job
+  -> copy one command or snippet
+    -> get valid and invalid fixture material
+      -> verify or audit the bundle
+        -> understand the proof boundary
+```
+
+This is a v0.10.0 product-quality buildout lane. It is not release
+preparation.
+
+## Scope
+
+This lane covers:
+
+- a real user workflow contract for Rust developer, CI/platform, and explicit
+  materialization paths;
+- a first-class negative fixture taxonomy;
+- taxonomy-backed JWK/JWKS and token-shape negative fixture gaps;
+- one downstream OIDC/JWKS validator workflow example;
+- a bundle product-surface spec for manifest and receipt contracts;
+- tighter bundle manifest and receipt proof where needed;
+- task-first docs for common fixture jobs;
+- public crate surface discipline so public crates remain user promises.
+
+## Planned Specs
+
+This lane adds the following specs in later PRs:
+
+```text
+USELESSKEY-SPEC-0015-real-user-workflows.md
+USELESSKEY-SPEC-0016-negative-fixture-taxonomy.md
+USELESSKEY-SPEC-0017-bundle-product-surface.md
+USELESSKEY-SPEC-0018-task-first-docs.md
+USELESSKEY-SPEC-0019-public-surface-discipline.md
+```
+
+The lane-open PR links only existing specs in front matter. Later spec PRs must
+update this plan and the active goal as each spec lands.
+
+## Non-goals
+
+Do not mix these into this lane:
+
+- v0.10.0 release prep;
+- version bumps;
+- tags or crates.io publish;
+- new contract packs before negative-fixture and bundle rails are stable;
+- new README badges;
+- shipper migration work;
+- provider compatibility claims;
+- production security claims;
+- scanner-evasion language;
+- installed CLI execution of `xtask` or claim-ledger commands;
+- broad SRP refactors;
+- dependency churn.
+
+## PR Sequence
+
+1. `ops: start real workflow closure lane`
+   - Open `.uselesskey/goals/active.toml` for this lane.
+   - Add this plan area.
+   - Update `plans/README.md`.
+   - Validation:
+
+     ```bash
+     cargo xtask spec-check --strict
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+2. `docs(spec): define real user workflow contract`
+   - Add `docs/specs/USELESSKEY-SPEC-0015-real-user-workflows.md`.
+   - Define Rust developer, CI/platform, and materialization workflows.
+   - Each workflow must have one copyable command or Rust snippet, one positive
+     case, one negative case, one verification command, one receipt or smoke
+     path, and one boundary.
+   - Validation:
+
+     ```bash
+     cargo xtask spec-check --strict
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+3. `docs(spec): define negative fixture taxonomy`
+   - Add `docs/specs/USELESSKEY-SPEC-0016-negative-fixture-taxonomy.md`.
+   - Cover JWK, JWKS, JWT/token, webhook, and X.509 negative fixture families.
+   - A negative fixture must be deterministic, scanner-safe unless explicitly
+     materialized, tied to a realistic downstream parser/verifier failure, tested
+     for intended shape, and documented by failure mode.
+   - Validation:
+
+     ```bash
+     cargo xtask spec-check --strict
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+4. `feat(jwk): add realistic JWK and JWKS negative fixtures`
+   - Implement only taxonomy-backed JWK/JWKS cases.
+   - Preserve deterministic fixture identity for existing fixtures.
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-jwk --all-features
+     cargo test -p uselesskey --all-features
+     cargo +nightly xtask pr-lite
+     git diff --check
+     ```
+
+5. `feat(token): add realistic token negative fixtures`
+   - Cover bad segment count, malformed base64url, `alg: none`, missing `kid`,
+     expired/`nbf`, bad `aud`/`iss`, and scanner-safe malformed bearer/API token
+     shapes where they match the taxonomy.
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-token --all-features
+     cargo test -p uselesskey --all-features
+     cargo +nightly xtask pr-lite
+     git diff --check
+     ```
+
+6. `examples: add OIDC JWKS validator workflow`
+   - Add a downstream-shaped OIDC/JWKS validator example with valid JWKS and
+     duplicate-kid, wrong-kty, and unsupported-alg negatives.
+   - Prove users can test auth validation without managing real keys.
+   - Validation:
+
+     ```bash
+     cargo xtask external-adoption-smoke --path .
+     cargo xtask adoption-regression --external
+     git diff --check
+     ```
+
+7. `docs(spec): define bundle product surface`
+   - Add `docs/specs/USELESSKEY-SPEC-0017-bundle-product-surface.md`.
+   - Define manifest and receipt contracts before broad emitter expansion.
+   - Do not implement every future emitter in this PR.
+   - Validation:
+
+     ```bash
+     cargo xtask spec-check --strict
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+8. `feat(cli): add bundle manifest verification receipt`
+   - Add or tighten `bundle-verification`, `scanner-safety`, and
+     `negative-coverage` receipts where the bundle product-surface spec requires
+     them.
+   - Keep receipts metadata-only.
+   - Validation:
+
+     ```bash
+     cargo test -p uselesskey-cli --all-features bundle verify_bundle audit_bundle
+     cargo xtask external-adoption-smoke --path .
+     cargo xtask no-blob
+     cargo +nightly xtask pr-lite
+     git diff --check
+     ```
+
+9. `docs: add task-first fixture workflows`
+   - Add `docs/specs/USELESSKEY-SPEC-0018-task-first-docs.md`.
+   - Add or update task-first how-tos for OIDC/JWKS validation, JWT claim
+     validation, scanner-safe Kubernetes secrets, build-time RSA
+     materialization, and bundle verification.
+   - Each page must include install/dependency line, copyable command or code,
+     expected output, scanner-safety note, failure mode, exact verification
+     command, and boundary.
+   - Validation:
+
+     ```bash
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     cargo xtask external-adoption-smoke --path .
+     git diff --check
+     ```
+
+10. `docs: define public crate surface promises`
+    - Add `docs/specs/USELESSKEY-SPEC-0019-public-surface-discipline.md`.
+    - Add a public surface matrix that answers who imports each public crate,
+      what job it solves, which docs prove that job, required feature flags, and
+      stability promise.
+    - Mark crates without a downstream import story as candidate-internal rather
+      than expanding user promises by accident.
+    - Validation:
+
+      ```bash
+      cargo xtask public-surface
+      cargo xtask docs-sync --check
+      cargo xtask typos
+      git diff --check
+      ```
+
+11. `docs: close out real workflow closure lane`
+    - Add `plans/real-workflow-closure/closeout.md`.
+    - Add `docs/learnings/2026-05-real-workflow-closure.md`.
+    - Archive `.uselesskey/goals/active.toml`.
+    - Validation:
+
+      ```bash
+      cargo xtask external-adoption-smoke --path . --format json
+      cargo xtask adoption-regression --external
+      cargo xtask claim-report --check-public-claims
+      cargo xtask contract-packs --check
+      cargo xtask check-no-panic-family
+      cargo xtask docs-sync --check
+      cargo xtask typos
+      cargo +nightly xtask pr-lite
+      cargo xtask pr
+      git diff --check
+      ```
+
+## Review Rails
+
+Every PR should make these points explicit:
+
+```text
+User path:
+  What user job does this improve?
+
+Boundary:
+  What does this not prove?
+
+Proof:
+  Which command proves it?
+
+Receipts:
+  Which artifact changed or was added?
+
+Risk:
+  Does this change deterministic fixture identity?
+
+Rollback:
+  Can this PR be reverted without invalidating later receipts?
+```
+
+## Acceptance
+
+The lane is complete when a user can:
+
+- pick a Rust test, CI/platform bundle, or materialization job;
+- copy one command or snippet;
+- get deterministic valid and invalid fixture material;
+- verify or audit the generated bundle;
+- attach metadata-only receipts when needed;
+- understand scanner-safety and "does not prove" boundaries without learning
+  the repo operating system.
+
+## Proof Commands
+
+Docs-only lane setup:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Implementation and closeout proof:
+
+```bash
+cargo xtask external-adoption-smoke --path . --format json
+cargo xtask adoption-regression --external
+cargo +nightly xtask pr-lite
+cargo xtask pr
+git diff --check
+```
+
+## Rollback
+
+Before code lands, revert the lane-open PR or archive the active goal with a
+superseded closeout note.
+
+After implementation lands, revert the smallest failing PR. Do not loosen
+deterministic fixture identity, scanner-safe defaults, metadata-only receipts,
+or claim boundaries to keep the lane moving.
+
+## Stop Conditions
+
+Pause or split the lane if:
+
+- the work starts preparing or cutting v0.10.0;
+- a proof command requires a version bump, tag, publish, or shipper migration;
+- a doc or implementation implies provider compatibility, production security,
+  or scanner-evasion behavior;
+- an installed CLI command needs to execute repo-local `xtask` or claim-ledger
+  commands;
+- a receipt needs to copy generated secret-shaped payloads;
+- new contract packs, badges, dependency churn, or broad refactors become
+  necessary.


### PR DESCRIPTION
Summary
- Open the real workflow closure lane as the next active repo goal.
- Add the PR sequence for real workflow specs, negative fixture taxonomy, JWK/JWKS and token negative waves, bundle product rails, task-first docs, and public-surface discipline.
- Update the plan index with the new lane area.

Files added/changed
- `.uselesskey/goals/active.toml`
- `plans/real-workflow-closure/README.md`
- `plans/real-workflow-closure/implementation-plan.md`
- `plans/README.md`

User path
- This starts the lane that moves uselesskey from repo proof toward task-shaped workflows: Rust tests, CI/platform bundles, and explicit materialization.

Boundary
- This PR does not add new fixture behavior, release prep, version bumps, tags, publishing, new contract packs, provider compatibility claims, production security claims, scanner-evasion language, or dependency churn.

Proof
- `cargo xtask spec-check --strict`
- `cargo xtask docs-sync --check`
- `cargo xtask typos`
- `git diff --check`

Receipts
- Active goal now points at `plans/real-workflow-closure/implementation-plan.md`.
- Plan index includes `plans/real-workflow-closure/README.md`.

Risk
- No deterministic fixture identity changes. Docs/control-plane only.

Rollback
- Revert this PR to restore the archived downstream CI polish active-goal state and remove the new plan area.

Non-goals
- No v0.10.0 release prep, version bump, tag, publish, new badges, shipper work, or broad refactors.

What this enables next
- The next PR can add `USELESSKEY-SPEC-0015-real-user-workflows.md` against an active lane instead of relying on chat state.