### PR TITLE
examples: sharpen facade-first external fixtures

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -92,7 +92,7 @@ commands = [
 
 [[work_item]]
 id = "facade-first-external-examples"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0019"
 plan = "plans/usability-polish/implementation-plan.md"
@@ -104,7 +104,7 @@ commands = [
 
 [[work_item]]
 id = "external-library-smoke"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0019"
 plan = "plans/usability-polish/implementation-plan.md"

--- a/examples/external/downstream-ci-bundle-audit/README.md
+++ b/examples/external/downstream-ci-bundle-audit/README.md
@@ -36,5 +36,6 @@ you want GitHub Actions to run it.
 ## Boundary
 
 This proves local generated bundle consistency in downstream CI. It does not
-prove repo public claims, production security, provider compatibility, scanner
-evasion, release readiness, or downstream verifier correctness.
+prove repo public claims, production security, provider compatibility,
+permission to bypass scanner policy, release readiness, or downstream verifier
+correctness.

--- a/examples/external/oidc-jwks-validation/README.md
+++ b/examples/external/oidc-jwks-validation/README.md
@@ -3,6 +3,43 @@
 Use this downstream-shaped example when an OIDC or JWT validator test needs
 deterministic JWKS shapes plus key-selection negatives.
 
+User job:
+
+```text
+I need deterministic OIDC/JWKS valid and invalid shapes in Rust tests.
+```
+
+Dependency:
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk"] }
+```
+
+First imports:
+
+```rust
+use uselesskey::jwk::{NegativeJwk, NegativeJwks};
+use uselesskey::{Factory, RsaFactoryExt, RsaSpec};
+```
+
+Positive path:
+
+```text
+Factory::deterministic_from_str("external-oidc-jwks")
+  -> fx.rsa("issuer", RsaSpec::rs256())
+  -> public_jwks() accepted by the example validator
+```
+
+Negative paths:
+
+```text
+NegativeJwks::DuplicateKid  -> duplicate kid rejection
+NegativeJwk::WrongKty       -> wrong kty rejection
+NegativeJwk::UnsupportedAlg -> unsupported alg rejection
+NegativeJwks::MissingKid    -> missing kid rejection
+```
+
 ```bash
 cargo test
 ```

--- a/examples/external/rust-test-fixtures/README.md
+++ b/examples/external/rust-test-fixtures/README.md
@@ -1,7 +1,43 @@
 # Rust Test Fixtures
 
 Use this downstream-shaped example when a Rust test crate needs deterministic
-RSA/JWK and token-shaped fixtures without committed payload blobs.
+RSA/JWK and token-shaped fixtures through the `uselesskey` facade crate without
+committed payload blobs.
+
+User job:
+
+```text
+I need deterministic valid and invalid fixtures inside Rust tests.
+```
+
+Dependency:
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk", "token"] }
+```
+
+First imports:
+
+```rust
+use uselesskey::{Factory, NegativeToken, RsaFactoryExt, RsaSpec, TokenFactoryExt, TokenSpec};
+```
+
+Positive path:
+
+```text
+Factory::deterministic_from_str("external-rust-test-fixtures")
+  -> fx.rsa("issuer", RsaSpec::rs256())
+  -> public JWK with kty=RSA and alg=RS256
+```
+
+Negative path:
+
+```text
+fx.token("api", TokenSpec::api_key())
+  -> negative_value(NegativeToken::NearMissApiKey)
+  -> parser rejects a token-like value that does not start with uk_test_
+```
 
 ```bash
 cargo test
@@ -14,3 +50,11 @@ smoke, `cargo xtask external-adoption-smoke --path .` copies this project under
 For generated CLI bundles, use `uselesskey audit-bundle` to create
 metadata-only reviewer receipts. The Rust crate example does not write bundle
 payloads by itself.
+
+Boundary:
+
+- This proves a clean Rust test project can use the facade crate without leaf
+  crate imports.
+- It does not prove production key generation, production authorization, or
+  downstream verifier correctness.
+- It does not give permission to commit generated secret-shaped payloads.

--- a/examples/external/rust-test-fixtures/src/lib.rs
+++ b/examples/external/rust-test-fixtures/src/lib.rs
@@ -1,7 +1,9 @@
-use uselesskey::{Factory, RsaFactoryExt, RsaSpec, TokenFactoryExt, TokenSpec};
+use uselesskey::{
+    Factory, NegativeToken, RsaFactoryExt, RsaSpec, TokenFactoryExt, TokenSpec,
+};
 
 #[test]
-fn deterministic_rust_fixtures_work_from_a_clean_project() {
+fn facade_generates_positive_rsa_jwk_fixture() {
     let fx = Factory::deterministic_from_str("external-rust-test-fixtures");
     let issuer = fx.rsa("issuer", RsaSpec::rs256());
     let issuer_again = fx.rsa("issuer", RsaSpec::rs256());
@@ -9,7 +11,20 @@ fn deterministic_rust_fixtures_work_from_a_clean_project() {
     assert_eq!(issuer.kid(), issuer_again.kid());
     assert_eq!(issuer.public_jwk().to_value()["kty"], "RSA");
     assert_eq!(issuer.public_jwk().to_value()["alg"], "RS256");
+}
 
+#[test]
+fn facade_generates_negative_token_shape_for_parser_tests() {
+    let fx = Factory::deterministic_from_str("external-rust-test-fixtures");
     let token = fx.token("api", TokenSpec::api_key());
+    let near_miss = token.negative_value(NegativeToken::NearMissApiKey);
+
     assert!(token.value().starts_with("uk_test_"));
+    assert!(!near_miss.starts_with("uk_test_"));
+    assert!(example_api_key_parser_accepts(token.value()));
+    assert!(!example_api_key_parser_accepts(&near_miss));
+}
+
+fn example_api_key_parser_accepts(value: &str) -> bool {
+    value.starts_with("uk_test_")
 }

--- a/examples/external/tls-chain-validation/README.md
+++ b/examples/external/tls-chain-validation/README.md
@@ -3,6 +3,42 @@
 Use this downstream-shaped example when a TLS verifier or adapter test needs
 deterministic certificate-chain fixtures and rustls config construction.
 
+User job:
+
+```text
+I need deterministic TLS chain fixtures in Rust tests.
+```
+
+Dependencies:
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.9.1", default-features = false, features = ["x509"] }
+uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+```
+
+First imports:
+
+```rust
+use uselesskey::{ChainSpec, Factory, X509FactoryExt};
+use uselesskey_rustls::{RustlsClientConfigExt, RustlsServerConfigExt};
+```
+
+Positive path:
+
+```text
+Factory::deterministic_from_str("external-tls-chain-validation")
+  -> fx.x509_chain("service", ChainSpec::new("valid.tls.uselesskey.test"))
+  -> PEM chain plus rustls server/client config construction
+```
+
+Negative path:
+
+```text
+Use the CLI `tls` bundle profile when the test needs file-based expired,
+hostname-mismatch, unknown-CA, or revoked-leaf fixtures.
+```
+
 ```bash
 cargo test
 ```

--- a/examples/external/webhook-verifier/README.md
+++ b/examples/external/webhook-verifier/README.md
@@ -3,6 +3,41 @@
 Use this downstream-shaped example when a webhook consumer test needs
 deterministic HMAC request fixtures plus realistic rejection cases.
 
+User job:
+
+```text
+I need deterministic valid and invalid webhook request fixtures in Rust tests.
+```
+
+Dependency:
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.9.1", default-features = false, features = ["webhook"] }
+```
+
+First imports:
+
+```rust
+use uselesskey::{Factory, NearMissScenario, WebhookFactoryExt, WebhookPayloadSpec};
+```
+
+Positive path:
+
+```text
+Factory::deterministic_from_str("external-webhook-verifier")
+  -> fx.webhook_stripe("payment", WebhookPayloadSpec::Canonical)
+  -> signed request with Stripe-Signature header and canonical payload
+```
+
+Negative paths:
+
+```text
+near_miss_stale_timestamp(300) -> stale timestamp rejection
+near_miss_wrong_secret()       -> wrong secret rejection
+near_miss_tampered_payload()   -> tampered payload rejection
+```
+
 ```bash
 cargo test
 ```


### PR DESCRIPTION
﻿## Summary
- expand external example READMEs with SPEC-0019-style user job, dependency, import, positive path, negative path, and boundary sections
- split the rust-test-fixtures example into a positive RSA/JWK facade path and a negative API-key near-miss parser path
- reword the downstream CI audit example boundary away from scanner-evasion language
- advance the usability-polish goal from facade examples to external library smoke

## Boundaries
- no release prep, version bump, tag, or publish
- no new contract packs, badges, provider compatibility claims, production security claims, or broad facade redesign
- no installed CLI execution of xtask or claim-ledger commands

## Validation
- cargo fmt --all -- --check
- cargo test --manifest-path examples/external/rust-test-fixtures/Cargo.toml
- cargo test -p xtask external_adoption_smoke
- cargo +nightly xtask external-adoption-smoke --path .
- cargo +nightly xtask docs-sync --check
- cargo +nightly xtask typos
- cargo +nightly xtask pr-lite
- git diff --check
- scanner-evasion wording search returned no matches in the edited examples and active goal

Note: the generated external example Cargo.lock was removed before final validation and is not committed.
