### PR TITLE
feat(cli): add bundle product receipts

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -115,12 +115,14 @@ commands = [
 
 [[work_item]]
 id = "bundle-manifest-receipts"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0014"
+spec = "USELESSKEY-SPEC-0017"
 plan = "plans/real-workflow-closure/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-cli --all-features bundle verify_bundle audit_bundle",
+  "cargo test -p uselesskey-cli --all-features bundle",
+  "cargo test -p uselesskey-cli --all-features verify_bundle",
+  "cargo test -p uselesskey-cli --all-features audit_bundle",
   "cargo xtask external-adoption-smoke --path .",
   "cargo xtask no-blob",
   "cargo +nightly xtask pr-lite",

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -893,7 +893,10 @@ fn build_bundle_audit(bundle_dir: &Path) -> Result<BundleAudit> {
         .iter()
         .map(|receipt| receipt.kind.clone())
         .collect::<BTreeSet<_>>();
-    for required in ["materialization", "audit-surface"] {
+    for required in bundle_receipt_records(profile)
+        .iter()
+        .map(|receipt| receipt.kind.as_str())
+    {
         if !receipt_kinds.contains(required) {
             bail!("missing_receipt: {required}");
         }
@@ -952,7 +955,7 @@ fn build_bundle_audit(bundle_dir: &Path) -> Result<BundleAudit> {
             BundleAuditCheck::pass(
                 "receipts",
                 "missing_receipt",
-                "materialization and audit-surface receipts are present",
+                "bundle product receipts are present",
             ),
             BundleAuditCheck::pass(
                 "scanner-safe-classification",
@@ -2473,6 +2476,24 @@ fn bundle_receipt_records(profile: BundleProfile) -> Vec<BundleReceiptRecord> {
             profile: profile.manifest_name().to_string(),
             description: "scanner-safety and lane metadata receipt".to_string(),
         },
+        BundleReceiptRecord {
+            path: "receipts/bundle-verification.json".to_string(),
+            kind: "bundle-verification".to_string(),
+            profile: profile.manifest_name().to_string(),
+            description: "bundle verification contract receipt".to_string(),
+        },
+        BundleReceiptRecord {
+            path: "receipts/scanner-safety.json".to_string(),
+            kind: "scanner-safety".to_string(),
+            profile: profile.manifest_name().to_string(),
+            description: "per-artifact scanner-safety classification receipt".to_string(),
+        },
+        BundleReceiptRecord {
+            path: "receipts/negative-coverage.json".to_string(),
+            kind: "negative-coverage".to_string(),
+            profile: profile.manifest_name().to_string(),
+            description: "taxonomy-backed negative fixture coverage receipt".to_string(),
+        },
     ]
 }
 
@@ -2523,7 +2544,167 @@ fn generate_bundle_receipt_artifact(
                 }).collect::<Vec<_>>(),
             })))
         }
+        "bundle-verification" => {
+            let receipts = bundle_receipt_records(profile);
+            Ok(Artifact::Json(json!({
+                "receipt": "bundle-verification",
+                "version": 1,
+                "profile": profile.manifest_name(),
+                "status": "generated",
+                "verification_command": "uselesskey verify-bundle --path <bundle-dir>",
+                "artifact_count": artifacts.len(),
+                "fixture_files": fixture_files,
+                "expected_receipts": receipts.iter().map(|receipt| {
+                    json!({
+                        "path": receipt.path,
+                        "kind": receipt.kind,
+                        "description": receipt.description,
+                    })
+                }).collect::<Vec<_>>(),
+                "checks": [
+                    {
+                        "name": "manifest-paths",
+                        "failure_class": "path_escape",
+                        "detail": "manifest artifact and receipt paths must stay relative to the bundle root",
+                    },
+                    {
+                        "name": "artifact-content",
+                        "failure_class": "missing_artifact",
+                        "detail": "verify-bundle regenerates profile artifacts and compares bytes",
+                    },
+                    {
+                        "name": "receipt-content",
+                        "failure_class": "missing_receipt",
+                        "detail": "verify-bundle regenerates metadata-only receipts and compares bytes",
+                    },
+                    {
+                        "name": "profile-validation",
+                        "failure_class": "profile_validation_failed",
+                        "detail": "verify-bundle validates the expected profile file set",
+                    },
+                ],
+                "boundaries": [
+                    "bundle-verification is local bundle consistency metadata, not repo public-claim proof",
+                    "verify-bundle does not prove provider compatibility or production security",
+                    "this receipt does not copy raw generated fixture payloads",
+                ],
+            })))
+        }
+        "scanner-safety" => {
+            let scanner_safe_count = artifacts
+                .iter()
+                .filter(|artifact| artifact.scanner_safe)
+                .count();
+            Ok(Artifact::Json(json!({
+                "receipt": "scanner-safety",
+                "version": 1,
+                "profile": profile.manifest_name(),
+                "scanner_safe": scanner_safe_count == artifacts.len(),
+                "artifact_count": artifacts.len(),
+                "scanner_safe_count": scanner_safe_count,
+                "runtime_material_count": artifacts.len() - scanner_safe_count,
+                "artifacts": artifacts.iter().map(|artifact| {
+                    json!({
+                        "path": artifact.path,
+                        "kind": artifact.kind,
+                        "format": artifact.format,
+                        "scanner_safe": artifact.scanner_safe,
+                        "runtime_material": !artifact.scanner_safe,
+                        "lanes": artifact.lanes,
+                        "description": artifact.description,
+                    })
+                }).collect::<Vec<_>>(),
+                "boundaries": [
+                    "scanner_safe=true means uselesskey classifies the generated artifact as scanner-safe fixture material",
+                    "runtime_material=true means keep the generated artifact under an explicit output directory such as target/",
+                    "scanner-safety metadata is not scanner evasion, production secret handling, or provider compatibility proof",
+                ],
+            })))
+        }
+        "negative-coverage" => {
+            let coverage = artifacts
+                .iter()
+                .filter_map(negative_coverage_entry)
+                .collect::<Vec<_>>();
+            Ok(Artifact::Json(json!({
+                "receipt": "negative-coverage",
+                "version": 1,
+                "profile": profile.manifest_name(),
+                "negative_count": coverage.len(),
+                "coverage": coverage,
+                "boundaries": [
+                    "negative coverage records generated fixture classes, not downstream verifier correctness",
+                    "failure classes map to USELESSKEY-SPEC-0016 taxonomy IDs",
+                    "this receipt is metadata-only and does not copy generated fixture payloads",
+                ],
+            })))
+        }
         other => bail!("unsupported bundle receipt `{other}`"),
