### PR TITLE
release: record v0.10.0 candidate evidence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ Release-candidate proof and public promise evidence.
 - [v0.10-receipt-contract.md](release/v0.10-receipt-contract.md) - bundle audit receipt contract and fail-closed CI consumer boundary
 - [v0.10-adoption-proof-inventory.md](release/v0.10-adoption-proof-inventory.md) - adoption proof inventory for CLI, facade, schema, and package checks
 - [v0.10.0-package-dry-run.md](release/v0.10.0-package-dry-run.md) - package dry-run proof boundary for the v0.10.0 candidate
+- [v0.10.0-candidate-evidence.md](release/v0.10.0-candidate-evidence.md) - immutable source-candidate evidence record before explicit release execution
 
 - [evidence-matrix-v0.9.0.md](release/evidence-matrix-v0.9.0.md) — v0.9.0 command-backed claim, verification-pack, PR-lite, and webhook proof matrix
 - [evidence-matrix-v0.9.1.md](release/evidence-matrix-v0.9.1.md) — v0.9.1 adoption-confidence patch proof matrix

--- a/docs/release/v0.10.0-candidate-evidence.md
+++ b/docs/release/v0.10.0-candidate-evidence.md
@@ -1,0 +1,228 @@
+# v0.10.0 Candidate Evidence Record
+
+This record captures the source-repository v0.10.0 candidate evidence after the
+swarm handoff import, version-candidate preparation, and packaged-adoption proof.
+It is evidence, not a release action.
+
+Swarm has prepared and proven the release-adoption surface.
+It has not created a source release candidate, published crates, tagged v0.10.0,
+or changed release authority.
+
+## Boundary
+
+This record does not:
+
+- publish crates;
+- tag `v0.10.0`;
+- push a tag;
+- create a GitHub release;
+- sign artifacts;
+- approve release execution;
+- move release authority out of `EffortlessMetrics/uselesskey`.
+
+The source candidate SHA below is the package and proof input. This PR is a
+docs-only evidence record on top of that candidate. Cargo package archives embed
+`.cargo_vcs_info.json`, so package hashes are intentionally tied to the candidate
+source SHA named here rather than to the later evidence-only record commit.
+
+## Exact Inputs
+
+| Input | Value |
+| --- | --- |
+| Source candidate SHA | `5ea65e1cc6309042731cf4ec91cb39f00a91253a` |
+| Source base SHA before handoff import | `32bb2398c2f31a32d37f03bb0151c4eb88a7c9d5` |
+| Swarm handoff SHA | `fd00a23f1efb3dd4701c1d15715ea032569fea85` |
+| Evidence refresh time | `2026-06-20T04:10:04.0094437Z` |
+| Host | Windows 11 Professional, `x86_64-pc-windows-msvc` |
+
+Source PR sequence:
+
+| PR | Merge commit | Scope |
+| --- | --- | --- |
+| `#862` | `ace29dd2ae0dc76069eaaa572a1ad67456423b87` | Import v0.10 adoption handoff |
+| `#864` | `320032df0fad0361238babd253b092953b640a1d` | Prepare v0.10.0 candidate versions and docs |
+| `#865` | `5ea65e1cc6309042731cf4ec91cb39f00a91253a` | Prove packaged adoption |
+
+## Toolchain
+
+| Tool | Version |
+| --- | --- |
+| `rustc` | `rustc 1.95.0 (59807616e 2026-04-14)` |
+| `cargo` | `cargo 1.95.0 (f2d3ce0bd 2026-03-21)` |
+| Rust host | `x86_64-pc-windows-msvc` |
+| LLVM | `22.1.2` |
+| Cargo libgit2 | `1.9.2` |
+| Cargo libcurl | `8.15.0-DEV` with Schannel |
+
+## Package Artifacts
+
+`rtk cargo xtask publish-preflight` regenerated package archives from source
+candidate SHA `5ea65e1cc6309042731cf4ec91cb39f00a91253a` and passed:
+`28 passed, 0 failed, 0 skipped`.
+
+Package contents were inspected with:
+
+```bash
+rtk cargo package --list --exclude-lockfile -p <crate>
+```
+
+The hard local-state scan found no package-list entries matching `Cargo.lock`,
+`target/`, `.git/`, `*.lock`, `*.tmp`, or `*.crate`:
+
+```text
+PACKAGE_LIST_HARD_SUSPICIOUS none
+```
+
+`cargo xtask publish-check` completed with expected skips for crates whose
+v0.10 workspace siblings are not yet on crates.io. Native `cargo publish
+--dry-run` remains a registry resolver check; `publish-preflight` and the file
+list inspection use `cargo package --exclude-lockfile` for package-source proof.
+
+| Crate | Files | Bytes | SHA-256 |
+| --- | ---: | ---: | --- |
+| `uselesskey-jwk` | 20 | 16050 | `ab83138329fc80f43cd0511fcdcfba10598bfe08ec327f214d189061f73032cc` |
+| `uselesskey-core` | 36 | 38626 | `0ca45b22a4a21b7ab8f23640999469ca32c9544216ebb6de03d4c921a921febc` |
+| `uselesskey-entropy` | 6 | 5002 | `ea91bd14bc1c65bc21b2a278983629e590e5de2c452916c1aae1ab4d90aa5d8b` |
+| `uselesskey-rsa` | 31 | 22403 | `09581e8e88e36257598919d362ed8203e95cef3b55152fc667192a5228826a86` |
+| `uselesskey-ecdsa` | 32 | 19845 | `a7a72627cc33404c43b6cb8e83ea9114c209796220a77e64cfa83b30e1d15dc4` |
+| `uselesskey-ed25519` | 28 | 14508 | `08fef7a2eb33958f0b5654ff3ad39ebb9bce0e5224cc6b6853c4d10b01e4dd9c` |
+| `uselesskey-hmac` | 27 | 14856 | `0378c450eff4534c5586b9c8aae3dfbfd9bfdd318f788ccfca8d500c6a974137` |
+| `uselesskey-token` | 38 | 31663 | `91d08038e54997834cec0645a76d777cea357fd442fcddb9e82b3469b3bbc452` |
+| `uselesskey-webhook` | 10 | 9739 | `e1f4a4bf70d581a49f6907ba97d1e3f8170f62dd4d077ba7f00c62a9e56ffe88` |
+| `uselesskey-pkcs11-mock` | 5 | 6578 | `7e0ebf89e40c77af80af2076b66daef9abbf5528289c1b7f6363858035e1977d` |
+| `uselesskey-webauthn` | 5 | 7438 | `3b25392bfbb235c52b49f5c3248900d7f58b64e80f73c4555402d54d4014018f` |
+| `uselesskey-ssh` | 9 | 6331 | `8fdf13a4796a15e82b75c6fbd512a6a610d6c71b4a7783af7a28670a5687bf6a` |
+| `uselesskey-pgp` | 26 | 15577 | `b542bd230c5ef89ca94e82ec76c90869bac47b336a6cbf4c3970e4f57af26f37` |
+| `uselesskey-x509` | 38 | 48330 | `d67a4d4f84902a558c7922a670165a01fc4bc68220857dd1cdd8f35fdc5f3643` |
+| `uselesskey-test-server` | 7 | 10189 | `be9e64386310fbc775271ea495778f804703bb5b84827e055f3def0100f713e4` |
+| `uselesskey-axum` | 8 | 10083 | `b9e2b324310ea1d33517602680fda72ae07903bea545627e7194a5d4f7a633ca` |
+| `uselesskey-cli` | 20 | 55034 | `35d96075c719fafbe3c4592bee471da20f7f189f176b685eaf9e2c4884651f9e` |
+| `uselesskey-jsonwebtoken` | 23 | 17808 | `9de2257ca101383c89df2d705542807ba9cf4691ab6ea1b87736754b34264141` |
+| `uselesskey-rustls` | 35 | 19799 | `481c2ff2f2660ac019ea15b58ef18aaab5609d06da75f61a6192cc3aea6aa63b` |
+| `uselesskey-tonic` | 25 | 16313 | `c186f927ea294715f2370121ab301f6108d496ec2045e7016778d428b7ec451a` |
+| `uselesskey-ring` | 21 | 11968 | `dd4b966a51e9b11b58793f275b74874dcea52255923416385660f9a28a310954` |
+| `uselesskey-rustcrypto` | 23 | 13365 | `a281e4d04a9daac773c628e42d0d2f1200a59deefc2b0bc91bbdb1489a36d507` |
+| `uselesskey-aws-lc-rs` | 21 | 13505 | `37a40f650605a5f7e1ccd98829cb937116d12d1e3860e36c065e71a00befa776` |
+| `uselesskey` | 69 | 86249 | `87f1238de731001e055ac89ef350e9fbc0d35b776100e4100b67af886eaf7908` |
+
+## Local Proof
+
+All commands in this table were run against source candidate SHA
+`5ea65e1cc6309042731cf4ec91cb39f00a91253a` unless otherwise noted.
+
+| Command | Result | Evidence |
+| --- | --- | --- |
+| `rtk cargo xtask publish-preflight` | Pass | `28 passed, 0 failed, 0 skipped` |
+| `rtk cargo xtask publish-check` | Pass with expected skips | Skips were for unpublished v0.10 workspace siblings |
+| `rtk cargo xtask no-blob` | Pass | No committed secret-shaped blobs reported |
+| `rtk cargo xtask check-bundle-schemas` | Pass | `5 profiles; 0 errors` |
+| `rtk cargo xtask check-audit-receipts` | Pass | `11 examples; 0 errors` |
+| `rtk cargo xtask check-adoption-command-ledger` | Pass | `21 command rows` validated |
+| `rtk cargo xtask external-adoption-smoke --path . --ci-recipes --format json` | Pass | JSON report `git_sha` was `5ea65e1cc6309042731cf4ec91cb39f00a91253a` |
+| `rtk cargo xtask external-adoption-smoke --path . --library-examples` | Pass | `projects=4, steps=4` |
+| `rtk cargo xtask adoption-regression --external` | Pass | `steps=7` |
+| `rtk cargo test -p uselesskey-cli --all-features audit_bundle --locked` | Pass | `37 passed, 84 filtered out` |
+| `rtk cargo test --workspace --all-features --locked` | Pass | `4469 passed (291 suites)` |
+| `rtk cargo xtask claim-report --check-public-claims` | Pass | `docs/status/PUBLIC_CLAIMS.md` matched `policy/claim-ledger.toml` |
+| `rtk cargo xtask spec-check --strict` | Pass | `artifacts=51, claims=9, warnings=0, errors=0` |
+
+## Receipt And Claim Proof
+
+The release-facing receipt contract is `docs/release/v0.10-receipt-contract.md`.
+The schema and example checks above prove:
+
+- generated bundle manifests validate against `docs/schemas/bundle-manifest.schema.json`;
+- negative coverage receipts validate against `docs/schemas/negative-coverage.schema.json`;
+- fail-closed audit receipt examples remain parseable and command-backed;
+- the adoption command ledger has an owner and proof boundary for each release
+  command row.
+
+Public claim and support evidence is represented by
+`policy/claim-ledger.toml`, `docs/status/PUBLIC_CLAIMS.md`, and the strict
+spec inventory. Source xtask does not currently expose the swarm-era
+`check-support-tiers` or `check-claim-proof-policy` command names; this record
+uses the source-available `claim-report --check-public-claims` and
+`spec-check --strict` proof instead.
+
+## Hosted CI
+
+Live GitHub status was checked on 2026-06-20.
+
+| PR | State | Merge commit | Hosted proof |
+| --- | --- | --- | --- |
+| `#862` | Merged at `2026-06-19T22:59:20Z` | `ace29dd2ae0dc76069eaaa572a1ad67456423b87` | CI `pr` and `perf` succeeded; `main` skipped; CodeRabbit and GitGuardian succeeded; Cursor Bugbot neutral |
+| `#864` | Merged at `2026-06-20T00:23:06Z` | `320032df0fad0361238babd253b092953b640a1d` | CI run `27852818452`: `pr` and `perf` succeeded; `main` skipped; CodeRabbit and GitGuardian succeeded; Cursor Bugbot neutral; Codecov skipped |
+| `#865` | Merged at `2026-06-20T03:47:41Z` | `5ea65e1cc6309042731cf4ec91cb39f00a91253a` | CI run `27858570837`: `pr` and `perf` succeeded; `main` skipped; CodeRabbit and GitGuardian succeeded; Cursor Bugbot neutral; Codecov skipped |
+
+## Known Non-blockers
+
+- No crates have been published for `0.10.0`; registry availability remains
+  unknown until the explicit release gate is approved and executed.
+- `cargo xtask publish-check` reports expected skips for crates whose v0.10
+  workspace siblings are not yet present on crates.io.
+- Cargo 1.95 does not expose `--exclude-lockfile` on `cargo publish`; package
+  source proof therefore uses `cargo package --exclude-lockfile`, while
+  `publish-check` remains a resolver-oriented dry-run.
+- Source xtask lacks the swarm-era `check-support-tiers` and
+  `check-claim-proof-policy` command names. Public claims are checked through
+  `claim-report --check-public-claims` and `spec-check --strict`.
+- The evidence record PR is docs-only and should not be treated as publish,
+  tag, registry, or release-approval evidence.
+
+## Publish Order
+
+Use the workspace publish order:
+
+1. `uselesskey-jwk`
+2. `uselesskey-core`
+3. `uselesskey-entropy`
+4. `uselesskey-rsa`
+5. `uselesskey-ecdsa`
+6. `uselesskey-ed25519`
+7. `uselesskey-hmac`
+8. `uselesskey-token`
+9. `uselesskey-webhook`
+10. `uselesskey-pkcs11-mock`
+11. `uselesskey-webauthn`
+12. `uselesskey-ssh`
+13. `uselesskey-pgp`
+14. `uselesskey-x509`
+15. `uselesskey-test-server`
+16. `uselesskey-axum`
+17. `uselesskey-cli`
+18. `uselesskey-jsonwebtoken`
+19. `uselesskey-rustls`
+20. `uselesskey-tonic`
+21. `uselesskey-ring`
+22. `uselesskey-rustcrypto`
+23. `uselesskey-aws-lc-rs`
+24. `uselesskey`
+
+## Rollback
+
+Before publication:
+
+- revert the evidence-only PR if the record is wrong;
+- revert or supersede PR `#862`, `#864`, or `#865` if their imported source,
+  version-candidate, or packaged-adoption changes are rejected;
+- rerun the source-candidate proof commands after any rollback or corrective
+  source PR;
+- do not publish a partial release to compensate for a failed candidate check.
+
+During publication, use the repo publish-state resume flow rather than changing
+publish order ad hoc. A failure after any crate is public becomes an explicit
+corrective-release decision, not an implicit continuation of this candidate
+record.
+
+## Explicit Release Gate
+
+Only after explicit approval:
+
+1. publish crates in dependency order;
+2. verify each registry publication;
+3. publish the `uselesskey` facade;
+4. publish `uselesskey-cli`;
+5. tag `v0.10.0`;
+6. push the tag;
+7. run published-version CLI and facade smoke;
+8. archive post-publication evidence.


