### PR TITLE
ops: start usability polish lane

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -1,26 +1,27 @@
-id = "uselesskey-real-workflow-closure"
-title = "Real workflow closure"
+id = "uselesskey-usability-polish"
+title = "Usability polish"
 status = "active"
 owner = "EffortlessMetrics"
 created = "2026-05-18"
 
 objective = """
-Make uselesskey prove real user workflows, not just repo proof machinery.
-Downstream users should be able to solve deterministic valid/invalid fixture
-jobs for Rust tests, scanner-safe CI/platform bundles, and explicit
-materialization paths without learning the repo operating system.
+Make uselesskey feel obvious, installable, and usable outside the repo.
+Downstream users should be able to understand the product in one screen,
+install or depend on it, run a self-check, generate and audit fixtures, wire
+the audit into CI, use the Rust facade in a clean test project, and explain the
+metadata-only receipt to a reviewer without learning xtask, claim ledgers,
+release evidence, or repo internals.
 """
 
 end_state = [
-  "Real user workflows are specified for Rust developers, CI/platform users, and explicit materialization users.",
-  "Negative fixtures are a first-class taxonomy with deterministic shape, scanner-safety posture, downstream failure intent, tests, and task docs.",
-  "JWK/JWKS and token-shape negative fixture gaps are closed through taxonomy-backed implementation.",
-  "An OIDC/JWKS validator example proves a downstream auth-validation workflow with positive and negative cases.",
-  "The bundle product surface has a documented manifest and receipt contract before broad emitter expansion.",
-  "Bundle verification/scanner-safety/negative-coverage receipts are tightened without copying generated payloads.",
-  "Task-first fixture workflow docs route by user job instead of crate layout.",
-  "Public crate promises are audited so public crates have a direct downstream import story or candidate-internal status.",
-  "The lane closes without release prep, version bump, tag, publish, new contract packs, provider/security overclaims, scanner-evasion language, or broad refactors.",
+  "The front door explains the core user jobs and product boundary in one screen.",
+  "Install and dependency paths are explicit without starting release prep.",
+  "Installed CLI help and self-check behavior are audited and improved where needed.",
+  "Rust facade examples show clean-project adoption without crate archaeology.",
+  "External smoke covers the facade examples when bounded.",
+  "Downstream policy guidance uses presets and reviewer checklists, not a broad DSL.",
+  "Tiny audit-bundle policy controls exist only if they stay simple and stable.",
+  "The lane closes without version bump, tag, publish, release prep, new contract pack, provider/security overclaims, scanner-evasion language, shipper work, broad dependency churn, or installed CLI execution of xtask/claim-ledger commands.",
 ]
 
 [[work_item]]
@@ -28,7 +29,7 @@ id = "lane-open"
 status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
@@ -37,11 +38,11 @@ commands = [
 ]
 
 [[work_item]]
-id = "real-user-workflow-spec"
+id = "install-distribution-polish-spec"
 status = "done"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0015"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0018"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
@@ -50,62 +51,76 @@ commands = [
 ]
 
 [[work_item]]
-id = "negative-fixture-taxonomy-spec"
-status = "done"
+id = "readme-front-door"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0016"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0018"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
-  "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
   "cargo xtask typos",
+  "cargo xtask external-adoption-smoke --path .",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "jwk-jwks-negative-wave"
-status = "done"
+id = "cli-help-self-check-audit"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0016"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0018"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-jwk --all-features",
-  "cargo test -p uselesskey --all-features",
+  "cargo test -p uselesskey-cli --all-features doctor",
+  "cargo run -p uselesskey-cli -- --help",
+  "cargo run -p uselesskey-cli -- doctor --format json",
   "cargo +nightly xtask pr-lite",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "token-shape-negatives"
