### PR TITLE
release: prepare v0.10.0 candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-19
+
+v0.10.0 is the release-adoption and installed-workflow release. It makes the
+CLI and facade paths easier to use from clean downstream projects, adds a
+metadata-only bundle audit contract for reviewers and CI, and records the
+source handoff for package-proven release evidence.
+
+This release does not claim production security, provider compatibility,
+scanner-policy approval, downstream verifier correctness, or publication until
+the explicit release gate has completed.
+
+### Added
+
+- Added installed-user bundle audit flows that write `bundle-audit.json` and
+  `bundle-audit.md`, keep generated fixture payloads out of reviewer packets,
+  and expose stable `failure_class` values for CI branching.
+- Added downstream CI recipes and policy presets for generating, verifying,
+  auditing, and uploading metadata-only bundle audit evidence.
+- Added clean-project external adoption smoke for CLI recipes and facade
+  examples, including downstream-shaped webhook, OIDC/JWKS, TLS, and Rust test
+  fixture examples.
+- Added taxonomy-backed negative JWK/JWKS and token fixtures for validator
+  failure-path tests.
+- Added the v0.10 source handoff record that pins the swarm handoff SHA,
+  command ledger, receipt contract, package-proof boundary, deferred source
+  PRs, non-claims, and rollback path.
+
+### Changed
+
+- Refreshed workspace crate versions, internal path dependency constraints,
+  lockfile state, and copyable install/dependency snippets for the v0.10.0
+  source candidate.
+- Reworked README, Start Here, feature-choice, and task-focused docs around
+  user jobs instead of repo-internal crate discovery.
+- Improved installed CLI help, `doctor`, `profiles`, `inspect-bundle`, and
+  `audit-bundle` wording so terminal summaries stay separate from durable
+  machine-readable receipts.
+
+### Fixed
+
+- Returned usage errors for conflicting audit modes.
+- Improved audit-bundle failure diagnostics while preserving stable machine
+  failure classes.
+- Strengthened deterministic, cache, PEM corruption, WebAuthn, SSH, CLI, and
+  fuzz coverage around the release-adoption surface.
+
 ## [0.9.1] - 2026-05-17
 
 v0.9.1 is an adoption-confidence patch. It publishes the runtime scanner-safe
@@ -660,7 +706,9 @@ Repository organised into four layers:
 - **Determinism regression** — hardcoded expected-value snapshots ensure
   derivation stability across releases
 
-[Unreleased]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.9.1...v0.10.0
+[0.9.1]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/EffortlessMetrics/uselesskey/compare/v0.7.0...v0.7.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "insta",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-aws-lc-rs"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "aws-lc-rs",
  "hex",
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-axum"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "axum",
  "http",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-bdd-steps"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -4692,7 +4692,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-cli"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4719,7 +4719,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "blake3",
@@ -4739,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ecdsa"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "elliptic-curve 0.14.0-rc.29",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ed25519"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-entropy"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "proptest",
  "uselesskey-core",
@@ -4784,14 +4784,14 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-feature-grid"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "uselesskey-test-support",
 ]
 
 [[package]]
 name = "uselesskey-hmac"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "insta",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jsonwebtoken"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "insta",
  "jsonwebtoken",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jwk"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "blake3",
@@ -4903,7 +4903,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pgp"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "insta",
  "pgp",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pkcs11-mock"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "sha2 0.11.0",
  "uselesskey-core",
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ring"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "hex",
  "insta",
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rsa"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "insta",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustcrypto"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustls"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "hex",
  "insta",
@@ -5002,7 +5002,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ssh"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "proptest",
  "rand_chacha 0.3.1",
@@ -5013,14 +5013,14 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-test-grid"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "uselesskey-feature-grid",
 ]
 
 [[package]]
 name = "uselesskey-test-server"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "axum",
  "blake3",
@@ -5040,11 +5040,11 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-test-support"
-version = "0.9.1"
+version = "0.10.0"
 
 [[package]]
 name = "uselesskey-token"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "insta",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-tonic"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "insta",
  "proptest",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-webauthn"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ciborium",
  "serde_json",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-webhook"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "hex",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-x509"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,20 +58,20 @@ thiserror = "2.0.18"
 uselesskey-test-grid = { path = "crates/uselesskey-test-grid" }
 uselesskey-test-support = { path = "crates/uselesskey-test-support" }
 uselesskey-feature-grid = { path = "crates/uselesskey-feature-grid" }
-uselesskey = { path = "crates/uselesskey", version = "0.9.1", default-features = false }
-uselesskey-cli = { path = "crates/uselesskey-cli", version = "0.9.1" }
-uselesskey-entropy = { path = "crates/uselesskey-entropy", version = "0.9.1" }
-uselesskey-core = { path = "crates/uselesskey-core", version = "0.9.1" }
-uselesskey-rsa = { path = "crates/uselesskey-rsa", version = "0.9.1" }
-uselesskey-ecdsa = { path = "crates/uselesskey-ecdsa", version = "0.9.1" }
-uselesskey-ed25519 = { path = "crates/uselesskey-ed25519", version = "0.9.1" }
-uselesskey-hmac = { path = "crates/uselesskey-hmac", version = "0.9.1" }
-uselesskey-token = { path = "crates/uselesskey-token", version = "0.9.1" }
-uselesskey-pgp = { path = "crates/uselesskey-pgp", version = "0.9.1" }
-uselesskey-x509 = { path = "crates/uselesskey-x509", version = "0.9.1" }
-uselesskey-webhook = { path = "crates/uselesskey-webhook", version = "0.9.1" }
-uselesskey-ssh = { path = "crates/uselesskey-ssh", version = "0.9.1" }
-uselesskey-rustls = { path = "crates/uselesskey-rustls", version = "0.9.1" }
+uselesskey = { path = "crates/uselesskey", version = "0.10.0", default-features = false }
+uselesskey-cli = { path = "crates/uselesskey-cli", version = "0.10.0" }
+uselesskey-entropy = { path = "crates/uselesskey-entropy", version = "0.10.0" }
+uselesskey-core = { path = "crates/uselesskey-core", version = "0.10.0" }
+uselesskey-rsa = { path = "crates/uselesskey-rsa", version = "0.10.0" }
+uselesskey-ecdsa = { path = "crates/uselesskey-ecdsa", version = "0.10.0" }
+uselesskey-ed25519 = { path = "crates/uselesskey-ed25519", version = "0.10.0" }
+uselesskey-hmac = { path = "crates/uselesskey-hmac", version = "0.10.0" }
+uselesskey-token = { path = "crates/uselesskey-token", version = "0.10.0" }
+uselesskey-pgp = { path = "crates/uselesskey-pgp", version = "0.10.0" }
+uselesskey-x509 = { path = "crates/uselesskey-x509", version = "0.10.0" }
+uselesskey-webhook = { path = "crates/uselesskey-webhook", version = "0.10.0" }
+uselesskey-ssh = { path = "crates/uselesskey-ssh", version = "0.10.0" }
+uselesskey-rustls = { path = "crates/uselesskey-rustls", version = "0.10.0" }
 
 # determinism / hashing
 blake3 = "1.8.5"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Pick the job first; the repo proof machinery is behind links when you need it.
 
 | I need to... | Start with | Copy this |
 | --- | --- | --- |
-| use fixtures in Rust tests | facade crate | `uselesskey = { version = "0.9.1", features = ["rsa"] }` |
+| use fixtures in Rust tests | facade crate | `uselesskey = { version = "0.10.0", features = ["rsa"] }` |
 | generate deterministic bundles on disk | installed CLI | `uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle` |
 | test webhook, TLS, or OIDC/JWKS verifier paths | contract-pack profiles | `uselesskey profiles` |
 | fail CI on bundle drift | downstream policy pack | `uselesskey audit-bundle --path target/uselesskey-webhook --ci --expect-profile webhook --policy strict` |