+    }
+}
+
+fn negative_coverage_entry(artifact: &BundleArtifactRecord) -> Option<serde_json::Value> {
+    let (failure_class, expected_failure) = negative_failure_class(artifact)?;
+    Some(json!({
+        "path": artifact.path,
+        "kind": artifact.kind,
+        "failure_class": failure_class,
+        "expected_failure": expected_failure,
+        "scanner_safe": artifact.scanner_safe,
+        "runtime_material": !artifact.scanner_safe,
+        "description": artifact.description,
+    }))
+}
+
+fn negative_failure_class(artifact: &BundleArtifactRecord) -> Option<(&'static str, &'static str)> {
+    match artifact.path.as_str() {
+        "token.json" if artifact.profile == "scanner-safe" => Some((
+            "token_near_miss",
+            "parser or application policy rejects token shape",
+        )),
+        "jwks/negative-duplicate-kid.json" => {
+            Some(("jwks_duplicate_kid", "ambiguous key selection"))
+        }
+        "jwks/negative-missing-kid.json" => {
+            Some(("jwks_missing_kid", "key selection cannot identify the key"))
+        }
+        "tokens/negative-alg-none.json" => {
+            Some(("jwt_alg_none", "verifier policy rejects unsigned algorithm"))
+        }
+        "tokens/negative-bad-audience.json" => {
+            Some(("jwt_bad_audience", "claim validation rejects token"))
+        }
+        "certs/negative-expired-leaf.pem" => {
+            Some(("x509_expired_leaf", "verifier rejects expiration"))
+        }
+        "certs/negative-not-yet-valid.pem" => {
+            Some(("x509_not_yet_valid_leaf", "verifier rejects not-before"))
+        }
+        "certs/negative-wrong-hostname.pem" => {
+            Some(("x509_wrong_hostname", "hostname validation rejects"))
+        }
+        "certs/negative-untrusted-root.pem" => Some((
+            "x509_untrusted_root",
+            "path validation rejects untrusted root",
+        )),
+        "requests/negative-tampered-body.json" => {
+            Some(("webhook_tampered_body", "canonical signature check rejects"))
+        }
+        "requests/negative-wrong-secret.json" => {
+            Some(("webhook_wrong_secret", "signature verification rejects"))
+        }
+        "requests/negative-stale-timestamp.json" => {
+            Some(("webhook_stale_timestamp", "replay-window policy rejects"))
+        }
+        "requests/negative-missing-signature.json" => Some((
+            "webhook_missing_signature",
+            "verifier rejects missing credential",
+        )),
+        "requests/negative-malformed-signature.json" => Some((
+            "webhook_malformed_signature",
+            "parser or verifier rejects signature encoding",
+        )),
+        _ => None,
     }
 }
 

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -2034,6 +2034,47 @@ mod inspect_bundle_tests {
         ));
     }
 