-status = "done"
+id = "library-facade-polish-spec"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0016"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0018"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-token --all-features",
-  "cargo test -p uselesskey --all-features",
-  "cargo +nightly xtask pr-lite",
+  "cargo xtask spec-check --strict",
+  "cargo xtask docs-sync --check",
+  "cargo xtask typos",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "oidc-jwks-validator-example"
-status = "done"
+id = "facade-first-external-examples"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0015"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0018"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
+  "cargo xtask external-adoption-smoke --path .",
+  "cargo test -p xtask external_adoption_smoke",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "external-library-smoke"
+status = "planned"
+proposal = "USELESSKEY-PROP-0001"
+spec = "USELESSKEY-SPEC-0018"
+plan = "plans/usability-polish/implementation-plan.md"
+commands = [
+  "cargo test -p xtask external_adoption_smoke",
   "cargo xtask external-adoption-smoke --path .",
   "cargo xtask adoption-regression --external",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "bundle-product-surface-spec"
-status = "done"
+id = "downstream-policy-pack-spec"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0017"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0018"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
   "cargo xtask spec-check --strict",
   "cargo xtask docs-sync --check",
@@ -114,42 +129,25 @@ commands = [
 ]
 
 [[work_item]]
-id = "bundle-manifest-receipts"
-status = "done"
+id = "audit-bundle-policy-controls"
+status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0017"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0018"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
-  "cargo test -p uselesskey-cli --all-features bundle",
-  "cargo test -p uselesskey-cli --all-features verify_bundle",
   "cargo test -p uselesskey-cli --all-features audit_bundle",
   "cargo xtask external-adoption-smoke --path .",
-  "cargo xtask no-blob",
   "cargo +nightly xtask pr-lite",
   "git diff --check",
 ]
 
 [[work_item]]
-id = "task-first-docs-spec-and-guides"
+id = "downstream-policy-docs"
 status = "planned"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0005"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+spec = "USELESSKEY-SPEC-0018"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
