### PR TITLE
docs/cli: improve installed help and doctor

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -65,7 +65,7 @@ commands = [
 
 [[work_item]]
 id = "cli-help-self-check-audit"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0018"
 plan = "plans/usability-polish/implementation-plan.md"
@@ -79,7 +79,7 @@ commands = [
 
 [[work_item]]
 id = "library-facade-polish-spec"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0018"
 plan = "plans/usability-polish/implementation-plan.md"

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -26,7 +26,19 @@ use uselesskey_webhook::{WebhookFactoryExt, WebhookPayloadSpec};
 use uselesskey_x509::{ChainNegative, ChainSpec, X509Chain, X509FactoryExt, X509Spec};
 
 #[derive(Parser, Debug)]
-#[command(name = "uselesskey", about = "Deterministic fixture generation CLI")]
+#[command(
+    name = "uselesskey",
+    about = "Generate deterministic test fixtures with metadata-only audit receipts",
+    after_help = "Start here:
+  uselesskey doctor
+  uselesskey profiles
+  uselesskey bundle --profile webhook --out target/uselesskey-webhook
+  uselesskey audit-bundle --path target/uselesskey-webhook --ci
+
+Boundaries:
+  Installed CLI commands generate, verify, inspect, and audit local fixtures.
+  Repo public-claim proof is separate from installed CLI setup."
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -34,17 +46,29 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    #[command(about = "Generate one fixture artifact")]
     Generate(GenerateArgs),
+    #[command(about = "List bundle profiles and copyable installed commands")]
     Profiles(ProfilesArgs),
+    #[command(about = "Explain one bundle profile and its proof boundary")]
     Profile(ProfileArgs),
+    #[command(about = "Generate a deterministic fixture bundle")]
     Bundle(BundleArgs),
+    #[command(about = "Check a bundle manifest and listed files")]
     VerifyBundle(VerifyBundleArgs),
+    #[command(about = "Print a quick human summary of bundle metadata")]
     InspectBundle(InspectBundleArgs),
+    #[command(about = "Emit metadata-only bundle audit receipts for reviewers or CI")]
     AuditBundle(AuditBundleArgs),
+    #[command(about = "Check installed CLI readiness and safe default output paths")]
     Doctor(DoctorArgs),
+    #[command(about = "Export generated fixtures into platform-friendly shapes")]
     Export(ExportArgs),
+    #[command(about = "Inspect a materialization manifest")]
     Inspect(InspectArgs),
+    #[command(about = "Materialize fixtures from a reviewed manifest")]
     Materialize(MaterializeArgs),
+    #[command(about = "Verify a materialization manifest")]
     Verify(VerifyArgs),
 }
 
@@ -75,51 +99,89 @@ struct GenerateArgs {
 }
 
 #[derive(clap::Args, Debug)]
+#[command(after_help = "Examples:
+  uselesskey bundle --profile webhook --out target/uselesskey-webhook
+  uselesskey verify-bundle --path target/uselesskey-webhook
+  uselesskey inspect-bundle --path target/uselesskey-webhook
+  uselesskey audit-bundle --path target/uselesskey-webhook --ci
+
+Boundary:
+  bundle writes test fixtures; keep generated payloads under target/ unless
+  your project has reviewed another output path.")]
 struct BundleArgs {
+    /// Deterministic seed for this bundle. This is test input, not a secret.
     #[arg(long, default_value = "uselesskey-bundle-seed")]
     seed: String,
+    /// Stable label used in deterministic artifact identity.
     #[arg(long, default_value = "bundle")]
     label: String,
+    /// Preferred artifact format when the profile supports multiple formats.
     #[arg(long, default_value = "jwk")]
     format: Format,
+    /// Bundle profile to generate.
     #[arg(long, default_value = "scanner-safe")]
     profile: BundleProfile,
+    /// Output directory for the generated bundle.
     #[arg(long)]
     out: Option<PathBuf>,
+    /// Explain the profile, generated files, audit path, and boundary without writing files.
     #[arg(long)]
     explain: bool,
 }
 
 #[derive(clap::Args, Debug)]
 struct VerifyBundleArgs {
-    #[arg(long = "bundle-dir", alias = "path")]
+    /// Bundle directory to verify.
+    #[arg(long = "path", visible_alias = "bundle-dir", value_name = "BUNDLE_DIR")]
     bundle_dir: PathBuf,
 }
 
 #[derive(clap::Args, Debug)]
 struct InspectBundleArgs {
-    #[arg(long = "bundle-dir", alias = "path")]
+    /// Bundle directory to inspect.
+    #[arg(long = "path", visible_alias = "bundle-dir", value_name = "BUNDLE_DIR")]
     bundle_dir: PathBuf,
+    /// Optional path for writing the human summary.
     #[arg(long)]
     out: Option<PathBuf>,
 }
 
 #[derive(clap::Args, Debug)]
+#[command(after_help = "Examples:
+  uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit
+  uselesskey audit-bundle --path target/uselesskey-webhook --ci
+  uselesskey audit-bundle --path target/uselesskey-webhook --summary
+
+Boundary:
+  audit-bundle checks local bundle consistency and metadata labels. It does
+  not prove production security, provider compatibility, or repo public claims.")]
 struct AuditBundleArgs {
-    #[arg(long = "bundle-dir", alias = "path")]
+    /// Bundle directory to audit. `--bundle-dir` remains available as an alias.
+    #[arg(long = "path", visible_alias = "bundle-dir", value_name = "BUNDLE_DIR")]
     bundle_dir: PathBuf,
+    /// Directory for metadata-only Markdown and JSON audit receipts.
     #[arg(long)]
     out: Option<PathBuf>,
+    /// Output format when writing to stdout.
     #[arg(long, default_value = "markdown")]
     format: AuditOutputFormat,
+    /// Emit CI-oriented JSON and exit non-zero on stable audit failure classes.
     #[arg(long, conflicts_with = "summary")]
     ci: bool,
+    /// Print a compact human summary for terminals or CI logs.
     #[arg(long)]
     summary: bool,
 }
 
 #[derive(clap::Args, Debug)]
+#[command(after_help = "Examples:
+  uselesskey doctor
+  uselesskey doctor --format json
+
+Checks installed CLI concerns only: version, working directory, target write
+access, safe default profile paths, JSON output, and known profiles.")]
 struct DoctorArgs {
+    /// Doctor output format.
     #[arg(long, default_value = "text")]
     format: DoctorOutputFormat,
 }
@@ -1277,6 +1339,11 @@ fn build_doctor_report() -> DoctorReport {
         current_dir,
         known_profiles,
         checks,
+        next_steps: vec![
+            "uselesskey profiles".to_string(),
+            "uselesskey bundle --profile webhook --out target/uselesskey-webhook".to_string(),
+            "uselesskey audit-bundle --path target/uselesskey-webhook --ci".to_string(),
+        ],
         boundaries: vec![
             "doctor checks installed CLI concerns only".to_string(),
             "public claim proof and release proof remain repo-local workflows".to_string(),
@@ -1362,6 +1429,10 @@ fn render_doctor_report(report: &DoctorReport) -> String {
             "- {}: {} - {}\n",
             check.name, check.status, check.detail
         ));
+    }
+    out.push_str("\nNext steps:\n");
+    for step in &report.next_steps {
+        out.push_str(&format!("- {step}\n"));
     }
     out.push_str("\nBoundaries:\n");
     for boundary in &report.boundaries {
@@ -3367,6 +3438,7 @@ struct DoctorReport {
     current_dir: String,
     known_profiles: Vec<String>,
     checks: Vec<DoctorCheck>,
+    next_steps: Vec<String>,
     boundaries: Vec<String>,
 }
 

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -114,6 +114,66 @@ fn bundle_explain_has_copyable_webhook_paths_without_writing_bundle() -> TestRes
 }
 
 #[test]
+fn top_level_help_routes_installed_users_to_self_check_and_audit() -> TestResult<()> {
+    let out = run(["--help"])?;
+
+    assert!(out.contains("Generate deterministic test fixtures"));
+    assert!(out.contains("Start here:"));
+    assert!(out.contains("uselesskey doctor"));
+    assert!(out.contains("uselesskey profiles"));
+    assert!(out.contains("uselesskey audit-bundle --path target/uselesskey-webhook --ci"));
+    assert!(out.contains("Generate a deterministic fixture bundle"));
+    assert!(out.contains("Check installed CLI readiness"));
+    assert!(out.contains("Repo public-claim proof is separate from installed CLI setup."));
+    Ok(())
+}
+
+#[test]
+fn bundle_help_shows_installed_generate_verify_inspect_audit_loop() -> TestResult<()> {
+    let out = run(["bundle", "--help"])?;
+
+    assert!(out.contains("Generate a deterministic fixture bundle"));
+    assert!(out.contains("uselesskey bundle --profile webhook --out target/uselesskey-webhook"));
+    assert!(out.contains("uselesskey verify-bundle --path target/uselesskey-webhook"));
+    assert!(out.contains("uselesskey inspect-bundle --path target/uselesskey-webhook"));
+    assert!(out.contains("uselesskey audit-bundle --path target/uselesskey-webhook --ci"));
+    assert!(out.contains("keep generated payloads under target/"));
+    assert!(out.contains("Explain the profile"));
+    Ok(())
+}
+
+#[test]
+fn audit_bundle_help_explains_ci_receipts_and_boundaries() -> TestResult<()> {
+    let out = run(["audit-bundle", "--help"])?;
+
+    assert!(out.contains("Emit metadata-only bundle audit receipts"));
+    assert!(out.contains("--path <BUNDLE_DIR>"));
+    assert!(out.contains("uselesskey audit-bundle --path target/uselesskey-webhook --out"));
+    assert!(out.contains("uselesskey audit-bundle --path target/uselesskey-webhook --ci"));
+    assert!(out.contains("Emit CI-oriented JSON"));
+    assert!(out.contains("stable audit failure classes"));
+    assert!(out.contains("not prove production security"));
+    assert!(out.contains("provider compatibility"));
+    assert!(out.contains("repo public claims"));
+    Ok(())
+}
+
+#[test]
+fn doctor_help_stays_installed_user_scoped() -> TestResult<()> {
+    let out = run(["doctor", "--help"])?;
+
+    assert!(out.contains("Check installed CLI readiness and safe default output paths"));
+    assert!(out.contains("uselesskey doctor --format json"));
+    assert!(out.contains("Checks installed CLI concerns only"));
+    assert!(out.contains("target write"));
+    assert!(out.contains("known profiles"));
+    assert!(!out.contains("cargo xtask"));
+    assert!(!out.contains("claim-ledger"));
+    assert!(!out.contains("release-evidence"));
+    Ok(())
+}
+
+#[test]
 fn doctor_text_reports_installed_cli_checks_only() -> TestResult<()> {
     let dir = tempdir().test_context("tempdir")?;
     let mut cmd = Command::cargo_bin("uselesskey").test_context("bin exists")?;
@@ -128,6 +188,10 @@ fn doctor_text_reports_installed_cli_checks_only() -> TestResult<()> {
     assert!(report.contains("output-path-safety: pass"));
     assert!(report.contains("known-profiles: pass"));
     assert!(report.contains("scanner-safe, tls, oidc, webhook, runtime"));
+    assert!(report.contains("Next steps:"));
+    assert!(report.contains("uselesskey profiles"));
+    assert!(report.contains("uselesskey bundle --profile webhook --out target/uselesskey-webhook"));
+    assert!(report.contains("uselesskey audit-bundle --path target/uselesskey-webhook --ci"));
     assert!(report.contains("installed CLI concerns only"));
     assert!(report.contains("repo-local workflows"));
     assert!(!report.contains("cargo xtask"));
@@ -177,6 +241,17 @@ fn doctor_json_reports_known_profiles_and_boundaries() -> TestResult<()> {
                 .iter()
                 .any(|check| check["name"] == check_name && check["status"] == "pass"),
             "missing passing check {check_name}"
+        );
+    }
+    let next_steps = report["next_steps"].as_array().test_context("next steps")?;
+    for step in [
+        "uselesskey profiles",
+        "uselesskey bundle --profile webhook --out target/uselesskey-webhook",
+        "uselesskey audit-bundle --path target/uselesskey-webhook --ci",
+    ] {
+        assert!(
+            next_steps.iter().any(|value| value.as_str() == Some(step)),
+            "missing next step {step}"
         );
     }
     assert!(stdout.contains("installed CLI concerns only"));


### PR DESCRIPTION
## Summary
- Add installed-user descriptions and next-step examples to top-level CLI, `bundle`, `audit-bundle`, and `doctor` help.
- Make `--path` the visible installed-user flag for `verify-bundle`, `inspect-bundle`, and `audit-bundle`, while preserving `--bundle-dir` as an alias.
- Add `doctor` next steps in text and JSON output so installed users can self-check and move directly to profiles, bundle generation, and CI audit.
- Mark `cli-help-self-check-audit` done and move `library-facade-polish-spec` to ready.

## Boundaries
- No release prep, version bump, tag, or publish.
- No new contract pack, provider compatibility claim, production security claim, or installed CLI execution of repo-local proof machinery.

## Validation
- `cargo test -p uselesskey-cli --all-features help`
- `cargo test -p uselesskey-cli --all-features doctor`
- `cargo run -p uselesskey-cli -- --help`
- `cargo run -p uselesskey-cli -- bundle --help`
- `cargo run -p uselesskey-cli -- audit-bundle --help`
- `cargo run -p uselesskey-cli -- doctor --format json`
- `cargo run -p uselesskey-cli -- verify-bundle --help`
- `cargo run -p uselesskey-cli -- inspect-bundle --help`
- `cargo fmt --all -- --check`
- `cargo +nightly xtask pr-lite`
- `cargo +nightly xtask external-adoption-smoke --path .`
- `git diff --check`