@@ -42,7 +42,7 @@ Pick the job first; the repo proof machinery is behind links when you need it.
 Install the CLI when you want fixture bundles outside this workspace:
 
 ```bash
-cargo install uselesskey-cli --version 0.9.1
+cargo install uselesskey-cli --version 0.10.0
 uselesskey doctor
 uselesskey profiles
 uselesskey bundle --profile webhook --explain
@@ -68,7 +68,7 @@ Rust test authors start with the facade crate:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["rsa"] }
+uselesskey = { version = "0.10.0", features = ["rsa"] }
 ```
 
 Then generate deterministic fixtures at runtime:
@@ -184,31 +184,31 @@ Common starting points:
 ```toml
 # Entropy-only fixtures
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["entropy"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["entropy"] }
 ```
 
 ```toml
 # RSA fixtures
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["rsa"] }
+uselesskey = { version = "0.10.0", features = ["rsa"] }
 ```
 
 ```toml
 # Token-only fixtures, no RSA/X.509 pull-in
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["token"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["token"] }
 ```
 
 ```toml
 # RSA + JWK/JWKS
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["rsa", "jwk"] }
+uselesskey = { version = "0.10.0", features = ["rsa", "jwk"] }
 ```
 
 ```toml
 # X.509 fixtures
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["x509"] }
+uselesskey = { version = "0.10.0", features = ["x509"] }
 ```
 
 The following materialization commands are repo-checkout examples. Installed
@@ -226,13 +226,13 @@ For `build.rs` consumers:
 ```toml
 # Common shape-only build-time path
 [build-dependencies]
-uselesskey-cli = { version = "0.9.1", default-features = false }
+uselesskey-cli = { version = "0.10.0", default-features = false }
 ```
 
 ```toml
 # Specialized RSA PKCS#8 build-time path
 [build-dependencies]
-uselesskey-cli = { version = "0.9.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.10.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 Use the facade for convenience. Depend on leaf crates only when compile-time minimization matters enough to justify the sharper API.
@@ -285,37 +285,37 @@ Dependency snippets:
 - **Quick start (RSA)**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["rsa"] }
+  uselesskey = { version = "0.10.0", features = ["rsa"] }
   ```
 
 
 - **Token-only**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", default-features = false, features = ["token"] }
+  uselesskey = { version = "0.10.0", default-features = false, features = ["token"] }
   ```
 
 
 - **JWT/JWK**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["rsa", "jwk"] }
+  uselesskey = { version = "0.10.0", features = ["rsa", "jwk"] }
   ```
 
 
 - **X.509 + rustls**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["x509"] }
-  uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+  uselesskey = { version = "0.10.0", features = ["x509"] }
+  uselesskey-rustls = { version = "0.10.0", features = ["tls-config", "rustls-ring"] }
   ```
 
 
 - **jsonwebtoken adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jsonwebtoken = { version = "0.9.1" }
+  uselesskey = { version = "0.10.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jsonwebtoken = { version = "0.10.0" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 
@@ -481,8 +481,8 @@ With the `tls-config` feature, build rustls configs in one step:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["x509"] }
-uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+uselesskey = { version = "0.10.0", features = ["x509"] }
+uselesskey-rustls = { version = "0.10.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```rust
@@ -500,8 +500,8 @@ let client_config = chain.client_config_rustls();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["rsa"] }
-uselesskey-ring = { version = "0.9.1", features = ["all"] }
+uselesskey = { version = "0.10.0", features = ["rsa"] }
+uselesskey-ring = { version = "0.10.0", features = ["all"] }
 ```
 
 ```rust
@@ -517,8 +517,8 @@ let ring_kp = rsa.rsa_key_pair_ring();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["rsa"] }
-uselesskey-rustcrypto = { version = "0.9.1", features = ["all"] }
+uselesskey = { version = "0.10.0", features = ["rsa"] }
+uselesskey-rustcrypto = { version = "0.10.0", features = ["all"] }
 ```
 
 ```rust
@@ -534,8 +534,8 @@ let rsa_pk = rsa.rsa_private_key();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["rsa"] }
-uselesskey-aws-lc-rs = { version = "0.9.1", features = ["native", "all"] }
+uselesskey = { version = "0.10.0", features = ["rsa"] }
+uselesskey-aws-lc-rs = { version = "0.10.0", features = ["native", "all"] }
 ```
 
 ```rust
@@ -551,8 +551,8 @@ let lc_kp = rsa.rsa_key_pair_aws_lc_rs();
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["x509"] }
-uselesskey-tonic = "0.9.1"
+uselesskey = { version = "0.10.0", features = ["x509"] }
+uselesskey-tonic = "0.10.0"
 ```
 
 ```rust

--- a/crates/materialize-buildrs-example/Cargo.toml
+++ b/crates/materialize-buildrs-example/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 description = "Build-time materialization example for uselesskey fixtures."
 
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.9.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.10.0", default-features = false, features = ["rsa-materialize"] }
 
 [lints]
 workspace = true

--- a/crates/materialize-shape-buildrs-example/Cargo.toml
+++ b/crates/materialize-shape-buildrs-example/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 description = "Build-time shape-only materialization example for uselesskey fixtures."
 
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.9.1", default-features = false }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.10.0", default-features = false }
 
 
 [lints]

--- a/crates/uselesskey-aws-lc-rs/Cargo.toml
+++ b/crates/uselesskey-aws-lc-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-aws-lc-rs"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,9 +18,9 @@ authors.workspace = true
 aws-lc-rs = { version = "1", optional = true }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -38,10 +38,10 @@ ed25519 = ["dep:uselesskey-ed25519"]
 all = ["native", "rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0" }
 aws-lc-rs = "1"
 hex = "0.4"
 serde.workspace = true

