### PR TITLE
docs: lock workflow contract source truth

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -55,3 +55,5 @@ public crate-surface cleanup.
 - [USELESSKEY-SPEC-0018: Install and distribution polish](USELESSKEY-SPEC-0018-install-distribution-polish.md)
 - [USELESSKEY-SPEC-0019: Library facade polish](USELESSKEY-SPEC-0019-library-facade-polish.md)
 - [USELESSKEY-SPEC-0020: Downstream policy pack](USELESSKEY-SPEC-0020-downstream-policy-pack.md)
+- [USELESSKEY-SPEC-0021: Material classification](USELESSKEY-SPEC-0021-material-classification.md)
+- [USELESSKEY-SPEC-0022: Task-first workflow docs](USELESSKEY-SPEC-0022-task-first-docs.md)

--- a/docs/specs/USELESSKEY-SPEC-0016-negative-fixture-taxonomy.md
+++ b/docs/specs/USELESSKEY-SPEC-0016-negative-fixture-taxonomy.md
@@ -21,7 +21,9 @@ linked_specs = [
   "USELESSKEY-SPEC-0015",
 ]
 support_tier_impact = []
-policy_impact = []
+policy_impact = [
+  "policy/negative-fixtures.toml",
+]
 +++
 
 # USELESSKEY-SPEC-0016: Negative Fixture Taxonomy
@@ -79,6 +81,35 @@ negative-malformed-signature
 Implementation PRs may add only a subset of this taxonomy. They must not imply
 that unimplemented taxonomy classes already exist.
 
+## Implementation State
+
+The taxonomy is broader than the currently implemented product surface. The
+machine-readable implementation ledger is:
+
+```text
+policy/negative-fixtures.toml
+```
+
+The human status mirror is:
+
+```text
+docs/status/negative-fixture-matrix.md
+```
+
+Those files distinguish:
+
+| Status | Meaning |
+| --- | --- |
+| `implemented` | The class has an owner crate or CLI bundle surface, tests, and docs/status mapping. |
+| `accepted_planned` | The taxonomy class is accepted, but implementation is intentionally deferred. |
+| `deferred` | The class is useful but not part of the current product lane or support surface. |
+| `out_of_scope` | The class would overclaim provider compatibility, production security, or scanner-evasion behavior. |
+
+Implementation PRs must update the ledger and status mirror when they add,
+defer, rename, or expose a negative class. Docs may describe the broad taxonomy,
+but user-facing how-tos, bundle receipts, and examples must only present
+`implemented` classes as available product behavior.
+
 ## Family Taxonomy
 
 ### JWK
@@ -117,6 +148,7 @@ JWKS negatives cover set-level key discovery failures.
 | Class | Stable ID | Shape | Expected downstream failure |
 | --- | --- | --- | --- |
 | empty keys | `jwks_empty_keys` | `{ "keys": [] }` | no usable verification key |
+| missing `kid` | `jwks_missing_kid` | key-set member without `kid` | key selection cannot identify the key |
 | duplicate `kid` | `jwks_duplicate_kid` | two distinct public keys with the same `kid` | ambiguous key selection |
 | duplicate key | `jwks_duplicate_key` | repeated equivalent public key entry | policy rejects duplicate material |
 | mixed valid/invalid set | `jwks_mixed_valid_invalid` | valid key plus malformed or policy-invalid key | parser or policy surfaces bad set member |
@@ -145,12 +177,16 @@ JWT and token negatives cover parser, header, claim, and policy failures.
 | --- | --- | --- | --- |
 | bad segment count | `jwt_bad_segment_count` | fewer or more than three JWT segments | parser rejects token shape |
 | malformed base64url | `jwt_malformed_base64url` | invalid base64url in header, payload, or signature | parser rejects segment encoding |
+| invalid header shape | `jwt_invalid_header_shape` | decodable JWT header that is not a header object | parser or validator rejects header type |
+| missing `alg` | `jwt_missing_alg` | JWT header without `alg` | verifier policy cannot select an algorithm |
 | `alg: none` | `jwt_alg_none` | JWT header with `alg` set to `none` | verifier policy rejects unsigned algorithm |
 | missing `kid` | `jwt_missing_kid` | signed-looking token with no header `kid` | key selection cannot identify verification key |
+| mismatched `kid` | `jwt_mismatched_kid` | header and payload carry different key IDs | key-selection or policy check rejects inconsistent identity |
 | expired claims | `jwt_expired` | `exp` before validation time | claim validation rejects token |
 | not-yet-valid claims | `jwt_not_yet_valid` | future `nbf` | claim validation rejects token |
 | bad audience | `jwt_bad_audience` | `aud` does not match expected audience | claim validation rejects token |
 | bad issuer | `jwt_bad_issuer` | `iss` does not match expected issuer | claim validation rejects token |
+| malformed bearer | `token_malformed_bearer` | bearer-shaped value with invalid base64url/token syntax | parser rejects bearer token format |
 | near-miss bearer/API token | `token_near_miss` | scanner-safe token-shaped string that fails prefix or format policy | parser or application policy rejects token |
 
 Scanner-safety posture:
