### PR TITLE
examples: add OIDC JWKS validator workflow

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -90,7 +90,7 @@ commands = [
 
 [[work_item]]
 id = "oidc-jwks-validator-example"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0015"
 plan = "plans/real-workflow-closure/implementation-plan.md"
@@ -102,7 +102,7 @@ commands = [
 
 [[work_item]]
 id = "bundle-product-surface-spec"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/real-workflow-closure/implementation-plan.md"

--- a/docs/how-to/test-oidc-jwks-validation.md
+++ b/docs/how-to/test-oidc-jwks-validation.md
@@ -70,6 +70,10 @@ assert!(validator_rejects(duplicate_kid));
 Replace `validator_rejects` with the downstream validator assertion. The useful
 assertion is the validator's rejection reason, not just that JSON parsing failed.
 
+For a clean-project example that does this with a tiny downstream validator, see
+`examples/external/oidc-jwks-validation/`. It accepts the valid JWKS and rejects
+duplicate-`kid`, wrong-`kty`, unsupported-`alg`, and missing-`kid` negatives.
+
 ## Scanner-safety note
 
 The OIDC profile is scanner-safe by default. It is intended for key-set parsing,

--- a/examples/external/oidc-jwks-validation/Cargo.toml
+++ b/examples/external/oidc-jwks-validation/Cargo.toml
@@ -6,5 +6,6 @@ publish = false
 
 [dependencies]
 uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk"] }
+serde_json = "1"
 
 [workspace]

--- a/examples/external/oidc-jwks-validation/README.md
+++ b/examples/external/oidc-jwks-validation/README.md
@@ -7,6 +7,14 @@ deterministic JWKS shapes plus key-selection negatives.
 cargo test
 ```
 
+The example models a small downstream JWKS validator. It accepts a valid RSA
+JWKS and rejects taxonomy-backed fixture shapes for:
+
+- duplicate `kid`
+- wrong `kty`
+- unsupported `alg`
+- missing `kid`
+
 Installed CLI bundle audit path:
 
 ```bash
@@ -14,6 +22,7 @@ uselesskey bundle --profile oidc --out target/uselesskey-oidc
 uselesskey audit-bundle --path target/uselesskey-oidc --out target/uselesskey-oidc-audit
 ```
 
-This proves fixture shape and negative input generation for validator tests. It
-does not prove OpenID discovery behavior, production signing-key custody, issuer
-policy, or downstream validator correctness.
+This proves fixture shape and negative input generation for validator tests, and
+shows how a downstream validator can assert specific rejection classes. It does
+not prove OpenID discovery behavior, production signing-key custody, issuer
+policy, provider compatibility, or production verifier correctness.

--- a/examples/external/oidc-jwks-validation/src/lib.rs
+++ b/examples/external/oidc-jwks-validation/src/lib.rs
@@ -1,23 +1,50 @@
-use uselesskey::jwk::NegativeJwks;
-use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
+use std::collections::BTreeSet;
 
-#[test]
-fn oidc_jwks_fixtures_cover_valid_and_negative_key_sets() {
-    let fx = Factory::deterministic_from_str("external-oidc-jwks");
-    let issuer = fx.rsa("issuer", RsaSpec::rs256());
-    let jwks = issuer.public_jwks();
-    let valid = jwks.to_value();
+use serde_json::Value;
 
-    let keys = valid["keys"].as_array();
-    assert_eq!(keys.map(Vec::len), Some(1));
-    assert_eq!(valid["keys"][0]["kty"], "RSA");
-    assert!(valid["keys"][0]["kid"].as_str().is_some_and(|kid| !kid.is_empty()));
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum JwksValidationError {
+    MissingKeys,
+    EmptyKeys,
+    MissingKid,
+    DuplicateKid,
+    WrongKty,
+    UnsupportedAlg,
+    MissingMaterial,
+}
 
-    let duplicate_kid = jwks.negative_value(NegativeJwks::DuplicateKid);
-    let duplicate_keys = duplicate_kid["keys"].as_array();
-    assert_eq!(duplicate_keys.map(Vec::len), Some(2));
-    assert_eq!(duplicate_kid["keys"][0]["kid"], duplicate_kid["keys"][1]["kid"]);
+pub fn validate_oidc_jwks(jwks: &Value) -> Result<(), JwksValidationError> {
+    let keys = jwks
+        .get("keys")
+        .and_then(Value::as_array)
+        .ok_or(JwksValidationError::MissingKeys)?;
+    if keys.is_empty() {
+        return Err(JwksValidationError::EmptyKeys);
+    }
 
-    let missing_kid = jwks.negative_value(NegativeJwks::MissingKid);
-    assert!(missing_kid["keys"][0].get("kid").is_none());
+    let mut kids = BTreeSet::new();
+    for key in keys {
+        let kid = key
+            .get("kid")
+            .and_then(Value::as_str)
+            .filter(|kid| !kid.is_empty())
+            .ok_or(JwksValidationError::MissingKid)?;
+        if !kids.insert(kid.to_string()) {
+            return Err(JwksValidationError::DuplicateKid);
+        }
+
+        if key.get("kty").and_then(Value::as_str) != Some("RSA") {
+            return Err(JwksValidationError::WrongKty);
+        }
+        if key.get("alg").and_then(Value::as_str) != Some("RS256") {
+            return Err(JwksValidationError::UnsupportedAlg);
+        }
+        if key.get("n").and_then(Value::as_str).is_none()
+            || key.get("e").and_then(Value::as_str).is_none()
+        {
+            return Err(JwksValidationError::MissingMaterial);
+        }
+    }
+
+    Ok(())
 }

--- a/examples/external/oidc-jwks-validation/tests/validator_workflow.rs
+++ b/examples/external/oidc-jwks-validation/tests/validator_workflow.rs
@@ -1,0 +1,64 @@
+use serde_json::json;
+use uselesskey::jwk::{NegativeJwk, NegativeJwks};
+use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
+use uselesskey_external_oidc_jwks_validation::{JwksValidationError, validate_oidc_jwks};
+
+fn issuer() -> uselesskey::RsaKeyPair {
+    let fx = Factory::deterministic_from_str("external-oidc-jwks");
+    fx.rsa("issuer", RsaSpec::rs256())
+}
+
+#[test]
+fn accepts_valid_jwks() {
+    let jwks = issuer().public_jwks().to_value();
+
+    assert_eq!(validate_oidc_jwks(&jwks), Ok(()));
+}
+
+#[test]
+fn rejects_duplicate_kid() {
+    let jwks = issuer()
+        .public_jwks()
+        .negative_value(NegativeJwks::DuplicateKid);
+
+    assert_eq!(
+        validate_oidc_jwks(&jwks),
+        Err(JwksValidationError::DuplicateKid)
+    );
+}
+
+#[test]
+fn rejects_wrong_kty() {
+    let key = issuer().public_jwk().negative_value(NegativeJwk::WrongKty);
+    let jwks = json!({ "keys": [key] });
+
+    assert_eq!(
+        validate_oidc_jwks(&jwks),
+        Err(JwksValidationError::WrongKty)
+    );
+}
+
+#[test]
+fn rejects_unsupported_alg() {
+    let key = issuer()
+        .public_jwk()
+        .negative_value(NegativeJwk::UnsupportedAlg);
+    let jwks = json!({ "keys": [key] });
+
+    assert_eq!(
+        validate_oidc_jwks(&jwks),
+        Err(JwksValidationError::UnsupportedAlg)
+    );
+}
+
+#[test]
+fn rejects_missing_kid() {
+    let jwks = issuer()
+        .public_jwks()
+        .negative_value(NegativeJwks::MissingKid);
+
+    assert_eq!(
+        validate_oidc_jwks(&jwks),
+        Err(JwksValidationError::MissingKid)
+    );
+}


### PR DESCRIPTION
## Summary
- turn `examples/external/oidc-jwks-validation` into a downstream-shaped validator workflow
- add a tiny JWKS validator that accepts the valid RSA JWKS and returns stable rejection classes
- add tests for duplicate `kid`, wrong `kty`, unsupported `alg`, and missing `kid` taxonomy-backed negatives
- link the example from the OIDC/JWKS how-to and advance the active goal to the bundle product surface spec

## User path
A Rust user can copy the clean-project example, run `cargo test`, and see how `uselesskey` fixtures drive both the valid OIDC/JWKS path and realistic validator rejection paths.

## Boundary
This remains fixture workflow proof. It does not claim OpenID discovery behavior, provider compatibility, production signing-key custody, production verifier correctness, scanner evasion, or release readiness.

## Proof
- `cargo +nightly test --manifest-path examples/external/oidc-jwks-validation/Cargo.toml`
- `cargo +nightly clippy --manifest-path examples/external/oidc-jwks-validation/Cargo.toml --all-targets -- -D warnings`
- `RUSTUP_TOOLCHAIN=nightly cargo xtask external-adoption-smoke --path .`
- `RUSTUP_TOOLCHAIN=nightly cargo xtask adoption-regression --external`
- `cargo +nightly xtask docs-sync --check`
- `cargo +nightly xtask typos`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

## Known local gate gap
`cargo +nightly xtask pr-lite` currently fails in `publish-check` while dry-running unchanged `uselesskey-rsa`: the packaged crate resolves `uselesskey-core@0.9.1` from crates.io and cannot find the newer local `impl_pkcs8_spki_fixture_accessors` macro. This PR only changes the external example, docs, and active goal state; the passing checks above cover the touched user path.

## Receipts
- external adoption smoke includes `external-example-oidc-jwks-validation`
- adoption regression includes the external smoke path and OIDC bundle proof

## Risk
No deterministic fixture identity changes. The only dependency addition is `serde_json` inside the standalone external example so the downstream validator can name `serde_json::Value` directly.

## Rollback
This PR can be reverted independently before the bundle product surface spec work begins.