--- a/crates/uselesskey-aws-lc-rs/README.md
+++ b/crates/uselesskey-aws-lc-rs/README.md
@@ -20,7 +20,7 @@ When `native` is disabled, this crate builds as a no-op and exports no adapter t
 
 ```toml
 [dev-dependencies]
-uselesskey-aws-lc-rs = { version = "0.9.1", features = ["native", "rsa"] }
+uselesskey-aws-lc-rs = { version = "0.10.0", features = ["native", "rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-axum/Cargo.toml
+++ b/crates/uselesskey-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-axum"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -21,8 +21,8 @@ jsonwebtoken.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tower = { version = "0.5.2", features = ["util"] }
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1", features = ["jwk"] }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0", features = ["jwk"] }
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/uselesskey-bdd-steps/Cargo.toml
+++ b/crates/uselesskey-bdd-steps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-bdd-steps"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -29,11 +29,11 @@ x509-parser = "0.18.1"
 serde_json.workspace = true
 base64.workspace = true
 pgp = { version = "0.19.0", default-features = false }
-uselesskey-aws-lc-rs = { path = "../uselesskey-aws-lc-rs", version = "0.9.1", optional = true, default-features = false, features = ["all"] }
-uselesskey-ring = { path = "../uselesskey-ring", version = "0.9.1", optional = true, default-features = false, features = ["all"] }
-uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", version = "0.9.1", optional = true, default-features = false, features = ["all"] }
-uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.9.1", optional = true, default-features = false, features = ["x509", "tls-config", "rustls-ring"] }
-uselesskey-tonic = { path = "../uselesskey-tonic", version = "0.9.1", optional = true, default-features = false, features = ["x509"] }
+uselesskey-aws-lc-rs = { path = "../uselesskey-aws-lc-rs", version = "0.10.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-ring = { path = "../uselesskey-ring", version = "0.10.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-rustcrypto = { path = "../uselesskey-rustcrypto", version = "0.10.0", optional = true, default-features = false, features = ["all"] }
+uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.10.0", optional = true, default-features = false, features = ["x509", "tls-config", "rustls-ring"] }
+uselesskey-tonic = { path = "../uselesskey-tonic", version = "0.10.0", optional = true, default-features = false, features = ["x509"] }
 hmac = { version = "0.13.0-rc.6", optional = true }
 aws-lc-rs = { version = "1", optional = true }
 ring = { workspace = true, optional = true }

--- a/crates/uselesskey-bench/Cargo.toml
+++ b/crates/uselesskey-bench/Cargo.toml
@@ -18,8 +18,8 @@ serde_json.workspace = true
 tempfile.workspace = true
 uselesskey = { path = "../uselesskey", features = ["full"] }
 uselesskey-cli.workspace = true
-uselesskey-pkcs11-mock = { path = "../uselesskey-pkcs11-mock", version = "0.9.1" }
-uselesskey-webauthn = { path = "../uselesskey-webauthn", version = "0.9.1" }
+uselesskey-pkcs11-mock = { path = "../uselesskey-pkcs11-mock", version = "0.10.0" }
+uselesskey-webauthn = { path = "../uselesskey-webauthn", version = "0.10.0" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/uselesskey-cli/Cargo.toml
+++ b/crates/uselesskey-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-cli"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -42,7 +42,7 @@ uselesskey-core.workspace = true
 uselesskey-ecdsa = { workspace = true, features = ["jwk"], optional = true }
 uselesskey-ed25519 = { workspace = true, features = ["jwk"], optional = true }
 uselesskey-hmac = { workspace = true, features = ["jwk"], optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.9.1" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.10.0" }
 uselesskey-rsa = { workspace = true, features = ["jwk"], optional = true }
 uselesskey-token.workspace = true
 uselesskey-webhook = { workspace = true, optional = true }

--- a/crates/uselesskey-cli/README.md
+++ b/crates/uselesskey-cli/README.md
@@ -27,14 +27,14 @@ cargo run -p uselesskey-cli -- verify \
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.9.1", default-features = false }
+uselesskey-cli = { version = "0.10.0", default-features = false }
 ```
 
 Specialized RSA PKCS#8 build-time lane:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.9.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.10.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 The workspace ships both compiled build-time examples:

--- a/crates/uselesskey-core/Cargo.toml
+++ b/crates/uselesskey-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-core"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-ecdsa/Cargo.toml
+++ b/crates/uselesskey-ecdsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ecdsa"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-ecdsa"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 
 # Elliptic curve support from RustCrypto's current RC line
 p256 = { version = "0.14.0-rc.8", features = ["ecdsa", "pkcs8", "pem"] }
@@ -27,7 +27,7 @@ rand_core10.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.9.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.10.0", optional = true }
 
 [features]
 default = []

--- a/crates/uselesskey-ed25519/Cargo.toml
+++ b/crates/uselesskey-ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ed25519"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,14 +15,14 @@ documentation = "https://docs.rs/uselesskey-ed25519"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 ed25519-dalek.workspace = true
 pkcs8.workspace = true
 
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.9.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.10.0", optional = true }
 
 [features]
 default = []

--- a/crates/uselesskey-entropy/Cargo.toml
+++ b/crates/uselesskey-entropy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-entropy"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-entropy"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/uselesskey-feature-grid/Cargo.toml
+++ b/crates/uselesskey-feature-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-feature-grid"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-hmac/Cargo.toml
+++ b/crates/uselesskey-hmac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-hmac"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,12 +15,12 @@ documentation = "https://docs.rs/uselesskey-hmac"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 
 # Optional JWK/JWKS support
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.9.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.10.0", optional = true }
 base64 = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]

--- a/crates/uselesskey-jsonwebtoken/Cargo.toml
+++ b/crates/uselesskey-jsonwebtoken/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-jsonwebtoken"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -20,10 +20,10 @@ authors.workspace = true
 jsonwebtoken = { version = "10", features = ["use_pem"] }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.9.1", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.10.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -37,11 +37,11 @@ hmac = ["dep:uselesskey-hmac"]
 all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1" }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.10.0" }
 serde.workspace = true
 insta.workspace = true
 proptest.workspace = true

--- a/crates/uselesskey-jsonwebtoken/README.md
+++ b/crates/uselesskey-jsonwebtoken/README.md
@@ -24,7 +24,7 @@ Implements `JwtKeyExt` so fixture types return `jsonwebtoken::EncodingKey` and
 
 ```toml
 [dev-dependencies]
-uselesskey-jsonwebtoken = { version = "0.9.1", features = ["rsa"] }
+uselesskey-jsonwebtoken = { version = "0.10.0", features = ["rsa"] }
 jsonwebtoken = { version = "10", features = ["use_pem", "rust_crypto"] }
 ```
 

--- a/crates/uselesskey-jwk/Cargo.toml
+++ b/crates/uselesskey-jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-jwk"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-pgp/Cargo.toml
+++ b/crates/uselesskey-pgp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-pgp"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-pgp"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 pgp = { workspace = true }
 rand_chacha = { version = "0.3.1", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }

--- a/crates/uselesskey-pkcs11-mock/Cargo.toml
+++ b/crates/uselesskey-pkcs11-mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-pkcs11-mock"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,11 +15,11 @@ documentation = "https://docs.rs/uselesskey-pkcs11-mock"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 sha2.workspace = true
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 uselesskey-test-support = { workspace = true }
 
 [lints]

