### PR TITLE
feat(token): add taxonomy-backed missing-kid negative

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -77,7 +77,7 @@ commands = [
 
 [[work_item]]
 id = "token-shape-negatives"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0016"
 plan = "plans/real-workflow-closure/implementation-plan.md"
@@ -90,7 +90,7 @@ commands = [
 
 [[work_item]]
 id = "oidc-jwks-validator-example"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0015"
 plan = "plans/real-workflow-closure/implementation-plan.md"

--- a/crates/uselesskey-token/README.md
+++ b/crates/uselesskey-token/README.md
@@ -42,9 +42,12 @@ assert!(bearer.authorization_header().starts_with("Bearer "));
 assert_eq!(oauth.value().split('.').count(), 3);
 
 let expired = oauth.negative_value(NegativeToken::ExpiredClaims);
+let missing_kid = oauth.negative_value(NegativeToken::MissingKid);
 let near_miss_api_key = api_key.negative_value(NegativeToken::NearMissApiKey);
 
 assert_eq!(expired.split('.').count(), 3);
+assert_eq!(missing_kid.split('.').count(), 3);
+assert_eq!(NegativeToken::MissingKid.stable_id(), "jwt_missing_kid");
 assert!(near_miss_api_key.starts_with("uk_tset_"));
 assert!(!near_miss_api_key.starts_with("uk_test_"));
 ```

--- a/crates/uselesskey-token/src/srp/shape.rs
+++ b/crates/uselesskey-token/src/srp/shape.rs
@@ -80,6 +80,8 @@ pub enum NegativeToken {
     MissingAlg,
     /// Set the JWT header algorithm to `none`.
     AlgNone,
+    /// Omit `kid` from the JWT header while keeping key-selection context.
+    MissingKid,
     /// Emit different `kid` values in the header and payload.
     MismatchedKid,
     /// Set an already-expired `exp` claim.
@@ -105,6 +107,7 @@ impl NegativeToken {
             Self::InvalidJwtHeaderShape => "invalid_jwt_header_shape",
             Self::MissingAlg => "missing_alg",
             Self::AlgNone => "alg_none",
+            Self::MissingKid => "missing_kid",
             Self::MismatchedKid => "mismatched_kid",
             Self::ExpiredClaims => "expired_claims",
             Self::NotYetValidClaims => "not_yet_valid_claims",
@@ -112,6 +115,25 @@ impl NegativeToken {
             Self::BadAudience => "bad_audience",
             Self::MalformedBearer => "malformed_bearer",
             Self::NearMissApiKey => "near_miss_api_key",
+        }
+    }
+
+    /// Stable taxonomy identifier for docs, manifests, and receipts.
+    pub const fn stable_id(&self) -> &'static str {
+        match self {
+            Self::MalformedJwtSegmentCount => "jwt_bad_segment_count",
+            Self::BadBase64UrlSegment => "jwt_malformed_base64url",
+            Self::InvalidJwtHeaderShape => "jwt_invalid_header_shape",
+            Self::MissingAlg => "jwt_missing_alg",
+            Self::AlgNone => "jwt_alg_none",
+            Self::MissingKid => "jwt_missing_kid",
+            Self::MismatchedKid => "jwt_mismatched_kid",
+            Self::ExpiredClaims => "jwt_expired",
+            Self::NotYetValidClaims => "jwt_not_yet_valid",
+            Self::BadIssuer => "jwt_bad_issuer",
+            Self::BadAudience => "jwt_bad_audience",
+            Self::MalformedBearer => "token_malformed_bearer",
+            Self::NearMissApiKey => "token_near_miss",
         }
     }
 }
@@ -138,6 +160,7 @@ pub fn generate_negative_token(
         NegativeToken::InvalidJwtHeaderShape => invalid_jwt_header_shape(label, seed),
         NegativeToken::MissingAlg => missing_alg(label, seed),
         NegativeToken::AlgNone => alg_none(label, seed),
+        NegativeToken::MissingKid => missing_kid(label, seed),
         NegativeToken::MismatchedKid => mismatched_kid(label, seed),
         NegativeToken::ExpiredClaims => token_with_payload_claim(label, seed, "exp", json!(1u64)),
         NegativeToken::NotYetValidClaims => not_yet_valid_claims(label, seed),
@@ -223,6 +246,14 @@ fn missing_alg(label: &str, seed: Seed) -> String {
 
 fn alg_none(label: &str, seed: Seed) -> String {
     token_with_header_claim(label, seed, "alg", json!("none"))
+}
+
+fn missing_kid(label: &str, seed: Seed) -> String {
+    let parts = JwtParts::generated(label, seed);
+    let mut payload = parts.payload_object();
+    payload.insert("kid".to_string(), json!("expected-kid"));
+
+    parts.with_payload_object(payload).into_token()
 }
 
 fn mismatched_kid(label: &str, seed: Seed) -> String {
@@ -441,6 +472,7 @@ mod tests {
         );
         assert_eq!(NegativeToken::MissingAlg.variant_name(), "missing_alg");
         assert_eq!(NegativeToken::AlgNone.variant_name(), "alg_none");
+        assert_eq!(NegativeToken::MissingKid.variant_name(), "missing_kid");
         assert_eq!(
             NegativeToken::MismatchedKid.variant_name(),
             "mismatched_kid"
@@ -463,6 +495,41 @@ mod tests {
             NegativeToken::NearMissApiKey.variant_name(),
             "near_miss_api_key"
         );
+    }
+
+    #[test]
+    fn negative_token_stable_ids_match_taxonomy() {
+        assert_eq!(
+            NegativeToken::MalformedJwtSegmentCount.stable_id(),
+            "jwt_bad_segment_count"
+        );
+        assert_eq!(
+            NegativeToken::BadBase64UrlSegment.stable_id(),
+            "jwt_malformed_base64url"
+        );
+        assert_eq!(
+            NegativeToken::InvalidJwtHeaderShape.stable_id(),
+            "jwt_invalid_header_shape"
+        );
+        assert_eq!(NegativeToken::MissingAlg.stable_id(), "jwt_missing_alg");
+        assert_eq!(NegativeToken::AlgNone.stable_id(), "jwt_alg_none");
+        assert_eq!(NegativeToken::MissingKid.stable_id(), "jwt_missing_kid");
+        assert_eq!(
+            NegativeToken::MismatchedKid.stable_id(),
+            "jwt_mismatched_kid"
+        );
+        assert_eq!(NegativeToken::ExpiredClaims.stable_id(), "jwt_expired");
+        assert_eq!(
+            NegativeToken::NotYetValidClaims.stable_id(),
+            "jwt_not_yet_valid"
+        );
+        assert_eq!(NegativeToken::BadIssuer.stable_id(), "jwt_bad_issuer");
+        assert_eq!(NegativeToken::BadAudience.stable_id(), "jwt_bad_audience");
+        assert_eq!(
+            NegativeToken::MalformedBearer.stable_id(),
+            "token_malformed_bearer"
+        );
+        assert_eq!(NegativeToken::NearMissApiKey.stable_id(), "token_near_miss");
     }
 
     #[test]
@@ -602,6 +669,26 @@ mod tests {
         assert_eq!(payload["sub"], "svc");
         assert_eq!(payload["kid"], "expected-kid");
         assert_ne!(header["kid"], payload["kid"]);
+    }
+
+    #[test]
+    fn negative_missing_kid_keeps_payload_key_context() {
+        let value = generate_negative_token(
+            "svc",
+            TokenKind::OAuthAccessToken,
+            Seed::new([41u8; 32]),
+            NegativeToken::MissingKid,
+        );
+        let parts = jwt_parts(&value);
+        let header = decode_object_segment(parts[0]);
+        let payload = decode_object_segment(parts[1]);
+
+        assert_eq!(parts.len(), 3);
+        assert_eq!(header["alg"], "RS256");
+        assert_eq!(header["typ"], "JWT");
+        assert!(header.get("kid").is_none());
+        assert_eq!(payload["sub"], "svc");
+        assert_eq!(payload["kid"], "expected-kid");
     }
 
     #[test]

--- a/crates/uselesskey-token/tests/negative_value_variants.rs
+++ b/crates/uselesskey-token/tests/negative_value_variants.rs
@@ -1,9 +1,10 @@
 //! Integration coverage for `TokenFixture::negative_value` variants.
 //!
-//! `negative_fixtures.rs` exercises 5 of the 12 `NegativeToken` variants at the
+//! `negative_fixtures.rs` exercises 5 of the 13 `NegativeToken` variants at the
 //! public `TokenFixture` layer. The remaining JWT-shaped variants
 //! (`MalformedJwtSegmentCount`, `BadBase64UrlSegment`, `InvalidJwtHeaderShape`,
-//! `MissingAlg`, `AlgNone`, `MismatchedKid`, `NotYetValidClaims`) are only
+//! `MissingAlg`, `AlgNone`, `MissingKid`, `MismatchedKid`,
+//! `NotYetValidClaims`) are only
 //! covered by inline tests against the internal `generate_negative_token`
 //! function. These tests close that gap and additionally verify:
 //!
@@ -123,6 +124,31 @@ fn alg_none_only_changes_alg_field() -> TestResult<()> {
 }
 
 #[test]
+fn missing_kid_drops_header_kid_but_keeps_payload_context() -> TestResult<()> {
+    let fx = Factory::deterministic_from_str("token-neg-missing-kid");
+    let token = fx.token("issuer", TokenSpec::oauth_access_token());
+
+    let value = token.negative_value(NegativeToken::MissingKid);
+    let parts = split_segments(&value);
+    let header = decode_object(parts[0])?;
+    let payload = decode_object(parts[1])?;
+
+    ensure_eq!(parts.len(), 3);
+    ensure_eq!(header.get("alg"), Some(&Value::String("RS256".into())));
+    ensure_eq!(header.get("typ"), Some(&Value::String("JWT".into())));
+    ensure!(
+        !header.contains_key("kid"),
+        "header kid must be absent for missing-kid negative"
+    );
+    ensure_eq!(
+        payload.get("kid"),
+        Some(&Value::String("expected-kid".into()))
+    );
+    ensure!(value != token.value(), "negative value must differ");
+    Ok(())
+}
+
+#[test]
 fn mismatched_kid_puts_different_kid_in_header_and_payload() -> TestResult<()> {
     let fx = Factory::deterministic_from_str("token-neg-mismatched-kid");
     let token = fx.token("issuer", TokenSpec::oauth_access_token());
@@ -171,6 +197,7 @@ fn negative_value_is_deterministic_across_factories_for_all_variants() -> TestRe
         NegativeToken::InvalidJwtHeaderShape,
         NegativeToken::MissingAlg,
         NegativeToken::AlgNone,
+        NegativeToken::MissingKid,
         NegativeToken::MismatchedKid,
         NegativeToken::NotYetValidClaims,
     ];
@@ -196,6 +223,7 @@ fn negative_value_does_not_perturb_positive_token_value() -> TestResult<()> {
         NegativeToken::InvalidJwtHeaderShape,
         NegativeToken::MissingAlg,
         NegativeToken::AlgNone,
+        NegativeToken::MissingKid,
         NegativeToken::MismatchedKid,
         NegativeToken::NotYetValidClaims,
     ];
@@ -253,6 +281,7 @@ fn distinct_negative_variants_yield_distinct_outputs() -> TestResult<()> {
         NegativeToken::InvalidJwtHeaderShape,
         NegativeToken::MissingAlg,
         NegativeToken::AlgNone,
+        NegativeToken::MissingKid,
         NegativeToken::MismatchedKid,
         NegativeToken::NotYetValidClaims,
     ];

--- a/docs/reference/failure-atlas.md
+++ b/docs/reference/failure-atlas.md
@@ -32,6 +32,7 @@ test.
 | `tokens/negative-alg-none.json` | insecure algorithm | validator rejects `alg: none` or refuses unsigned-token policy | `uselesskey bundle --profile oidc` |
 | `tokens/negative-bad-audience.json` | authorization failure | validator rejects the wrong `aud` claim | `uselesskey bundle --profile oidc` |
 | `NegativeToken::AlgNone` | insecure algorithm in Rust tests | validator rejects an unsigned-algorithm header | `uselesskey-token` or facade `token` feature |
+| `NegativeToken::MissingKid` | key identification failure in Rust tests | key-selection code rejects a JWT without a header `kid` | `uselesskey-token` or facade `token` feature |
 | `NegativeToken::BadAudience` | authorization failure in Rust tests | validator rejects a token with the wrong audience | `uselesskey-token` or facade `token` feature |
 | `NegativeToken::NearMissApiKey` | scanner-safe parser test | parser rejects a token-like value that is close to, but not, the real test prefix | `uselesskey-token` or facade `token` feature |
 


### PR DESCRIPTION
## Summary
- add `NegativeToken::MissingKid` for deterministic JWT-shaped missing-header-kid fixtures
- add `NegativeToken::stable_id()` values that align token negatives with SPEC-0016 taxonomy IDs
- cover the new public `TokenFixture::negative_value` path, README example, and failure atlas row
- advance the real workflow goal to the OIDC/JWKS validator example slice

## User path
Rust developers can request a deterministic missing-`kid` JWT-shaped negative through the token fixture API, then use it to exercise verifier rejection paths without changing positive token fixtures.

## Boundary
This does not change positive token derivation, OIDC bundle layout, provider compatibility claims, production security claims, or scanner-evasion posture.

## Proof
- `cargo test -p uselesskey-token --all-features`
- `cargo test -p uselesskey --all-features`
- `cargo fmt --all -- --check`
- `cargo +nightly xtask pr-lite`
- `git diff --check`

## Receipts
`NegativeToken::stable_id()` now exposes taxonomy-backed IDs, and tests cover the missing-kid token shape, deterministic output, positive cache isolation, and distinct negative output.

## Risk
This adds a public enum variant and public helper method. Existing `variant_name()` strings and positive token fixture identity are unchanged.

## Rollback
The PR can be reverted independently before the OIDC/JWKS validator workflow consumes the missing-kid negative.