### PR TITLE
feat(jwk): add taxonomy-backed negative fixtures

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -64,7 +64,7 @@ commands = [
 
 [[work_item]]
 id = "jwk-jwks-negative-wave"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0016"
 plan = "plans/real-workflow-closure/implementation-plan.md"
@@ -77,7 +77,7 @@ commands = [
 
 [[work_item]]
 id = "token-shape-negatives"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0016"
 plan = "plans/real-workflow-closure/implementation-plan.md"

--- a/crates/uselesskey-jwk/README.md
+++ b/crates/uselesskey-jwk/README.md
@@ -25,6 +25,13 @@ assert_eq!(jwks.keys.len(), 1);
 
 let duplicate = jwks.negative_value(uselesskey_jwk::NegativeJwks::DuplicateKey);
 assert_eq!(duplicate["keys"].as_array().unwrap().len(), 2);
+
+let mixed = jwks.negative_value(uselesskey_jwk::NegativeJwks::MixedValidInvalid);
+assert_eq!(
+    uselesskey_jwk::NegativeJwks::MixedValidInvalid.stable_id(),
+    "jwks_mixed_valid_invalid"
+);
+assert_eq!(mixed["keys"].as_array().unwrap().len(), 2);
 ```
 
 ## License

--- a/crates/uselesskey-jwk/src/srp/shape.rs
+++ b/crates/uselesskey-jwk/src/srp/shape.rs
@@ -79,6 +79,13 @@ impl Jwks {
                 let first = first_or_scanner_safe_key(&keys, "duplicate-key");
                 vec![first.clone(), first]
             }
+            NegativeJwks::MixedValidInvalid => {
+                let valid = first_or_scanner_safe_key(&keys, "mixed-valid");
+                let mut invalid = valid.clone();
+                set_string_field(&mut invalid, "kid", "mixed-invalid");
+                let invalid = negative_jwk_value(invalid, NegativeJwk::MalformedBase64url);
+                vec![valid, invalid]
+            }
         };
 
         json!({ "keys": negative_keys })
@@ -99,12 +106,29 @@ pub enum NegativeJwk {
     MissingKid,
     /// Replace one material field with scanner-safe invalid base64url text.
     MalformedField,
+    /// Replace one material field with scanner-safe invalid base64url text.
+    MalformedBase64url,
     /// Replace `kty` with a key type that does not match the material fields.
     WrongKty,
     /// Replace `alg` with an unsupported algorithm name.
     UnsupportedAlg,
     /// Change one material parameter while preserving the metadata shape.
     MismatchedParameters,
+}
+
+impl NegativeJwk {
+    /// Stable taxonomy identifier for manifests, docs, and receipts.
+    pub fn stable_id(self) -> &'static str {
+        match self {
+            NegativeJwk::MissingKid => "jwk_missing_kid",
+            NegativeJwk::MalformedField | NegativeJwk::MalformedBase64url => {
+                "jwk_malformed_base64url"
+            }
+            NegativeJwk::WrongKty => "jwk_wrong_kty",
+            NegativeJwk::UnsupportedAlg => "jwk_unsupported_alg",
+            NegativeJwk::MismatchedParameters => "jwk_mismatched_parameters",
+        }
+    }
 }
 
 /// Negative JWKS shape variants for downstream key-set tests.
@@ -118,6 +142,21 @@ pub enum NegativeJwks {
     DuplicateKid,
     /// Emit the same key twice.
     DuplicateKey,
+    /// Emit one valid key and one malformed key in the same set.
+    MixedValidInvalid,
+}
+
+impl NegativeJwks {
+    /// Stable taxonomy identifier for manifests, docs, and receipts.
+    pub fn stable_id(self) -> &'static str {
+        match self {
+            NegativeJwks::EmptyKeys => "jwks_empty_keys",
+            NegativeJwks::MissingKid => "jwks_missing_kid",
+            NegativeJwks::DuplicateKid => "jwks_duplicate_kid",
+            NegativeJwks::DuplicateKey => "jwks_duplicate_key",
+            NegativeJwks::MixedValidInvalid => "jwks_mixed_valid_invalid",
+        }
+    }
 }
 
 /// RSA public key in JWK format (contains `n` and `e`).
@@ -451,7 +490,7 @@ fn negative_jwk_value(mut value: Value, variant: NegativeJwk) -> Value {
                 obj.remove("kid");
             }
         }
-        NegativeJwk::MalformedField => {
+        NegativeJwk::MalformedField | NegativeJwk::MalformedBase64url => {
             set_first_material_field(
                 &mut value,
                 &["n", "e", "x", "y", "k", "d", "p", "q", "dp", "dq", "qi"],

--- a/crates/uselesskey-jwk/tests/jwk_extra_coverage.rs
+++ b/crates/uselesskey-jwk/tests/jwk_extra_coverage.rs
@@ -6,6 +6,7 @@
 //!   (RSA, EC, OKP, Oct) with branch-focused coverage for representative
 //!   `NegativeJwk` variants and field lookup orders.
 //! - `NegativeJwks::DuplicateKey` on a populated set (the no-empty-source path).
+//! - Taxonomy stable IDs and mixed valid/invalid JWKS shape.
 
 use serde_json::Value;
 use uselesskey_jwk::srp::ordering::{HasKid, KidSorted};
@@ -213,6 +214,9 @@ fn public_ec_negative_variants_all_supported() {
     assert_kid_present(&bad, "ec-pub");
     assert_eq!(bad["x"], SCANNER_INVALID);
 
+    let bad_named = mk().negative_value(NegativeJwk::MalformedBase64url);
+    assert_eq!(bad_named, bad);
+
     let wrong = mk().negative_value(NegativeJwk::WrongKty);
     assert_kid_present(&wrong, "ec-pub");
     assert_eq!(wrong["kty"], "RSA");
@@ -344,4 +348,59 @@ fn negative_jwks_duplicate_key_on_populated_set_repeats_first_entry() -> TestRes
     // The duplicate uses the first key in the set, not the second.
     assert_eq!(keys[0]["kid"], "primary");
     Ok(())
+}
+
+#[test]
+fn negative_jwks_mixed_valid_invalid_keeps_one_valid_and_one_malformed_key() -> TestResult<()> {
+    let jwks = Jwks {
+        keys: vec![AnyJwk::from(rsa_public("valid-key"))],
+    };
+
+    let value = jwks.negative_value(NegativeJwks::MixedValidInvalid);
+    let keys = require_some(value["keys"].as_array(), "keys array")?;
+
+    assert_eq!(keys.len(), 2);
+    assert_eq!(keys[0]["kid"], "valid-key");
+    assert_eq!(keys[0]["n"], "n-value");
+    assert_eq!(keys[1]["kid"], "mixed-invalid");
+    assert_eq!(keys[1]["n"], SCANNER_INVALID);
+    assert_ne!(keys[0], keys[1]);
+    Ok(())
+}
+
+#[test]
+fn taxonomy_stable_ids_match_spec_0016() {
+    assert_eq!(NegativeJwk::MissingKid.stable_id(), "jwk_missing_kid");
+    assert_eq!(
+        NegativeJwk::MalformedField.stable_id(),
+        "jwk_malformed_base64url"
+    );
+    assert_eq!(
+        NegativeJwk::MalformedBase64url.stable_id(),
+        "jwk_malformed_base64url"
+    );
+    assert_eq!(NegativeJwk::WrongKty.stable_id(), "jwk_wrong_kty");
+    assert_eq!(
+        NegativeJwk::UnsupportedAlg.stable_id(),
+        "jwk_unsupported_alg"
+    );
+    assert_eq!(
+        NegativeJwk::MismatchedParameters.stable_id(),
+        "jwk_mismatched_parameters"
+    );
+
+    assert_eq!(NegativeJwks::EmptyKeys.stable_id(), "jwks_empty_keys");
+    assert_eq!(NegativeJwks::MissingKid.stable_id(), "jwks_missing_kid");
+    assert_eq!(
+        NegativeJwks::DuplicateKid.stable_id(),
+        "jwks_duplicate_kid"
+    );
+    assert_eq!(
+        NegativeJwks::DuplicateKey.stable_id(),
+        "jwks_duplicate_key"
+    );
+    assert_eq!(
+        NegativeJwks::MixedValidInvalid.stable_id(),
+        "jwks_mixed_valid_invalid"
+    );
 }

--- a/crates/uselesskey-jwk/tests/jwk_extra_coverage.rs
+++ b/crates/uselesskey-jwk/tests/jwk_extra_coverage.rs
@@ -391,14 +391,8 @@ fn taxonomy_stable_ids_match_spec_0016() {
 
     assert_eq!(NegativeJwks::EmptyKeys.stable_id(), "jwks_empty_keys");
     assert_eq!(NegativeJwks::MissingKid.stable_id(), "jwks_missing_kid");
-    assert_eq!(
-        NegativeJwks::DuplicateKid.stable_id(),
-        "jwks_duplicate_kid"
-    );
-    assert_eq!(
-        NegativeJwks::DuplicateKey.stable_id(),
-        "jwks_duplicate_key"
-    );
+    assert_eq!(NegativeJwks::DuplicateKid.stable_id(), "jwks_duplicate_kid");
+    assert_eq!(NegativeJwks::DuplicateKey.stable_id(), "jwks_duplicate_key");
     assert_eq!(
         NegativeJwks::MixedValidInvalid.stable_id(),
         "jwks_mixed_valid_invalid"


### PR DESCRIPTION
## Summary
- add taxonomy stable IDs for `NegativeJwk` and `NegativeJwks`
- add explicit `MalformedBase64url` naming while keeping `MalformedField` as the compatibility path for the same generated shape
- add `NegativeJwks::MixedValidInvalid` for a realistic key-set negative containing one valid key and one malformed key
- update tests and README coverage, then advance the lane goal to the token-shape negative wave

## User path
Rust developers can now generate and name taxonomy-backed JWK/JWKS negative fixtures for downstream parser/verifier tests without hand-rolling broken key shapes.

## Boundary
This does not add an OIDC provider compatibility claim, change contract-pack files, add production security claims, or change existing positive fixture derivation.

## Proof
- `cargo test -p uselesskey-jwk --all-features`
- `cargo test -p uselesskey --all-features`
- `cargo +nightly xtask pr-lite`
- `git diff --check`

## Receipts
- `NegativeJwk::stable_id()` / `NegativeJwks::stable_id()` expose SPEC-0016 names
- JWK tests cover the stable IDs and mixed valid/invalid JWKS shape

## Risk
This adds public enum surface for a new JWKS negative and a named malformed-base64url variant. Existing generated negative values and positive deterministic fixture identity are unchanged.

## Rollback
This PR can be reverted independently; later token and bundle work should continue from SPEC-0016 without relying on this branch until merged.