--- a/crates/uselesskey-ring/Cargo.toml
+++ b/crates/uselesskey-ring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ring"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -18,9 +18,9 @@ authors.workspace = true
 ring = "0.17"
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -33,7 +33,7 @@ ed25519 = ["dep:uselesskey-ed25519"]
 all = ["rsa", "ecdsa", "ed25519"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 hex = "0.4"
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-ring/README.md
+++ b/crates/uselesskey-ring/README.md
@@ -17,7 +17,7 @@ Converts fixture keypairs into native ring signing key types for tests that call
 
 ```toml
 [dev-dependencies]
-uselesskey-ring = { version = "0.9.1", features = ["rsa"] }
+uselesskey-ring = { version = "0.10.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-rsa/Cargo.toml
+++ b/crates/uselesskey-rsa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rsa"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-rsa"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 rsa.workspace = true
 rsa09 = { package = "rsa", version = "0.9.10", features = ["pem"], optional = true }
 rand_chacha = { version = "0.3.1", default-features = false, optional = true }
@@ -26,7 +26,7 @@ rand_chacha10.workspace = true
 # Optional JWK/JWKS support
 serde_json = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.9.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.10.0", optional = true }
 
 [features]
 default = ["legacy-rsa09"]

--- a/crates/uselesskey-rustcrypto/Cargo.toml
+++ b/crates/uselesskey-rustcrypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rustcrypto"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -23,10 +23,10 @@ hmac = { version = "0.13.0-rc.6", optional = true }
 sha2 = { version = "0.11", optional = true }
 
 # Key type crates (all optional)
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1", optional = true, default-features = false }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.9.1", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0", optional = true, default-features = false }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.10.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all"]
@@ -40,11 +40,11 @@ hmac = ["dep:hmac", "dep:sha2", "dep:uselesskey-hmac"]
 all = ["rsa", "ecdsa", "ed25519", "hmac"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1", default-features = false }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1" }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0", default-features = false }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0" }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.10.0" }
 rand_chacha10.workspace = true
 proptest.workspace = true
 rsa = { workspace = true, features = ["sha2"] }

--- a/crates/uselesskey-rustcrypto/README.md
+++ b/crates/uselesskey-rustcrypto/README.md
@@ -18,7 +18,7 @@ Converts fixture key material into native RustCrypto types (`rsa`, `p256`/`p384`
 
 ```toml
 [dev-dependencies]
-uselesskey-rustcrypto = { version = "0.9.1", features = ["rsa"] }
+uselesskey-rustcrypto = { version = "0.10.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey-rustls/Cargo.toml
+++ b/crates/uselesskey-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-rustls"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -19,10 +19,10 @@ rustls-pki-types = "1"
 rustls = { version = "0.23", default-features = false, features = ["std", "tls12"], optional = true }
 
 # Key type crates (all optional)
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.9.1", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.10.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["all", "tls-config", "rustls-ring"]
@@ -42,11 +42,11 @@ rustls-aws-lc-rs = ["rustls?/aws_lc_rs"]
 
 [dev-dependencies]
 rustls-pki-types = "1"
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.9.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1" }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.10.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0" }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0" }
 uselesskey-test-support.workspace = true
 rustls = { version = "0.23", features = ["ring"] }
 hex = "0.4"

--- a/crates/uselesskey-rustls/README.md
+++ b/crates/uselesskey-rustls/README.md
@@ -30,7 +30,7 @@ optional `ServerConfig` / `ClientConfig` builders (including mTLS support).
 
 ```toml
 [dev-dependencies]
-uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+uselesskey-rustls = { version = "0.10.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```rust

--- a/crates/uselesskey-ssh/Cargo.toml
+++ b/crates/uselesskey-ssh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-ssh"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-ssh"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 ssh-key = { version = "0.6.7", default-features = false, features = ["std", "ed25519", "rsa", "rand_core"] }
 rand_chacha = { version = "0.3.1", default-features = false }
 

--- a/crates/uselesskey-test-grid/Cargo.toml
+++ b/crates/uselesskey-test-grid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-grid"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-test-server/Cargo.toml
+++ b/crates/uselesskey-test-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-server"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -23,11 +23,11 @@ blake3.workspace = true
 axum = { version = "0.8.6", default-features = false, features = ["tokio", "http1", "json"] }
 http = "1.3.1"
 
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.9.1" }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1", features = ["jwk"] }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1", features = ["jwk"] }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1", features = ["jwk"] }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.10.0" }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0", features = ["jwk"] }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0", features = ["jwk"] }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0", features = ["jwk"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }

--- a/crates/uselesskey-test-support/Cargo.toml
+++ b/crates/uselesskey-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-test-support"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/uselesskey-token/Cargo.toml
+++ b/crates/uselesskey-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-token"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -19,7 +19,7 @@ base64.workspace = true
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 serde_json.workspace = true
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/uselesskey-tonic/Cargo.toml
+++ b/crates/uselesskey-tonic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-tonic"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ authors.workspace = true
 
 [dependencies]
 tonic = { version = "0.14.6", default-features = false, features = ["transport", "tls-ring"] }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.9.1", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.10.0", optional = true }
 
 [package.metadata.docs.rs]
 features = ["x509"]
@@ -26,8 +26,8 @@ default = ["x509"]
 x509 = ["dep:uselesskey-x509"]
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.10.0" }
 proptest.workspace = true
 serde.workspace = true
 insta.workspace = true

--- a/crates/uselesskey-tonic/README.md
+++ b/crates/uselesskey-tonic/README.md
@@ -19,9 +19,9 @@ Converts fixture certs and chains into `tonic::transport` TLS types:
 
 ```toml
 [dev-dependencies]
-uselesskey-tonic = "0.9.1"
-uselesskey-core = "0.9.1"
-uselesskey-x509 = "0.9.1"
+uselesskey-tonic = "0.10.0"
+uselesskey-core = "0.10.0"
+uselesskey-x509 = "0.10.0"
 ```
 
 ```rust

--- a/crates/uselesskey-webauthn/Cargo.toml
+++ b/crates/uselesskey-webauthn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-webauthn"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,13 +15,13 @@ documentation = "https://docs.rs/uselesskey-webauthn"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 serde_json.workspace = true
 ciborium.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 serde_json.workspace = true
 
 [lints]

--- a/crates/uselesskey-webhook/Cargo.toml
+++ b/crates/uselesskey-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-webhook"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/uselesskey-webhook"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 rand_chacha10.workspace = true
 rand_core10.workspace = true
 base64.workspace = true

--- a/crates/uselesskey-x509/Cargo.toml
+++ b/crates/uselesskey-x509/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey-x509"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -15,9 +15,9 @@ documentation = "https://docs.rs/uselesskey-x509"
 authors.workspace = true
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1" }
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.9.1", optional = true }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0" }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.10.0", optional = true }
 rcgen = "0.14.8"
 rustls-pki-types = "1"
 x509-parser = "0.18"

--- a/crates/uselesskey/Cargo.toml
+++ b/crates/uselesskey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uselesskey"
-version = "0.9.1"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -22,20 +22,20 @@ maintenance = { status = "actively-developed" }
 features = ["full"]
 
 [dependencies]
-uselesskey-core = { path = "../uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../uselesskey-core", version = "0.10.0" }
 
 # Key type crates - all optional
-uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.9.1", optional = true }
-uselesskey-entropy = { path = "../uselesskey-entropy", version = "0.9.1", optional = true }
-uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.9.1", optional = true }
-uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.9.1", optional = true }
-uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.9.1", optional = true }
-uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.9.1", optional = true }
-uselesskey-token = { path = "../uselesskey-token", version = "0.9.1", optional = true }
-uselesskey-ssh = { path = "../uselesskey-ssh", version = "0.9.1", optional = true }
-uselesskey-webhook = { path = "../uselesskey-webhook", version = "0.9.1", optional = true }
-uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.9.1", optional = true }
-uselesskey-x509 = { path = "../uselesskey-x509", version = "0.9.1", optional = true }
+uselesskey-jwk = { path = "../uselesskey-jwk", version = "0.10.0", optional = true }
+uselesskey-entropy = { path = "../uselesskey-entropy", version = "0.10.0", optional = true }
+uselesskey-rsa = { path = "../uselesskey-rsa", version = "0.10.0", optional = true }
+uselesskey-ecdsa = { path = "../uselesskey-ecdsa", version = "0.10.0", optional = true }
+uselesskey-ed25519 = { path = "../uselesskey-ed25519", version = "0.10.0", optional = true }
+uselesskey-hmac = { path = "../uselesskey-hmac", version = "0.10.0", optional = true }
+uselesskey-token = { path = "../uselesskey-token", version = "0.10.0", optional = true }
+uselesskey-ssh = { path = "../uselesskey-ssh", version = "0.10.0", optional = true }
+uselesskey-webhook = { path = "../uselesskey-webhook", version = "0.10.0", optional = true }
+uselesskey-pgp = { path = "../uselesskey-pgp", version = "0.10.0", optional = true }
+uselesskey-x509 = { path = "../uselesskey-x509", version = "0.10.0", optional = true }
 
 [features]
 default = []
@@ -77,8 +77,8 @@ x509-parser = "0.18"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 jsonwebtoken = { workspace = true, features = ["rust_crypto"] }
-uselesskey-jsonwebtoken = { path = "../uselesskey-jsonwebtoken", version = "0.9.1", features = ["all"] }
-uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.9.1", features = ["all", "tls-config", "rustls-ring"] }
+uselesskey-jsonwebtoken = { path = "../uselesskey-jsonwebtoken", version = "0.10.0", features = ["all"] }
+uselesskey-rustls = { path = "../uselesskey-rustls", version = "0.10.0", features = ["all", "tls-config", "rustls-ring"] }
 rustls-pki-types.workspace = true
 
 [[bench]]

--- a/crates/uselesskey/README.md
+++ b/crates/uselesskey/README.md
@@ -50,37 +50,37 @@ Dependency snippets:
 - **Quick start (RSA)**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["rsa"] }
+  uselesskey = { version = "0.10.0", features = ["rsa"] }
   ```
 
 
 - **Token-only**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", default-features = false, features = ["token"] }