### PR DESCRIPTION
## Description

Records the immutable v0.10.0 source-candidate evidence after the handoff import,
candidate preparation, and packaged-adoption proof PRs.

This adds `docs/release/v0.10.0-candidate-evidence.md` and links it from the
release docs index. The record pins the source candidate SHA, swarm handoff SHA,
toolchain, package archive hashes and file counts, CLI/facade smoke results,
schema/receipt/public-claim proof, hosted CI state, known non-blockers, publish
order, rollback path, and explicit release gate.

This PR does not publish crates, tag `v0.10.0`, create a GitHub release, approve
release execution, or move release authority.

Fixes # (none)

## Type of change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `style`: Code style (formatting, etc)
- [ ] `refactor`: Refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Testing
- [ ] `chore`: Maintenance
- [ ] `revert`: Revert change

## DevEx Checklist

Run these locally before submitting:

- [ ] `cargo xtask gate`: Fmt, check, clippy, and test compile pass. Not run; docs-only evidence record.
- [x] `cargo xtask typos`: No misspellings.
- [ ] `cargo xtask bdd`: BDD tests pass (if applicable). Not applicable.
- [ ] `cargo xtask mutants`: Mutation testing passes (if applicable). Not applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules. Not applicable; source PRs `#862`, `#864`, and `#865` are merged, and no downstream publish is part of this lane.