-  "cargo xtask docs-sync --check",
-  "cargo xtask typos",
-  "cargo xtask external-adoption-smoke --path .",
-  "git diff --check",
-]
-
-[[work_item]]
-id = "public-surface-discipline"
-status = "planned"
-proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0002"
-plan = "plans/real-workflow-closure/implementation-plan.md"
-commands = [
-  "cargo xtask public-surface",
   "cargo xtask docs-sync --check",
   "cargo xtask typos",
   "git diff --check",
@@ -160,7 +158,7 @@ id = "lane-closeout"
 status = "planned"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
-plan = "plans/real-workflow-closure/implementation-plan.md"
+plan = "plans/usability-polish/implementation-plan.md"
 commands = [
   "cargo xtask external-adoption-smoke --path . --format json",
   "cargo xtask adoption-regression --external",

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -52,3 +52,4 @@ public crate-surface cleanup.
 - [USELESSKEY-SPEC-0015: Real user workflows](USELESSKEY-SPEC-0015-real-user-workflows.md)
 - [USELESSKEY-SPEC-0016: Negative fixture taxonomy](USELESSKEY-SPEC-0016-negative-fixture-taxonomy.md)
 - [USELESSKEY-SPEC-0017: Bundle product surface](USELESSKEY-SPEC-0017-bundle-product-surface.md)
+- [USELESSKEY-SPEC-0018: Install and distribution polish](USELESSKEY-SPEC-0018-install-distribution-polish.md)

--- a/docs/specs/USELESSKEY-SPEC-0018-install-distribution-polish.md
+++ b/docs/specs/USELESSKEY-SPEC-0018-install-distribution-polish.md
@@ -1,0 +1,168 @@
++++
+id = "USELESSKEY-SPEC-0018"
+kind = "spec"
+title = "Install and distribution polish"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-18"
+milestone = "v0.10.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_adrs = [
+  "USELESSKEY-ADR-0001",
+  "USELESSKEY-ADR-0002",
+  "USELESSKEY-ADR-0003",
+  "USELESSKEY-ADR-0004",
+]
+linked_plan = "plans/usability-polish/implementation-plan.md"
+linked_specs = [
+  "USELESSKEY-SPEC-0012",
+  "USELESSKEY-SPEC-0013",
+  "USELESSKEY-SPEC-0014",
+  "USELESSKEY-SPEC-0015",
+  "USELESSKEY-SPEC-0017",
+]
+support_tier_impact = []
+policy_impact = []
++++
+
+# USELESSKEY-SPEC-0018: Install and Distribution Polish
+
+## Problem
+
+`uselesskey` has strong repo-local proof and an installed CLI loop, but the
+front door still has to make the product obvious to someone who did not build
+the repo.
+
+The installed user should see:
+
+```text
+what uselesskey does
+  -> how to install it or add the facade crate
+    -> how to self-check the CLI
+      -> how to generate and audit fixtures
+        -> what the receipt proves and does not prove
+```
+
+This spec defines install and distribution polish for the v0.10.0 product
+quality target. It does not start release prep.
+
+## Behavior
+
+Docs and installed CLI surfaces must present these user paths before internal
+proof machinery:
+
+| User | First interface | Expected first command or snippet |
+| --- | --- | --- |
+| Installed CLI user | `uselesskey` | `cargo install uselesskey-cli --version <current-stable>` |
+| Rust test author | facade crate | `uselesskey = { version = "<current-stable>", ... }` |
+| CI user | installed CLI | `uselesskey bundle ... && uselesskey audit-bundle ... --ci` |
+| Reviewer with repo checkout | repo proof | `cargo xtask verification-pack ...` |
+| Maintainer | repo proof | `cargo xtask pr`, `adoption-regression`, `release-evidence` |
+
+The top-level README and task docs must keep the first screen focused on:
+
+- generate deterministic auth, TLS, webhook, token, and test fixtures;
+- keep raw generated material out of git by default;
+- audit generated bundles with metadata-only receipts;
+- upload audit receipts in CI;
+- understand the proof boundary.
+
+Installed CLI help and `doctor` output should answer installed-user questions:
+
+- which command to run next;
+- whether the CLI can write under `target/`;
+- which profiles are known;
+- whether JSON output is available;
+- which operations are repo-local proof rather than installed-user setup.
+
+## Non-goals
+
+This spec does not:
+
+- prepare, cut, tag, or publish v0.10.0;
+- add binary release artifacts or checksums before the release lane chooses a
+  distribution path;
+- add new contract packs or fixture families;
+- add README badges;
+- make provider compatibility, production security, or scanner-evasion claims;
+- require installed CLI commands to execute `xtask`, release evidence, or
+  claim-ledger command strings;
+- redesign the facade API broadly.
+
+## Required Evidence
+
+Install/distribution polish is proven by:
+
+- docs that name the current stable install/dependency snippets;
+- CLI help and `doctor` tests or smoke runs for installed-user behavior;
+- `external-adoption-smoke --path .` for clean-project installed paths;
+- `adoption-regression --external` when the change touches bundled user paths;
+- `docs-sync`, `typos`, and `spec-check` for source-of-truth consistency.
+
+## Test Mapping
+
+| Requirement | Evidence |
+| --- | --- |
+| Current install/dependency snippets stay synced | `cargo xtask docs-sync --check` |
+| Installed CLI commands work in clean projects | `cargo xtask external-adoption-smoke --path .` |
+| Installed self-check remains machine-readable | `cargo test -p uselesskey-cli --all-features doctor` |
+| Bundle audit remains metadata-only | `cargo test -p uselesskey-cli --all-features audit_bundle`; `cargo xtask no-blob` |
+| Repo public claims remain separate | `cargo xtask claim-report --check-public-claims` in closeout |
+
+## Implementation Mapping
+
+| Surface | Owner |
+| --- | --- |
+| README/front door | `README.md` |
+| Installed CLI help and doctor | `crates/uselesskey-cli/src/main.rs` |
+| Clean-project smoke | `xtask/src/external_adoption_smoke.rs` |
+| Bundle audit receipts | `docs/specs/USELESSKEY-SPEC-0014-installed-bundle-audit.md` |
+| Bundle product surface | `docs/specs/USELESSKEY-SPEC-0017-bundle-product-surface.md` |
+| Usability lane plan | `plans/usability-polish/implementation-plan.md` |
+
+## CI Proof
+
+Every PR in this spec lane must run the narrowest relevant proof plus the
+standard docs/spec gates:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+PRs that touch installed CLI behavior must also run:
+
+```bash
+cargo test -p uselesskey-cli --all-features <focused-filter>
+cargo xtask external-adoption-smoke --path .
+```
+
+## Acceptance
+
+This spec is satisfied when:
+
+- the front door names the installed CLI, Rust facade, CI audit, reviewer, and
+  maintainer paths without leading with repo internals;
+- copyable install and dependency snippets use the current stable version in
+  current how-to docs;
+- installed CLI help and `doctor` output answer installed-user next steps
+  without requiring `xtask`;
+- external adoption smoke proves the documented installed-user path;
+- no doc in this lane implies release readiness, provider compatibility,
+  production security, or scanner evasion.
+
+## Boundaries
+
+Install polish may make `uselesskey` easier to adopt. It must not blur the
+claim boundary:
+
+- installed bundle audit proves local bundle consistency, not repo public
+  claims;
+- scanner-safe means the project classifies generated material as scanner-safe
+  test fixtures, not scanner evasion;
+- generated fixtures do not prove production secret handling;
+- TLS/OIDC/webhook fixtures do not prove provider compatibility or production
+  security;
+- release proof remains a release lane concern.

--- a/plans/usability-polish/README.md
+++ b/plans/usability-polish/README.md
@@ -1,0 +1,14 @@
+# Usability Polish
+
+This plan area owns the v0.10.0 product-quality lane for making `uselesskey`
+obvious, installable, and usable outside the repo.
+
+The lane starts after downstream CI polish and the current open PR quality wave
+triage. Its job is to make existing machinery feel like a product surface:
+front door, install path, CLI self-check, fixture generation, audit/CI path,
+Rust facade example, and downstream policy/reviewer handoff.
+
+## Plan Files
+
+- [implementation-plan.md](implementation-plan.md) - PR sequence, proof commands, non-goals, and stop conditions
+- `closeout.md` - implemented surface, proof, boundaries, and next-lane handoff

--- a/plans/usability-polish/implementation-plan.md
+++ b/plans/usability-polish/implementation-plan.md
@@ -1,0 +1,210 @@
++++
+id = "USELESSKEY-PLAN-0025"
+kind = "plan"
+title = "Usability polish"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-18"
+milestone = "v0.10.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_specs = [
+  "USELESSKEY-SPEC-0003",
+  "USELESSKEY-SPEC-0005",
+  "USELESSKEY-SPEC-0012",
+  "USELESSKEY-SPEC-0013",
+  "USELESSKEY-SPEC-0014",
+  "USELESSKEY-SPEC-0015",
+  "USELESSKEY-SPEC-0017",
+  "USELESSKEY-SPEC-0018",
+]
+linked_adrs = [
+  "USELESSKEY-ADR-0001",
+  "USELESSKEY-ADR-0002",
+  "USELESSKEY-ADR-0003",
+  "USELESSKEY-ADR-0004",
+]
++++
+
+# Usability Polish
+
+## Objective
+
+Make `uselesskey` feel obvious, installable, and usable outside the repo.
+
+The target experience is:
+
+```text
+front door
+  -> install path
+    -> CLI self-check
+      -> fixture generation
+        -> audit/CI path
+          -> Rust facade example
+            -> downstream policy/reviewer handoff
+```
+
+This is a v0.10.0 product-quality buildout lane. It is not release
+preparation.
+
+## Scope
+
+This lane covers:
+
+- install and distribution polish without release execution;
+- a sharper README/front-door narrative for core user jobs;
+- installed CLI help and `doctor` self-check behavior;
+- library facade examples that compile in clean external projects;
+- bounded external smoke for facade-first examples;
+- downstream policy presets and reviewer checklist guidance;
+- tiny `audit-bundle` policy controls only if they remain simple and stable;
+- closeout with no version bump, tag, publish, or new contract pack.
+
+## Non-goals
+
+Do not mix these into this lane:
+
+- v0.10.0 release prep;
+- version bumps;
+- tags or crates.io publish;
+- new contract packs;
+- WebAuthn, PKCS#11, Vault/Kubernetes, or other fixture breadth work;
+- provider compatibility claims;
+- production security claims;
+- scanner-evasion language;
+- broad policy DSL;
+- broad facade redesign;
+- shipper work;
+- dependency churn;
+- installed CLI execution of `xtask` or claim-ledger commands.
+
+## PR Sequence
+
+0. PR-wave triage
+   - Merge only non-overlapping, current, green, useful quality PRs.
+   - Close or park redundant PRs with explicit disposition.
+   - Do not let quality coverage PRs become product direction.
+
+1. `ops: start usability polish lane`
+   - Replace `.uselesskey/goals/active.toml` with this lane.
+   - Add this plan area.
+   - Add `USELESSKEY-SPEC-0018-install-distribution-polish.md`.
+   - Validation:
+
+     ```bash
+     cargo xtask spec-check --strict
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     git diff --check
+     ```
+
+2. `docs: sharpen README front door`
+   - Make the first screen answer:
+
+     ```text
+     What does this do?
+     What job do I have?
+     How do I install or depend on it?
+     How do I generate/audit fixtures?
+     What does this not prove?
+     ```
+
+   - Keep proof machinery behind links.
+   - Validation:
+
+     ```bash
+     cargo xtask docs-sync --check
+     cargo xtask typos
+     cargo xtask external-adoption-smoke --path .
+     git diff --check
+     ```
+
+3. `docs/cli: audit installed help and self-check`
+   - Inspect `uselesskey --help`, `uselesskey bundle --help`,
+     `uselesskey audit-bundle --help`, and `uselesskey doctor`.
+   - Improve wording only where it helps installed users pick the next command.
+   - Do not route installed users through `xtask`.
+
+4. `docs(spec): define library facade polish`
+   - Add `USELESSKEY-SPEC-0019-library-facade-polish.md`.
+   - Define clean-project Rust test author requirements, feature flag
+     discoverability, examples, missing-feature diagnostics, and boundaries.
+
+5. `examples: add facade-first external Rust examples`
+   - Add small examples that use the `uselesskey` facade crate first.
+   - Avoid requiring users to discover leaf crate internals before first value.
+
+6. `xtask: smoke facade-first external examples`
+   - Extend external adoption smoke only if it stays bounded.
+   - Keep published-version mode as audit/reference, not release prep.
+
+7. `docs(spec): define downstream policy pack`
+   - Add `USELESSKEY-SPEC-0020-downstream-policy-pack.md`.
+   - Define presets such as `strict`, not a broad DSL.
+
+8. `feat(cli): add tiny audit-bundle policy controls`
+   - Only implement controls that remain stable and obvious, such as:
+
+     ```bash
+     uselesskey audit-bundle --path target/uselesskey-webhook --ci --expect-profile webhook
+     uselesskey audit-bundle --path target/uselesskey-webhook --ci --policy strict
+     ```
+
+   - Skip this PR if it starts becoming a policy language.
+
+9. `docs: add downstream policy docs and reviewer checklist`
+   - Explain what audit receipts prove, what they do not prove, and what a
+     reviewer should attach.
+
+10. `docs: close out usability polish lane`
+    - Add closeout and learning record.
+    - Archive `.uselesskey/goals/active.toml`.
+
+## Acceptance
+
+A downstream user can:
+
+- understand `uselesskey` in one screen;
+- install the CLI or add the facade crate as a dev-dependency;
+- run an installed self-check;
+- generate scanner-safe/TLS/OIDC/webhook fixtures;
+- audit the bundle and upload metadata-only receipts in CI;
+- use the Rust facade in a clean external test project;
+- explain the receipt boundary to a reviewer.
+
+## Proof Commands
+
+Lane setup:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Full closeout:
+
+```bash
+cargo xtask external-adoption-smoke --path . --format json
+cargo xtask adoption-regression --external
+cargo xtask claim-report --check-public-claims
+cargo xtask contract-packs --check
+cargo xtask check-no-panic-family
+cargo xtask docs-sync --check
+cargo xtask typos
+cargo +nightly xtask pr-lite
+cargo xtask pr
+git diff --check
+```
+
+## Stop Conditions
+
+Pause or split the lane if:
+
+- the work starts preparing or cutting v0.10.0;
+- a change requires a version bump, tag, publish, or shipper migration;
+- a policy feature becomes a broad DSL;
+- installed CLI commands need to execute repo-local proof machinery;
+- a new fixture family or contract pack becomes necessary;
+- a doc claim implies provider compatibility, production security, or scanner
+  evasion.


### PR DESCRIPTION
## Summary
- opens the usability-polish active goal after the downstream CI polish lane
- adds `plans/usability-polish/` with the PR sequence, proof commands, boundaries, and stop conditions
- adds `USELESSKEY-SPEC-0018` for install/distribution polish and indexes it in the specs README

## Boundaries
- no release prep, version bump, tag, or publish
- no new contract packs or fixture families
- no provider compatibility, production security, or scanner-evasion claims
- no installed CLI execution of `xtask` or claim-ledger commands

## Validation
- `cargo +nightly xtask spec-check --strict`
- `cargo +nightly xtask docs-sync --check`
- `cargo +nightly xtask typos`
- `cargo +nightly xtask pr-lite`
- `git diff --check`

## Queue context
Before opening this lane, the open PR wave was triaged: useful current quality PRs were merged, redundant overlap was closed, and the remaining fmt-failing candidates were left parked for separate review rather than mixed into the product lane.