+  uselesskey = { version = "0.10.0", default-features = false, features = ["token"] }
   ```
 
 
 - **JWT/JWK**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["rsa", "jwk"] }
+  uselesskey = { version = "0.10.0", features = ["rsa", "jwk"] }
   ```
 
 
 - **X.509 + rustls**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["x509"] }
-  uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+  uselesskey = { version = "0.10.0", features = ["x509"] }
+  uselesskey-rustls = { version = "0.10.0", features = ["tls-config", "rustls-ring"] }
   ```
 
 
 - **jsonwebtoken adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jsonwebtoken = { version = "0.9.1" }
+  uselesskey = { version = "0.10.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jsonwebtoken = { version = "0.10.0" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 
@@ -97,7 +97,7 @@ Entropy-only consumers can stay lighter still:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["entropy"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["entropy"] }
 ```
 
 ```rust
@@ -119,7 +119,7 @@ If you want RSA fixtures, enable `rsa` explicitly:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["rsa"] }
+uselesskey = { version = "0.10.0", features = ["rsa"] }
 ```
 
 ```rust

--- a/crates/uselesskey/src/lib.rs
+++ b/crates/uselesskey/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! uselesskey = { version = "0.9.1", default-features = false, features = ["token"] }
+//! uselesskey = { version = "0.10.0", default-features = false, features = ["token"] }
 //! ```
 //!
 //! ```
@@ -42,7 +42,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! uselesskey = { version = "0.9.1", default-features = false, features = ["entropy"] }
+//! uselesskey = { version = "0.10.0", default-features = false, features = ["entropy"] }
 //! ```
 //!
 //! ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,8 @@ Validation lanes and the claim boundaries behind them.
 
 Release-candidate proof and public promise evidence.
 
+- [v0.10.0-release-notes.md](release/v0.10.0-release-notes.md) - v0.10.0 source-candidate release notes and explicit non-claims
+
 - [evidence-matrix-v0.9.0.md](release/evidence-matrix-v0.9.0.md) — v0.9.0 command-backed claim, verification-pack, PR-lite, and webhook proof matrix
 - [evidence-matrix-v0.9.1.md](release/evidence-matrix-v0.9.1.md) — v0.9.1 adoption-confidence patch proof matrix
 - [post-release-audit-v0.9.1.md](release/post-release-audit-v0.9.1.md) — v0.9.1 crates.io, docs.rs, adoption-regression, and claim-proof audit

--- a/docs/contract-packs/README.md
+++ b/docs/contract-packs/README.md
@@ -10,7 +10,7 @@ copyable command first. For a broader task router, see
 Run installed CLI commands as shown below:
 
 ```bash
-cargo install uselesskey-cli --version 0.9.1
+cargo install uselesskey-cli --version 0.10.0
 ```
 
 Inside this workspace, prefix CLI examples with `cargo run -p uselesskey-cli --`.

--- a/docs/how-to/choose-features.md
+++ b/docs/how-to/choose-features.md
@@ -35,37 +35,37 @@ Dependency snippets:
 - **Quick start (RSA)**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["rsa"] }
+  uselesskey = { version = "0.10.0", features = ["rsa"] }
   ```
 
 
 - **Token-only**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", default-features = false, features = ["token"] }
+  uselesskey = { version = "0.10.0", default-features = false, features = ["token"] }
   ```
 
 
 - **JWT/JWK**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["rsa", "jwk"] }
+  uselesskey = { version = "0.10.0", features = ["rsa", "jwk"] }
   ```
 
 
 - **X.509 + rustls**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["x509"] }
-  uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+  uselesskey = { version = "0.10.0", features = ["x509"] }
+  uselesskey-rustls = { version = "0.10.0", features = ["tls-config", "rustls-ring"] }
   ```
 
 
 - **jsonwebtoken adapter**
   ```toml
   [dev-dependencies]
-  uselesskey = { version = "0.9.1", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
-  uselesskey-jsonwebtoken = { version = "0.9.1" }
+  uselesskey = { version = "0.10.0", features = ["rsa", "ecdsa", "ed25519", "hmac"] }
+  uselesskey-jsonwebtoken = { version = "0.10.0" }
   ```
 <!-- docs-sync:dependency-snippets-end -->
 
@@ -98,7 +98,7 @@ If you need every key family, use `all-keys`.
 - Use `uselesskey-cli verify` in CI to prove generated outputs still match the
   manifest.
 - If `build.rs` calls the library directly, use:
-  `uselesskey-cli = { version = "0.9.1", default-features = false }`
+  `uselesskey-cli = { version = "0.10.0", default-features = false }`
   for the common shape-only path.
 - Add `features = ["rsa-materialize"]` only when the build-time path needs RSA
   PKCS#8 fixtures.

--- a/docs/how-to/choose-lane.md
+++ b/docs/how-to/choose-lane.md
@@ -35,14 +35,14 @@ For shape-only build-time fixtures, depend on the slim library surface:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.9.1", default-features = false }
+uselesskey-cli = { version = "0.10.0", default-features = false }
 ```
 
 For RSA PKCS#8 build-time fixtures, opt into the specialized RSA materialize support:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.9.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.10.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 See `crates/materialize-shape-buildrs-example/` for the common shape-only pattern and `crates/materialize-buildrs-example/` for the specialized RSA pattern.

--- a/docs/how-to/downstream-fixture-policy.md
+++ b/docs/how-to/downstream-fixture-policy.md
@@ -53,14 +53,14 @@ Shape-only common lane:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.9.1", default-features = false }
+uselesskey-cli = { version = "0.10.0", default-features = false }
 ```
 
 Specialized RSA build-time lane:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { version = "0.9.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { version = "0.10.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 ## Materialize in CI or build scripts

--- a/docs/how-to/materialize-fixtures-in-build-rs.md
+++ b/docs/how-to/materialize-fixtures-in-build-rs.md
@@ -146,7 +146,7 @@ Shape-only — `crates/materialize-shape-buildrs-example/Cargo.toml`:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.9.1", default-features = false }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.10.0", default-features = false }
 ```
 
 Shape-only manifests use kinds like `entropy.bytes`, `token.jwt_shape`,
@@ -158,7 +158,7 @@ Runtime RSA — `crates/materialize-buildrs-example/Cargo.toml`:
 
 ```toml
 [build-dependencies]
-uselesskey-cli = { path = "../uselesskey-cli", version = "0.9.1", default-features = false, features = ["rsa-materialize"] }
+uselesskey-cli = { path = "../uselesskey-cli", version = "0.10.0", default-features = false, features = ["rsa-materialize"] }
 ```
 
 The `rsa-materialize` feature is what unlocks `rsa.pkcs8_der` and

--- a/docs/how-to/migration.md
+++ b/docs/how-to/migration.md
@@ -19,7 +19,7 @@ Use `uselesskey` as a `dev-dependency`, then opt into only the fixture families 
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "jwk"] }
 ```
 
 ### Minimal feature examples