+    #[test]
+    fn negative_failure_class_pins_scanner_safe_token_guard() {
+        let mut scanner_safe_token = record("token", "json", true);
+        scanner_safe_token.path = "token.json".to_string();
+        scanner_safe_token.profile = "scanner-safe".to_string();
+
+        assert_eq!(
+            negative_failure_class(&scanner_safe_token).map(|(class, _)| class),
+            Some("token_near_miss")
+        );
+
+        let mut oidc_token = scanner_safe_token.clone();
+        oidc_token.profile = "oidc".to_string();
+
+        assert_eq!(negative_failure_class(&oidc_token), None);
+    }
+
+    #[test]
+    fn negative_failure_class_pins_tls_taxonomy_classes() {
+        let cases = [
+            ("certs/negative-expired-leaf.pem", "x509_expired_leaf"),
+            (
+                "certs/negative-not-yet-valid.pem",
+                "x509_not_yet_valid_leaf",
+            ),
+            ("certs/negative-wrong-hostname.pem", "x509_wrong_hostname"),
+            ("certs/negative-untrusted-root.pem", "x509_untrusted_root"),
+        ];
+
+        for (path, expected_class) in cases {
+            let mut artifact = record("x509", "pem", true);
+            artifact.path = path.to_string();
+            artifact.profile = "tls".to_string();
+
+            assert_eq!(
+                negative_failure_class(&artifact).map(|(class, _)| class),
+                Some(expected_class)
+            );
+        }
+    }
+
     fn record(kind: &str, format: &str, scanner_safe: bool) -> BundleArtifactRecord {
         BundleArtifactRecord {
             path: format!("{kind}.{format}"),

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -229,6 +229,13 @@ fn bundle_writes_manifest_schema() -> TestResult<()> {
     assert!(bundle_dir.join("receipts/materialization.json").exists());
     assert!(bundle_dir.join("receipts/audit-surface.json").exists());
     assert!(
+        bundle_dir
+            .join("receipts/bundle-verification.json")
+            .exists()
+    );
+    assert!(bundle_dir.join("receipts/scanner-safety.json").exists());
+    assert!(bundle_dir.join("receipts/negative-coverage.json").exists());
+    assert!(
         value["files"]
             .as_array()
             .test_context("array")?
@@ -242,17 +249,38 @@ fn bundle_writes_manifest_schema() -> TestResult<()> {
             .iter()
             .any(|file| file.as_str() == Some("receipts/audit-surface.json"))
     );
+    assert!(
+        value["files"]
+            .as_array()
+            .test_context("array")?
+            .iter()
+            .any(|file| file.as_str() == Some("receipts/bundle-verification.json"))
+    );
+    assert!(
+        value["files"]
+            .as_array()
+            .test_context("array")?
+            .iter()
+            .any(|file| file.as_str() == Some("receipts/scanner-safety.json"))
+    );
+    assert!(
+        value["files"]
+            .as_array()
+            .test_context("array")?
+            .iter()
+            .any(|file| file.as_str() == Some("receipts/negative-coverage.json"))
+    );
     let artifacts = value["artifacts"]
         .as_array()
         .test_context("artifacts array")?;
     assert_eq!(
         artifacts.len(),
-        value["files"].as_array().test_context("array")?.len() - 2
+        value["files"].as_array().test_context("array")?.len() - 5
     );
     let receipts = value["receipts"]
         .as_array()
         .test_context("receipts array")?;
-    assert_eq!(receipts.len(), 2);
+    assert_eq!(receipts.len(), 5);
     assert!(receipts.iter().any(|receipt| {
         receipt["path"].as_str() == Some("receipts/materialization.json")
             && receipt["kind"].as_str() == Some("materialization")
@@ -260,6 +288,18 @@ fn bundle_writes_manifest_schema() -> TestResult<()> {
     assert!(receipts.iter().any(|receipt| {
         receipt["path"].as_str() == Some("receipts/audit-surface.json")
             && receipt["kind"].as_str() == Some("audit-surface")
+    }));
+    assert!(receipts.iter().any(|receipt| {
+        receipt["path"].as_str() == Some("receipts/bundle-verification.json")
+            && receipt["kind"].as_str() == Some("bundle-verification")
+    }));
+    assert!(receipts.iter().any(|receipt| {
+        receipt["path"].as_str() == Some("receipts/scanner-safety.json")
+            && receipt["kind"].as_str() == Some("scanner-safety")
+    }));
+    assert!(receipts.iter().any(|receipt| {
+        receipt["path"].as_str() == Some("receipts/negative-coverage.json")
+            && receipt["kind"].as_str() == Some("negative-coverage")
     }));
     assert!(
         artifacts
@@ -554,6 +594,9 @@ fn bundle_profile_oidc_writes_contract_pack() -> TestResult<()> {
     assert_eq!(manifest["files"][5], "tokens/negative-bad-audience.json");
     assert_eq!(manifest["files"][6], "receipts/materialization.json");
     assert_eq!(manifest["files"][7], "receipts/audit-surface.json");
+    assert_eq!(manifest["files"][8], "receipts/bundle-verification.json");
+    assert_eq!(manifest["files"][9], "receipts/scanner-safety.json");
+    assert_eq!(manifest["files"][10], "receipts/negative-coverage.json");
 
     let artifacts = manifest["artifacts"].as_array().test_context("artifacts")?;
     assert_eq!(artifacts.len(), 6);
@@ -637,6 +680,39 @@ fn bundle_profile_oidc_writes_contract_pack() -> TestResult<()> {
     assert_eq!(audit["artifact_count"], 6);
     assert_eq!(audit["runtime_material_count"], 0);
 
+    let scanner_safety: Value = serde_json::from_slice(
+        &fs::read(bundle_dir.join("receipts/scanner-safety.json"))
+            .test_context("scanner-safety receipt")?,
+    )
+    .test_context("scanner-safety receipt json")?;
+    assert_eq!(scanner_safety["receipt"], "scanner-safety");
+    assert_eq!(scanner_safety["scanner_safe_count"], 6);
+    assert_eq!(scanner_safety["runtime_material_count"], 0);
+
+    let negative_coverage: Value = serde_json::from_slice(
+        &fs::read(bundle_dir.join("receipts/negative-coverage.json"))
+            .test_context("negative coverage receipt")?,
+    )
+    .test_context("negative coverage receipt json")?;
+    assert_eq!(negative_coverage["receipt"], "negative-coverage");
+    assert_eq!(negative_coverage["negative_count"], 4);
+    let coverage = negative_coverage["coverage"]
+        .as_array()
+        .test_context("coverage array")?;
+    for class in [
+        "jwks_duplicate_kid",
+        "jwks_missing_kid",
+        "jwt_alg_none",
+        "jwt_bad_audience",
+    ] {
+        assert!(
+            coverage
+                .iter()
+                .any(|entry| entry["failure_class"].as_str() == Some(class)),
+            "missing negative coverage class {class}"
+        );
+    }
+
     let mut verify = Command::cargo_bin("uselesskey").test_context("bin exists")?;
     verify.args([
         "verify-bundle",
@@ -679,14 +755,14 @@ fn inspect_bundle_summarizes_verified_scanner_safe_receipts() -> TestResult<()> 
             "Summary type: quick human bundle summary",
         ))
         .stdout(predicate::str::contains("Artifacts: 8"))
-        .stdout(predicate::str::contains("Verified files: 10"))
+        .stdout(predicate::str::contains("Verified files: 13"))
         .stdout(predicate::str::contains("Scanner-safe: yes"))
         .stdout(predicate::str::contains("Private key material: no"))
         .stdout(predicate::str::contains("Symmetric secret material: no"))
         .stdout(predicate::str::contains("Runtime material artifacts: 0"))
         .stdout(predicate::str::contains("Verification: ok"))
         .stdout(predicate::str::contains(
-            "Receipts: materialization, audit-surface",
+            "Receipts: materialization, audit-surface, bundle-verification, scanner-safety, negative-coverage",
         ))
         .stdout(predicate::str::contains(
             "Durable audit receipt: uselesskey audit-bundle --path <bundle-dir> --out <audit-dir>",

--- a/crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_json_golden.snap
+++ b/crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_json_golden.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/uselesskey-cli/tests/cli.rs
+assertion_line: 849
 expression: audit
 ---
 artifact_count: 7
@@ -66,7 +67,7 @@ checks:
     failure_class: missing_artifact
     name: artifact-content
     status: pass
-  - detail: materialization and audit-surface receipts are present
+  - detail: bundle product receipts are present
     failure_class: missing_receipt
     name: receipts
     status: pass
@@ -98,11 +99,14 @@ files:
   - evidence/webhook-profile.md
   - receipts/materialization.json
   - receipts/audit-surface.json
+  - receipts/bundle-verification.json
+  - receipts/scanner-safety.json
+  - receipts/negative-coverage.json
 manifest_path: manifest.json
 manifest_version: 1
 missing_files: []
 profile: webhook
-receipt_count: 2
+receipt_count: 5
 receipts:
   - description: deterministic bundle materialization receipt
     kind: materialization
@@ -111,6 +115,18 @@ receipts:
   - description: scanner-safety and lane metadata receipt
     kind: audit-surface
     path: receipts/audit-surface.json
+    profile: webhook
+  - description: bundle verification contract receipt
+    kind: bundle-verification
+    path: receipts/bundle-verification.json
+    profile: webhook
+  - description: per-artifact scanner-safety classification receipt
+    kind: scanner-safety
+    path: receipts/scanner-safety.json
+    profile: webhook
+  - description: taxonomy-backed negative fixture coverage receipt
+    kind: negative-coverage
+    path: receipts/negative-coverage.json
     profile: webhook
 runtime_material_count: 6
 scanner_safe_count: 1

--- a/crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_markdown_golden.snap
+++ b/crates/uselesskey-cli/tests/snapshots/cli__audit_bundle_webhook_markdown_golden.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/uselesskey-cli/tests/cli.rs
+assertion_line: 883
 expression: audit_md
 ---
 # uselesskey Bundle Audit
@@ -12,7 +13,7 @@ expression: audit_md
 - Payload posture: raw generated fixture payloads are not copied into this receipt
 - Manifest: manifest.json (version 1)
 - Artifacts: 7
-- Receipts: 2
+- Receipts: 5
 - Scanner-safe artifacts: 1
 - Runtime material artifacts: 6
 
@@ -23,7 +24,7 @@ expression: audit_md
 | manifest | pass | invalid_manifest | manifest parsed |
 | path-containment | pass | path_escape | manifest paths are relative and contained by the bundle |
 | artifact-content | pass | missing_artifact | manifest artifacts regenerate and verify |
-| receipts | pass | missing_receipt | materialization and audit-surface receipts are present |
+| receipts | pass | missing_receipt | bundle product receipts are present |
 | scanner-safe-classification | pass | scanner_safe_mismatch | audit-surface receipt matches manifest scanner-safe counts |
 | runtime-material-classification | pass | runtime_material_mismatch | audit-surface receipt matches manifest runtime-material counts |
 | profile-validation | pass | profile_validation_failed | profile-specific generated files match the manifest |
@@ -44,6 +45,9 @@ expression: audit_md
 
 - materialization: receipts/materialization.json
 - audit-surface: receipts/audit-surface.json
+- bundle-verification: receipts/bundle-verification.json
+- scanner-safety: receipts/scanner-safety.json
+- negative-coverage: receipts/negative-coverage.json
 
 ## Boundaries
 

--- a/crates/uselesskey-cli/tests/tls_profile.rs
+++ b/crates/uselesskey-cli/tests/tls_profile.rs
@@ -39,7 +39,7 @@ fn tls_bundle_emits_expected_layout() {
     let bundle_dir = dir.path().join("tls");
     run_bundle(&bundle_dir);
 
-    // Six certificate fixtures, one evidence doc, two receipts, plus manifest.
+    // Six certificate fixtures, one evidence doc, bundle receipts, plus manifest.
     for relative in [
         "certs/valid-leaf.pem",
         "certs/valid-chain.pem",
@@ -50,6 +50,9 @@ fn tls_bundle_emits_expected_layout() {
         "evidence/tls-profile.md",
         "receipts/materialization.json",
         "receipts/audit-surface.json",
+        "receipts/bundle-verification.json",
+        "receipts/scanner-safety.json",
+        "receipts/negative-coverage.json",
         "manifest.json",
     ] {
         let path = bundle_dir.join(relative);
@@ -151,6 +154,9 @@ fn tls_bundle_is_deterministic_across_runs() {
         "evidence/tls-profile.md",
         "receipts/materialization.json",
         "receipts/audit-surface.json",
+        "receipts/bundle-verification.json",
+        "receipts/scanner-safety.json",
+        "receipts/negative-coverage.json",
         "manifest.json",
     ] {
         let a = fs::read(first_dir.join(relative)).expect("read first");

--- a/crates/uselesskey-cli/tests/webhook_profile.rs
+++ b/crates/uselesskey-cli/tests/webhook_profile.rs
@@ -44,6 +44,9 @@ fn webhook_bundle_emits_expected_layout() -> TestResult<()> {
         "evidence/webhook-profile.md",
         "receipts/materialization.json",
         "receipts/audit-surface.json",
+        "receipts/bundle-verification.json",
+        "receipts/scanner-safety.json",
+        "receipts/negative-coverage.json",
         "manifest.json",
     ] {
         let path = bundle_dir.join(relative);
@@ -82,6 +85,14 @@ fn webhook_bundle_emits_expected_layout() -> TestResult<()> {
     ensure_eq!(audit["profile"], "webhook");
     ensure_eq!(audit["scanner_safe"], false);
     ensure_eq!(audit["runtime_material_count"], 6);
+
+    let negative_coverage = read_json(&bundle_dir.join("receipts/negative-coverage.json"))?;
+    ensure_eq!(negative_coverage["negative_count"], 5);
+    let coverage = require_some(negative_coverage["coverage"].as_array(), "coverage array")?;
+    assert!(coverage.iter().any(|entry| {
+        entry["failure_class"].as_str() == Some("webhook_malformed_signature")
+            && entry["runtime_material"] == true
+    }));
     Ok(())
 }
 
@@ -164,6 +175,9 @@ fn webhook_bundle_is_deterministic_and_verifiable() -> TestResult<()> {
         "evidence/webhook-profile.md",
         "receipts/materialization.json",
         "receipts/audit-surface.json",
+        "receipts/bundle-verification.json",
+        "receipts/scanner-safety.json",
+        "receipts/negative-coverage.json",
         "manifest.json",
     ] {
         let a = require_ok(fs::read(first_dir.join(relative)), "read first")?;

--- a/docs/how-to/export-vault-kv-fixtures.md
+++ b/docs/how-to/export-vault-kv-fixtures.md
@@ -138,7 +138,9 @@ cargo xtask no-blob
 
 `scanner-safe-reference --check` regenerates the bundle under
 `target/scanner-safe-reference/` and diffs `manifest.json`,
-`receipts/audit-surface.json`, and `receipts/materialization.json`
+`receipts/audit-surface.json`, `receipts/bundle-verification.json`,
+`receipts/materialization.json`, `receipts/negative-coverage.json`, and
+`receipts/scanner-safety.json`
 against the committed reference. It also asserts the encoded
 `secret.yaml` and `kv-v2.json` payloads are not committed under
 `examples/scanner-safe-bundle/expected/`.

--- a/docs/how-to/generate-scanner-safe-k8s-secret.md
+++ b/docs/how-to/generate-scanner-safe-k8s-secret.md
@@ -81,7 +81,9 @@ cargo xtask no-blob
 
 `cargo xtask scanner-safe-reference --check` regenerates the bundle under
 `target/scanner-safe-reference/` and diffs `manifest.json`,
-`receipts/audit-surface.json`, and `receipts/materialization.json` against the
+`receipts/audit-surface.json`, `receipts/bundle-verification.json`,
+`receipts/materialization.json`, `receipts/negative-coverage.json`, and
+`receipts/scanner-safety.json` against the
 committed reference under `examples/scanner-safe-bundle/expected/`. It also
 asserts the encoded `secret.yaml` and `kv-v2.json` payloads are not committed
 under that directory.

--- a/docs/how-to/test-oidc-jwks-validation.md
+++ b/docs/how-to/test-oidc-jwks-validation.md
@@ -30,6 +30,9 @@ The profile writes:
 - `tokens/negative-bad-audience.json`
 - `receipts/materialization.json`
 - `receipts/audit-surface.json`
+- `receipts/bundle-verification.json`
+- `receipts/scanner-safety.json`
+- `receipts/negative-coverage.json`
 
 ## Positive case
 

--- a/docs/how-to/test-tls-chain-validation.md
+++ b/docs/how-to/test-tls-chain-validation.md
@@ -37,6 +37,9 @@ The profile writes:
 - `evidence/tls-profile.md`
 - `receipts/materialization.json`
 - `receipts/audit-surface.json`
+- `receipts/bundle-verification.json`
+- `receipts/scanner-safety.json`
+- `receipts/negative-coverage.json`
 - `manifest.json`
 
 `inspect-bundle` prints the profile, artifact count, scanner-safety

--- a/docs/how-to/test-webhook-signature-validation.md
+++ b/docs/how-to/test-webhook-signature-validation.md
@@ -57,6 +57,9 @@ The contract pack writes:
 - `evidence/webhook-profile.md`
 - `receipts/materialization.json`
 - `receipts/audit-surface.json`
+- `receipts/bundle-verification.json`
+- `receipts/scanner-safety.json`
+- `receipts/negative-coverage.json`
 - `manifest.json`
 
 Each request fixture records `method`, `path`, `timestamp`, `body`,

--- a/docs/specs/USELESSKEY-SPEC-0011-webhook-contract-pack.md
+++ b/docs/specs/USELESSKEY-SPEC-0011-webhook-contract-pack.md
@@ -57,6 +57,9 @@ requests/negative-missing-signature.json
 requests/negative-malformed-signature.json
 receipts/materialization.json
 receipts/audit-surface.json
+receipts/bundle-verification.json
+receipts/scanner-safety.json
+receipts/negative-coverage.json
 evidence/webhook-profile.md
 ```
 

--- a/docs/specs/USELESSKEY-SPEC-0015-real-user-workflows.md
+++ b/docs/specs/USELESSKEY-SPEC-0015-real-user-workflows.md
@@ -208,6 +208,9 @@ Receipt or smoke path:
 ```text
 target/uselesskey-scanner-safe/receipts/materialization.json
 target/uselesskey-scanner-safe/receipts/audit-surface.json
+target/uselesskey-scanner-safe/receipts/bundle-verification.json
+target/uselesskey-scanner-safe/receipts/scanner-safety.json
+target/uselesskey-scanner-safe/receipts/negative-coverage.json
 ```
 
 Boundary:

--- a/docs/specs/USELESSKEY-SPEC-0017-bundle-product-surface.md
+++ b/docs/specs/USELESSKEY-SPEC-0017-bundle-product-surface.md
@@ -82,6 +82,9 @@ target/uselesskey-oidc/
   receipts/
     materialization.json
     audit-surface.json
+    bundle-verification.json
+    scanner-safety.json
+    negative-coverage.json
 ```
 
 Future profile or export work may add directories such as `k8s/`, `vault/`, or
@@ -133,23 +136,19 @@ metadata, and boundaries. Receipts must not copy raw PEM, DER, token, JWK, JWKS,
 webhook body, HMAC key, certificate payload, or generated secret-shaped payload
 contents into reviewer packets.
 
-Current required receipts:
+Required receipts:
 
 | Receipt | Purpose |
 | --- | --- |
 | `receipts/materialization.json` | Records deterministic generation inputs, profile, output format, file list, and artifact metadata. |
 | `receipts/audit-surface.json` | Records scanner-safe, runtime-material, lane, and profile metadata for bundle audit. |
-
-Target receipts for the real workflow closure lane:
-
-| Receipt | Purpose |
-| --- | --- |
 | `receipts/bundle-verification.json` | Records local `verify-bundle` consistency checks and profile validation outcome. |
 | `receipts/scanner-safety.json` | Records scanner-safe classification for each artifact and explains runtime-material boundaries. |
 | `receipts/negative-coverage.json` | Records negative fixture classes present in the bundle and maps them to SPEC-0016 stable IDs. |
 
-The target receipts are not required until the implementation PR for this spec
-lands. This spec defines their shape before broad emitter expansion.
+These receipts are metadata-only. They are required for bundle profiles but do
+not create repo public-claim proof, release evidence, provider compatibility
+proof, production security assurance, or scanner-evasion claims.
 
 ### Negative Fixture Metadata
 

--- a/examples/scanner-safe-bundle/expected/manifest.json
+++ b/examples/scanner-safe-bundle/expected/manifest.json
@@ -14,7 +14,10 @@
     "jwk.jwk.json",
     "jwks.jwks.json",
     "receipts/materialization.json",
-    "receipts/audit-surface.json"
+    "receipts/audit-surface.json",
+    "receipts/bundle-verification.json",
+    "receipts/scanner-safety.json",
+    "receipts/negative-coverage.json"
   ],
   "artifacts": [
     {
@@ -126,6 +129,24 @@
       "kind": "audit-surface",
       "profile": "scanner-safe",
       "description": "scanner-safety and lane metadata receipt"
+    },
+    {
+      "path": "receipts/bundle-verification.json",
+      "kind": "bundle-verification",
+      "profile": "scanner-safe",
+      "description": "bundle verification contract receipt"
+    },
+    {
+      "path": "receipts/scanner-safety.json",
+      "kind": "scanner-safety",
+      "profile": "scanner-safe",
+      "description": "per-artifact scanner-safety classification receipt"
+    },
+    {
+      "path": "receipts/negative-coverage.json",
+      "kind": "negative-coverage",
+      "profile": "scanner-safe",
+      "description": "taxonomy-backed negative fixture coverage receipt"
     }
   ]
 }

--- a/examples/scanner-safe-bundle/expected/receipts/bundle-verification.json
+++ b/examples/scanner-safe-bundle/expected/receipts/bundle-verification.json
@@ -1,0 +1,72 @@
+{
+  "artifact_count": 8,
+  "boundaries": [
+    "bundle-verification is local bundle consistency metadata, not repo public-claim proof",
+    "verify-bundle does not prove provider compatibility or production security",
+    "this receipt does not copy raw generated fixture payloads"
+  ],
+  "checks": [
+    {
+      "detail": "manifest artifact and receipt paths must stay relative to the bundle root",
+      "failure_class": "path_escape",
+      "name": "manifest-paths"
+    },
+    {
+      "detail": "verify-bundle regenerates profile artifacts and compares bytes",
+      "failure_class": "missing_artifact",
+      "name": "artifact-content"
+    },
+    {
+      "detail": "verify-bundle regenerates metadata-only receipts and compares bytes",
+      "failure_class": "missing_receipt",
+      "name": "receipt-content"
+    },
+    {
+      "detail": "verify-bundle validates the expected profile file set",
+      "failure_class": "profile_validation_failed",
+      "name": "profile-validation"
+    }
+  ],
+  "expected_receipts": [
+    {
+      "description": "deterministic bundle materialization receipt",
+      "kind": "materialization",
+      "path": "receipts/materialization.json"
+    },
+    {
+      "description": "scanner-safety and lane metadata receipt",
+      "kind": "audit-surface",
+      "path": "receipts/audit-surface.json"
+    },
+    {
+      "description": "bundle verification contract receipt",
+      "kind": "bundle-verification",
+      "path": "receipts/bundle-verification.json"
+    },
+    {
+      "description": "per-artifact scanner-safety classification receipt",
+      "kind": "scanner-safety",
+      "path": "receipts/scanner-safety.json"
+    },
+    {
+      "description": "taxonomy-backed negative fixture coverage receipt",
+      "kind": "negative-coverage",
+      "path": "receipts/negative-coverage.json"
+    }
+  ],
+  "fixture_files": [
+    "rsa.jwk.json",
+    "ecdsa.jwk.json",
+    "ed25519.jwk.json",
+    "hmac.jwk.json",
+    "token.json",
+    "x509.pem",
+    "jwk.jwk.json",
+    "jwks.jwks.json"
+  ],
+  "profile": "scanner-safe",
+  "receipt": "bundle-verification",
+  "status": "generated",
+  "verification_command": "uselesskey verify-bundle --path <bundle-dir>",
+  "version": 1
+}

--- a/examples/scanner-safe-bundle/expected/receipts/negative-coverage.json
+++ b/examples/scanner-safe-bundle/expected/receipts/negative-coverage.json
@@ -1,0 +1,22 @@
+{
+  "boundaries": [
+    "negative coverage records generated fixture classes, not downstream verifier correctness",
+    "failure classes map to USELESSKEY-SPEC-0016 taxonomy IDs",
+    "this receipt is metadata-only and does not copy generated fixture payloads"
+  ],
+  "coverage": [
+    {
+      "description": "scanner-safe near-miss token shape for parser tests",
+      "expected_failure": "parser or application policy rejects token shape",
+      "failure_class": "token_near_miss",
+      "kind": "token",
+      "path": "token.json",
+      "runtime_material": false,
+      "scanner_safe": true
+    }
+  ],
+  "negative_count": 1,
+  "profile": "scanner-safe",
+  "receipt": "negative-coverage",
+  "version": 1
+}

--- a/examples/scanner-safe-bundle/expected/receipts/scanner-safety.json
+++ b/examples/scanner-safe-bundle/expected/receipts/scanner-safety.json
@@ -1,0 +1,112 @@
+{
+  "artifact_count": 8,
+  "artifacts": [
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "rsa",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "rsa.jwk.json",
+      "runtime_material": false,
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "ecdsa",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "ecdsa.jwk.json",
+      "runtime_material": false,
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "ed25519",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "ed25519.jwk.json",
+      "runtime_material": false,
+      "scanner_safe": true
+    },
+    {
+      "description": "scanner-safe symmetric JWK shape with invalid material",
+      "format": "jwk",
+      "kind": "hmac",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "hmac.jwk.json",
+      "runtime_material": false,
+      "scanner_safe": true
+    },
+    {
+      "description": "scanner-safe near-miss token shape for parser tests",
+      "format": "json-manifest",
+      "kind": "token",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "token.json",
+      "runtime_material": false,
+      "scanner_safe": true
+    },
+    {
+      "description": "public certificate fixture",
+      "format": "pem",
+      "kind": "x509",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "x509.pem",
+      "runtime_material": false,
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwk",
+      "kind": "jwk",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "jwk.jwk.json",
+      "runtime_material": false,
+      "scanner_safe": true
+    },
+    {
+      "description": "public fixture material",
+      "format": "jwks",
+      "kind": "jwks",
+      "lanes": [
+        "runtime",
+        "materialized"
+      ],
+      "path": "jwks.jwks.json",
+      "runtime_material": false,
+      "scanner_safe": true
+    }
+  ],
+  "boundaries": [
+    "scanner_safe=true means uselesskey classifies the generated artifact as scanner-safe fixture material",
+    "runtime_material=true means keep the generated artifact under an explicit output directory such as target/",
+    "scanner-safety metadata is not scanner evasion, production secret handling, or provider compatibility proof"
+  ],
+  "profile": "scanner-safe",
+  "receipt": "scanner-safety",
+  "runtime_material_count": 0,
+  "scanner_safe": true,
+  "scanner_safe_count": 8,
+  "version": 1
+}

--- a/xtask/src/external_adoption_smoke.rs
+++ b/xtask/src/external_adoption_smoke.rs
@@ -700,6 +700,9 @@ fn verify_bundle_shape(bundle_dir: &Path, expected_profile: &str) -> Result<()> 
     for required in [
         "receipts/materialization.json",
         "receipts/audit-surface.json",
+        "receipts/bundle-verification.json",
+        "receipts/scanner-safety.json",
+        "receipts/negative-coverage.json",
     ] {
         if !bundle_dir.join(required).is_file() {
             bail!(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4295,7 +4295,10 @@ const SCANNER_SAFE_REFERENCE_OUT_DIR: &str = "target/scanner-safe-reference";
 const SCANNER_SAFE_REFERENCE_COMPARED_FILES: &[&str] = &[
     "manifest.json",
     "receipts/audit-surface.json",
+    "receipts/bundle-verification.json",
     "receipts/materialization.json",
+    "receipts/negative-coverage.json",
+    "receipts/scanner-safety.json",
 ];
 const SCANNER_SAFE_REFERENCE_FORBIDDEN_FILES: &[&str] = &["secret.yaml", "kv-v2.json"];
 


### PR DESCRIPTION
## Summary
- emits required metadata-only bundle product receipts: `bundle-verification`, `scanner-safety`, and `negative-coverage`
- requires those receipts in `verify-bundle`, `audit-bundle`, external-adoption smoke, and scanner-safe reference checks
- updates scanner-safe reference metadata, golden audit snapshots, current how-tos, SPEC-0011/0015/0017, and the active real-workflow goal

## User path
A downstream user who generates a scanner-safe, TLS, OIDC, or webhook bundle now gets receipts that explain local verification, scanner-safety classification, and negative fixture coverage without copying generated payloads.

## Boundary
This proves local bundle consistency and metadata classification only. It does not prove repo public claims, release readiness, provider compatibility, production security, scanner evasion, or downstream verifier correctness. It does not add profiles, contract packs, badges, release prep, tags, or publishing.

## Proof
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly test -p uselesskey-cli --all-features bundle`
- `cargo +nightly test -p uselesskey-cli --all-features verify_bundle`
- `cargo +nightly test -p uselesskey-cli --all-features audit_bundle`
- `cargo +nightly test -p xtask external_adoption_smoke`
- `cargo +nightly clippy -p uselesskey-cli --all-targets --all-features -- -D warnings`
- `cargo +nightly xtask spec-check --strict`
- `cargo +nightly xtask docs-sync --check`
- `cargo +nightly xtask typos`
- `cargo +nightly xtask external-adoption-smoke --path .`
- `cargo +nightly xtask scanner-safe-reference --check`
- `cargo +nightly xtask no-blob`
- `cargo +nightly xtask adoption-regression --external`
- `cargo +nightly xtask pr-lite`
- `cargo +nightly xtask pr`
- `git diff --check`

## Risk / rollback
The diff changes generated bundle metadata and committed reference receipts, not fixture payload identity. It should be revertable as one bundle-receipt slice before later task-first docs or public-surface work depends on the new receipt contract.