### PR TITLE
feat(cli): add audit bundle policy controls

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -131,7 +131,7 @@ commands = [
 
 [[work_item]]
 id = "audit-bundle-policy-controls"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0020"
 plan = "plans/usability-polish/implementation-plan.md"
@@ -144,9 +144,9 @@ commands = [
 
 [[work_item]]
 id = "downstream-policy-docs"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
-spec = "USELESSKEY-SPEC-0018"
+spec = "USELESSKEY-SPEC-0020"
 plan = "plans/usability-polish/implementation-plan.md"
 commands = [
   "cargo xtask docs-sync --check",

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -1817,6 +1817,110 @@ mod tests {
         }
     }
 
+    fn audit_bundle_policy_test_args(
+        expect_profile: Option<&str>,
+        policy: Option<AuditPolicy>,
+    ) -> AuditBundleArgs {
+        AuditBundleArgs {
+            bundle_dir: PathBuf::from("target/uselesskey-webhook"),
+            out: None,
+            format: AuditOutputFormat::Markdown,
+            ci: true,
+            expect_profile: expect_profile.map(str::to_string),
+            policy,
+            summary: false,
+        }
+    }
+
+    fn audit_bundle_policy_test_audit() -> BundleAudit {
+        BundleAudit {
+            version: 1,
+            status: "pass".to_string(),
+            bundle_path: "target/uselesskey-webhook".to_string(),
+            profile: "webhook".to_string(),
+            manifest_version: 1,
+            manifest_path: "manifest.json".to_string(),
+            artifact_count: 1,
+            receipt_count: 1,
+            scanner_safe_count: 0,
+            runtime_material_count: 1,
+            files: vec!["manifest.json".to_string()],
+            artifacts: vec![],
+            receipts: vec![],
+            missing_files: vec![],
+            unexpected_files: vec![],
+            checks: vec![BundleAuditCheck::pass(
+                "manifest",
+                "invalid_manifest",
+                "manifest parsed",
+            )],
+            boundaries: vec!["audit-bundle proves local bundle consistency only".to_string()],
+            does_not_prove: vec!["production security".to_string()],
+        }
+    }
+
+    #[test]
+    fn audit_bundle_policy_accepts_matching_profile_and_strict_pass() {
+        let audit = audit_bundle_policy_test_audit();
+        let args = audit_bundle_policy_test_args(Some("webhook"), Some(AuditPolicy::Strict));
+
+        assert!(bundle_audit_policy_failure(&audit, &args).is_none());
+    }
+
+    #[test]
+    fn audit_bundle_policy_rejects_expected_profile_mismatch() {
+        let audit = audit_bundle_policy_test_audit();
+        let args = audit_bundle_policy_test_args(Some("tls"), Some(AuditPolicy::Strict));
+        let diagnostic = bundle_audit_policy_failure(&audit, &args).unwrap();
+
+        assert_eq!(diagnostic.failure_class, "profile_validation_failed");
+        assert!(diagnostic.detail.contains("expected profile `tls`"));
+    }
+
+    #[test]
+    fn audit_bundle_policy_strict_rejects_non_pass_status() {
+        let mut audit = audit_bundle_policy_test_audit();
+        audit.status = "fail".to_string();
+        let args = audit_bundle_policy_test_args(None, Some(AuditPolicy::Strict));
+        let diagnostic = bundle_audit_policy_failure(&audit, &args).unwrap();
+
+        assert_eq!(diagnostic.failure_class, "profile_validation_failed");
+        assert!(diagnostic.detail.contains("requires audit status `pass`"));
+    }
+
+    #[test]
+    fn audit_bundle_policy_strict_rejects_non_pass_check() {
+        let mut audit = audit_bundle_policy_test_audit();
+        audit.checks[0].status = "fail".to_string();
+        let args = audit_bundle_policy_test_args(None, Some(AuditPolicy::Strict));
+        let diagnostic = bundle_audit_policy_failure(&audit, &args).unwrap();
+
+        assert_eq!(diagnostic.failure_class, "profile_validation_failed");
+        assert!(diagnostic.detail.contains("requires all checks to pass"));
+    }
+
+    #[test]
+    fn audit_bundle_policy_strict_rejects_missing_files() {
+        let mut audit = audit_bundle_policy_test_audit();
+        audit.missing_files.push("manifest.json".to_string());
+        let args = audit_bundle_policy_test_args(None, Some(AuditPolicy::Strict));
+        let diagnostic = bundle_audit_policy_failure(&audit, &args).unwrap();
+
+        assert_eq!(diagnostic.failure_class, "missing_artifact");
+        assert!(diagnostic.detail.contains("missing bundle files"));
+    }
+
+    #[test]
+    fn audit_bundle_policy_strict_rejects_unexpected_files() {
+        let mut audit = audit_bundle_policy_test_audit();
+        audit.unexpected_files.push("extra.json".to_string());
+        let args = audit_bundle_policy_test_args(None, Some(AuditPolicy::Strict));
+        let diagnostic = bundle_audit_policy_failure(&audit, &args).unwrap();
+
+        assert_eq!(diagnostic.failure_class, "unexpected_artifact");
+        assert!(diagnostic.detail.contains("unexpected bundle files"));
+    }
+
     #[test]
     fn default_output_hint_safety_requires_relative_target_paths() {
         assert!(is_safe_default_output_hint("target/uselesskey-webhook"));

--- a/crates/uselesskey-cli/src/main.rs
+++ b/crates/uselesskey-cli/src/main.rs
@@ -150,6 +150,8 @@ struct InspectBundleArgs {
 #[command(after_help = "Examples:
   uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit
   uselesskey audit-bundle --path target/uselesskey-webhook --ci
+  uselesskey audit-bundle --path target/uselesskey-webhook --ci --expect-profile webhook
+  uselesskey audit-bundle --path target/uselesskey-webhook --ci --policy strict
   uselesskey audit-bundle --path target/uselesskey-webhook --summary
 
 Boundary:
@@ -168,6 +170,12 @@ struct AuditBundleArgs {
     /// Emit CI-oriented JSON and exit non-zero on stable audit failure classes.
     #[arg(long, conflicts_with = "summary")]
     ci: bool,
+    /// Require the audited manifest profile to match the CI job's expected profile.
+    #[arg(long, value_name = "PROFILE")]
+    expect_profile: Option<String>,
+    /// Apply a built-in audit policy preset.
+    #[arg(long, value_enum)]
+    policy: Option<AuditPolicy>,
     /// Print a compact human summary for terminals or CI logs.
     #[arg(long)]
     summary: bool,
@@ -190,6 +198,11 @@ struct DoctorArgs {
 enum AuditOutputFormat {
     Markdown,
     Json,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum AuditPolicy {
+    Strict,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -527,6 +540,13 @@ fn run_audit_bundle(args: AuditBundleArgs) -> Result<()> {
             );
         }
     };
+    if let Some(diagnostic) = bundle_audit_policy_failure(&audit, &args) {
+        bail!(
+            "audit policy failed: {}: {}",
+            diagnostic.failure_class,
+            diagnostic.detail
+        );
+    }
 
     if let Some(out_dir) = args.out.as_deref() {
         let (json_path, md_path) = write_bundle_audit_receipts(&audit, out_dir)?;
@@ -568,6 +588,15 @@ fn run_audit_bundle(args: AuditBundleArgs) -> Result<()> {
 fn run_audit_bundle_ci(args: AuditBundleArgs) -> Result<()> {
     match build_bundle_audit(&args.bundle_dir) {
         Ok(audit) => {
+            if let Some(diagnostic) = bundle_audit_policy_failure(&audit, &args) {
+                let failure = bundle_audit_policy_failure_json(&audit, &diagnostic);
+                emit_artifact(&Artifact::Json(failure), None)?;
+                bail!(
+                    "audit policy failed: {}: {}",
+                    diagnostic.failure_class,
+                    diagnostic.detail
+                );
+            }
             if let Some(out_dir) = args.out.as_deref() {
                 write_bundle_audit_receipts(&audit, out_dir)?;
             }
@@ -1496,6 +1525,97 @@ fn bundle_audit_failure_json(
             "downstream verifier correctness",
         ],
     })
+}
+
+fn bundle_audit_policy_failure_json(
+    audit: &BundleAudit,
+    diagnostic: &BundleAuditFailureDiagnostic,
+) -> serde_json::Value {
+    json!({
+        "version": audit.version,
+        "status": "fail",
+        "bundle_path": &audit.bundle_path,
+        "profile": &audit.profile,
+        "manifest_version": audit.manifest_version,
+        "manifest_path": &audit.manifest_path,
+        "artifact_count": audit.artifact_count,
+        "receipt_count": audit.receipt_count,
+        "scanner_safe_count": audit.scanner_safe_count,
+        "runtime_material_count": audit.runtime_material_count,
+        "files": &audit.files,
+        "artifacts": &audit.artifacts,
+        "receipts": &audit.receipts,
+        "missing_files": &audit.missing_files,
+        "unexpected_files": &audit.unexpected_files,
+        "checks": [
+            {
+                "name": "bundle-audit-policy",
+                "status": "fail",
+                "failure_class": diagnostic.failure_class,
+                "detail": diagnostic.detail,
+            }
+        ],
+        "boundaries": &audit.boundaries,
+        "does_not_prove": &audit.does_not_prove,
+    })
+}
+
+fn bundle_audit_policy_failure(
+    audit: &BundleAudit,
+    args: &AuditBundleArgs,
+) -> Option<BundleAuditFailureDiagnostic> {
+    if let Some(expected) = args.expect_profile.as_deref()
+        && audit.profile != expected
+    {
+        return Some(BundleAuditFailureDiagnostic {
+            failure_class: "profile_validation_failed",
+            detail: format!(
+                "expected profile `{expected}`, found `{}`. Fix: audit the matching bundle or update --expect-profile for this CI job.",
+                audit.profile
+            ),
+        });
+    }
+
+    if args.policy == Some(AuditPolicy::Strict) {
+        if audit.status != "pass" {
+            return Some(BundleAuditFailureDiagnostic {
+                failure_class: "profile_validation_failed",
+                detail: format!(
+                    "strict policy requires audit status `pass`, found `{}`. Fix: regenerate and audit the bundle.",
+                    audit.status
+                ),
+            });
+        }
+        if let Some(check) = audit.checks.iter().find(|check| check.status != "pass") {
+            return Some(BundleAuditFailureDiagnostic {
+                failure_class: "profile_validation_failed",
+                detail: format!(
+                    "strict policy requires all checks to pass; `{}` was `{}`. Fix: regenerate and audit the bundle.",
+                    check.name, check.status
+                ),
+            });
+        }
+        if !audit.missing_files.is_empty() {
+            return Some(BundleAuditFailureDiagnostic {
+                failure_class: "missing_artifact",
+                detail: format!(
+                    "strict policy found missing bundle files: {}. Fix: regenerate the bundle.",
+                    audit.missing_files.join(", ")
+                ),
+            });
+        }
+        if !audit.unexpected_files.is_empty() {
+            return Some(BundleAuditFailureDiagnostic {
+                failure_class: "unexpected_artifact",
+                detail: format!(
+                    "strict policy found unexpected bundle files: {}. Fix: remove extra files or regenerate into an empty target directory.",
+                    audit.unexpected_files.join(", ")
+                ),
+            });
+        }
+    }
+
+    None
 }
 
 fn bundle_audit_failure_class(err: &anyhow::Error) -> &'static str {

--- a/crates/uselesskey-cli/tests/cli.rs
+++ b/crates/uselesskey-cli/tests/cli.rs
@@ -150,6 +150,8 @@ fn audit_bundle_help_explains_ci_receipts_and_boundaries() -> TestResult<()> {
     assert!(out.contains("--path <BUNDLE_DIR>"));
     assert!(out.contains("uselesskey audit-bundle --path target/uselesskey-webhook --out"));
     assert!(out.contains("uselesskey audit-bundle --path target/uselesskey-webhook --ci"));
+    assert!(out.contains("--expect-profile <PROFILE>"));
+    assert!(out.contains("--policy <POLICY>"));
     assert!(out.contains("Emit CI-oriented JSON"));
     assert!(out.contains("stable audit failure classes"));
     assert!(out.contains("not prove production security"));
@@ -1128,6 +1130,82 @@ fn audit_bundle_ci_outputs_json_on_success() -> TestResult<()> {
     assert_eq!(audit["profile"], "webhook");
     assert_eq!(audit["checks"][0]["failure_class"], "invalid_manifest");
     assert!(!out.contains("whsec_"));
+    Ok(())
+}
+
+#[test]
+fn audit_bundle_ci_accepts_strict_policy_and_expected_profile() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("webhook");
+
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    bundle.assert().success();
+
+    let out = run([
+        "audit-bundle",
+        "--path",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--ci",
+        "--expect-profile",
+        "webhook",
+        "--policy",
+        "strict",
+    ])?;
+    let audit: Value = serde_json::from_str(&out).test_context("audit json")?;
+    assert_eq!(audit["status"], "pass");
+    assert_eq!(audit["profile"], "webhook");
+    assert!(!out.contains("whsec_"));
+    Ok(())
+}
+
+#[test]
+fn audit_bundle_ci_fails_on_expected_profile_mismatch() -> TestResult<()> {
+    let dir = tempdir().test_context("tempdir")?;
+    let bundle_dir = dir.path().join("webhook");
+
+    let mut bundle = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    bundle.args([
+        "bundle",
+        "--profile",
+        "webhook",
+        "--out",
+        bundle_dir.to_str().test_context("utf-8")?,
+    ]);
+    bundle.assert().success();
+
+    let mut audit = Command::cargo_bin("uselesskey").test_context("bin exists")?;
+    audit.args([
+        "audit-bundle",
+        "--path",
+        bundle_dir.to_str().test_context("utf-8")?,
+        "--ci",
+        "--expect-profile",
+        "tls",
+    ]);
+    let assert = audit.assert().code(1).stderr(predicate::str::contains(
+        "audit policy failed: profile_validation_failed",
+    ));
+    let output = assert.get_output();
+    let audit: Value = serde_json::from_slice(&output.stdout).test_context("audit failure json")?;
+    assert_eq!(audit["status"], "fail");
+    assert_eq!(audit["profile"], "webhook");
+    assert_eq!(audit["checks"][0]["status"], "fail");
+    assert_eq!(
+        audit["checks"][0]["failure_class"],
+        "profile_validation_failed"
+    );
+    let detail = audit["checks"][0]["detail"]
+        .as_str()
+        .test_context("failure detail")?;
+    assert!(detail.contains("expected profile `tls`, found `webhook`"));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("whsec_"));
     Ok(())
 }
 

--- a/xtask/src/external_adoption_smoke.rs
+++ b/xtask/src/external_adoption_smoke.rs
@@ -513,6 +513,8 @@ fn run_ci_recipe_profile(
         .arg(&bundle_dir)
         .args(["--out"])
         .arg(&audit_dir)
+        .args(["--expect-profile", profile])
+        .args(["--policy", "strict"])
         .arg("--ci")
         .current_dir(&project_dir);
     run_command_step(


### PR DESCRIPTION
﻿## Summary
- add udit-bundle --expect-profile <profile> for CI jobs that need profile mismatch failures without parsing JSON manually
- add udit-bundle --policy strict as the first tiny built-in policy preset from SPEC-0020
- emit CI failure JSON for policy mismatches with stable failure classes and metadata-only output
- wire downstream CI recipe smoke to run --expect-profile <profile> --policy strict
- mark udit-bundle-policy-controls done and move the usability-polish goal to downstream policy docs

## Boundaries
- no broad policy DSL, remote policy loading, script execution, or repo-local proof execution
- no release prep, version bump, tag, or publish
- no new contract packs, provider compatibility claims, production security claims, or raw payload copying

## Validation
- cargo fmt --all -- --check
- cargo test -p uselesskey-cli --all-features audit_bundle
- cargo test -p xtask external_adoption_smoke
- cargo +nightly xtask external-adoption-smoke --path . --ci-recipes
- cargo +nightly xtask pr-lite
- cargo clippy -p uselesskey-cli --all-targets --all-features -- -D warnings
- git diff --check