@@ -27,21 +27,21 @@ uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "
 ```toml
 # token-only tests
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["token"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["token"] }
 ```
 
 ```toml
 # TLS chain + rustls adapter
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["x509"] }
-uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["x509"] }
+uselesskey-rustls = { version = "0.10.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 ```toml
 # JWT signing and verification helpers
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "hmac", "jwk"] }
-uselesskey-jsonwebtoken = { version = "0.9.1" }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "hmac", "jwk"] }
+uselesskey-jsonwebtoken = { version = "0.10.0" }
 ```
 
 > Prefer adapter crates (`uselesskey-rustls`, `uselesskey-jsonwebtoken`, etc.) over broad feature bundles to keep compile and dependency surface small.

--- a/docs/how-to/release.md
+++ b/docs/how-to/release.md
@@ -67,6 +67,9 @@ Before tagging, make sure the release PR has already:
 
 For version-specific proof maps, use the matching release matrix:
 
+- [`docs/release/v0.10.0-release-notes.md`](../release/v0.10.0-release-notes.md)
+  for the v0.10.0 source-candidate release notes and non-claims
+
 - [`docs/release/evidence-matrix-v0.9.1.md`](../release/evidence-matrix-v0.9.1.md)
   for the v0.9.1 adoption-confidence patch
 - [`docs/release/evidence-matrix-v0.9.0.md`](../release/evidence-matrix-v0.9.0.md)

--- a/docs/how-to/share-installed-bundle-audit.md
+++ b/docs/how-to/share-installed-bundle-audit.md
@@ -10,7 +10,7 @@ assurance.
 ## Generate a Bundle
 
 ```bash
-cargo install uselesskey-cli --version 0.9.1
+cargo install uselesskey-cli --version 0.10.0
 uselesskey bundle --profile webhook --out target/uselesskey-webhook
 uselesskey verify-bundle --path target/uselesskey-webhook
 uselesskey inspect-bundle --path target/uselesskey-webhook

--- a/docs/how-to/start-here.md
+++ b/docs/how-to/start-here.md
@@ -11,8 +11,8 @@ or cryptographic assurance.
 
 | I need to... | Start with | Copy this |
 | --- | --- | --- |
-| use fake RSA/JWK fixtures in Rust tests | facade crate | `uselesskey = { version = "0.9.1", features = ["rsa", "jwk"] }` |
-| use token-shaped strings without keygen | token lane | `uselesskey = { version = "0.9.1", default-features = false, features = ["token"] }` |
+| use fake RSA/JWK fixtures in Rust tests | facade crate | `uselesskey = { version = "0.10.0", features = ["rsa", "jwk"] }` |
+| use token-shaped strings without keygen | token lane | `uselesskey = { version = "0.10.0", default-features = false, features = ["token"] }` |
 | generate a deterministic scanner-safe bundle | CLI scanner-safe profile | `uselesskey bundle --profile scanner-safe --out target/uselesskey-bundle` |
 | test TLS verifier behavior | TLS contract pack | `uselesskey bundle --profile tls --out target/uselesskey-tls` |
 | test OIDC/JWKS validator behavior | OIDC/JWKS contract pack | `uselesskey bundle --profile oidc --out target/uselesskey-oidc` |
@@ -24,7 +24,7 @@ or cryptographic assurance.
 Install the CLI when you want bundle commands outside this workspace:
 
 ```bash
-cargo install uselesskey-cli --version 0.9.1
+cargo install uselesskey-cli --version 0.10.0
 uselesskey profiles
 uselesskey bundle --profile webhook --explain
 ```
@@ -45,7 +45,7 @@ Add the smallest feature set that preserves your test semantics:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", features = ["rsa", "jwk"] }
+uselesskey = { version = "0.10.0", features = ["rsa", "jwk"] }
 ```
 
 Then generate fixtures at runtime:

--- a/docs/how-to/test-jwt-negative-validation.md
+++ b/docs/how-to/test-jwt-negative-validation.md
@@ -34,7 +34,7 @@ For runtime test generation:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["token"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["token"] }
 ```
 
 ```rust

--- a/docs/how-to/test-oidc-jwks-validation.md
+++ b/docs/how-to/test-oidc-jwks-validation.md
@@ -55,7 +55,7 @@ For Rust tests that do not need files, use the public fixture surface directly:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "jwk"] }
 ```
 
 ```rust

--- a/docs/how-to/test-webauthn-validation.md
+++ b/docs/how-to/test-webauthn-validation.md
@@ -14,8 +14,8 @@ Add the crate as a dev-dependency alongside the core factory:
 
 ```toml
 [dev-dependencies]
-uselesskey-core = "0.9.1"
-uselesskey-webauthn = "0.9.1"
+uselesskey-core = "0.10.0"
+uselesskey-webauthn = "0.10.0"
 ```
 
 Then derive a registration and an assertion fixture from the same seed

--- a/docs/how-to/test-webhook-signature-validation.md
+++ b/docs/how-to/test-webhook-signature-validation.md
@@ -14,7 +14,7 @@ should enforce.
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["webhook"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["webhook"] }
 ```
 
 Or depend on `uselesskey-webhook` directly if you only need this
@@ -22,8 +22,8 @@ surface:
 
 ```toml
 [dev-dependencies]
-uselesskey-webhook = "0.9.1"
-uselesskey-core = "0.9.1"
+uselesskey-webhook = "0.10.0"
+uselesskey-core = "0.10.0"
 ```
 
 ## Generate the contract pack

--- a/docs/how-to/use-downstream-policy-pack.md
+++ b/docs/how-to/use-downstream-policy-pack.md
@@ -21,7 +21,7 @@ approval.
 Generate, verify, inspect, and audit one profile per output directory:
 
 ```bash
-cargo install uselesskey-cli --version 0.9.1 --locked
+cargo install uselesskey-cli --version 0.10.0 --locked
 uselesskey bundle --profile webhook --out target/uselesskey-webhook
 uselesskey verify-bundle --path target/uselesskey-webhook
 uselesskey inspect-bundle --path target/uselesskey-webhook

--- a/docs/how-to/use-pkcs11-mock-fixtures.md
+++ b/docs/how-to/use-pkcs11-mock-fixtures.md
@@ -14,8 +14,8 @@ under test consumes; the cryptography is deliberately mock.
 
 ```toml
 [dev-dependencies]
-uselesskey-core = { version = "0.9.1", default-features = false }
-uselesskey-pkcs11-mock = { version = "0.9.1" }
+uselesskey-core = { version = "0.10.0", default-features = false }
+uselesskey-pkcs11-mock = { version = "0.10.0" }
 ```
 
 ```rust

