### PR TITLE
docs: add downstream policy checklist

### DIFF
--- a/.uselesskey/goals/active.toml
+++ b/.uselesskey/goals/active.toml
@@ -144,7 +144,7 @@ commands = [
 
 [[work_item]]
 id = "downstream-policy-docs"
-status = "ready"
+status = "done"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0020"
 plan = "plans/usability-polish/implementation-plan.md"
@@ -156,7 +156,7 @@ commands = [
 
 [[work_item]]
 id = "lane-closeout"
-status = "planned"
+status = "ready"
 proposal = "USELESSKEY-PROP-0001"
 spec = "USELESSKEY-SPEC-0005"
 plan = "plans/usability-polish/implementation-plan.md"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Pick the job first; the repo proof machinery is behind links when you need it.
 | use fixtures in Rust tests | facade crate | `uselesskey = { version = "0.9.1", features = ["rsa"] }` |
 | generate deterministic bundles on disk | installed CLI | `uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle` |
 | test webhook, TLS, or OIDC/JWKS verifier paths | contract-pack profiles | `uselesskey profiles` |
-| fail CI on bundle drift | metadata-only audit | `uselesskey audit-bundle --path target/uselesskey-webhook --ci` |
+| fail CI on bundle drift | downstream policy pack | `uselesskey audit-bundle --path target/uselesskey-webhook --ci --expect-profile webhook --policy strict` |
 | share a reviewer packet without cloning the repo | installed bundle audit | `uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit` |
 | prove repo public claims from a checkout | repo verification pack | `cargo xtask verification-pack --out target/uselesskey-verification` |
 
@@ -57,10 +57,11 @@ uselesskey inspect-bundle --path target/uselesskey-webhook
 uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit
 ```
 
-Use `--ci` when the audit is part of a downstream CI gate:
+Use `--ci --expect-profile <profile> --policy strict` when the audit is part
+of a downstream CI gate:
 
 ```bash
-uselesskey audit-bundle --path target/uselesskey-webhook --ci
+uselesskey audit-bundle --path target/uselesskey-webhook --ci --expect-profile webhook --policy strict
 ```
 
 Rust test authors start with the facade crate:

--- a/docs/how-to/share-installed-bundle-audit.md
+++ b/docs/how-to/share-installed-bundle-audit.md
@@ -35,6 +35,32 @@ Do not attach generated request payloads, PEM/DER material, token files,
 Kubernetes Secret YAML, Vault JSON, or other raw fixture payloads unless your
 review process explicitly asks for them.
 
+## Reviewer Checklist
+
+Attach the metadata-only receipts, then record:
+
+- the generated profile, such as `webhook`, `tls`, `oidc`, or `scanner-safe`;
+- the command used to verify the bundle;
+- the command used to audit the bundle;
+- whether `bundle-audit.json` reports `status: "pass"`;
+- whether every `checks[]` entry reports `status: "pass"`;
+- whether generated fixture payloads stayed under `target/` or another ignored
+  output directory;
+- the explicit "does not prove" boundary below.
+
+For CI jobs, prefer the strict policy preset:
+
+```bash
+uselesskey audit-bundle \
+  --path target/uselesskey-webhook \
+  --ci \
+  --expect-profile webhook \
+  --policy strict
+```
+
+For the full downstream policy preset list, see
+[use-downstream-policy-pack.md](use-downstream-policy-pack.md).
+
 ## JSON for CI
 
 ```bash

--- a/docs/how-to/start-here.md
+++ b/docs/how-to/start-here.md
@@ -17,6 +17,7 @@ or cryptographic assurance.
 | test TLS verifier behavior | TLS contract pack | `uselesskey bundle --profile tls --out target/uselesskey-tls` |
 | test OIDC/JWKS validator behavior | OIDC/JWKS contract pack | `uselesskey bundle --profile oidc --out target/uselesskey-oidc` |
 | test webhook signature negatives | webhook contract pack | `uselesskey bundle --profile webhook --out target/uselesskey-webhook` |
+| fail CI on installed bundle drift | downstream policy pack | `uselesskey audit-bundle --path target/uselesskey-webhook --ci --expect-profile webhook --policy strict` |
 | share what an installed bundle contains | installed bundle audit | `uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit` |
 | prove public claims for a reviewer with a repo checkout | verification pack | `cargo xtask verification-pack --out target/uselesskey-verification` |
 
@@ -171,6 +172,8 @@ consistency and metadata classification only. It does not prove repo public
 claims, release readiness, provider compatibility, production security, or
 downstream verifier correctness. See
 [share-installed-bundle-audit.md](share-installed-bundle-audit.md).
+For CI policy presets and the reviewer checklist, see
+[use-downstream-policy-pack.md](use-downstream-policy-pack.md).
 
 Build a metadata-only review bundle from a repo checkout:
 

--- a/docs/how-to/use-downstream-policy-pack.md
+++ b/docs/how-to/use-downstream-policy-pack.md
@@ -1,0 +1,113 @@
+# Use the Downstream Policy Pack
+
+Use this page when a downstream CI job should fail on meaningful bundle drift
+and produce reviewer-ready, metadata-only evidence.
+
+The policy pack is intentionally small. It gives installed CLI users named
+presets and copyable commands; it is not a policy language, governance engine,
+provider compatibility proof, production security proof, or scanner-policy
+approval.
+
+## Pick a Preset
+
+| Preset | Use it when | Copy this |
+| --- | --- | --- |
+| `default` | you want local audit JSON without stricter CI expectations | `uselesskey audit-bundle --path target/uselesskey-webhook --ci` |
+| `strict` | CI should fail on audit drift for one expected profile | `uselesskey audit-bundle --path target/uselesskey-webhook --ci --expect-profile webhook --policy strict` |
+| `reviewer` | you need files to attach to a security or platform review | `uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit` |
+
+## Strict CI Gate
+
+Generate, verify, inspect, and audit one profile per output directory:
+
+```bash
+cargo install uselesskey-cli --version 0.9.1 --locked
+uselesskey bundle --profile webhook --out target/uselesskey-webhook
+uselesskey verify-bundle --path target/uselesskey-webhook
+uselesskey inspect-bundle --path target/uselesskey-webhook
+uselesskey audit-bundle \
+  --path target/uselesskey-webhook \
+  --ci \
+  --expect-profile webhook \
+  --policy strict
+```
+
+The strict preset exits non-zero when the installed bundle audit reports a
+stable failure class such as `missing_manifest`, `path_escape`,
+`missing_artifact`, `unexpected_artifact`, `missing_receipt`,
+`scanner_safe_mismatch`, `runtime_material_mismatch`,
+`profile_validation_failed`, or `unsupported_profile`.
+
+Use `--expect-profile <profile>` so a reused CI step cannot accidentally audit
+the wrong bundle.
+
+## Reviewer Packet
+
+For a reviewer handoff, write metadata-only receipts:
+
+```bash
+uselesskey audit-bundle \
+  --path target/uselesskey-webhook \
+  --out target/uselesskey-webhook-audit
+```
+
+Attach:
+
+```text
+target/uselesskey-webhook-audit/bundle-audit.json
+target/uselesskey-webhook-audit/bundle-audit.md
+```
+
+Do not attach generated PEM, DER, JWT, JWK/JWKS, webhook request,
+Kubernetes Secret, Vault JSON, or other raw fixture payloads unless your
+organization has a separate reviewed policy for those files.
+
+## Reviewer Checklist
+
+A reviewer should check:
+
+- the CI job generated the intended profile;
+- `audit-bundle --ci --expect-profile <profile> --policy strict` passed;
+- `bundle-audit.json` and `bundle-audit.md` were uploaded as CI artifacts;
+- generated fixture payloads stayed under `target/` or another ignored output
+  directory;
+- the JSON `profile` matches the job being reviewed;
+- the JSON `status` is `pass`;
+- every `checks[]` entry has `status: "pass"`;
+- `scanner_safe` and `runtime_material` labels match the intended use of each
+  artifact;
+- the "does not prove" boundary is included in the review note.
+
+If the audit fails, branch on `failure_class`, not the English diagnostic text.
+The JSON schema and stable failure classes are documented in
+[`../reference/bundle-audit-json.md`](../reference/bundle-audit-json.md).
+
+## What This Proves
+
+The downstream policy pack proves local bundle consistency for an installed CLI
+bundle:
+
+- the manifest parses;
+- manifest-listed files stay under the bundle root;
+- listed artifacts and receipts exist;
+- unexpected files are reported;
+- scanner-safe and runtime-material counts match the bundle receipts;
+- the audited profile matches the CI job when `--expect-profile` is set.
+
+## What This Does Not Prove
+
+This does not prove:
+
+- repo public claims;
+- release readiness;
+- production security or production key management;
+- provider compatibility;
+- permission to ignore scanner policy;
+- downstream verifier correctness.
+
+Use repo-local proof only when a reviewer needs public-claim evidence:
+
+```bash
+cargo xtask verification-pack --out target/uselesskey-verification
+cargo xtask claim-proof --all-stable
+```

--- a/docs/how-to/use-uselesskey-in-downstream-ci.md
+++ b/docs/how-to/use-uselesskey-in-downstream-ci.md
@@ -11,7 +11,7 @@ steps:
   - run: cargo install uselesskey-cli --version 0.9.1
   - run: uselesskey bundle --profile webhook --out target/uselesskey-webhook
   - run: uselesskey verify-bundle --path target/uselesskey-webhook
-  - run: uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit --ci
+  - run: uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit --ci --expect-profile webhook --policy strict
 ```
 
 The audit files are safe reviewer metadata:
@@ -30,12 +30,18 @@ unless your project has a separate reviewed policy for those artifacts.
 Use JSON mode when CI needs a machine-readable decision point:
 
 ```bash
-uselesskey audit-bundle --path target/uselesskey-webhook --ci
+uselesskey audit-bundle \
+  --path target/uselesskey-webhook \
+  --ci \
+  --expect-profile webhook \
+  --policy strict
 ```
 
-Fail CI if the command exits non-zero. A non-zero exit means the local bundle
-failed a manifest, containment, receipt, scanner-safe/runtime-material, or
-profile validation check.
+Fail CI if the command exits non-zero. With `--policy strict`, a non-zero exit
+means the local bundle failed the strict installed-bundle policy: wrong profile,
+non-passing audit status, missing or unexpected files, containment failure,
+receipt drift, scanner-safe/runtime-material mismatch, or profile validation
+failure.
 
 For compact human CI logs without changing the machine-readable `--ci` path,
 run summary mode in a separate step:
@@ -49,6 +55,9 @@ uselesskey audit-bundle --path target/uselesskey-webhook --summary
 This downstream CI recipe proves local bundle consistency. It does not prove
 provider compatibility, production security, repo public claims, scanner
 evasion, or release readiness.
+
+For the preset policy names and reviewer checklist, see
+[use-downstream-policy-pack.md](use-downstream-policy-pack.md).
 
 Use repo-local proof only when a reviewer asks for public-claim receipts:
 

--- a/docs/how-to/use-uselesskey-in-github-actions.md
+++ b/docs/how-to/use-uselesskey-in-github-actions.md
@@ -41,12 +41,16 @@ jobs:
           uselesskey audit-bundle \
             --path target/uselesskey-webhook \
             --out target/uselesskey-webhook-audit \
-            --ci
+            --ci \
+            --expect-profile webhook \
+            --policy strict
 ```
 
 `--ci` emits machine-readable audit JSON on stdout and exits non-zero when the
 bundle fails a stable audit class such as `missing_manifest`, `path_escape`,
 `missing_artifact`, `scanner_safe_mismatch`, or `runtime_material_mismatch`.
+`--expect-profile webhook --policy strict` makes the job fail if a reused CI step
+audits the wrong profile or the audit is not clean.
 
 ## TLS and OIDC Fixtures
 
@@ -81,7 +85,9 @@ jobs:
           uselesskey audit-bundle \
             --path target/uselesskey-tls \
             --out target/uselesskey-tls-audit \
-            --ci
+            --ci \
+            --expect-profile tls \
+            --policy strict
 
       - name: Generate OIDC fixtures
         run: uselesskey bundle --profile oidc --out target/uselesskey-oidc
@@ -94,7 +100,9 @@ jobs:
           uselesskey audit-bundle \
             --path target/uselesskey-oidc \
             --out target/uselesskey-oidc-audit \
-            --ci
+            --ci \
+            --expect-profile oidc \
+            --policy strict
 ```
 
 ## Upload Audit Receipts
@@ -148,3 +156,5 @@ Use repo-local proof only when a reviewer needs public-claim evidence:
 cargo xtask verification-pack --out target/uselesskey-verification
 ```
 
+For preset policy names and the reviewer checklist, see
+[use-downstream-policy-pack.md](use-downstream-policy-pack.md).


### PR DESCRIPTION
## Summary
- add a downstream policy pack how-to with default, strict, and reviewer presets
- update CI recipes and README/start-here examples to use --expect-profile with --policy strict
- add reviewer checklist language for metadata-only bundle audit handoffs
- mark downstream-policy-docs done and lane closeout ready

## Validation
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask spec-check --strict
- git diff --check

## Boundaries
- no release prep, version bump, tag, or publish
- no new contract pack, badges, provider compatibility claim, production security claim, or policy DSL