## Validation

Source candidate proof refreshed on `5ea65e1cc6309042731cf4ec91cb39f00a91253a`:

- `rtk cargo xtask publish-preflight`
- `rtk cargo xtask publish-check`
- `rtk cargo xtask no-blob`
- `rtk cargo xtask check-bundle-schemas`
- `rtk cargo xtask check-audit-receipts`
- `rtk cargo xtask check-adoption-command-ledger`
- `rtk cargo xtask external-adoption-smoke --path . --ci-recipes --format json`
- `rtk cargo xtask external-adoption-smoke --path . --library-examples`
- `rtk cargo xtask adoption-regression --external`
- `rtk cargo test -p uselesskey-cli --all-features audit_bundle --locked`
- `rtk cargo test --workspace --all-features --locked`
- `rtk cargo xtask claim-report --check-public-claims`
- `rtk cargo xtask spec-check --strict`

PR-local docs validation:

- `rtk git diff --check`
- `rtk cargo xtask docs-sync --check`
- `rtk cargo xtask spec-check --strict`
- `rtk cargo xtask typos`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or publish behavior changes—only governance/evidence text that could mislead reviewers if facts were wrong.
> 
> **Overview**
> Adds **`docs/release/v0.10.0-candidate-evidence.md`**, an immutable **pre-release** evidence record for source candidate SHA `5ea65e1cc6309042731cf4ec91cb39f00a91253a` (after merged PRs `#862`–`#865`). It pins handoff SHAs, toolchain, per-crate package SHA-256s, local xtask/test proof results, hosted CI status, known non-blockers, workspace publish order, rollback guidance, and an explicit gate that **does not** publish, tag, or approve release execution.
> 
> **`docs/README.md`** gains a Release index link to that document, described as evidence before explicit release execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8295561f2d249aca989cd277ce368f42f1d164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->