--- a/docs/how-to/use-uselesskey-in-downstream-ci.md
+++ b/docs/how-to/use-uselesskey-in-downstream-ci.md
@@ -8,7 +8,7 @@ For GitHub Actions-specific workflow files, see
 
 ```yaml
 steps:
-  - run: cargo install uselesskey-cli --version 0.9.1
+  - run: cargo install uselesskey-cli --version 0.10.0
   - run: uselesskey bundle --profile webhook --out target/uselesskey-webhook
   - run: uselesskey verify-bundle --path target/uselesskey-webhook
   - run: uselesskey audit-bundle --path target/uselesskey-webhook --out target/uselesskey-webhook-audit --ci --expect-profile webhook --policy strict

--- a/docs/how-to/use-uselesskey-in-github-actions.md
+++ b/docs/how-to/use-uselesskey-in-github-actions.md
@@ -28,7 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install uselesskey CLI
-        run: cargo install uselesskey-cli --version 0.9.1 --locked
+        run: cargo install uselesskey-cli --version 0.10.0 --locked
 
       - name: Generate webhook fixtures
         run: uselesskey bundle --profile webhook --out target/uselesskey-webhook
@@ -72,7 +72,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install uselesskey CLI
-        run: cargo install uselesskey-cli --version 0.9.1 --locked
+        run: cargo install uselesskey-cli --version 0.10.0 --locked
 
       - name: Generate TLS fixtures
         run: uselesskey bundle --profile tls --out target/uselesskey-tls

--- a/docs/metadata/workspace-docs.json
+++ b/docs/metadata/workspace-docs.json
@@ -781,7 +781,7 @@
       "minimal_example_command": "cargo run -p uselesskey --example adapter_jsonwebtoken --no-default-features --features rsa,ecdsa,ed25519,hmac"
     }
   ],
-  "release_version": "0.9.1",
+  "release_version": "0.10.0",
   "public_features": [
     "rsa",
     "ecdsa",

--- a/docs/release/v0.10.0-release-notes.md
+++ b/docs/release/v0.10.0-release-notes.md
@@ -1,0 +1,82 @@
+# v0.10.0 Release Notes
+
+Status: source candidate draft. These notes describe the intended v0.10.0
+release content, but they do not prove publication, crates.io state, docs.rs
+state, or tag creation.
+
+## Highlights
+
+- Installed CLI users can generate, verify, inspect, and audit fixture bundles
+  without learning the repo-local `xtask` proof plane first.
+- `uselesskey audit-bundle` writes metadata-only JSON and Markdown receipts for
+  downstream CI and reviewer handoff.
+- `bundle-audit.json` carries stable `status`, `profile`, and
+  `checks[].failure_class` fields for automation. Markdown and diagnostic prose
+  remain reviewer aids, not machine contracts.
+- Downstream CI examples show how to upload only `bundle-audit.json` and
+  `bundle-audit.md`, not generated fixture payloads.
+- Clean-project examples cover facade Rust tests, webhook signatures, OIDC/JWKS
+  validation, and TLS chain validation.
+- README, Start Here, feature-choice, and task-focused docs route users by job:
+  facade dependencies, installed CLI bundles, downstream CI audits, reviewer
+  handoffs, and repo-local claim proof.
+
+## Upgrade Notes
+
+Update dependency snippets to the v0.10.0 candidate line:
+
+```toml
+[dev-dependencies]
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "jwk", "token"] }
+```
+
+Install the CLI from the v0.10.0 line after publication:
+
+```bash
+cargo install uselesskey-cli --version 0.10.0 --locked
+```
+
+Before publication, maintainers must prove the same paths from source and
+package artifacts. Do not treat these snippets as registry evidence until the
+explicit publish gate completes.
+
+## Candidate Proof Plan
+
+The package-proven source candidate must still run:
+
+```bash
+cargo xtask publish-preflight
+cargo xtask publish-check
+cargo xtask no-blob
+cargo xtask check-bundle-schemas
+cargo xtask check-audit-receipts
+cargo xtask check-adoption-command-ledger
+cargo xtask external-adoption-smoke --path . --ci-recipes --format json
+cargo xtask external-adoption-smoke --path . --library-examples
+cargo xtask adoption-regression --external
+cargo test -p uselesskey-cli --all-features audit_bundle
+cargo test --workspace --all-features --locked
+git diff --check
+```
+
+The immutable candidate evidence PR should then record source SHA, swarm
+handoff SHA, toolchain, package hashes and contents, CLI smoke, facade smoke,
+receipt/schema proof, claims/support proof, hosted CI status, known
+non-blockers, publish order, and rollback procedure.
+
+## Non-claims
+
+v0.10.0 remains a test-fixture release. It does not claim:
+
+- production security;
+- provider compatibility;
+- scanner-policy approval;
+- downstream verifier correctness;
+- registry publication before the publish gate;
+- tag or GitHub release creation before explicit approval.
+
+## Release Gate
+
+Publishing crates, verifying each registry publication, publishing the facade
+and CLI, tagging `v0.10.0`, pushing the tag, running published-version smoke,
+and archiving post-publication evidence all require explicit release approval.

--- a/docs/specs/USELESSKEY-SPEC-0015-real-user-workflows.md
+++ b/docs/specs/USELESSKEY-SPEC-0015-real-user-workflows.md
@@ -77,7 +77,7 @@ Copyable snippet:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk", "token"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "jwk", "token"] }
 ```
 
 ```rust

--- a/docs/specs/USELESSKEY-SPEC-0019-library-facade-polish.md
+++ b/docs/specs/USELESSKEY-SPEC-0019-library-facade-polish.md
@@ -74,7 +74,7 @@ The primary snippet pattern is:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa"] }
 ```
 
 ```rust
@@ -186,7 +186,7 @@ Good facade-first example:
 
 ```text
 Job: test a JWT verifier with deterministic RSA/JWKS fixtures
-Dependency: uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk"] }
+Dependency: uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "jwk"] }
 Imports: Factory, RsaFactoryExt, RsaSpec
 Positive: valid public JWK/JWKS accepted by the test verifier
 Negative: duplicate kid or wrong-kty fixture rejected by the test verifier

--- a/examples/external/oidc-jwks-validation/Cargo.toml
+++ b/examples/external/oidc-jwks-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "jwk"] }
 serde_json = "1"
 
 [workspace]

--- a/examples/external/oidc-jwks-validation/README.md
+++ b/examples/external/oidc-jwks-validation/README.md
@@ -13,7 +13,7 @@ Dependency:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "jwk"] }
 ```
 
 First imports:

--- a/examples/external/rust-test-fixtures/Cargo.toml
+++ b/examples/external/rust-test-fixtures/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk", "token"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "jwk", "token"] }
 
 [workspace]

--- a/examples/external/rust-test-fixtures/README.md
+++ b/examples/external/rust-test-fixtures/README.md
@@ -14,7 +14,7 @@ Dependency:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa", "jwk", "token"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa", "jwk", "token"] }
 ```
 
 First imports:

--- a/examples/external/tls-chain-validation/Cargo.toml
+++ b/examples/external/tls-chain-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["x509"] }
-uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["x509"] }
+uselesskey-rustls = { version = "0.10.0", features = ["tls-config", "rustls-ring"] }
 
 [workspace]

