### PR TITLE
xtask: add external library smoke mode

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -104,12 +104,13 @@ commands = [
 
 [[work_item]]
 id = "external-library-smoke"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0019"
 plan = "plans/usability-polish/implementation-plan.md"
 commands = [
   "cargo test -p xtask external_adoption_smoke",
+  "cargo xtask external-adoption-smoke --path . --library-examples",
   "cargo xtask external-adoption-smoke --path .",
   "cargo xtask adoption-regression --external",
   "git diff --check",
@@ -117,7 +118,7 @@ commands = [
 
 [[work_item]]
 id = "downstream-policy-pack-spec"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0018"
 plan = "plans/usability-polish/implementation-plan.md"

--- a/docs/specs/USELESSKEY-SPEC-0013-external-adoption-smoke.md
+++ b/docs/specs/USELESSKEY-SPEC-0013-external-adoption-smoke.md
@@ -57,6 +57,17 @@ cargo xtask external-adoption-smoke --path .
 cargo xtask external-adoption-smoke --path . --format json
 ```
 
+Facade/library example mode is explicit and bounded:
+
+```bash
+cargo xtask external-adoption-smoke --path . --library-examples
+cargo xtask external-adoption-smoke --path . --library-examples --format json
+```
+
+Library example mode must run only the clean-project Rust examples that prove
+facade-first adoption. It must not build the installed CLI, run bundle profiles,
+or exercise downstream CI recipes.
+
 Downstream CI recipe mode is explicit and opt-in:
 
 ```bash
@@ -268,6 +279,8 @@ External adoption smoke maps to:
 - `cargo xtask external-adoption-smoke --path .` for current-checkout adoption;
 - `cargo xtask external-adoption-smoke --path . --format json` for
   machine-readable receipts;
+- `cargo xtask external-adoption-smoke --path . --library-examples --format json`
+  for bounded facade-first Rust example proof;
 - `cargo xtask external-adoption-smoke --path . --ci-recipes --format json` for
   downstream CI recipe proof;
 - `cargo xtask external-adoption-smoke --version <published>` for crates.io

--- a/docs/specs/USELESSKEY-SPEC-0019-library-facade-polish.md
+++ b/docs/specs/USELESSKEY-SPEC-0019-library-facade-polish.md
@@ -161,6 +161,7 @@ Library facade polish is proven by:
 When a PR changes a facade example or external smoke path, it should also run:
 
 ```bash
+cargo xtask external-adoption-smoke --path . --library-examples
 cargo xtask external-adoption-smoke --path .
 cargo test -p xtask external_adoption_smoke
 ```
@@ -209,7 +210,7 @@ Smoke: not run in a clean project
 | Requirement | Evidence |
 | --- | --- |
 | Dependency snippets stay current | `cargo xtask docs-sync --check` |
-| Facade examples compile externally | `cargo xtask external-adoption-smoke --path .` |
+| Facade examples compile externally | `cargo xtask external-adoption-smoke --path . --library-examples` |
 | External smoke stays bounded | `cargo test -p xtask external_adoption_smoke` |
 | Generated payloads are not committed | `cargo xtask no-blob` in `pr-lite` or closeout |
 | Public claims remain separate from examples | `cargo xtask claim-report --check-public-claims` in closeout |
@@ -240,6 +241,7 @@ git diff --check
 Example or smoke changes must also run:
 
 ```bash
+cargo xtask external-adoption-smoke --path . --library-examples
 cargo xtask external-adoption-smoke --path .
 cargo test -p xtask external_adoption_smoke
 ```

--- a/plans/usability-polish/implementation-plan.md
+++ b/plans/usability-polish/implementation-plan.md
@@ -136,6 +136,8 @@ Do not mix these into this lane:
 
 6. `xtask: smoke facade-first external examples`
    - Extend external adoption smoke only if it stays bounded.
+   - Add an explicit `--library-examples` mode for facade-first clean-project
+     examples so library proof does not require the installed CLI bundle loop.
    - Keep published-version mode as audit/reference, not release prep.
 
 7. `docs(spec): define downstream policy pack`

--- a/xtask/src/adoption_regression.rs
+++ b/xtask/src/adoption_regression.rs
@@ -259,6 +259,7 @@ fn external_adoption_smoke_step(root: &Path, quiet_stdout: bool) -> Result<()> {
                 path: Some(root.to_path_buf()),
                 version: None,
                 ci_recipes: false,
+                library_examples: false,
                 format: external_adoption_smoke::OutputFormat::Human,
             },
         )

--- a/xtask/src/external_adoption_smoke.rs
+++ b/xtask/src/external_adoption_smoke.rs
@@ -16,27 +16,38 @@ const REPORT_MD: &str = "target/external-adoption-smoke/report.md";
 
 const CLI_PROFILES: &[&str] = &["scanner-safe", "tls", "oidc", "webhook"];
 const CI_RECIPE_PROFILES: &[&str] = &["webhook", "tls", "oidc"];
+const RUST_TEST_FIXTURES_EXAMPLE: ExternalExample = ExternalExample {
+    name: "rust-test-fixtures",
+    source_dir: "examples/external/rust-test-fixtures",
+};
+const WEBHOOK_VERIFIER_EXAMPLE: ExternalExample = ExternalExample {
+    name: "webhook-verifier",
+    source_dir: "examples/external/webhook-verifier",
+};
+const OIDC_JWKS_VALIDATION_EXAMPLE: ExternalExample = ExternalExample {
+    name: "oidc-jwks-validation",
+    source_dir: "examples/external/oidc-jwks-validation",
+};
+const TLS_CHAIN_VALIDATION_EXAMPLE: ExternalExample = ExternalExample {
+    name: "tls-chain-validation",
+    source_dir: "examples/external/tls-chain-validation",
+};
+const DOWNSTREAM_CI_BUNDLE_AUDIT_EXAMPLE: ExternalExample = ExternalExample {
+    name: "downstream-ci-bundle-audit",
+    source_dir: "examples/external/downstream-ci-bundle-audit",
+};
+const LIBRARY_EXAMPLES: &[ExternalExample] = &[
+    RUST_TEST_FIXTURES_EXAMPLE,
+    WEBHOOK_VERIFIER_EXAMPLE,
+    OIDC_JWKS_VALIDATION_EXAMPLE,
+    TLS_CHAIN_VALIDATION_EXAMPLE,
+];
 const EXTERNAL_EXAMPLES: &[ExternalExample] = &[
-    ExternalExample {
-        name: "rust-test-fixtures",
-        source_dir: "examples/external/rust-test-fixtures",
-    },
-    ExternalExample {
-        name: "webhook-verifier",
-        source_dir: "examples/external/webhook-verifier",
-    },
-    ExternalExample {
-        name: "oidc-jwks-validation",
-        source_dir: "examples/external/oidc-jwks-validation",
-    },
-    ExternalExample {
-        name: "tls-chain-validation",
-        source_dir: "examples/external/tls-chain-validation",
-    },
-    ExternalExample {
-        name: "downstream-ci-bundle-audit",
-        source_dir: "examples/external/downstream-ci-bundle-audit",
-    },
+    RUST_TEST_FIXTURES_EXAMPLE,
+    WEBHOOK_VERIFIER_EXAMPLE,
+    OIDC_JWKS_VALIDATION_EXAMPLE,
+    TLS_CHAIN_VALIDATION_EXAMPLE,
+    DOWNSTREAM_CI_BUNDLE_AUDIT_EXAMPLE,
 ];
 const BOUNDARIES: &[&str] = &[
     "external-adoption-smoke proves clean-project user paths, not release readiness",
@@ -63,6 +74,7 @@ pub struct RunOptions {
     pub path: Option<PathBuf>,
     pub version: Option<String>,
     pub ci_recipes: bool,
+    pub library_examples: bool,
     pub format: OutputFormat,
 }
 
@@ -103,6 +115,7 @@ struct ExternalAdoptionSmokeReceipt {
     source: String,
     work_root: String,
     ci_recipes: bool,
+    library_examples: bool,
     projects: Vec<ExternalAdoptionProject>,
     steps: Vec<ExternalAdoptionStep>,
     artifacts: Vec<String>,
@@ -150,6 +163,7 @@ pub fn run(root: &Path, options: RunOptions) -> Result<()> {
         source: source.label.clone(),
         work_root: relative_artifact(root, &work_dir),
         ci_recipes: options.ci_recipes,
+        library_examples: options.library_examples,
         projects: Vec::new(),
         steps: Vec::new(),
         artifacts: vec![
@@ -167,6 +181,7 @@ pub fn run(root: &Path, options: RunOptions) -> Result<()> {
         &work_dir,
         &log_dir,
         options.ci_recipes,
+        options.library_examples,
         &mut receipt,
     );
     receipt.status = if result.is_ok() { "pass" } else { "failed" }.to_string();
@@ -185,10 +200,16 @@ fn run_matrix(
     work_dir: &Path,
     log_dir: &Path,
     ci_recipes: bool,
+    library_examples: bool,
     receipt: &mut ExternalAdoptionSmokeReceipt,
 ) -> Result<()> {
+    if library_examples {
+        run_external_examples(root, source, LIBRARY_EXAMPLES, work_dir, log_dir, receipt)?;
+        return Ok(());
+    }
+
     let cli_bin = prepare_cli(root, source, work_dir, log_dir, receipt)?;
-    run_external_examples(root, source, work_dir, log_dir, receipt)?;
+    run_external_examples(root, source, EXTERNAL_EXAMPLES, work_dir, log_dir, receipt)?;
     run_cli_discovery(&cli_bin, work_dir, log_dir, receipt)?;
     for profile in CLI_PROFILES {
         run_cli_profile(&cli_bin, profile, work_dir, log_dir, receipt)?;
@@ -255,11 +276,12 @@ fn prepare_cli(
 fn run_external_examples(
     root: &Path,
     source: &SmokeSource,
+    examples: &[ExternalExample],
     work_dir: &Path,
     log_dir: &Path,
     receipt: &mut ExternalAdoptionSmokeReceipt,
 ) -> Result<()> {
-    for example in EXTERNAL_EXAMPLES {
+    for example in examples {
         run_external_example(root, source, example, work_dir, log_dir, receipt)?;
     }
     Ok(())
@@ -910,6 +932,11 @@ fn render_markdown(receipt: &ExternalAdoptionSmokeReceipt) -> String {
     md.push_str(&format!("Status: `{}`\n\n", receipt.status));
     md.push_str(&format!("Mode: `{:?}`\n\n", receipt.mode));
     md.push_str(&format!("Source: `{}`\n\n", receipt.source));
+    md.push_str(&format!(
+        "Library examples only: `{}`\n\n",
+        receipt.library_examples
+    ));
+    md.push_str(&format!("CI recipes: `{}`\n\n", receipt.ci_recipes));
     if let Some(git_sha) = &receipt.git_sha {
         md.push_str(&format!("Git SHA: `{git_sha}`\n\n"));
     }
@@ -1010,6 +1037,23 @@ mod tests {
     }
 
     #[test]
+    fn external_adoption_library_examples_are_bounded() {
+        let names: Vec<&str> = LIBRARY_EXAMPLES
+            .iter()
+            .map(|example| example.name)
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "rust-test-fixtures",
+                "webhook-verifier",
+                "oidc-jwks-validation",
+                "tls-chain-validation",
+            ]
+        );
+    }
+
+    #[test]
     fn external_adoption_examples_are_bounded() {
         let names: Vec<&str> = EXTERNAL_EXAMPLES
             .iter()
@@ -1097,6 +1141,7 @@ uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"
             source: ".".to_string(),
             work_root: WORK_DIR.to_string(),
             ci_recipes: true,
+            library_examples: false,
             projects: vec![ExternalAdoptionProject {
                 name: "webhook-cli".to_string(),
                 path: "target/external-adoption-smoke/work/webhook-cli".to_string(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -124,6 +124,9 @@ enum Cmd {
         /// Also run downstream CI recipe commands from the docs.
         #[arg(long)]
         ci_recipes: bool,
+        /// Run only facade-first clean-project library examples.
+        #[arg(long, conflicts_with = "ci_recipes")]
+        library_examples: bool,
         /// Output format.
         #[arg(long, value_enum, default_value = "human")]
         format: ExternalAdoptionSmokeFormat,
@@ -649,6 +652,7 @@ fn main() -> Result<()> {
             path,
             version,
             ci_recipes,
+            library_examples,
             format,
         } => external_adoption_smoke::run(
             &workspace_root_path(),
@@ -656,6 +660,7 @@ fn main() -> Result<()> {
                 path,
                 version,
                 ci_recipes,
+                library_examples,
                 format: format.into(),
             },
         ),
@@ -10634,11 +10639,16 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
                 path,
                 version,
                 ci_recipes,
+                library_examples,
                 format,
             } => {
                 assert!(path.is_none(), "path should default to None");
                 assert!(version.is_none(), "version should default to None");
                 assert!(!ci_recipes, "ci_recipes should default to false");
+                assert!(
+                    !library_examples,
+                    "library_examples should default to false"
+                );
                 assert!(matches!(format, ExternalAdoptionSmokeFormat::Human));
                 let err = external_adoption_smoke::run(
                     Path::new("."),
@@ -10646,6 +10656,7 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
                         path,
                         version,
                         ci_recipes,
+                        library_examples,
                         format: format.into(),
                     },
                 );
@@ -10700,6 +10711,35 @@ uselesskey = { version = "0.4.0", features = ["rsa"] }
             }
             _ => bail!("expected Cmd::ExternalAdoptionSmoke"),
         }
+
+        let ok_library_examples = Cli::try_parse_from([
+            "xtask",
+            "external-adoption-smoke",
+            "--path",
+            ".",
+            "--library-examples",
+        ])?;
+        match ok_library_examples.cmd {
+            Cmd::ExternalAdoptionSmoke {
+                library_examples, ..
+            } => {
+                assert!(library_examples, "library examples flag should propagate");
+            }
+            _ => bail!("expected Cmd::ExternalAdoptionSmoke"),
+        }
+
+        let library_examples_conflict = Cli::try_parse_from([
+            "xtask",
+            "external-adoption-smoke",
+            "--path",
+            ".",
+            "--library-examples",
+            "--ci-recipes",
+        ]);
+        assert!(
+            library_examples_conflict.is_err(),
+            "clap must reject --library-examples + --ci-recipes together"
+        );
 
         let ok_version = Cli::try_parse_from([
             "xtask",


### PR DESCRIPTION
﻿## Summary
- add xternal-adoption-smoke --library-examples for bounded facade-first clean-project library proof
- keep the default external adoption smoke and downstream CI recipe modes separate from the library-only path
- record library_examples in external smoke receipts and document the new mode in SPEC-0013/SPEC-0019
- mark xternal-library-smoke done and move the usability-polish goal to downstream policy-pack spec

## Boundaries
- no release prep, version bump, tag, or publish
- no new contract packs, provider compatibility claims, production security claims, broad policy DSL, or facade redesign
- no installed CLI execution of xtask or claim-ledger commands

## Validation
- cargo fmt --all -- --check
- cargo test -p xtask external_adoption_smoke
- cargo +nightly xtask external-adoption-smoke --path . --library-examples
- cargo +nightly xtask external-adoption-smoke --path . --library-examples --format json
- cargo +nightly xtask external-adoption-smoke --path .
- cargo +nightly xtask adoption-regression --external
- cargo +nightly xtask spec-check --strict
- cargo +nightly xtask docs-sync --check
- cargo +nightly xtask typos
- cargo +nightly xtask pr-lite
- git diff --check