@@ -250,6 +286,26 @@ failure-class boundary. A shared malformed-base64url helper is acceptable. A
 generic "broken string" helper that hides whether the failure is header, claim,
 key, or signature related is not acceptable.
 
+## Stable Failure-Class Lifecycle
+
+Stable failure classes are product contracts once they appear in public docs,
+bundle manifests, audit JSON, receipts, examples, or public APIs such as
+`stable_id()`.
+
+Lifecycle rules:
+
+- stable IDs are append-only once documented;
+- removing or renaming a stable ID requires a compatibility note and migration
+  path;
+- display labels, descriptions, and Markdown headings may change, but stable IDs
+  must not change silently;
+- bundle manifests, negative-coverage receipts, audit JSON, and downstream CI
+  docs must use stable IDs rather than prose labels for machine decisions;
+- docs may group stable IDs, but must not alias two distinct behaviors to one
+  stable ID;
+- aliases in code must map to an existing stable ID only when they intentionally
+  expose the same downstream failure class.
+
 ## Manifest and Receipt Mapping
 
 When a negative fixture appears in a bundle, metadata should include:
@@ -315,6 +371,8 @@ This spec is accepted when:
   named classes;
 - each class records a stable ID, fixture shape, expected downstream failure,
   and scanner-safety posture;
+- the implementation ledger and status matrix distinguish implemented,
+  accepted/planned, deferred, and out-of-scope classes;
 - cross-family rules preserve deterministic identity, metadata-only receipts,
   and task-first docs;
 - non-goals prevent provider compatibility, production security, scanner

--- a/docs/specs/USELESSKEY-SPEC-0017-bundle-product-surface.md
+++ b/docs/specs/USELESSKEY-SPEC-0017-bundle-product-surface.md
@@ -112,6 +112,17 @@ The manifest must record:
   audit rule;
 - receipt links.
 
+The JSON schema for this contract is:
+
+```text
+docs/schemas/bundle-manifest.schema.json
+```
+
+That schema is intentionally tolerant of additive fields, but it locks the
+stable product surface that downstream CI and docs can rely on: relative paths,
+profile, artifact list, receipt list, scanner-safe classification, and optional
+negative failure-class metadata.
+
 Artifact paths and receipt paths must be relative to the bundle root. They must
 not escape the bundle directory, contain absolute paths, or depend on the
 developer's local checkout path.
@@ -149,6 +160,15 @@ Required receipts:
 These receipts are metadata-only. They are required for bundle profiles but do
 not create repo public-claim proof, release evidence, provider compatibility
 proof, production security assurance, or scanner-evasion claims.
+
+The negative coverage receipt schema is:
+
+```text
+docs/schemas/negative-coverage.schema.json
+```
+
+Downstream CI must branch on stable IDs in `failure_class`, not on English
+descriptions or Markdown text.
 
 ### Negative Fixture Metadata
 
@@ -264,6 +284,8 @@ git diff --check
 This spec is accepted when:
 
 - it defines bundle directory, manifest, artifact, and receipt contracts;
+- it records JSON schema paths for bundle manifests and negative-coverage
+  receipts;
 - it names existing bundle profiles and their user jobs;
 - it defines current receipts and target receipts before implementation;
 - it maps negative fixture metadata to SPEC-0016 stable IDs;