--- a/examples/external/tls-chain-validation/README.md
+++ b/examples/external/tls-chain-validation/README.md
@@ -13,8 +13,8 @@ Dependencies:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["x509"] }
-uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["x509"] }
+uselesskey-rustls = { version = "0.10.0", features = ["tls-config", "rustls-ring"] }
 ```
 
 First imports:

--- a/examples/external/webhook-verifier/Cargo.toml
+++ b/examples/external/webhook-verifier/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["webhook"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["webhook"] }
 
 [workspace]

--- a/examples/external/webhook-verifier/README.md
+++ b/examples/external/webhook-verifier/README.md
@@ -13,7 +13,7 @@ Dependency:
 
 ```toml
 [dev-dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["webhook"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["webhook"] }
 ```
 
 First imports:

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -2527,7 +2527,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uselesskey"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "uselesskey-core",
  "uselesskey-ecdsa",
@@ -2541,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-core"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "blake3",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ecdsa"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "elliptic-curve 0.14.0-rc.29",
  "p256 0.14.0-rc.8",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ed25519"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ed25519-dalek",
  "pkcs8 0.10.2",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-hmac"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "rand_chacha 0.10.0",
  "rand_core 0.10.1",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jsonwebtoken"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "jsonwebtoken",
  "uselesskey-ecdsa",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-jwk"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "blake3",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-pgp"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "pgp",
  "rand_chacha 0.3.1",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-ring"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ring",
  "uselesskey-ecdsa",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rsa"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "rand_chacha 0.10.0",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustcrypto"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ed25519-dalek",
  "hmac 0.13.0-rc.6",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-rustls"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "rustls-pki-types",
  "uselesskey-ecdsa",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-token"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "rand_chacha 0.10.0",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "uselesskey-x509"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "base64",
  "rand_chacha 0.10.0",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,28 +14,28 @@ keywords = ["testing", "integration", "fixtures", "crypto", "deterministic"]
 
 [dependencies]
 # Core
-uselesskey-core = { path = "../crates/uselesskey-core", version = "0.9.1" }
+uselesskey-core = { path = "../crates/uselesskey-core", version = "0.10.0" }
 blake3.workspace = true
 
 # Key types (all optional features)
-uselesskey-rsa = { path = "../crates/uselesskey-rsa", version = "0.9.1", optional = true, features = ["jwk"] }
-uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa", version = "0.9.1", optional = true, features = ["jwk"] }
-uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519", version = "0.9.1", optional = true, features = ["jwk"] }
-uselesskey-hmac = { path = "../crates/uselesskey-hmac", version = "0.9.1", optional = true, features = ["jwk"] }
-uselesskey-x509 = { path = "../crates/uselesskey-x509", version = "0.9.1", optional = true }
-uselesskey-token = { path = "../crates/uselesskey-token", version = "0.9.1", optional = true }
+uselesskey-rsa = { path = "../crates/uselesskey-rsa", version = "0.10.0", optional = true, features = ["jwk"] }
+uselesskey-ecdsa = { path = "../crates/uselesskey-ecdsa", version = "0.10.0", optional = true, features = ["jwk"] }
+uselesskey-ed25519 = { path = "../crates/uselesskey-ed25519", version = "0.10.0", optional = true, features = ["jwk"] }
+uselesskey-hmac = { path = "../crates/uselesskey-hmac", version = "0.10.0", optional = true, features = ["jwk"] }
+uselesskey-x509 = { path = "../crates/uselesskey-x509", version = "0.10.0", optional = true }
+uselesskey-token = { path = "../crates/uselesskey-token", version = "0.10.0", optional = true }
 
 # JWK/JWKS
-uselesskey-jwk = { path = "../crates/uselesskey-jwk", version = "0.9.1", optional = true }
+uselesskey-jwk = { path = "../crates/uselesskey-jwk", version = "0.10.0", optional = true }
 
 # Adapters
-uselesskey-jsonwebtoken = { path = "../crates/uselesskey-jsonwebtoken", version = "0.9.1", optional = true, features = ["all"] }
-uselesskey-rustls = { path = "../crates/uselesskey-rustls", version = "0.9.1", optional = true, features = ["server-config", "client-config"] }
-uselesskey-ring = { path = "../crates/uselesskey-ring", version = "0.9.1", optional = true, features = ["all"] }
-uselesskey-rustcrypto = { path = "../crates/uselesskey-rustcrypto", version = "0.9.1", optional = true, features = ["all"] }
+uselesskey-jsonwebtoken = { path = "../crates/uselesskey-jsonwebtoken", version = "0.10.0", optional = true, features = ["all"] }
+uselesskey-rustls = { path = "../crates/uselesskey-rustls", version = "0.10.0", optional = true, features = ["server-config", "client-config"] }
+uselesskey-ring = { path = "../crates/uselesskey-ring", version = "0.10.0", optional = true, features = ["all"] }
+uselesskey-rustcrypto = { path = "../crates/uselesskey-rustcrypto", version = "0.10.0", optional = true, features = ["all"] }
 
 # Facade crate (for determinism tests)
-uselesskey = { path = "../crates/uselesskey", version = "0.9.1", optional = true, features = ["full"] }
+uselesskey = { path = "../crates/uselesskey", version = "0.10.0", optional = true, features = ["full"] }
 
 # External dependencies
 jsonwebtoken = { workspace = true, optional = true }

--- a/xtask/src/external_adoption_smoke.rs
+++ b/xtask/src/external_adoption_smoke.rs
@@ -1076,8 +1076,8 @@ mod tests {
     #[test]
     fn external_adoption_dependency_patch_switches_versions_to_paths() {
         let manifest = r#"[dependencies]
-uselesskey = { version = "0.9.1", default-features = false, features = ["rsa"] }
-uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"] }
+uselesskey = { version = "0.10.0", default-features = false, features = ["rsa"] }
+uselesskey-rustls = { version = "0.10.0", features = ["tls-config", "rustls-ring"] }
 "#;
 
         let patched = patch_dependency_path(
@@ -1097,7 +1097,7 @@ uselesskey-rustls = { version = "0.9.1", features = ["tls-config", "rustls-ring"
         assert!(patched.contains(
             r#"uselesskey-rustls = { path = "C:\\Code\\Rust\\uselesskey\\crates\\uselesskey-rustls", features = ["tls-config", "rustls-ring"] }"#
         ));
-        assert!(!patched.contains("version = \"0.9.1\""));
+        assert!(!patched.contains("version = \""));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Prepares the v0.10.0 source candidate after the imported swarm handoff. This updates workspace crate versions, internal dependency constraints, lockfiles, install snippets, task docs, CHANGELOG, and source-candidate release notes.

This PR does not publish crates, tag v0.10.0, create a GitHub release, or move release authority. Package-proven adoption evidence remains the next PR.

Fixes # (none)

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] docs: Documentation update
- [ ] style: Code style (formatting, etc)
- [ ] refactor: Refactoring
- [ ] perf: Performance improvement
- [ ] test: Testing
- [x] chore: Maintenance
- [ ] revert: Revert change

## DevEx Checklist

Run these locally before submitting:

- [ ] cargo xtask gate: Fmt, check, clippy, and test compile pass.
- [x] cargo xtask typos: No misspellings.
- [ ] cargo xtask bdd: BDD tests pass (if applicable).
- [ ] cargo xtask mutants: Mutation testing passes (if applicable).

Additional proof run:

- [x] cargo xtask docs-sync --check
- [x] cargo test -p xtask external_adoption_dependency_patch_switches_versions_to_paths --locked
- [x] cargo check --workspace --all-targets --all-features --locked
- [x] cargo xtask publish-preflight
- [x] git diff --check

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide semver and lockfile churn across the whole workspace affects every downstream version pin and publish order, but the diff is mostly mechanical versioning and docs with no runtime API changes in this PR itself.
> 
> **Overview**
> Bumps the workspace from **0.9.1** to **0.10.0** as the v0.10.0 **source candidate** after the swarm handoff: every published crate `version`, `workspace.dependencies` constraints, `Cargo.lock` / `fuzz/Cargo.lock`, and path dependency pins move together.
> 
> **CHANGELOG** gains a **[0.10.0]** section (adoption/installed-workflow themes—bundle audit receipts, downstream CI, external adoption smoke) and compare links are repointed so `[Unreleased]` tracks `v0.10.0...HEAD`.
> 
> Copyable **0.10.0** install and `dev-dependencies` snippets are rolled through the root **README**, crate READMEs, how-to docs, specs, `docs/metadata/workspace-docs.json` (`release_version`), and `examples/external/*` manifests so docs-sync and adoption smoke stay aligned.
> 
> Adds **`docs/release/v0.10.0-release-notes.md`** (highlights, upgrade snippets, candidate proof commands, explicit non-claims) and links it from **`docs/README.md`** and **`docs/how-to/release.md`**.
> 
> **`xtask` external adoption** test fixtures are updated to expect **0.10.0** in dependency patching assertions.
> 
> This PR does **not** publish to crates.io, tag, or cut a GitHub release; package-proven evidence is called out as follow-up work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0842d871928087a7c4b392c46a67e9c531cd8f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->