--- a/docs/specs/USELESSKEY-SPEC-0021-material-classification.md
+++ b/docs/specs/USELESSKEY-SPEC-0021-material-classification.md
@@ -1,0 +1,216 @@
++++
+id = "USELESSKEY-SPEC-0021"
+kind = "spec"
+title = "Material classification"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-19"
+milestone = "v0.10.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_adrs = [
+  "USELESSKEY-ADR-0001",
+  "USELESSKEY-ADR-0002",
+]
+linked_plan = "plans/real-workflow-closure/implementation-plan.md"
+linked_specs = [
+  "USELESSKEY-SPEC-0014",
+  "USELESSKEY-SPEC-0015",
+  "USELESSKEY-SPEC-0016",
+  "USELESSKEY-SPEC-0017",
+]
+support_tier_impact = []
+policy_impact = [
+  "policy/negative-fixtures.toml",
+]
++++
+
+# USELESSKEY-SPEC-0021: Material Classification
+
+## Problem
+
+`uselesskey` now exposes the same generated fixture through several product
+surfaces: Rust APIs, installed bundle output, audit receipts, external examples,
+and task docs. Those surfaces need one operational vocabulary for whether an
+artifact is scanner-safe, runtime material, or metadata-only.
+
+Without a shared classification contract, a fixture can be easy to generate but
+hard to review:
+
+```text
+Is this file safe to commit?
+Is it generated runtime material that should stay under target/?
+Is this receipt allowed to leave CI?
+Does this audit packet contain raw payloads?
+```
+
+## Behavior
+
+Every artifact, receipt, and reviewer handoff should use these classifications:
+
+| Classification | Meaning |
+| --- | --- |
+| `scanner_safe` | The artifact is public material, malformed shape data, or metadata that `uselesskey` intentionally treats as safe for scanner-friendly examples when documented. |
+| `runtime_material` | The artifact is generated for tests under an explicit output directory such as `target/`; it should not be committed or copied into reviewer packets unless separately documented scanner-safe. |
+| `metadata_only` | The artifact is a receipt, audit packet, schema, status page, or proof summary that may name paths/classes/counts/boundaries but must not copy raw fixture payloads. |
+
+The same file may have more than one lane in a manifest, but the user-facing
+classification must stay unambiguous. For example, a public JWK can be generated
+at runtime and still be scanner-safe. A webhook request fixture is runtime
+material and not scanner-safe. A bundle audit JSON file is metadata-only.
+
+### Required Labels
+
+Bundle manifests, audit receipts, and negative coverage receipts must expose or
+derive:
+
+```text
+scanner_safe
+runtime_material
+metadata-only receipt boundary
+```
+
+Where a current schema derives `runtime_material` from `scanner_safe`, the docs
+must say so explicitly and future schema changes must preserve a migration path.
+
+### Forbidden Metadata-Only Payloads
+
+Metadata-only surfaces must not copy:
+
+- PEM private keys;
+- DER private material;
+- JWT token values;
+- HMAC secrets;
+- JWK private members;
+- JWK `k` values;
+- webhook request bodies;
+- Vault or Kubernetes secret payload values;
+- generated secret-shaped payloads from runtime bundles.
+
+Metadata-only surfaces may include relative paths, artifact kinds, failure
+classes, counts, profile names, command names, schema versions, and boundary
+language.
+
+## Non-goals
+
+This spec does not make scanner-safe a production security guarantee.
+
+This spec does not claim scanner evasion or promise that every third-party
+scanner will classify every shape the same way.
+
+This spec does not permit committing generated runtime material.
+
+This spec does not move repo-local claim proof into the installed CLI.
+
+This spec does not add a new bundle profile, contract pack, fixture family,
+version bump, tag, publish, or release lane.
+
+## Required Evidence
+
+Docs-only changes should run:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Implementation changes that alter classification should run:
+
+```bash
+cargo test -p uselesskey-cli --all-features bundle verify_bundle audit_bundle
+cargo xtask external-adoption-smoke --path .
+cargo xtask no-blob
+cargo +nightly xtask pr-lite
+git diff --check
+```
+
+## Acceptance
+
+This spec is accepted when:
+
+- it defines scanner-safe, runtime-material, and metadata-only classifications;
+- it names forbidden metadata-only payloads;
+- it requires bundle/audit surfaces to expose or derive scanner-safe and
+  runtime-material labels;
+- it preserves existing proof boundaries and non-goals.
+
+This spec is implemented when:
+
+- bundle manifests and audit receipts expose the classification labels required
+  by SPEC-0014 and SPEC-0017;
+- `audit-bundle` and reviewer docs keep receipts metadata-only;
+- task-first docs say whether generated outputs belong under `target/`;
+- `cargo xtask no-blob` remains green for docs, examples, and receipts.
+
+## Acceptance Examples
+
+Acceptable metadata-only audit entry:
+
+```json
+{
+  "path": "requests/negative-missing-signature.json",
+  "kind": "webhook",
+  "scanner_safe": false,
+  "runtime_material": true,
+  "failure_class": "webhook_missing_signature"
+}
+```
+
+Not acceptable:
+
+```text
+bundle-audit.json embeds the generated webhook request body, signature header,
+or verifier secret.
+```
+
+## Test Mapping
+
+Material classification maps to:
+
+- CLI bundle tests for manifest metadata;
+- CLI audit tests for receipt metadata;
+- `cargo xtask no-blob` for committed docs/examples/fixtures;
+- external adoption smoke for installed-user bundle paths;
+- docs-sync and typos for copyable docs.
+
+## Implementation Mapping
+
+Owners:
+
+- `crates/uselesskey-cli` owns bundle manifest, audit, inspect, and receipt
+  classification display;
+- `policy/negative-fixtures.toml` records scanner-safe and runtime-material
+  posture for negative classes;
+- `docs/reference/bundle-audit-json.md` documents stable audit JSON fields;
+- `docs/status/negative-fixture-matrix.md` mirrors negative-class posture for
+  readers;
+- `docs/how-to/` owns task-specific guidance on what belongs under `target/`.
+
+## CI Proof
+
+Docs-only PR:
+
+```bash
+cargo xtask spec-check --strict
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Classification implementation PR:
+
+```bash
+cargo test -p uselesskey-cli --all-features bundle verify_bundle audit_bundle
+cargo xtask external-adoption-smoke --path .
+cargo xtask no-blob
+cargo +nightly xtask pr-lite
+git diff --check
+```
+
+## Metrics / Promotion Rule
+
+This spec can move to implemented when all current bundle profiles expose
+scanner-safe/runtime-material posture through manifest and audit surfaces, and
+the docs/status matrix names the classification for user-visible negative
+classes.

--- a/docs/specs/USELESSKEY-SPEC-0022-task-first-docs.md
+++ b/docs/specs/USELESSKEY-SPEC-0022-task-first-docs.md
@@ -1,0 +1,203 @@
++++
+id = "USELESSKEY-SPEC-0022"
+kind = "spec"
+title = "Task-first workflow docs"
+status = "accepted"
+owner = "EffortlessMetrics"
+created = "2026-05-19"
+milestone = "v0.10.0"
+linked_proposal = "USELESSKEY-PROP-0001"
+linked_adrs = [
+  "USELESSKEY-ADR-0002",
+  "USELESSKEY-ADR-0003",
+]
+linked_plan = "plans/real-workflow-closure/implementation-plan.md"
+linked_specs = [
+  "USELESSKEY-SPEC-0013",
+  "USELESSKEY-SPEC-0015",
+  "USELESSKEY-SPEC-0016",
+  "USELESSKEY-SPEC-0017",
+  "USELESSKEY-SPEC-0021",
+]
+support_tier_impact = []
+policy_impact = []
++++
+
+# USELESSKEY-SPEC-0022: Task-First Workflow Docs
+
+## Problem
+
+`uselesskey` has a large crate graph and a strong proof system. New users should
+not need to understand either before solving a test problem. Task docs need a
+stable shape so future pages do not drift back into crate-layout tours or
+maintainer-only proof machinery.
+
+The first screen should answer:
+
+```text
+What are you trying to test?
+What do you copy?
+What positive case do you get?
+What negative case do you get?
+How do you verify or audit it?
+What does this not prove?
+```
+
+## Behavior
+
+User-facing how-tos for fixture adoption must route by job first and use this
+shape unless a page has a documented reason to differ:
+
+```text
+# I need to <job>
+
+## Copy this
+<command or code>
+
+## What you get
+<files, values, fixtures, or types>
+
+## Positive path
+<valid fixture behavior>
+
+## Negative path
+<SPEC-0016 stable class or documented negative behavior>
+
+## Verify
+<installed CLI command, cargo test, or repo-local proof where appropriate>
+
+## Audit / receipt
+<metadata-only artifact or smoke path>
+
+## What this does not prove
+<boundary>
+```
+
+Task docs may link to specs, claim ledgers, `xtask`, and release evidence as
+deeper references. They must not require a first-time installed user to read
+those internals before seeing the copyable command or facade snippet.
+
+Required current task docs include:
+
+| Page | User job |
+| --- | --- |
+| `docs/how-to/test-oidc-jwks-validation.md` | Test OIDC/JWKS validator positive and negative paths. |
+| `docs/how-to/test-jwt-negative-validation.md` | Test JWT/token claim and parser rejection paths. |
+| `docs/how-to/materialize-rsa-fixtures-at-build-time.md` | Materialize RSA fixtures explicitly at build/test time. |
+| `docs/how-to/verify-a-fixture-bundle.md` | Verify, inspect, and audit an installed CLI bundle. |
+
+Kubernetes and Vault export docs may follow the same shape, but they remain
+bounded to existing export behavior and must not imply a bundle profile or
+contract pack unless that surface exists.
+
+## Non-goals
+
+This spec does not reorganize the whole documentation tree.
+
+This spec does not add a fixture family, contract pack, provider compatibility
+claim, production security claim, scanner-evasion claim, version bump, tag,
+publish, or release lane.
+
+This spec does not move repo-local claim-proof, verification-pack, or release
+evidence into installed-user docs except as deeper reviewer references.
+
+## Required Evidence
+
+Docs-only changes should run:
+
+```bash
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Changes to examples, commands, or snippets should also run the narrow adoption
+proof:
+
+```bash
+cargo xtask external-adoption-smoke --path .
+cargo xtask external-adoption-smoke --path . --library-examples
+git diff --check
+```
+
+## Acceptance
+
+This spec is accepted when:
+
+- it defines the task-first page shape;
+- it names the required current how-tos;
+- it keeps internal proof machinery behind the user path;
+- it requires positive path, negative path, verification, receipt, and boundary
+  content for each accepted workflow page.
+
+This spec is implemented when:
+
+- the required how-tos use the task-first shape or record an explicit
+  exception;
+- each page names the relevant SPEC-0016 negative class when a negative fixture
+  is part of the job;
+- docs-sync and external adoption smoke cover the copyable commands/snippets
+  where practical.
+
+## Acceptance Examples
+
+Acceptable:
+
+```text
+The OIDC/JWKS page starts with `uselesskey bundle --profile oidc`, names
+`jwks_duplicate_kid`, and shows `verify-bundle`/`audit-bundle` before linking
+to repo-local bundle proof.
+```
+
+Not acceptable:
+
+```text
+The first task page tells a user to understand claim-ledger, active goal files,
+and release evidence before showing how to generate the fixture.
+```
+
+## Test Mapping
+
+Task-first docs map to:
+
+- `cargo xtask docs-sync --check` for version and snippet drift;
+- `cargo xtask external-adoption-smoke --path .` for installed CLI paths;
+- `cargo xtask external-adoption-smoke --path . --library-examples` for facade
+  examples;
+- `cargo xtask typos` for docs hygiene.
+
+## Implementation Mapping
+
+Owners:
+
+- `docs/how-to/` owns task-first workflow pages;
+- `README.md` and `docs/how-to/start-here.md` route users into those pages;
+- `docs/reference/` owns deeper schemas, matrices, and long-form references;
+- `docs/status/` owns compact status tables and current support surfaces;
+- `xtask` owns receipt-backed proof that copyable commands remain valid.
+
+## CI Proof
+
+Docs-only PR:
+
+```bash
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+Task-doc command PR:
+
+```bash
+cargo xtask external-adoption-smoke --path .
+cargo xtask external-adoption-smoke --path . --library-examples
+cargo xtask docs-sync --check
+cargo xtask typos
+git diff --check
+```
+
+## Metrics / Promotion Rule
+
+This spec can move to implemented when the required task docs have a copyable
+command or snippet, positive case, negative case, verification command,
+metadata-only receipt or smoke path, and explicit "does not prove" boundary.

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -21,3 +21,5 @@ check exist.
 ## Index
 
 - [PUBLIC_CLAIMS.md](PUBLIC_CLAIMS.md) - Public claim to proof-command and boundary map
+- [negative-fixture-matrix.md](negative-fixture-matrix.md) - Negative fixture stable ID implementation state
+- [public-surface-matrix.md](public-surface-matrix.md) - Compact public crate promise matrix

--- a/docs/status/negative-fixture-matrix.md
+++ b/docs/status/negative-fixture-matrix.md
@@ -1,0 +1,82 @@
+# Negative Fixture Matrix
+
+This page is the human mirror of
+[`policy/negative-fixtures.toml`](../../policy/negative-fixtures.toml). It
+answers whether a taxonomy class is available product behavior, accepted but
+planned, deferred, or out of scope.
+
+The taxonomy contract lives in
+[`USELESSKEY-SPEC-0016`](../specs/USELESSKEY-SPEC-0016-negative-fixture-taxonomy.md).
+Machine-readable product surfaces should branch on stable IDs, not display
+labels.
+
+## Status Values
+
+| Status | Meaning |
+| --- | --- |
+| `implemented` | The class has an owner crate or bundle surface, tests, docs/status mapping, and stable ID. |
+| `accepted_planned` | The class is accepted by taxonomy, but not exposed as current product behavior. |
+| `deferred` | The class is useful, but parked outside the current product lane. |
+| `out_of_scope` | The class would overclaim provider compatibility, production security, or scanner-evasion behavior. |
+
+## JWK / JWKS
+
+| Stable ID | Status | Public surface | Bundle exposed | Proof |
+| --- | --- | --- | --- | --- |
+| `jwk_missing_kid` | `implemented` | `NegativeJwk::MissingKid` | no | `cargo test -p uselesskey-jwk --all-features` |
+| `jwk_wrong_kty` | `implemented` | `NegativeJwk::WrongKty` | no | `cargo test -p uselesskey-jwk --all-features` |
+| `jwk_unsupported_alg` | `implemented` | `NegativeJwk::UnsupportedAlg` | no | `cargo test -p uselesskey-jwk --all-features` |
+| `jwk_malformed_base64url` | `implemented` | `NegativeJwk::MalformedBase64url` | no | `cargo test -p uselesskey-jwk --all-features` |
+| `jwk_mismatched_parameters` | `implemented` | `NegativeJwk::MismatchedParameters` | no | `cargo test -p uselesskey-jwk --all-features` |
+| `jwks_empty_keys` | `implemented` | `NegativeJwks::EmptyKeys` | no | `cargo test -p uselesskey-jwk --all-features` |
+| `jwks_missing_kid` | `implemented` | `NegativeJwks::MissingKid` | `oidc` | `cargo test -p uselesskey-cli --all-features bundle` |
+| `jwks_duplicate_kid` | `implemented` | `NegativeJwks::DuplicateKid` | `oidc` | `cargo test -p uselesskey-cli --all-features bundle` |
+| `jwks_duplicate_key` | `implemented` | `NegativeJwks::DuplicateKey` | no | `cargo test -p uselesskey-jwk --all-features` |
+| `jwks_mixed_valid_invalid` | `implemented` | `NegativeJwks::MixedValidInvalid` | no | `cargo test -p uselesskey-jwk --all-features` |
+
+## JWT / Token
+
+| Stable ID | Status | Public surface | Bundle exposed | Proof |
+| --- | --- | --- | --- | --- |
+| `jwt_bad_segment_count` | `implemented` | `NegativeToken::MalformedJwtSegmentCount` | no | `cargo test -p uselesskey-token --all-features` |
+| `jwt_malformed_base64url` | `implemented` | `NegativeToken::BadBase64UrlSegment` | no | `cargo test -p uselesskey-token --all-features` |
+| `jwt_invalid_header_shape` | `implemented` | `NegativeToken::InvalidJwtHeaderShape` | no | `cargo test -p uselesskey-token --all-features` |
+| `jwt_missing_alg` | `implemented` | `NegativeToken::MissingAlg` | no | `cargo test -p uselesskey-token --all-features` |
+| `jwt_alg_none` | `implemented` | `NegativeToken::AlgNone` | `oidc` | `cargo test -p uselesskey-cli --all-features bundle` |
+| `jwt_missing_kid` | `implemented` | `NegativeToken::MissingKid` | no | `cargo test -p uselesskey-token --all-features` |
+| `jwt_mismatched_kid` | `implemented` | `NegativeToken::MismatchedKid` | no | `cargo test -p uselesskey-token --all-features` |
+| `jwt_expired` | `implemented` | `NegativeToken::ExpiredClaims` | no | `cargo test -p uselesskey-token --all-features` |
+| `jwt_not_yet_valid` | `implemented` | `NegativeToken::NotYetValidClaims` | no | `cargo test -p uselesskey-token --all-features` |
+| `jwt_bad_issuer` | `implemented` | `NegativeToken::BadIssuer` | no | `cargo test -p uselesskey-token --all-features` |
+| `jwt_bad_audience` | `implemented` | `NegativeToken::BadAudience` | `oidc` | `cargo test -p uselesskey-cli --all-features bundle` |
+| `token_malformed_bearer` | `implemented` | `NegativeToken::MalformedBearer` | no | `cargo test -p uselesskey-token --all-features` |
+| `token_near_miss` | `implemented` | `NegativeToken::NearMissApiKey` | `scanner-safe` | `cargo test -p uselesskey-cli --all-features bundle` |
+
+## Webhook
+
+| Stable ID | Status | Public surface | Bundle exposed | Proof |
+| --- | --- | --- | --- | --- |
+| `webhook_near_miss_signature` | `accepted_planned` | none yet | no | taxonomy only |
+| `webhook_tampered_body` | `implemented` | `uselesskey bundle --profile webhook` | `webhook` | `cargo test -p uselesskey-cli --all-features webhook` |
+| `webhook_wrong_secret` | `implemented` | `uselesskey bundle --profile webhook` | `webhook` | `cargo test -p uselesskey-cli --all-features webhook` |
+| `webhook_stale_timestamp` | `implemented` | `uselesskey bundle --profile webhook` | `webhook` | `cargo test -p uselesskey-cli --all-features webhook` |
+| `webhook_missing_signature` | `implemented` | `uselesskey bundle --profile webhook` | `webhook` | `cargo test -p uselesskey-cli --all-features webhook` |
+| `webhook_malformed_signature` | `implemented` | `uselesskey bundle --profile webhook` | `webhook` | `cargo test -p uselesskey-cli --all-features webhook` |
+| `webhook_malformed_canonical_payload` | `accepted_planned` | none yet | no | taxonomy only |
+
+## X.509 / TLS
+
+| Stable ID | Status | Public surface | Bundle exposed | Proof |
+| --- | --- | --- | --- | --- |
+| `x509_expired_leaf` | `implemented` | `ChainNegative::ExpiredLeaf` | `tls` | `cargo test -p uselesskey-cli --all-features tls` |
+| `x509_not_yet_valid_leaf` | `implemented` | `ChainNegative::NotYetValidLeaf` | `tls` | `cargo test -p uselesskey-cli --all-features tls` |
+| `x509_wrong_hostname` | `implemented` | `ChainNegative::HostnameMismatch` | `tls` | `cargo test -p uselesskey-cli --all-features tls` |
+| `x509_untrusted_root` | `implemented` | `ChainNegative::UnknownCa` | `tls` | `cargo test -p uselesskey-cli --all-features tls` |
+| `x509_revoked_leaf` | `implemented` | `ChainNegative::RevokedLeaf` | no | `cargo test -p uselesskey-x509 --all-features` |
+| `x509_invalid_key_usage` | `implemented` | `X509Negative::WrongKeyUsage` | no | `cargo test -p uselesskey-x509 --all-features` |
+
+## Boundary
+
+Implemented means `uselesskey` exposes a deterministic fixture class and proof
+path. It does not prove provider compatibility, production security, scanner
+evasion, release readiness, or downstream verifier correctness.

--- a/docs/status/public-surface-matrix.md
+++ b/docs/status/public-surface-matrix.md
@@ -1,0 +1,74 @@
+# Public Surface Matrix
+
+This page is the compact status view for public crate promises. The architecture
+policy lives in [`docs/architecture/public-surface.md`](../architecture/public-surface.md),
+and the generated support table lives in
+[`docs/reference/support-matrix.md`](../reference/support-matrix.md).
+
+Rule:
+
+```text
+Public crates are user promises.
+Workspace-only crates are load-bearing structure.
+```
+
+## Primary User Surfaces
+
+| Crate | Status | User job | Public promise | Feature flags | Docs | Action |
+| --- | --- | --- | --- | --- | --- | --- |
+| `uselesskey` | primary public | Rust test author needs deterministic fixture APIs. | Facade crate for valid/negative fixtures and materialization helpers. | `rsa`, `jwk`, `token`, family flags | `docs/how-to/start-here.md` | keep |
+| `uselesskey-cli` | primary public | Installed user needs bundle, verify, inspect, audit, and doctor commands. | Installed CLI product surface for deterministic bundles and metadata-only receipts. | n/a | `README.md`, `docs/how-to/verify-a-fixture-bundle.md` | keep |
+
+## Fixture-Family Surfaces
+
+| Crate | Status | User job | Public promise | Docs | Action |
+| --- | --- | --- | --- | --- | --- |
+| `uselesskey-core` | public foundation | Advanced users need `Factory`, `Seed`, and shared fixture primitives. | Stable fixture foundation used by facade and family crates. | `docs/architecture/public-surface.md` | keep |
+| `uselesskey-entropy` | public family | Tests need deterministic byte fixtures or scanner-safe placeholder data. | Entropy and placeholder fixture generation. | `docs/reference/support-matrix.md` | keep |
+| `uselesskey-rsa` | public family | Tests need RSA PEM/DER/JWK-compatible fixtures. | RSA fixture extension trait and specs. | `docs/how-to/materialize-rsa-fixtures-at-build-time.md` | keep |
+| `uselesskey-ecdsa` | public family | Tests need ECDSA P-256/P-384 fixtures. | ECDSA fixture extension trait and specs. | `docs/reference/support-matrix.md` | keep |
+| `uselesskey-ed25519` | public family | Tests need Ed25519 fixtures. | Ed25519 fixture extension trait. | `docs/reference/support-matrix.md` | keep |
+| `uselesskey-hmac` | public family | Tests need deterministic HMAC fixture material. | HMAC fixture extension trait and specs. | `docs/reference/support-matrix.md` | keep |
+| `uselesskey-token` | public family | Tests need token-shaped positives and negatives. | Token fixture extension trait plus `NegativeToken` stable IDs. | `docs/how-to/test-jwt-negative-validation.md` | keep |
+| `uselesskey-jwk` | public family | Tests need typed JWK/JWKS shapes and negatives. | JWK/JWKS builders and `NegativeJwk`/`NegativeJwks` stable IDs. | `docs/how-to/test-oidc-jwks-validation.md` | keep |
+| `uselesskey-x509` | public family | Tests need certificates, chains, and TLS-shaped negatives. | X.509 fixture extension trait and negative chain helpers. | `docs/how-to/test-tls-chain-validation.md` | keep |
+| `uselesskey-ssh` | public family | Tests need SSH key and certificate fixtures. | OpenSSH fixture traits and specs. | `docs/reference/support-matrix.md` | keep |
+| `uselesskey-pgp` | public family | Tests need OpenPGP-shaped fixtures. | PGP fixture extension trait and armored/binary output. | `docs/reference/support-matrix.md` | keep |
+| `uselesskey-webhook` | public family | Tests need deterministic HMAC webhook requests. | Webhook fixture APIs for valid and negative verifier paths. | `docs/how-to/test-webhook-signature-validation.md` | keep |
+| `uselesskey-test-server` | public test infrastructure | Integration tests need OIDC/JWKS HTTP routes. | Test server fixture surface. | `docs/reference/support-matrix.md` | keep |
+| `uselesskey-pkcs11-mock` | public test infrastructure | Tests need PKCS#11 mock/provider fixtures. | Mock provider fixture surface. | `docs/reference/support-matrix.md` | keep |
+| `uselesskey-webauthn` | public test infrastructure | Tests need WebAuthn credential/assertion fixtures. | WebAuthn fixture surface. | `docs/reference/support-matrix.md` | keep |
+
+## Adapter Surfaces
+
+| Crate | Status | User job | Public promise | Action |
+| --- | --- | --- | --- | --- |
+| `uselesskey-jsonwebtoken` | public adapter | Users already chose `jsonwebtoken`. | Native `jsonwebtoken` encoding/decoding fixture helpers. | keep |
+| `uselesskey-rustls` | public adapter | Users already chose `rustls`. | Native `rustls` PKI/config fixture helpers. | keep |
+| `uselesskey-tonic` | public adapter | Users already chose `tonic`. | Native tonic TLS identity/config fixture helpers. | keep |
+| `uselesskey-axum` | public adapter | Users already chose `axum`. | Auth-test route and request fixture helpers. | keep |
+| `uselesskey-ring` | public adapter | Users already chose `ring`. | Native `ring` fixture conversions. | keep |
+| `uselesskey-rustcrypto` | public adapter | Users already chose RustCrypto APIs. | Native RustCrypto fixture conversions. | keep |
+| `uselesskey-aws-lc-rs` | public adapter | Users already chose `aws-lc-rs`. | Native aws-lc-rs fixture conversions. | keep |
+
+## Workspace-Only Structure
+
+| Crate | Status | User job | Public promise | Action |
+| --- | --- | --- | --- | --- |
+| `uselesskey-test-grid` | workspace-only | CI/test grid only. | none | keep internal |
+| `uselesskey-feature-grid` | workspace-only | CI feature matrix only. | none | keep internal |
+| `uselesskey-bdd` | workspace-only | BDD runner only. | none | keep internal |
+| `uselesskey-bdd-steps` | workspace-only | BDD shared steps only. | none | keep internal |
+| `uselesskey-interop-tests` | workspace-only | Cross-adapter repo tests only. | none | keep internal |
+| `uselesskey-bench` | workspace-only | Bench receipts only. | none | keep internal |
+| `uselesskey-integration-tests` | workspace-only | Root integration tests only. | none | keep internal |
+| `materialize-buildrs-example` | workspace-only | Example crate users copy, not depend on. | none | keep internal |
+| `materialize-shape-buildrs-example` | workspace-only | Example crate users copy, not depend on. | none | keep internal |
+| `xtask` | workspace-only | Maintainer/repo proof automation. | none as a crate | keep internal |
+
+## Boundary
+
+This matrix does not demote or remove crates. Public-surface changes that affect
+publish status, support tier, or semver expectations must update the generated
+support matrix, `docs/metadata/workspace-docs.json`, and the release story in a
+separate release-aware PR.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -290,3 +290,36 @@ surface = "examples"
 classification = "test"
 reason = "Scanner-safe bundle reference outputs (manifest, payload shapes, receipts) used by examples/scanner-safe-bundle/README.md to demonstrate deterministic generator stability. Shape-only — never real secret material."
 covered_by = ["examples/scanner-safe-bundle/README.md", "manual review"]
+
+[[allow]]
+glob = "examples/audit-receipts/*.json"
+kind = "audit_receipt_example"
+owner = "cli"
+surface = "examples"
+classification = "test"
+reason = "Committed metadata-only bundle-audit failure receipt examples for stable failure-class handling. They contain only paths, counts, failure classes, and claim boundaries."
+covered_by = ["cargo xtask check-audit-receipts", "cargo xtask check-file-policy"]
+
+[[allow]]
+glob = "examples/ci/*.sh"
+kind = "ci_receipt_consumer"
+owner = "cli"
+surface = "examples"
+classification = "tooling"
+reason = "Portable fail-closed CI consumer examples for bundle-audit JSON receipts."
+covered_by = [
+  "bash examples/ci/consume-bundle-audit.sh target/uselesskey-webhook-audit/bundle-audit.json",
+  "cargo xtask check-file-policy",
+]
+
+[[allow]]
+glob = "examples/external/ci-recipes/*.yml.example"
+kind = "external_ci_recipe"
+owner = "cli"
+surface = "examples"
+classification = "docs"
+reason = "Downstream-shaped inert CI recipe examples for installed CLI bundle verification and metadata-only audit receipts."
+covered_by = [
+  "cargo xtask external-adoption-smoke --path . --ci-recipes --format json",
+  "cargo xtask check-file-policy",
+]


### PR DESCRIPTION
## Description

Locks the workflow-contract docs that were left dirty on the source repo branch:

- adds accepted source-truth specs for material classification and task-first workflow docs;
- records compact status matrices for negative fixtures and public crate surfaces;
- ties SPEC-0016/SPEC-0017 to stable failure-class and schema contracts;
- adds file-policy rows for existing audit receipt examples and external CI recipe examples.

Fixes # (none)

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] docs: Documentation update
- [ ] style: Code style (formatting, etc)
- [ ] refactor: Refactoring
- [ ] perf: Performance improvement
- [ ] test: Testing
- [x] chore: Maintenance
- [ ] revert: Revert change

## DevEx Checklist

Run these locally before submitting:

- [ ] cargo xtask gate: Fmt, check, clippy, and test compile pass.
- [x] cargo xtask typos: No misspellings.
- [ ] cargo xtask bdd: BDD tests pass (if applicable).
- [ ] cargo xtask mutants: Mutation testing passes (if applicable).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Local proof

Passed:

- cargo xtask spec-check --strict
- cargo xtask docs-sync --check
- cargo xtask typos
- cargo xtask no-blob
- cargo xtask check-bundle-schemas
- cargo xtask check-file-policy
- cargo xtask check-audit-receipts
- git diff --check

Not run:

- cargo xtask gate because this is a docs/source-truth and policy-ledger cleanup with no Rust code changes.
- cargo xtask check-negative-fixtures because this source checkout does not currently register that xtask subcommand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs, specs, and policy-ledger updates only; no Rust or runtime behavior changes, though the matrices document product promises reviewers may treat as contracts.
> 
> **Overview**
> This PR **locks documentation and policy as the source of truth** for workflow contracts: two new accepted specs (**SPEC-0021** material classification, **SPEC-0022** task-first how-tos), plus status matrices and tighter links between negative taxonomy, bundle manifests, and downstream CI.
> 
> **SPEC-0016** now points at `policy/negative-fixtures.toml` and `docs/status/negative-fixture-matrix.md`, adds implementation-state rules, expands JWT/JWKS stable IDs, and defines **append-only stable failure-class lifecycle** (machine branching on stable IDs, not prose).
> 
> **SPEC-0017** now names `docs/schemas/bundle-manifest.schema.json` and `negative-coverage.schema.json`, and requires CI to branch on `failure_class` stable IDs.
> 
> New **negative-fixture** and **public-surface** status pages give compact implementation and crate-promise views. **`policy/non-rust-allowlist.toml`** gains explicit allow rows for committed audit-receipt examples, CI receipt consumers, and external CI recipe examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7caffc62733493e74efcd3b2646be2b9c01b16a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->